### PR TITLE
[Feature] Add runnable end-to-end quick start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ The project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 
 ## [Unreleased]
 
+### Added
+
+- A runnable CPU quick-start example with a complete native PyTorch training loop and GEMINI checkpoint resume.
+
 ### Changed
 
-- Quick Start installs the released package from PyPI, while editable installation remains in the development workflow.
+- Quick Start installs the core package from PyPI before introducing optional framework integrations.
 
 ## [0.1.0] - 2026-08-12
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include CODE_OF_CONDUCT.md
 include CONTRIBUTING.md
 include SECURITY.md
 recursive-include docs *.md
+recursive-include examples *.md *.py

--- a/README.md
+++ b/README.md
@@ -41,15 +41,33 @@
 python3.12 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip
-python -m pip install "lm-resiliency[megatron]"
+python -m pip install lm-resiliency
 ```
 
-Use `[torchtitan]`, `[deepspeed]`, `[all]`, or the core package without an extra for other environments.
+Install `[torchtitan]`, `[megatron]`, `[deepspeed]`, or `[all]` when integrating one of those frameworks.
+
+### Run a tiny end-to-end loop
+
+Clone the examples and run the CPU quick start with plain Python:
+
+```bash
+git clone --depth 1 https://github.com/LMResiliency/lm-resiliency.git
+python lm-resiliency/examples/quickstart.py \
+  --checkpoint-dir /tmp/lm-resiliency-quickstart/checkpoints
+```
+
+The example trains a tiny causal LM through a complete forward, backward, and optimizer loop while GEMINI saves recovery state.
+Run it again with `--steps 6` to resume from the saved checkpoint.
+See [Examples](examples/README.md) for the recovery command and distributed production loops that exercise SCOUT.
 
 ### Add resiliency to Megatron Core
 
 Attach resiliency after Megatron creates its model chunks, optimizer, and scheduler.
 Then resume the existing `train()` loop from the recovered iteration.
+
+```bash
+python -m pip install "lm-resiliency[megatron]"
+```
 
 ```python
 from megatron.training import get_args
