### PR TITLE
[Docs] Document permanent-failure localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 | | Protects against | What you gain |
 |---|---|---|
-| **SCOUT** | Latent SDC; selection of recovery checkpoints corrupted by SDC; compute, input-pipeline, and communication stragglers; collective desynchronization; process stalls; uncorrectable ECC, row-remap exhaustion, fatal XIDs, device loss, severe NVLink errors, and imminent thermal shutdown | Pinpoint faulty ranks, GPUs, nodes, communication endpoints, or telemetry-reported physical devices, and exclude checkpoints affected by recurring SDC from recovery; see the [coverage contract](docs/scout.md#coverage-contract) |
+| **SCOUT** | Latent SDC; selection of recovery checkpoints corrupted by SDC; compute, input-pipeline, and communication stragglers; collective desynchronization (hangs); process stalls; uncorrectable ECC, row-remap exhaustion, fatal XIDs, device loss, severe NVLink errors, and imminent thermal shutdown | Pinpoint faulty ranks, GPUs, nodes, communication endpoints, or telemetry-reported physical devices, and exclude checkpoints affected by recurring SDC from recovery; see the [coverage contract](docs/scout.md#coverage-contract) |
 | **GEMINI** | Slow, infrequent durable checkpoints | Frequent asynchronous in-memory checkpoints, peer replication, and fast recovery from nearby state |
 
 ## Why LLM Resiliency

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 | | Protects against | What you gain |
 |---|---|---|
-| **SCOUT** | Latent SDC; compute, input-pipeline, and communication stragglers; collective desynchronization; process stalls; uncorrectable ECC, row-remap exhaustion, fatal XIDs, device loss, severe NVLink errors, and imminent thermal shutdown | Pinpoint faulty ranks, GPUs, nodes, communication endpoints, or telemetry-reported physical devices, and exclude checkpoints affected by recurring SDC from recovery; see the [coverage contract](docs/scout.md#coverage-contract) |
+| **SCOUT** | Latent SDC; selection of recovery checkpoints corrupted by SDC; compute, input-pipeline, and communication stragglers; collective desynchronization; process stalls; uncorrectable ECC, row-remap exhaustion, fatal XIDs, device loss, severe NVLink errors, and imminent thermal shutdown | Pinpoint faulty ranks, GPUs, nodes, communication endpoints, or telemetry-reported physical devices, and exclude checkpoints affected by recurring SDC from recovery; see the [coverage contract](docs/scout.md#coverage-contract) |
 | **GEMINI** | Slow, infrequent durable checkpoints | Frequent asynchronous in-memory checkpoints, peer replication, and fast recovery from nearby state |
 
 ## Why LLM Resiliency

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@
 
 | | Protects against | What you gain |
 |---|---|---|
-| **SCOUT** | Silent data corruption (SDC); compute, input-pipeline, and communication stragglers; collective desynchronization; process stalls | Pinpoint faulty ranks, GPUs, nodes, or communication endpoints during training, and exclude checkpoints affected by recurring SDC from recovery; see the [coverage contract](docs/scout.md#coverage-contract) |
+| **SCOUT** | Latent SDC; compute, input-pipeline, and communication stragglers; collective desynchronization; process stalls; uncorrectable ECC, row-remap exhaustion, fatal XIDs, device loss, severe NVLink errors, and imminent thermal shutdown | Pinpoint faulty ranks, GPUs, nodes, communication endpoints, or telemetry-reported physical devices, and exclude checkpoints affected by recurring SDC from recovery; see the [coverage contract](docs/scout.md#coverage-contract) |
 | **GEMINI** | Slow, infrequent durable checkpoints | Frequent asynchronous in-memory checkpoints, peer replication, and fast recovery from nearby state |
 
 ## Why LLM Resiliency
 
 - **SDC-safe recovery-verified checkpoint:** SCOUT certifies recovery checkpoints and excludes candidates affected by recurring SDC, preventing corrupted state from being selected during recovery.
-- **Localize faulty components at runtime:** SCOUT identifies affected ranks, GPUs, nodes, communication endpoints, or peer groups, including communication hangs while the training job is blocked.
+- **Localize latent and permanent failures at runtime:** SCOUT identifies affected ranks, GPUs, nodes, communication endpoints, peer groups, or telemetry-reported physical devices, including failures observed while the training job is blocked.
 - **Minimize rollback:** GEMINI saves complete training state to CPU memory at high frequency with no measurable training-throughput loss, reducing lost computation after a failure.
 - **Retrieve checkpoints quickly:** GEMINI restores nearby state from memory, a surviving peer, or node-local storage, minimizing checkpoint retrieval time and global-storage reads.
 - **Keep protection lightweight:** SCOUT incurs less than 1% amortized overhead during training for runtime failure localization.

--- a/docs/api.md
+++ b/docs/api.md
@@ -510,6 +510,35 @@ The `"torch_dist"` and `"nixl"` backends share the `CheckpointTransfer` contract
 
 Launcher retry, placement, replacement, and quarantine policy remain outside this repository.
 
+## Monitor Hardware Health
+
+The optional hardware-health API complements replay and out-of-band consensus with direct telemetry for permanent or imminent device failures.
+It is not enabled automatically by `enable_resiliency()`.
+
+```python
+from lm_resiliency.manager_api import (
+    HardwareHealthMonitor,
+    HealthConfig,
+    NvmlSource,
+)
+
+monitor = HardwareHealthMonitor(
+    HealthConfig(poll_interval_s=5.0),
+    [NvmlSource(device_index=physical_gpu_index)],
+    on_event=manager_health_callback,
+)
+monitor.start()
+```
+
+The caller resolves `physical_gpu_index` and supplies `manager_health_callback`.
+`on_event` receives one deduplicated `HealthEvent` for each fatal device-and-metric pair.
+The built-in NVML source covers uncorrectable ECC, row-remap failure, NVLink error growth, temperature near shutdown, and device loss.
+Custom `HealthSource` implementations can supply XID, PCIe, InfiniBand, NIC, HCA, or fabric telemetry.
+Warnings such as correctable ECC growth, pending row remaps, nonfatal XIDs, and elevated temperature are logged but do not invoke `on_event`.
+
+Call `monitor.close()` when the manager or worker lifecycle ends.
+See [SCOUT hardware telemetry](scout.md#hardware-telemetry) for thresholds, localization granularity, and manager ownership.
+
 ## Lifecycle
 
 Every framework adapter returns the same lifecycle surface:

--- a/docs/scout.md
+++ b/docs/scout.md
@@ -1,7 +1,8 @@
 # SCOUT
 
-SCOUT localizes silent data corruption (SDC), stragglers, collective desynchronization, and process stalls by comparing equivalent training peers.
-It also certifies which checkpoints are safe to use for recovery.
+SCOUT localizes latent failures such as silent data corruption (SDC), stragglers, collective desynchronization, and process stalls by comparing equivalent training peers.
+It also localizes telemetry-visible permanent GPU and NVLink endpoint failures through direct hardware health sources.
+SCOUT also certifies which checkpoints are safe to use for recovery.
 
 For the system design, algorithms, and evaluation rationale, see [SCOUT: Symmetric Consensus Outlier Detection for Failure Localization in LLM Pre-Training](https://arxiv.org/abs/2608.11034).
 This guide defines the operational contract of the current implementation.
@@ -21,6 +22,13 @@ Coverage is sampled rather than continuous.
 | Process stall | Out-of-band stall timer | Visible progress has stopped. |
 | DataLoader stall | Instrumented `next()` latency | The delay exceeds absolute, relative, and persistence thresholds. |
 | Checkpoint I/O stall | Instrumented read or write latency | The delay exceeds absolute, relative, and persistence thresholds. |
+| Permanent GPU memory or device failure | Uncorrectable ECC, row-remap failure, fatal XID, or device loss | A health source reports the physical device and fatal metric. |
+| NVLink endpoint failure | Per-GPU NVLink recovery and CRC error growth | The counter delta exceeds the configured fatal threshold. |
+| Imminent thermal shutdown | GPU temperature and hardware shutdown limit | Temperature reaches the configured fatal margin below shutdown. |
+
+Replay and out-of-band progress localization require equivalent peers and consensus.
+Direct health telemetry identifies the reporting physical device without cross-rank consensus.
+Correctable ECC growth, pending row remaps, nonfatal XIDs, and elevated temperature produce warnings but do not trigger recovery.
 
 SCOUT does not provide an oracle for common-mode failures.
 Two disagreeing peers can detect a mismatch but cannot identify the faulty peer without an independent reference.
@@ -30,12 +38,14 @@ Use HSDP replication, a shadow copy, parity, trusted recomputation, or another i
 
 ## Runtime Paths
 
-SCOUT uses two complementary paths:
+SCOUT uses three complementary paths:
 
 - In-process replay checks numerical results, optimizer transitions, and timing at optimizer boundaries.
 - An out-of-band Gloo process compares progress and metadata while the training process may be blocked.
+- A low-frequency health-monitor thread polls direct device or fabric telemetry independently of training progress.
 
 Replay uses the training GPU and cannot run while that process is blocked.
+The health monitor can report telemetry-visible failures without replaying the workload.
 The out-of-band process exits with its parent.
 Worker termination, relaunch, placement, and quarantine remain manager responsibilities.
 
@@ -187,16 +197,47 @@ See the [API guide](api.md#configure-protection) for configuration examples and 
 
 ## Hardware Telemetry
 
-SCOUT consensus can be complemented by direct device telemetry.
-The built-in NVML source reports ECC state, row remapping, NVLink error growth, temperature, and device loss.
-Complete XID, InfiniBand, or fabric coverage requires DCGM, system-log, or deployment-specific sources.
+SCOUT complements workload-based inference with direct telemetry for permanent or imminent hardware failures.
+`HardwareHealthMonitor` polls caller-supplied `HealthSource` implementations in a low-frequency daemon thread and emits each fatal device-and-metric event once through `on_event`.
 
-Health events are advisory inputs to the manager.
+The built-in `NvmlSource` reports:
+
+- uncorrectable and correctable ECC state;
+- pending or failed row remapping;
+- aggregate per-GPU NVLink recovery and CRC errors;
+- temperature and hardware shutdown limit; and
+- device loss when all NVML queries fail.
+
+The monitor treats uncorrectable ECC, row-remap exhaustion, device loss, a configured fatal XID, severe NVLink error growth, and temperature near shutdown as fatal.
+Warnings record precursor conditions without requesting recovery.
+
+```python
+from lm_resiliency.manager_api import (
+    HardwareHealthMonitor,
+    HealthConfig,
+    NvmlSource,
+)
+
+health_monitor = HardwareHealthMonitor(
+    HealthConfig(),
+    [NvmlSource(device_index=physical_gpu_index)],
+    on_event=manager_health_callback,
+)
+health_monitor.start()
+```
+
+The caller resolves `physical_gpu_index` and supplies `manager_health_callback`.
+`device_index` is the physical NVML index, not necessarily the CUDA ordinal after `CUDA_VISIBLE_DEVICES` remapping.
+The built-in NVLink reading localizes a failing GPU endpoint, not an individual link, cable, or switch.
+Complete XID, InfiniBand, PCIe, NIC, HCA, or fabric coverage requires DCGM, system-log, or deployment-specific `HealthSource` implementations.
+
+Fatal health events are direct localization inputs to the manager.
 SCOUT does not terminate workers or quarantine hardware.
 
 ## Guarantee Boundary
 
-- SCOUT covers active permanent failures and intermittent failures that recur under a qualified replay.
+- SCOUT covers telemetry-visible permanent failures directly and active permanent or intermittent computational failures that recur under a qualified replay.
+- Health localization is limited to signals exposed by configured sources and their device or endpoint granularity.
 - One-shot transients, common-mode failures, and finite-signature collisions remain outside the guarantee.
 - Replay samples computation and is not continuous duplication.
 - Pure single-owner shards require an independent oracle.

--- a/docs/scout.md
+++ b/docs/scout.md
@@ -1,6 +1,6 @@
 # SCOUT
 
-SCOUT localizes latent failures such as silent data corruption (SDC), stragglers, collective desynchronization, and process stalls by comparing equivalent training peers.
+SCOUT localizes latent failures such as silent data corruption (SDC), stragglers, collective desynchronization (hangs), and process stalls by comparing equivalent training peers.
 It also localizes telemetry-visible permanent GPU and NVLink endpoint failures through direct hardware health sources.
 SCOUT also certifies which checkpoints are safe to use for recovery.
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,6 +1,6 @@
 # Validation
 
-Date: 2026-08-12 UTC.
+Date: 2026-08-13 UTC.
 
 This report summarizes the release-candidate validation evidence for GEMINI and SCOUT.
 Focused integration programs use deterministic training workloads and fault injection to verify checkpoint equivalence, exact fault localization, candidate exclusion, and framework topology handling.
@@ -33,7 +33,7 @@ Focused integration programs use deterministic training workloads and fault inje
 | 16-rank DeepSpeed matrix | 2/2 passed across ZeRO-1 and ZeRO-2 |
 | 16-rank framework lifecycle matrix | 11/11 passed across PyTorch, TorchTitan, Megatron, and durable dense and expert cases |
 
-The CPU suite covers checkpoint capture and recovery, replay preconditions, peer metadata, local persistence, integrity failures, recipe-cycle accounting, emergency scheduler preservation, recovery-mode selection, durable promotion, checkpoint I/O boundaries, representative AllToAll policy generation, FSDP materialization timing, framework adapters, and public lifecycle behavior.
+The CPU suite covers checkpoint capture and recovery, replay preconditions, peer metadata, local persistence, integrity failures, recipe-cycle accounting, emergency scheduler preservation, recovery-mode selection, durable promotion, checkpoint I/O boundaries, hardware-health classification and callback delivery, representative AllToAll policy generation, FSDP materialization timing, framework adapters, and public lifecycle behavior.
 
 The final distributed campaign used two hosts with eight A100 GPUs per host and 16 ranks over TCP on Amazon ENA.
 Every current-lifecycle and focused feature job completed successfully.


### PR DESCRIPTION
## Purpose

Clarify that SCOUT covers both latent workload failures and telemetry-visible permanent hardware failures.

## Changes

- expand the README coverage summary with permanent GPU and NVLink endpoint failures;
- document the three runtime paths: replay, out-of-band progress monitoring, and direct health telemetry;
- add the public `HardwareHealthMonitor` API and manager ownership boundary;
- distinguish built-in NVML signals from deployment-specific XID, PCIe, InfiniBand, NIC/HCA, and fabric sources;
- record hardware-health classification and callback delivery in the validation scope.

## Validation

- `20 passed` in focused health and orchestration tests;
- Ruff and `git diff --check` passed;
- 66 documentation links/fragments checked with zero errors.
