### PR TITLE
[CI/Release] Configure weekly dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+---
+version: 2
+
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "[CI/Release]"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "[CI/Release]"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- check Python dependencies weekly
- group GitHub Actions updates into one weekly pull request
- limit each ecosystem to five open update pull requests
- use the repository's `[CI/Release]` title prefix

## Validation

- Dependabot configuration validated against the SchemaStore schema
- YAML lint passed
- pre-commit hooks passed

GPU validation is not required for this configuration-only change.