@@ -77,6 +95,10 @@ See the [Megatron Core production-loop example](examples/production_loops/megatr
 
 Pass the initialized TorchTitan `Trainer` before entering its existing training loop.
 The adapter discovers the model, optimizer, scheduler, dataloader, topology, and checkpoint state.
+
+```bash
+python -m pip install "lm-resiliency[torchtitan]"
+```
 
 ```python
 from torchtitan.train import Trainer

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -9,7 +9,8 @@ Focused integration programs use deterministic training workloads and fault inje
 
 | Check | Result |
 |---|---|
-| CPU unit tests | 632 passed |
+| CPU unit tests | 634 passed |
+| Clean PyPI quick start | Python 3.12 environment passed `pip check`; tiny CPU causal LM trained through step 4, recovered step 4, and continued through step 6 |
 | Ruff | Passed |
 | Python bytecode compilation | Passed |
 | 4-rank two-host OOB checkpoint I/O | Delayed checkpoint write localized to rank 2 after two confirmations |

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,28 @@
 # Examples
 
+## Quick Start
+
+Run [quickstart.py](quickstart.py) with plain Python to train a tiny causal LM on CPU.
+The example executes the complete forward, backward, optimizer, and GEMINI checkpoint lifecycle without requiring a GPU.
+
+```bash
+python examples/quickstart.py \
+  --checkpoint-dir /tmp/lm-resiliency-quickstart/checkpoints
+```
+
+Run it again with a larger step target to resume from the saved GEMINI checkpoint:
+
+```bash
+python examples/quickstart.py \
+  --steps 6 \
+  --checkpoint-dir /tmp/lm-resiliency-quickstart/checkpoints
+```
+
+The single-process example validates training-loop integration and recovery.
+Use the distributed examples below to exercise SCOUT replay and multi-rank localization.
+
+## Production Loops
+
 The production-loop examples train tiny causal language models with deterministic synthetic tokens while preserving each framework's real training lifecycle.
 They support one or two hosts through standard `torchrun` arguments.
 

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -1,0 +1,127 @@
+"""Train and resume a tiny causal LM with native PyTorch on CPU.
+
+This example is intentionally single-process so it can run on a laptop or CI
+machine. It exercises the complete application-owned training loop and GEMINI
+checkpoint recovery. SCOUT replay and multi-rank localization require the
+distributed production-loop examples in ``examples/production_loops``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+
+from lm_resiliency import InMemoryCkptConfig, enable_resiliency
+
+VOCABULARY_SIZE = 128
+SEQUENCE_LENGTH = 12
+BATCH_SIZE = 4
+
+
+class TinyBlock(nn.Module):
+    def __init__(self, hidden_size: int) -> None:
+        super().__init__()
+        self.norm = nn.LayerNorm(hidden_size)
+        self.mlp = nn.Sequential(
+            nn.Linear(hidden_size, hidden_size * 2),
+            nn.GELU(),
+            nn.Linear(hidden_size * 2, hidden_size),
+        )
+
+    def forward(self, hidden: torch.Tensor) -> torch.Tensor:
+        return hidden + self.mlp(self.norm(hidden))
+
+
+class TinyCausalLM(nn.Module):
+    def __init__(self, hidden_size: int = 32, layers: int = 2) -> None:
+        super().__init__()
+        self.embed = nn.Embedding(VOCABULARY_SIZE, hidden_size)
+        self.layers = nn.ModuleList([TinyBlock(hidden_size) for _ in range(layers)])
+        self.output = nn.Linear(hidden_size, VOCABULARY_SIZE, bias=False)
+
+    def forward(self, tokens: torch.Tensor) -> torch.Tensor:
+        hidden = self.embed(tokens)
+        for layer in self.layers:
+            hidden = layer(hidden)
+        return self.output(hidden)
+
+
+def _batch(step: int) -> tuple[torch.Tensor, torch.Tensor]:
+    generator = torch.Generator().manual_seed(10_000 + step)
+    values = torch.randint(
+        0,
+        VOCABULARY_SIZE,
+        (BATCH_SIZE, SEQUENCE_LENGTH + 1),
+        generator=generator,
+    )
+    return values[:, :-1], values[:, 1:]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--steps", type=int, default=4)
+    parser.add_argument("--interval", type=int, default=2)
+    parser.add_argument(
+        "--checkpoint-dir",
+        type=Path,
+        default=Path("/tmp/lm-resiliency-quickstart/checkpoints"),
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.steps <= 0:
+        raise ValueError("--steps must be greater than zero")
+    if args.interval <= 0:
+        raise ValueError("--interval must be greater than zero")
+
+    torch.manual_seed(7)
+
+    model = TinyCausalLM()
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    resiliency = enable_resiliency(
+        model,
+        optimizer,
+        interval=args.interval,
+        enable_detection=False,
+        checkpoint=InMemoryCkptConfig(
+            disk_flush_interval=1,
+            disk_folder=str(args.checkpoint_dir),
+            pin_memory=False,
+            verify_integrity=True,
+        ),
+        device=torch.device("cpu"),
+    )
+
+    start_step = resiliency.step_count
+    loss_value: float | None = None
+    for step in range(start_step, args.steps):
+        tokens, labels = _batch(step)
+        optimizer.zero_grad(set_to_none=True)
+        logits = model(tokens)
+        loss = nn.functional.cross_entropy(
+            logits.reshape(-1, VOCABULARY_SIZE),
+            labels.reshape(-1),
+        )
+        loss.backward()
+        optimizer.step()
+        loss_value = float(loss.detach())
+
+    checkpoint_step = resiliency.flush_for_restart()
+    summary = {
+        "checkpoint_step": checkpoint_step,
+        "completed_step": resiliency.step_count,
+        "final_loss": round(loss_value, 6) if loss_value is not None else None,
+        "recovered_step": resiliency.recovered_step,
+        "start_step": start_step,
+    }
+    print(json.dumps(summary, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/lm_resiliency/checkpointing/manager.py
+++ b/lm_resiliency/checkpointing/manager.py
@@ -671,7 +671,9 @@ class InMemoryCheckpointManager:
 
         Blocking. Returns the latest own step flushed, or -1 if nothing flushed.
         """
-        return self._flush_slots(self._disk)
+        flushed_step = self._flush_slots(self._disk)
+        self._disarm_exit_flush()
+        return flushed_step
 
     def set_restart_destination(
         self,

--- a/tests/unit/test_checkpoint_recovery.py
+++ b/tests/unit/test_checkpoint_recovery.py
@@ -41,6 +41,26 @@ def test_flush_for_restart_own_shard_round_trip(tmp_path):
     reloaded_manager.close()
 
 
+def test_flush_for_restart_disarms_exit_flush_until_next_save(tmp_path):
+    config = InMemoryCkptConfig(
+        enable=True,
+        interval=1,
+        disk_flush_interval=0,
+        disk_folder=str(tmp_path),
+    )
+    manager = InMemoryCheckpointManager(config)
+    manager.save({"model": {"w": torch.ones(4)}}, step=1)
+    manager.maybe_wait()
+
+    assert manager._exit_flush_registered
+    assert manager.flush_for_restart() == 1
+    assert not manager._exit_flush_registered
+
+    manager.save({"model": {"w": torch.full((4,), 2.0)}}, step=2)
+    assert manager._exit_flush_registered
+    manager.close()
+
+
 def test_gemini_is_single_tier(tmp_path):
     config = InMemoryCkptConfig(
         enable=True,

--- a/tests/unit/test_quickstart_example.py
+++ b/tests/unit/test_quickstart_example.py
@@ -1,0 +1,43 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run_example(checkpoint_dir: Path, *, steps: int) -> dict:
+    environment = dict(os.environ)
+    environment["CUDA_VISIBLE_DEVICES"] = ""
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "examples/quickstart.py",
+            "--steps",
+            str(steps),
+            "--interval",
+            "1",
+            "--checkpoint-dir",
+            str(checkpoint_dir),
+        ],
+        check=True,
+        capture_output=True,
+        env=environment,
+        text=True,
+    )
+    return json.loads(completed.stdout.strip().splitlines()[-1])
+
+
+def test_quickstart_trains_and_resumes(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "checkpoints"
+
+    initial = _run_example(checkpoint_dir, steps=2)
+    assert initial["start_step"] == 0
+    assert initial["recovered_step"] == -1
+    assert initial["completed_step"] == 2
+    assert initial["checkpoint_step"] == 2
+
+    resumed = _run_example(checkpoint_dir, steps=3)
+    assert resumed["start_step"] == 2
+    assert resumed["recovered_step"] == 2
+    assert resumed["completed_step"] == 3
+    assert resumed["checkpoint_step"] == 3


### PR DESCRIPTION
## Summary

- make the core PyPI package the first Quick Start installation path
- add a complete CPU native-PyTorch training example with GEMINI checkpoint resume
- link framework extras and distributed SCOUT production-loop examples separately
- include examples in the source distribution
- avoid a redundant emergency exit flush after an explicit `flush_for_restart()`

## Clean-install validation

Created `/tmp/lm-resiliency-quickstart-core-20260812/.venv` with Python 3.12 and installed `lm-resiliency==0.1.0` from PyPI.

- `pip check` passed
- first run trained from step 0 through step 4 and persisted checkpoint step 4
- second run recovered step 4 and continued through step 6
- the branch implementation produced clean automatic-exit output without requiring `resiliency.close()`

## Repository validation

- `634 passed` with CUDA hidden
- Ruff, formatting, pre-commit, and bytecode compilation passed
- 78 Markdown links and fragments checked with zero errors
- wheel and source distribution passed Twine validation
- source distribution contains the quick-start and production-loop examples

The CPU quick start validates training-loop integration and GEMINI recovery. Existing distributed production-loop examples remain the path for SCOUT replay and fault localization; no GPU validation was required for this change.