### PR TITLE
[CI/Release] Trigger Codex re-review on PR updates

### DIFF
--- a/.github/workflows/codex-rereview.yml
+++ b/.github/workflows/codex-rereview.yml
@@ -1,0 +1,29 @@
+name: Trigger Codex re-review
+
+on:
+  pull_request_target:
+    types:
+      - synchronize
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  request_codex_review:
+    name: Request Codex review
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Comment Codex review trigger
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          gh api \
+            --method POST \
+            "repos/$REPOSITORY/issues/$PR_NUMBER/comments" \
+            -f body='@codex review'


### PR DESCRIPTION
## Summary

Automatically request a fresh native Codex code review whenever an existing pull request receives a new head commit.

GitHub emits the `synchronize` pull-request action when the PR head changes. This workflow responds by posting the documented native Codex trigger `@codex review` to that PR so the latest revision is reviewed without requiring a maintainer to add the comment manually.

## Related issues

No issue is needed; this is a focused repository-review automation requested by the maintainer.

## Changes

- Add `.github/workflows/codex-rereview.yml`.
- Trigger only on `pull_request_target` with action `synchronize`.
- Post the fixed `@codex review` comment using the runner's authenticated `gh` CLI.
- Grant only `contents: read` and `issues: write` permissions.
- Do not check out, inspect, or execute pull-request code.

`pull_request_target` is intentional here: it allows the base repository workflow to post the trigger for fork PRs while remaining safe because no contributor-controlled code is executed and contributor-controlled strings are not interpolated into shell commands.

## Compatibility

No compatibility impact. Public Python APIs, checkpoint formats, framework integrations, distributed topology, and manager contracts are unchanged.

## Validation

```text
Command: Review workflow event/permission contract and shell command statically
Result: The workflow handles only pull_request_target/synchronize, requests only contents:read + issues:write, performs no checkout, and posts exactly '@codex review' to github.event.pull_request.number.
```

End-to-end event validation requires the workflow to exist on the default branch; after merge, push a new commit to an open PR and verify the workflow posts `@codex review` and Codex acknowledges it with the expected reaction/review.

Distributed or GPU validation is not applicable because this change does not execute or modify runtime code.

## Documentation

No user-facing documentation change is required. The workflow is self-contained repository automation.

## Checklist

- [x] The pull request is focused on one coherent change.
- [x] I added or updated tests for changed behavior, or explained why tests are not required.
- [x] I ran the relevant CPU checks from `CONTRIBUTING.md`, or documented why runtime CPU checks are not applicable to this workflow-only change.
- [x] I ran relevant distributed or GPU validation, or documented why it was not required or available.
- [x] I updated public documentation, examples, and compatibility notes, or explained why no documentation change is required.
- [x] I preserved stable API compatibility or documented the compatibility impact.
- [x] I removed credentials, private data, generated environments, and local validation artifacts.
- [x] I identified copied or adapted code and preserved required attribution and licensing; no copied or adapted code is included.