### PR TITLE
[Feature][Torchrun] Add standby replacement protocol contracts

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -73,6 +73,10 @@ The training manager owns job launch, restart, placement, resource quarantine,
 and replacement coordination. Physical hardware repair or replacement remains an
 infrastructure operator responsibility.
 
+See the draft [torchrun native resiliency design](docs/torchrun_resiliency.md)
+for a fixed-size active fleet, standby-node admission, stable logical rank
+slots, and checkpoint-aware restart APIs.
+
 ## Fault Injection Evaluation Kit
 
 Create an independently enabled feature within `lm-resiliency` for injecting

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -15,24 +15,66 @@ general elastic training:
 - preserve a stable logical node slot and rank range across restart;
 - let SCOUT report fault evidence and GEMINI report recoverable checkpoint
   state;
-- let a torchrun-owned coordinator make the final quarantine, placement, and
-  restart decision; and
+- let an LM Resiliency coordinator make the final quarantine, placement, and
+  restart-plan decision;
+- use a custom `RendezvousHandler` to park standbys and expose only a
+  plan-selected replacement to torchrun's existing membership-change path; and
 - pass one fenced `RestartContext` to every relaunched worker so
   `lm-resiliency` and the framework recover the same checkpoint generation.
 
-The existing meaning of `torchrun --nnodes=min_nodes:max_nodes` is not sufficient
-for this design. It permits the active worker-group membership and world size to
-change. A late node is admitted through re-rendezvous and all workers restart.
-Ranks are not stable across those restarts. Treating the extra nodes as standbys
-therefore requires an explicit admission policy and stable logical slots rather
-than relying on the range alone.
+### Why `--nnodes=min:max` is not a standby contract
 
-The design should be implemented in two stages:
+In stock torchrun, `--nnodes=min_nodes:max_nodes` bounds the number of nodes
+that may participate in an elastic rendezvous. It does not divide an allocated
+fleet into active nodes and replacement-only standbys:
 
-1. an out-of-tree reference launcher using a custom elastic agent, control
-   coordinator, and rendezvous handler; then
-2. an upstreamable torchrun resiliency-policy interface that removes the need
-   to subclass internal agent methods.
+- `min_nodes` is the threshold at which a rendezvous is allowed to complete,
+  not the exact number of nodes that must run trainers;
+- `max_nodes` is the largest active membership for a rendezvous round, not a
+  fleet size whose excess capacity is reserved; and
+- every admitted node is an active worker-group member. There is no standard
+  state meaning "keep this agent registered, but do not start trainers unless a
+  particular active node is replaced."
+
+For example, `--nnodes=8:10` can initially form an active group of 8, 9, or 10
+nodes depending on which agents arrive before the rendezvous completes. If it
+starts with 8 and a ninth node arrives later, that node is a candidate for the
+next rendezvous round. The resulting membership change restarts the worker
+group and may increase `WORLD_SIZE`; it is not treated as passive reserve
+capacity. Conversely, after a departure, a new round may form with any allowed
+membership rather than waiting for a policy-selected replacement that restores
+exactly 8 active nodes.
+
+The semantic differences are:
+
+| Property | Stock `--nnodes=min:max` | Replacement-only design |
+|---|---|---|
+| Active size | Any rendezvous size in the configured range | Exactly `min_nodes` |
+| Extra nodes | Elastic scale-up candidates | Agent-only standbys |
+| Restart trigger | Worker failure or rendezvous membership change | Worker failure or a plan-selected membership change; admission is gated by `RestartPlan` |
+| Placement | Participants selected by rendezvous; ranks reassigned per round | Coordinator selects a node for a specific logical slot |
+| Rank identity | Global and group ranks may change after re-rendezvous | Logical slot and rank range remain stable |
+| Fault exclusion | No job-specific quarantine contract in the range | Quarantined node and resource IDs cannot be readmitted |
+| Recovery state | Restart is not coupled to checkpoint trust or completeness | Relaunch is fenced to one complete trusted checkpoint manifest |
+
+Even if a stock re-rendezvous happens to return to 8 nodes, it does not
+guarantee that the replacement inherits the departed node's rank range.
+Arbitrary renumbering can change framework parallel coordinates and disconnect
+GEMINI's rank-owned shards and peer replicas from their intended owners.
+`--max-restarts` only bounds retries; it does not add standby admission,
+quarantine, slot inheritance, or checkpoint-selection semantics. The design
+therefore needs an explicit replacement-only admission policy and stable
+logical slots in addition to a node-count range.
+
+The design uses existing torchrun extension points rather than adding a new
+resiliency-policy interface:
+
+1. register an out-of-tree `SlotAwareRendezvousHandler` through the
+   `torchrun.handlers` entry-point group;
+2. keep the stock `LocalElasticAgent` and its normal full-worker-group restart
+   behavior; and
+3. keep fault evaluation, checkpoint preparation, quarantine, and immutable
+   restart-plan selection in the LM Resiliency control plane.
 
 ## Scope
 
@@ -69,11 +111,13 @@ The design should be implemented in two stages:
 - Elastic scale-up or scale-down of the active training world.
 - Recovery with a different model-parallel layout or global batch size.
 - Partial restart of one rank while the rest of the worker group continues.
+- A planned restart that preserves the identical physical node membership;
+  version 1's healthy-group restart edge is admission of at least one standby.
 - Reusing a node that SCOUT could not safely clear.
 - Physical hardware repair.
 - Turning inconclusive peer evidence into confident node attribution.
 
-## Existing Behavior and Missing Hooks
+## Existing Interfaces and Required Integration
 
 Stock torchrun already provides useful foundations:
 
@@ -82,29 +126,40 @@ Stock torchrun already provides useful foundations:
 - worker-group restart after process failure;
 - dynamic rendezvous with `min_nodes` and `max_nodes`;
 - custom rendezvous handlers through the `torchrun.handlers` entry-point group;
+- `RendezvousHandler.next_rendezvous()` for admission and rank assignment;
+- `RendezvousHandler.num_nodes_waiting()` for requesting re-rendezvous;
 - restart-count and run-ID environment variables; and
 - full worker-group restart on failure or membership change.
 
-It does not currently provide the complete contract required here:
+The existing interfaces are sufficient for the torchrun lifecycle mechanics:
+
+- a standby agent remains blocked in `next_rendezvous()`, so its trainers are
+  not started;
+- the handler can return a deterministic group rank derived from a logical
+  slot;
+- parked standbys are kept outside the handler's reported wait count; and
+- after a restart plan commits, the handler reports only the selected
+  replacement through `num_nodes_waiting()`. The stock elastic agent then
+  performs its normal full-worker-group membership restart.
+
+The handler is not the recovery decision-maker. The integration still must
+provide contracts that stock torchrun does not:
 
 1. `min_nodes:max_nodes` describes elastic active membership, not
    `min_nodes` active nodes plus replacement-only standbys.
-2. A healthy late node is considered a scale-up candidate, which triggers a
-   worker-group restart and may increase `WORLD_SIZE`.
-3. Rank assignment is not stable across re-rendezvous.
-4. Worker failure handling does not consume SCOUT fault localization or
+2. The stock rendezvous handlers do not distinguish passive standbys from
+   scale-up candidates.
+3. Stock rank assignment is not stable across re-rendezvous.
+4. Torchrun failure handling does not consume SCOUT fault localization or
    checkpoint trust.
-5. Rendezvous admission has no standard quarantine database or logical-slot
+5. The rendezvous API does not define a quarantine database or logical-slot
    inheritance contract.
-6. The worker-to-agent control plane has no stable fault, checkpoint, or
-   graceful-restart API.
-7. A custom rendezvous handler alone cannot force all healthy agents to stop
-   their workers for a SCOUT-requested replacement.
+6. Checkpoint preparation and recovery-plan consensus remain application and
+   manager responsibilities.
 
 PyTorch 2.13 includes an experimental worker control-plane server, but it is a
 generic handler server and not a stable restart or quarantine protocol. The
-reference integration should not make its safety contract depend on that
-experimental surface.
+reference integration does not require that experimental surface.
 
 The integration must also avoid depending on `--max-restarts` as its only
 replacement budget. Failure retries and membership changes have had different
@@ -121,21 +176,24 @@ explicit `max_replacement_generations` policy.
 +------------------------------------------------------------------+
 | Layer 1: torchrun                                                 |
 |                                                                  |
-| ResilientElasticAgent  SlotAwareRendezvous  RestartCoordinator   |
-| - owns active/standby state                                      |
-| - maps stable node IDs to logical slots                          |
-| - commits one fenced RestartPlan                                 |
-| - stops all active workers                                       |
-| - excludes quarantined nodes                                     |
-| - launches exactly min_nodes slots                               |
+| Stock LocalElasticAgent     RendezvousHandler plugin              |
+| - monitors and restarts local workers                            |
+| - calls next_rendezvous() before worker launch                    |
+| - polls num_nodes_waiting() while workers are healthy             |
+| - performs the standard full-group membership restart            |
 +-----------------------------+------------------------------------+
                               |
-           local control socket| restart-context file/environment
+        control client / store | restart-context file/environment
                               v
 +------------------------------------------------------------------+
 | Layer 2: lm-resiliency                                           |
 |                                                                  |
-| TorchrunOrchestrationClient  SCOUT  GEMINI  manager_api          |
+| SlotAwareRendezvousHandler  RestartCoordinator  SCOUT  GEMINI    |
+| TorchrunOrchestrationClient  manager_api                          |
+| - owns active/standby state and logical-slot assignments         |
+| - commits one fenced RestartPlan                                 |
+| - exposes only the selected replacement as waiting               |
+| - excludes quarantined nodes                                     |
 | - reports normalized fault evidence                              |
 | - proposes checkpoint trust and locally available state          |
 | - flushes and transfers eligible checkpoint shards               |
@@ -162,15 +220,16 @@ explicit `max_replacement_generations` policy.
 |---|---|
 | Detection, localization, evidence confidence | SCOUT |
 | Checkpoint capture, trust, inventory, transfer | GEMINI |
-| Final node quarantine and replacement policy | torchrun layer |
-| Active/standby admission and logical-slot assignment | torchrun layer |
-| Final restart generation and worker termination | torchrun layer |
+| Final node quarantine and replacement policy | LM Resiliency coordinator |
+| Active/standby admission and logical-slot assignment | `SlotAwareRendezvousHandler` and coordinator |
+| Worker-group stop and relaunch | Stock torchrun elastic agent |
+| Final restart generation and checkpoint manifest | LM Resiliency coordinator |
 | Model and optimizer state semantics | framework adapter |
 | Physical repair or scheduler allocation | infrastructure manager |
 
-`lm-resiliency` may recommend a replacement scope, but it must not directly
-evict a physical host. A rank-local report is evidence, not a cluster-wide
-decision.
+SCOUT and GEMINI may recommend a replacement scope and recovery state, but they
+must not directly evict a physical host. A rank-local report is evidence, not a
+cluster-wide decision.
 
 ## Identity Model
 
@@ -235,11 +294,13 @@ checkpoint schema, and model configuration needed to interpret rank-local
 state. It is separate from `environment_digest`, which describes whether a node
 is eligible to run the same software and hardware workload.
 
-## API: lm-resiliency to torchrun
+## API: lm-resiliency to the coordinator
 
 The current `OrchestrationHooks` callbacks are the starting point. The torchrun
 integration wraps them in a versioned, incident-correlated envelope and sends
-them to the local agent over a Unix-domain socket.
+them to the coordinator through the configured manager transport. A local
+Unix-domain socket or sidecar may provide that transport, but the stock
+torchrun agent is not part of the protocol.
 
 ### Fault event
 
@@ -273,7 +334,7 @@ Requirements:
 - The original `SCOUTFaultReport` is preserved without upgrading its
   attribution. A direct `HealthEvent` is normalized to
   `HardwareFaultReport` without upgrading its resource granularity.
-- The torchrun layer resolves reported ranks through that generation's
+- The coordinator resolves reported ranks through that generation's
   `RankAssignment`.
 - The orchestration dispatcher allocates `incident_id` once and uses it for
   both the recovery and fault callbacks. The client must not infer correlation
@@ -304,8 +365,8 @@ missing or stale evidence blocks promotion to a less conservative mode
 ```
 
 A worker must never interpret its local `checkpoint_step` as the final global
-step. The restarted job still calls GEMINI's collective `find_latest()` before
-loading.
+step. The coordinator selects one step from the complete job-wide inventory,
+and the restarted job collectively validates that exact step before loading.
 
 ### Checkpoint inventory
 
@@ -356,7 +417,7 @@ The callbacks must be bounded and must not use the training process group.
 Delivery failure is visible and causes the coordinator to use conservative
 recovery; it must not be silently treated as a healthy report.
 
-## API: torchrun to lm-resiliency
+## API: coordinator to lm-resiliency
 
 Restart is a two-phase protocol:
 
@@ -384,9 +445,11 @@ class RestartIntent(TypedDict):
 ```
 
 The intent is a single-writer, compare-and-swap record for the current
-generation. It does not authorize a new worker group. Agents receiving it
-quiesce or terminate local training according to the incident, prepare eligible
-checkpoint state, and wait for either a committed plan or an explicit abort.
+generation. It does not authorize a new worker group. Accessible workers
+observe it through `TorchrunOrchestrationClient`, quiesce at a framework-safe
+boundary, prepare eligible checkpoint state, and wait for either a committed
+plan or an explicit abort. The stock torchrun agent still considers the worker
+group healthy during this preparation phase.
 
 An abort is allowed only before a plan is committed and only when resuming the
 same generation is safe. An SDC, inaccessible node, corrupted checkpoint, or
@@ -424,7 +487,7 @@ class RestartPlan(TypedDict):
     quarantined_node_ids: list[str]
     expected_world_size: int
     topology_digest: str
-    stop_deadline_unix_ms: int
+    restart_deadline_unix_ms: int
 ```
 
 Before commit, the coordinator validates:
@@ -441,8 +504,10 @@ Before commit, the coordinator validates:
 
 ### Restart context passed to workers
 
-The agent derives a rank-local context from the committed plan and writes it to
-an atomically replaced file. The worker receives only the file path:
+Before returning from `next_rendezvous()`, `SlotAwareRendezvousHandler` derives
+a node-local context from the committed plan and writes it to an atomically
+replaced file. The deployment places the fixed file path in the torchrun
+agent's environment before launch, so every local worker receives:
 
 ```text
 LM_RESILIENCY_RESTART_CONTEXT=/run/torchrun/<run-id>/restart-context.json
@@ -456,8 +521,8 @@ class RestartContext(TypedDict):
     generation: int
     node_id: str
     logical_node_slot: int
-    global_rank: int
-    local_rank: int
+    first_global_rank: int
+    local_world_size: int
     expected_world_size: int
     topology_digest: str
     recovery_mode: Literal["latest", "recovery_verified"]
@@ -468,9 +533,10 @@ class RestartContext(TypedDict):
     reason_code: str
 ```
 
-`lm-resiliency` rejects startup if the context conflicts with torchrun's
-`RANK`, `LOCAL_RANK`, `WORLD_SIZE`, `TORCHELASTIC_RUN_ID`, or the framework
-topology.
+Each worker derives its expected rank as
+`first_global_rank + LOCAL_RANK`. `lm-resiliency` rejects startup if the
+context conflicts with torchrun's `RANK`, `LOCAL_RANK`, `LOCAL_WORLD_SIZE`,
+`WORLD_SIZE`, `TORCHELASTIC_RUN_ID`, or the framework topology.
 
 The context must not contain a newer, less trusted local checkpoint merely
 because it exists on the replacement host.
@@ -497,8 +563,8 @@ step.
 
 ### Prepare-for-restart command
 
-For an accessible worker group, the agent derives a local command from the
-intent:
+For an accessible worker group, `TorchrunOrchestrationClient` derives a local
+command from the intent:
 
 ```python
 class PrepareRestart(TypedDict):
@@ -530,16 +596,15 @@ class RestartAck(TypedDict):
     reason: str
 ```
 
-The socket listener only validates and stages the command. It must not call
-CUDA, framework, or checkpoint operations from a background listener thread.
-The agent then requests a framework safe point or sends the configured
-catchable termination signal. GEMINI's bounded main-thread/signal path performs
-the flush and writes the acknowledgement.
+The listener only validates and stages the command. It must not call CUDA,
+framework, or checkpoint operations from a background listener thread. The
+framework adapter consumes the command at a safe optimizer boundary. GEMINI's
+bounded main-thread path performs the flush and writes the acknowledgement,
+after which the worker remains quiesced.
 
-The agent waits only until the intent deadline and reports missing
-acknowledgements. Missing or failed preparation cannot promote
-`LATEST_GEMINI`; the coordinator must commit a plan using a complete
-recovery-verified source or fail the restart.
+The coordinator waits only until the intent deadline. Missing or failed
+preparation cannot promote `LATEST_GEMINI`; the coordinator must commit a plan
+using a complete recovery-verified source or fail the restart.
 
 For a crashed or unreachable node, no preparation is assumed.
 
@@ -603,20 +668,23 @@ The adapter must additionally validate that the relaunched
 `ParallelDims/world_size` produces the committed topology digest before any
 checkpoint is loaded.
 
-## Torchrun Agent and Rendezvous Design
+## Torchrun Rendezvous Integration
 
 ### Node states
 
 ```text
-STANDBY -> ADMITTED -> ACTIVE -> DRAINING -> QUARANTINED
+STANDBY -> ADMITTED -> ACTIVE -> PREPARING -> RESTARTING
      \          \         \          \-> FAILED
-      \----------> REJECTED
+      \----------> REJECTED             \-> QUARANTINED
 ```
 
 - `STANDBY`: agent is registered; no trainer process is running.
 - `ADMITTED`: coordinator assigned a logical slot for the next generation.
 - `ACTIVE`: local workers are running for the committed generation.
-- `DRAINING`: restart is committed; bounded checkpoint preparation is running.
+- `PREPARING`: workers observed an intent, quiesced, and are performing bounded
+  checkpoint preparation; the stock agent still sees healthy worker processes.
+- `RESTARTING`: the plan is committed and torchrun is stopping, rendezvousing,
+  or relaunching the worker group.
 - `QUARANTINED`: node cannot enter another generation for this run.
 - `FAILED`: agent or node is unreachable; its slot may be reassigned.
 
@@ -661,52 +729,66 @@ not sufficiently available or persistent.
 
 ### Slot-aware rendezvous
 
-`SlotAwareRendezvous` admits only nodes named by the committed plan:
+`SlotAwareRendezvousHandler` implements the existing `RendezvousHandler`
+interface and is registered through `torchrun.handlers`. It admits only nodes
+named by the committed plan:
 
-- standby agents block without creating trainers;
-- quarantined nodes receive a terminal rejection;
+- `next_rendezvous()` blocks standby agents without creating trainers;
+- blocked standbys maintain a registration lease or heartbeat;
+- quarantined nodes remain blocked or receive a terminal rejection according to
+  deployment cleanup policy, but are never admitted;
 - a replacement node receives the failed node's logical slot;
 - exactly `min_nodes` slots complete the rendezvous; and
 - returned group rank is derived from logical slot, not arrival order.
 
-This is stricter than the normal dynamic-rendezvous wait list. A random late
-node must not trigger scale-up.
+Passive standbys are not reported by `num_nodes_waiting()`. After a plan
+commits, the selected replacement becomes the only newly waiting node visible
+to active agents. This is the restart edge: a random late node must not trigger
+scale-up. This mechanism is used only when the next plan admits at least one
+standby; it is not a generic restart signal for unchanged membership.
 
-### Resilient elastic agent
+Before returning an admitted node from `next_rendezvous()`, the handler:
 
-The prototype `ResilientElasticAgent` extends the local agent loop to poll the
-intent and committed generation. It:
+1. validates that the assignment belongs to the latest committed generation;
+2. writes the node-local `RestartContext`;
+3. returns the logical slot as the rendezvous group rank; and
+4. returns exactly `min_nodes` as the group world size.
 
-1. asks accessible workers to prepare when it observes an intent;
-2. waits in a quiesced state after acknowledgement or timeout;
-3. stops all local workers when it observes the committed plan;
-4. reports the local stop result;
-5. enters slot-aware rendezvous if admitted; and
-6. injects the rank-local `RestartContext` before starting workers.
+### Stock elastic agent behavior
 
-All active agents act on the same committed plan. A node-local SCOUT report
-cannot directly force only its own workers to restart.
+No custom elastic agent is required. The existing agent behavior is used in two
+ways:
 
-Current torchrun does not expose this policy as a stable public hook. The
-prototype will likely subclass protected agent behavior and must therefore be
-pinned and tested for each supported PyTorch minor version.
+1. a worker failure follows torchrun's normal failure-restart path; and
+2. while workers are healthy, a positive `num_nodes_waiting()` result causes
+   the agent to stop and re-rendezvous its local worker group.
 
-The upstream target is a public interface similar to:
+For an accessible replacement, workers first quiesce and acknowledge the
+`RestartIntent`. Only after the coordinator commits the plan does the handler
+expose the selected replacement as waiting. Each active agent then observes the
+same membership change and enters its standard restart path. A worker that
+missed the preparation deadline is treated as unavailable and cannot influence
+the committed checkpoint manifest. Correctness does not depend on agents
+stopping in the same polling instant because the plan is already immutable and
+the new rendezvous cannot complete without its assignments.
 
-```python
-class ElasticResiliencyPolicy(Protocol):
-    def register_agent(self, agent: AgentIdentity) -> AgentAdmission: ...
-    def poll_action(self, state: AgentState) -> AgentAction: ...
-    def prepare_worker_env(
-        self,
-        assignment: RankAssignment,
-        local_rank: int,
-    ) -> dict[str, str]: ...
-    def report_action_result(self, result: AgentActionResult) -> None: ...
-```
+For an inaccessible node, surviving workers eventually fail or their agents
+observe the normal failure path.
+`SlotAwareRendezvousHandler.next_rendezvous()` blocks the survivors until the
+coordinator commits a conservative plan and assigns a standby. A node-local
+SCOUT report never directly manipulates `num_nodes_waiting()` or chooses the
+next membership.
 
-This hook should run above process monitoring and below the CLI, so a policy can
-request a coordinated restart without pretending a healthy worker crashed.
+The handler cannot customize torchrun's worker-stop signal or timeout for an
+individual incident. Version 1 therefore requires workers to quiesce before a
+planned membership restart, relies on the agent's configured bounded shutdown,
+and treats failure to complete the next rendezvous before the plan deadline as
+a failed restart. If a supported torchrun version cannot satisfy those
+constraints, that version requires an out-of-tree agent fallback.
+
+On successful job completion or terminal failure, the coordinator closes the
+handler generation. Blocked standbys observe closure, release their leases, and
+exit without starting trainers.
 
 ## Control-Plane Integrity
 
@@ -731,7 +813,8 @@ steps.
   evidence.
 - Checkpoint inventory contains metadata only and is published asynchronously
   after a completed checkpoint transition.
-- Agent plan polling is out of process and bounded.
+- Control-client intent polling is bounded.
+- The stock agent's existing rendezvous wait-count polling is unchanged.
 - Standby agents do not allocate model state or join training collectives.
 - Checkpoint flush and transfer happen only after a restart intent.
 - Control delivery backpressure must not block the training thread
@@ -742,11 +825,11 @@ steps.
 | Incident | Node action | Recovery mode |
 |---|---|---|
 | Attributed SDC on one node/GPU | Quarantine affected node conservatively | `RECOVERY_VERIFIED` |
-| Inconclusive exact replay | Do not over-attribute; operator policy may replace a broader scope | `RECOVERY_VERIFIED` |
+| Inconclusive exact replay | Do not over-attribute; replace only a policy-defined conservative scope or fail closed | `RECOVERY_VERIFIED` |
 | Required node inaccessible | Mark failed and replace its slot | `RECOVERY_VERIFIED` |
 | Confirmed accessible compute or communication straggler | Drain and replace when policy threshold is met | `LATEST_GEMINI` if a complete generation is prepared; otherwise verified |
-| Hang with complete clean emergency replay and all ranks accessible | Restart or replace implicated scope | `LATEST_GEMINI` |
-| Hang with missing, stale, incomplete, or contradictory evidence | Restart conservatively; avoid unsupported attribution | `RECOVERY_VERIFIED` |
+| Hang with complete clean emergency replay and all ranks accessible | Replace a policy-selected scope | `LATEST_GEMINI` |
+| Hang with missing, stale, incomplete, or contradictory evidence | Replace a conservative policy-defined scope or fail closed | `RECOVERY_VERIFIED` |
 | Operator-initiated healthy migration | Drain source and replace slot | `LATEST_GEMINI` if preparation succeeds |
 
 ### Aggregation rules
@@ -822,7 +905,8 @@ framework durable checkpoint.
 1. All `max_nodes` agents register stable node identities.
 2. The coordinator validates compatibility and selects exactly `min_nodes`.
 3. Selected nodes receive logical slots; the rest enter `STANDBY`.
-4. Slot-aware rendezvous assigns deterministic rank ranges.
+4. Slot-aware rendezvous assigns deterministic rank ranges; parked standbys
+   remain blocked in `next_rendezvous()`.
 5. Agents start workers with generation `0`.
 6. `lm-resiliency` registers the worker identity and framework topology digest.
 
@@ -832,16 +916,20 @@ framework durable checkpoint.
 2. The coordinator maps the reported rank to its generation and node.
 3. The coordinator opens a restart intent and provisionally reserves a
    compatible standby for the affected logical slot.
-4. Every active agent enters `DRAINING`.
+4. Every accessible worker enters `PREPARING`, quiesces at a safe boundary, and
+   acknowledges the intent.
 5. Workers flush eligible GEMINI state and report transfer results.
 6. The coordinator commits a restart plan using the newest complete allowed
    generation, or falls back to verified recovery.
-7. Agents stop all workers.
-8. The source node becomes quarantined or standby according to policy.
-9. The replacement and surviving nodes rendezvous with the same slots/ranks.
-10. Relaunched workers validate the restart context and load exactly the
+7. `SlotAwareRendezvousHandler` exposes the selected standby through
+   `num_nodes_waiting()`.
+8. Stock elastic agents observe the membership change and restart their local
+   worker groups.
+9. The source node becomes quarantined or standby according to policy.
+10. The replacement and surviving nodes rendezvous with the same slots/ranks.
+11. Relaunched workers validate the restart context and load exactly the
     committed rank-consistent step.
-11. TorchTitan restores the complete state and resumes.
+12. TorchTitan restores the complete state and resumes.
 
 ### Inaccessible node
 
@@ -852,7 +940,8 @@ framework durable checkpoint.
 4. The committed manifest uses peer replicas or the durable verified
    checkpoint.
 5. A standby inherits the failed logical slot.
-6. Surviving workers are stopped and the fixed-size group is relaunched.
+6. Surviving agents follow torchrun's failure-restart path and block in
+   slot-aware rendezvous until the plan is committed.
 7. If any required shard is unavailable, the job fails rather than mixing
    checkpoint generations.
 
@@ -886,6 +975,8 @@ framework durable checkpoint.
   re-plan only from the same or a more conservative trust state.
 - **Agent crash after plan commit:** another agent cannot rewrite the plan; the
   same generation may be retried idempotently.
+- **Job closes while standbys are parked:** close the rendezvous generation and
+  wake blocked standby agents so they exit without spawning workers.
 
 ## Packaging and Compatibility
 
@@ -895,50 +986,39 @@ framework durable checkpoint.
 - Importing `lm_resiliency` must not import TorchTitan or CUDA-only packages.
 - Version every wire payload independently from the Python package version.
 - Reject unknown required fields or unsupported schema versions.
-- Pin the prototype agent integration to qualified PyTorch minor versions
-  because protected agent methods are not a stable API.
+- Implement standby admission through the documented `RendezvousHandler`
+  interface and `torchrun.handlers` registration mechanism.
+- Do not subclass protected elastic-agent methods.
+- Qualify the handler against every supported PyTorch minor because the stock
+  agent's membership-restart behavior remains a runtime compatibility
+  dependency.
 - Preserve the existing `OrchestrationHooks`, `RecoveryDecision`,
   `SCOUTFaultReport`, and framework entry points.
 - Use PyTorch 2.13 as the initial prototype baseline, then separately qualify
   the other PyTorch minors in the supported compatibility range.
 
-### Proposed prototype command
+### Proposed command
 
-An out-of-tree command avoids changing torchrun's existing CLI semantics:
-
-```bash
-python -m lm_resiliency.integrations.torchrun.launch \
-  --active-nnodes=8 \
-  --fleet-nnodes=10 \
-  --nproc-per-node=8 \
-  --rdzv-backend=c10d \
-  --rdzv-endpoint="${RDZV_ENDPOINT}" \
-  --rdzv-id="${JOB_ID}" \
-  --max-replacement-generations=2 \
-  --module torchtitan.train ...
-```
-
-### Upstream CLI target
-
-If PyTorch accepts a resiliency-policy hook, torchrun can preserve its current
-default and add explicit replacement-only semantics:
+The custom rendezvous backend makes replacement-only semantics explicit without
+changing torchrun's default behavior:
 
 ```bash
+export LM_RESILIENCY_RESTART_CONTEXT="/run/lm-resiliency/${JOB_ID}/restart-context.json"
+
 torchrun \
   --nnodes=8:10 \
-  --active-nnodes=8 \
-  --standby-policy=replace-only \
-  --resiliency-policy=lm_resiliency \
   --nproc-per-node=8 \
-  --rdzv-backend=c10d \
+  --rdzv-backend=lm_resiliency \
   --rdzv-endpoint="${RDZV_ENDPOINT}" \
   --rdzv-id="${JOB_ID}" \
+  --rdzv-conf="control_endpoint=${CONTROL_ENDPOINT},replacement_only=true,max_replacement_generations=2" \
   --module torchtitan.train ...
 ```
 
-The names are placeholders for upstream discussion. The important requirement
-is that replacement-only mode is opt-in and does not silently change the
-meaning of existing `--nnodes=min:max` jobs.
+The command runs on all `max_nodes` machines. The backend interprets
+`min_nodes` as the exact active-slot count and `max_nodes` as the registered
+fleet limit. Selecting `--rdzv-backend=lm_resiliency` is the explicit opt-in;
+the built-in rendezvous backends retain their existing elastic semantics.
 
 ## Validation Plan
 
@@ -956,9 +1036,13 @@ meaning of existing `--nnodes=min:max` jobs.
 
 - Standby agents do not spawn trainer workers.
 - A new standby does not cause scale-up.
-- A committed plan stops every active local worker group.
+- Parked standbys do not contribute to `num_nodes_waiting()`.
+- A committed plan exposes only the selected replacement as waiting.
+- The stock agent membership path restarts every active local worker group.
 - A replacement inherits the same logical slot and rank range.
 - A quarantined node cannot rejoin.
+- Closing the job wakes parked standbys and starts no trainer processes.
+- The node-local `RestartContext` is written before `next_rendezvous()` returns.
 - Restart context mismatch aborts before user code initializes recovery.
 - Agent/coordinator restart preserves idempotent generation state.
 
@@ -987,10 +1071,26 @@ generation and that the active world size remains exactly `min_nodes`.
 Insufficient. It cannot keep extra nodes standby-only, preserve stable rank
 slots, or exclude a localized bad node from later rendezvous.
 
-### Implement only a custom rendezvous handler
+### Use a custom rendezvous handler without a recovery coordinator
 
-Insufficient. It can control admission, but it cannot safely ask all currently
-healthy agents to prepare and stop their workers after a SCOUT decision.
+Insufficient. The handler provides standby admission, stable ranks, and the
+membership-restart edge, but it does not evaluate SCOUT evidence, prepare
+GEMINI state, select a complete checkpoint manifest, or decide quarantine.
+
+### Add a custom elastic agent
+
+Not selected for version 1. PyTorch exposes agent extension points, but the
+existing membership-change path already provides the required full-group
+restart after the rendezvous handler reveals a selected replacement. A custom
+agent would add version coupling without removing the need for the coordinator
+and worker preparation protocol.
+
+### Add a new upstream torchrun resiliency-policy interface
+
+Not required. The existing `RendezvousHandler` interface and stock elastic
+agent cover admission and restart mechanics. Reconsider an upstream change only
+if focused validation finds a correctness requirement that those interfaces
+cannot satisfy.
 
 ### Allow the active world to shrink after a failure
 
@@ -998,17 +1098,17 @@ Deferred. It changes framework parallelism, checkpoint sharding, batch size,
 optimizer semantics, and potentially the training trajectory. It requires a
 separate elastic-topology and resharding contract.
 
-### Put placement policy inside lm-resiliency
+### Put placement policy inside SCOUT or GEMINI
 
 Rejected. SCOUT and GEMINI do not own scheduler state, leases, or physical
 resource lifecycle. They should provide evidence and recovery state to a
-torchrun or infrastructure manager.
+coordinator or infrastructure manager.
 
-### Delegate everything to an external scheduler
+### Delegate replacement decisions to an external scheduler
 
 Viable for production, and the neutral manager API should continue supporting
-it. The reference design still adds value by defining the torchrun-native
-worker/agent contract and enabling local-agent standby replacement.
+it. The reference design still adds value by defining the rendezvous and
+recovery contracts needed for local standby replacement.
 
 ## Phased Implementation
 
@@ -1028,19 +1128,21 @@ worker/agent contract and enabling local-agent standby replacement.
 
 - Add the local orchestration client.
 - Add the coordinator and quarantine store.
-- Add standby-only admission and stable slot rendezvous.
-- Add a version-pinned resilient elastic agent and prototype launcher.
+- Add the `torchrun.handlers` rendezvous plugin.
+- Add standby-only admission, stable slot assignment, and restart-context
+  publication.
+- Use the stock `LocalElasticAgent` membership-restart path.
 
 ### Phase 3: framework validation
 
 - Validate native PyTorch and TorchTitan end to end.
 - Add Megatron Core and DeepSpeed after the neutral contract is stable.
 
-### Phase 4: upstream torchrun proposal
+### Phase 4: production hardening
 
-- Propose a public coordinated-restart policy hook.
-- Propose explicit replacement-only standby semantics.
-- Remove protected-method subclassing when the public hook is available.
+- Validate handler and agent behavior across every supported PyTorch minor.
+- Add durable coordinator failover and scheduler integration.
+- Exercise repeated replacement generations and bounded shutdown failures.
 
 ## Open Questions
 
@@ -1053,8 +1155,8 @@ Recommended defaults for the first prototype:
 - prefer healthy peer or durable verified copies over a suspect node;
 - keep framework durable checkpoint IDs opaque;
 - use a separate replacement-generation budget; and
-- propose the smallest upstream hooks for coordinated restart, worker
-  environment injection, and admission before proposing a broad policy API.
+- use the existing rendezvous plugin and stock agent before considering any
+  torchrun change.
 
 1. **Coordinator placement:** should the first prototype use a namespaced c10d
    rendezvous store, etcd, or a separate manager service?
@@ -1073,9 +1175,9 @@ Recommended defaults for the first prototype:
 7. **Durable checkpoint handoff:** should `checkpoint_id` remain framework
    opaque, or should the restart manifest expose a common durable-checkpoint
    URI contract?
-8. **Upstream surface:** is a general `ElasticResiliencyPolicy` acceptable to
-   torchrun, or should the first upstream change be a smaller coordinated
-   restart and worker-environment hook?
+8. **Compatibility fallback:** if a supported PyTorch minor changes the stock
+   membership-restart behavior, should that minor be excluded or supported by
+   a version-specific out-of-tree `SimpleElasticAgent` launcher?
 
 ## References
 

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -577,8 +577,10 @@ Before commit, the coordinator validates:
 - active size, local world size, total world size, and topology digest match the
   committed generation;
 - the checkpoint is complete for every required logical rank;
-- every copy belongs to the selected positive step and selected checkpoint
-  source;
+- every copy included in the committed manifest belongs to the selected
+  positive step and selected checkpoint source; a rank entry with one eligible
+  copy and any additional ineligible copy is rejected rather than left for the
+  loader to choose;
 - every copy exactly matches its referenced inventory event, and the source
   inventory trust satisfies the manifest trust;
 - the checkpoint trust satisfies the selected recovery mode;
@@ -632,6 +634,9 @@ against the currently committed `RestartPlan` for its node. The plan ID,
 successor generation, assignment, topology, recovery mode, checkpoint pin, and
 reason must match exactly. A leftover context from an earlier plan is rejected
 even when stable ranks make every torchrun environment value identical.
+This acceptance check receives trusted current time and rejects the context
+when the committed plan's restart deadline has elapsed. Rendezvous performs
+the same deadline check immediately before exposing the plan.
 
 The context must not contain a newer, less trusted local checkpoint merely
 because it exists on the replacement host.
@@ -986,15 +991,18 @@ class RecoveryManifest(TypedDict):
     rank_copies: list[RankCheckpointCopies]
 ```
 
-The manifest is usable only when every required rank has at least one eligible
-copy for the manifest's exact positive step and the plan's selected source.
-GEMINI plans use owner or peer copies; durable plans use durable copies. Only
-shared or remote storage is independent of holder-node availability. The
-manifest's trust label is not self-authenticating: every selected copy must
-match its referenced inventory record, and `RECOVERY_VERIFIED` manifests may
-use only recovery-verified inventory evidence. Durable recovery always requires
-a recovery-verified manifest and recovery-verified inventory, even if the
-originating intent allowed latest recovery.
+The manifest is usable only when every required rank has at least one copy and
+every included copy is eligible for the manifest's exact positive step and the
+plan's selected source. The coordinator must omit rejected alternatives before
+commit; an immutable committed manifest cannot advertise an incomplete,
+wrong-source, or unproven fallback. GEMINI plans use owner or peer copies;
+durable plans use durable copies. Only shared or remote storage is independent
+of holder-node availability. The manifest's trust label is not
+self-authenticating: every selected copy must match its referenced inventory
+record, and `RECOVERY_VERIFIED` manifests may use only recovery-verified
+inventory evidence. Durable recovery always requires a recovery-verified
+manifest and recovery-verified inventory, even if the originating intent
+allowed latest recovery.
 
 An in-memory or node-local copy is selectable only when its holder remains in
 the next assignment. Process-memory copies are never selectable because stock

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -376,6 +376,7 @@ know where every logical-rank shard can be obtained.
 ```python
 class CheckpointCopy(TypedDict):
     owner_global_rank: int
+    checkpoint_step: int
     holder_node_id: str
     holder_kind: Literal["owner", "peer", "durable"]
     storage_kind: Literal["memory", "node_local", "shared", "remote"]
@@ -396,9 +397,12 @@ class CheckpointInventoryEvent(TypedDict):
     copies: list[CheckpointCopy]
 ```
 
-Only completed checkpoint slots may appear with `complete=True`. A
+Only completed checkpoint slots may appear with `complete=True`.
+`checkpoint_step` must equal the enclosing inventory event's positive `step`;
+the coordinator validates it again when assembling the recovery manifest. A
 `CANDIDATE` inventory can be retained for diagnosis but is never selected for
-conservative recovery.
+conservative recovery. Durable copies must use shared or remote storage;
+node-local and in-memory copies remain subject to holder health and quarantine.
 
 `location_token` is an opaque control-plane reference, not an unchecked path
 that another worker is allowed to open.
@@ -492,15 +496,24 @@ class RestartPlan(TypedDict):
 
 Before commit, the coordinator validates:
 
+- the plan is fenced to the same intent ID, run, generation, incidents, and
+  reason;
+- the recovery mode is at least as conservative as the intent's minimum;
 - exactly `min_nodes` active logical slots are assigned;
 - every assigned node is healthy, compatible, and not quarantined;
 - each logical slot is assigned once;
-- the topology digest matches the prior generation;
+- active size, local world size, total world size, and topology digest match the
+  committed generation;
 - the checkpoint is complete for every required logical rank;
+- every copy belongs to the selected positive step and selected checkpoint
+  source;
 - the checkpoint trust satisfies the selected recovery mode;
 - the plan never selects `CANDIDATE`;
-- the target step is coherent across all selected shards; and
-- the plan generation is the successor of the current committed generation.
+- the target step is coherent across all selected shards;
+- the plan generation is the successor of the current committed generation;
+  and
+- the restart deadline has not elapsed when the plan is committed or exposed
+  through rendezvous.
 
 ### Restart context passed to workers
 
@@ -875,7 +888,9 @@ class RecoveryManifest(TypedDict):
 ```
 
 The manifest is usable only when every required rank has at least one eligible
-copy.
+copy for the manifest's exact positive step and the plan's selected source.
+GEMINI plans use owner or peer copies; durable plans use durable copies. Only
+shared or remote storage is independent of holder-node availability.
 
 Preferred source order:
 
@@ -1029,8 +1044,9 @@ the built-in rendezvous backends retain their existing elastic semantics.
 - Conservative recovery lattice across missing and conflicting proposals.
 - Rank-to-node mapping through immutable generation snapshots.
 - Quarantine by stable node ID, never by rank alone.
-- Plan validation for exact active size, unique slots, topology digest, and
-  complete checkpoint manifest.
+- Plan validation for intent fencing, unexpired deadlines, exact active and
+  worker counts, unique slots, topology digest, source-compatible copies, and a
+  complete single-step checkpoint manifest.
 
 ### CPU multi-process tests
 

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -469,6 +469,11 @@ boundary, prepare eligible checkpoint state, and wait for either a committed
 plan or an explicit abort. The stock torchrun agent still considers the worker
 group healthy during this preparation phase.
 
+`suspected_node_ids` is the policy-approved replacement scope for the
+incident. Every listed node must belong to the committed generation and must be
+absent from the next assignment. Policy may additionally quarantine a removed
+node when the evidence supports doing so.
+
 An abort is allowed only before a plan is committed and only when resuming the
 same generation is safe. An SDC, inaccessible node, corrupted checkpoint, or
 lost worker group cannot be aborted back to normal training.
@@ -513,6 +518,8 @@ Before commit, the coordinator validates:
 - the plan is fenced to the same intent ID, run, generation, incidents, and
   reason;
 - the recovery mode is at least as conservative as the intent's minimum;
+- every node in the intent's suspected scope is removed from the next
+  assignment;
 - exactly `min_nodes` active logical slots are assigned;
 - at least one assigned node is new to the active membership, because version
   1 uses standby admission as its healthy-group restart edge;

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -439,14 +439,16 @@ class CheckpointCertification(TypedDict):
         "dense_consensus",
         "dynamic_candidate_promotion",
     ]
-    inventory_event_ids: list[str]
+    inventory_event_digests: dict[str, str]  # event ID to canonical SHA-256
 ```
 
 This record is written only after job-wide dense acceptance or the documented
 two-cycle dynamic-catalog promotion. It is not accepted through the worker
 event sink. A worker-declared `recovery_verified` inventory is eligible only
 when a trusted certification matches its run, generation, step, topology,
-source, durable checkpoint ID, world size, and inventory event ID.
+source, durable checkpoint ID, world size, and canonical inventory-event
+digest. Reusing an event ID with different copy contents therefore cannot reuse
+the earlier certification.
 
 ### Local client protocol
 

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1,0 +1,1088 @@
+# Torchrun Native Resiliency Integration
+
+Status: draft for discussion
+
+Last updated: 2026-08-14
+
+## Decision Summary
+
+The recommended first design is **fixed-size training with replacement**, not
+general elastic training:
+
+- allocate a fleet of `max_nodes` homogeneous hosts;
+- run the training job on exactly `min_nodes` active hosts;
+- keep `max_nodes - min_nodes` hosts as agent-only standbys;
+- preserve a stable logical node slot and rank range across restart;
+- let SCOUT report fault evidence and GEMINI report recoverable checkpoint
+  state;
+- let a torchrun-owned coordinator make the final quarantine, placement, and
+  restart decision; and
+- pass one fenced `RestartContext` to every relaunched worker so
+  `lm-resiliency` and the framework recover the same checkpoint generation.
+
+The existing meaning of `torchrun --nnodes=min_nodes:max_nodes` is not sufficient
+for this design. It permits the active worker-group membership and world size to
+change. A late node is admitted through re-rendezvous and all workers restart.
+Ranks are not stable across those restarts. Treating the extra nodes as standbys
+therefore requires an explicit admission policy and stable logical slots rather
+than relying on the range alone.
+
+The design should be implemented in two stages:
+
+1. an out-of-tree reference launcher using a custom elastic agent, control
+   coordinator, and rendezvous handler; then
+2. an upstreamable torchrun resiliency-policy interface that removes the need
+   to subclass internal agent methods.
+
+## Scope
+
+### Goals
+
+- Replace a localized bad node with a healthy standby without changing the
+  training topology.
+- Prevent quarantined nodes from rejoining later rendezvous generations.
+- Select recovery state conservatively from SCOUT and GEMINI evidence.
+- Preserve the complete framework state for one coherent optimizer step.
+- Keep TorchTitan, native PyTorch, Megatron Core, and DeepSpeed integrations
+  independent of torchrun process-management details.
+- Fence stale fault reports and restart commands from earlier generations.
+- Fail closed when there are too few healthy nodes or no complete trusted
+  checkpoint.
+
+### Initial assumptions
+
+- `min_nodes` is the exact active training fleet size.
+- `max_nodes - min_nodes` is the maximum standby capacity.
+- Every admitted node has the same local worker count and compatible hardware,
+  software, model configuration, and framework version.
+- A replacement node inherits the failed node's logical slot and global-rank
+  range.
+- Version 1 does not change DP, TP, PP, CP, EP, expert-TP, FSDP/HSDP, or ZeRO
+  degrees during recovery.
+- Standby agents are running and reachable, but standby trainer processes are
+  not.
+- The control store is strongly consistent enough to publish a single restart
+  plan by compare-and-swap.
+
+### Non-goals for version 1
+
+- Elastic scale-up or scale-down of the active training world.
+- Recovery with a different model-parallel layout or global batch size.
+- Partial restart of one rank while the rest of the worker group continues.
+- Reusing a node that SCOUT could not safely clear.
+- Physical hardware repair.
+- Turning inconclusive peer evidence into confident node attribution.
+
+## Existing Behavior and Missing Hooks
+
+Stock torchrun already provides useful foundations:
+
+- an agent process on every participating node;
+- local worker lifecycle and failure monitoring;
+- worker-group restart after process failure;
+- dynamic rendezvous with `min_nodes` and `max_nodes`;
+- custom rendezvous handlers through the `torchrun.handlers` entry-point group;
+- restart-count and run-ID environment variables; and
+- full worker-group restart on failure or membership change.
+
+It does not currently provide the complete contract required here:
+
+1. `min_nodes:max_nodes` describes elastic active membership, not
+   `min_nodes` active nodes plus replacement-only standbys.
+2. A healthy late node is considered a scale-up candidate, which triggers a
+   worker-group restart and may increase `WORLD_SIZE`.
+3. Rank assignment is not stable across re-rendezvous.
+4. Worker failure handling does not consume SCOUT fault localization or
+   checkpoint trust.
+5. Rendezvous admission has no standard quarantine database or logical-slot
+   inheritance contract.
+6. The worker-to-agent control plane has no stable fault, checkpoint, or
+   graceful-restart API.
+7. A custom rendezvous handler alone cannot force all healthy agents to stop
+   their workers for a SCOUT-requested replacement.
+
+PyTorch 2.13 includes an experimental worker control-plane server, but it is a
+generic handler server and not a stable restart or quarantine protocol. The
+reference integration should not make its safety contract depend on that
+experimental surface.
+
+The integration must also avoid depending on `--max-restarts` as its only
+replacement budget. Failure retries and membership changes have had different
+accounting behavior across torchrun versions. The coordinator should own an
+explicit `max_replacement_generations` policy.
+
+## Three-Layer Architecture
+
+```text
+                    control store / coordinator
+              restart plans, slot leases, quarantine
+                              |
+                              v
++------------------------------------------------------------------+
+| Layer 1: torchrun                                                 |
+|                                                                  |
+| ResilientElasticAgent  SlotAwareRendezvous  RestartCoordinator   |
+| - owns active/standby state                                      |
+| - maps stable node IDs to logical slots                          |
+| - commits one fenced RestartPlan                                 |
+| - stops all active workers                                       |
+| - excludes quarantined nodes                                     |
+| - launches exactly min_nodes slots                               |
++-----------------------------+------------------------------------+
+                              |
+           local control socket| restart-context file/environment
+                              v
++------------------------------------------------------------------+
+| Layer 2: lm-resiliency                                           |
+|                                                                  |
+| TorchrunOrchestrationClient  SCOUT  GEMINI  manager_api          |
+| - reports normalized fault evidence                              |
+| - proposes checkpoint trust and locally available state          |
+| - flushes and transfers eligible checkpoint shards               |
+| - validates and consumes the committed RestartContext            |
+| - performs rank-consistent checkpoint selection after relaunch   |
++-----------------------------+------------------------------------+
+                              |
+             framework-neutral| recovery request and adapter
+                              v
++------------------------------------------------------------------+
+| Layer 3: TorchTitan or another torchrun framework                 |
+|                                                                  |
+| FrameworkAdapter / Trainer                                       |
+| - owns model, optimizer, scheduler, RNG, sampler/data position    |
+| - exposes safe optimizer boundaries                              |
+| - loads framework durable state when GEMINI is unavailable        |
+| - resumes at the step selected by lm-resiliency                  |
++------------------------------------------------------------------+
+```
+
+### Ownership boundary
+
+| Concern | Owner |
+|---|---|
+| Detection, localization, evidence confidence | SCOUT |
+| Checkpoint capture, trust, inventory, transfer | GEMINI |
+| Final node quarantine and replacement policy | torchrun layer |
+| Active/standby admission and logical-slot assignment | torchrun layer |
+| Final restart generation and worker termination | torchrun layer |
+| Model and optimizer state semantics | framework adapter |
+| Physical repair or scheduler allocation | infrastructure manager |
+
+`lm-resiliency` may recommend a replacement scope, but it must not directly
+evict a physical host. A rank-local report is evidence, not a cluster-wide
+decision.
+
+## Identity Model
+
+Ranks cannot be used as durable resource identities. Every event and plan must
+carry both the current rank mapping and stable infrastructure identities.
+
+```python
+class AgentIdentity(TypedDict):
+    run_id: str
+    node_id: str              # Stable scheduler or infrastructure identity.
+    agent_id: str             # Unique torchrun agent incarnation.
+    hostname: str
+    local_world_size: int
+    resource_ids: list[str]   # GPU UUIDs, NICs, HCAs, or deployment IDs.
+    environment_digest: str   # Software, configuration, and capability identity.
+
+
+class WorkerIdentity(TypedDict):
+    run_id: str
+    generation: int
+    node_id: str
+    agent_id: str
+    logical_node_slot: int    # Stable for the lifetime of the training job.
+    global_rank: int
+    local_rank: int
+    local_world_size: int
+    hostname: str
+    gpu_uuid: str | None
+    topology_digest: str
+```
+
+The coordinator records an immutable `RankAssignment` for each generation:
+
+```python
+@dataclass(frozen=True)
+class RankAssignment:
+    run_id: str
+    generation: int
+    active_nodes: int
+    local_world_size: int
+    slot_to_node_id: dict[int, str]
+    slot_to_rank_range: dict[int, tuple[int, int]]
+    topology_digest: str
+```
+
+When node `host-a` in slot `3` is replaced by `host-spare-1`, the new node
+inherits slot `3` and the same rank range. This keeps GEMINI shard ownership and
+framework parallel coordinates stable.
+
+`GROUP_RANK`, hostname, PID, and global rank alone are not valid quarantine
+keys. A quarantine record uses `node_id` and may also contain GPU, NIC, HCA, or
+other resource IDs.
+
+`node_id` must come from a trusted scheduler, cloud instance identity, or
+deployment inventory. A worker-provided hostname is diagnostic metadata and
+must not be allowed to choose its own quarantine identity. If no stable node
+identity is available, replacement mode should refuse to start.
+
+The topology digest covers at least the active world size, local worker count,
+framework parallel dimensions, logical rank-to-parallel-coordinate mapping,
+checkpoint schema, and model configuration needed to interpret rank-local
+state. It is separate from `environment_digest`, which describes whether a node
+is eligible to run the same software and hardware workload.
+
+## API: lm-resiliency to torchrun
+
+The current `OrchestrationHooks` callbacks are the starting point. The torchrun
+integration wraps them in a versioned, incident-correlated envelope and sends
+them to the local agent over a Unix-domain socket.
+
+### Fault event
+
+```python
+class HardwareFaultReport(TypedDict):
+    kind: Literal["hardware"]
+    resource_kind: Literal["gpu", "node", "nic", "hca", "link"]
+    resource_id: str
+    metric: str
+    value: float
+    severity: Literal["fatal"]
+    message: str
+
+
+class FaultEvent(TypedDict):
+    schema_version: int
+    event_id: str
+    incident_id: str
+    run_id: str
+    generation: int
+    reporter: WorkerIdentity
+    optimizer_step: int
+    report: SCOUTFaultReport | HardwareFaultReport
+```
+
+Requirements:
+
+- `event_id` is idempotent.
+- `incident_id` correlates the fault with recovery and checkpoint events.
+- The coordinator rejects a stale `generation`.
+- The original `SCOUTFaultReport` is preserved without upgrading its
+  attribution. A direct `HealthEvent` is normalized to
+  `HardwareFaultReport` without upgrading its resource granularity.
+- The torchrun layer resolves reported ranks through that generation's
+  `RankAssignment`.
+- The orchestration dispatcher allocates `incident_id` once and uses it for
+  both the recovery and fault callbacks. The client must not infer correlation
+  from callback timing.
+
+### Recovery proposal
+
+The existing `RecoveryDecision` remains a rank-local, noncollective result. At
+the torchrun boundary it is explicitly called a proposal:
+
+```python
+class RecoveryProposalEvent(TypedDict):
+    schema_version: int
+    event_id: str
+    incident_id: str
+    run_id: str
+    generation: int
+    reporter: WorkerIdentity
+    decision: RecoveryDecision
+```
+
+The coordinator combines proposals with a conservative lattice:
+
+```text
+RECOVERY_VERIFIED dominates LATEST_GEMINI
+unavailable required shard dominates locally available state
+missing or stale evidence blocks promotion to a less conservative mode
+```
+
+A worker must never interpret its local `checkpoint_step` as the final global
+step. The restarted job still calls GEMINI's collective `find_latest()` before
+loading.
+
+### Checkpoint inventory
+
+`RecoveryDecision` says what one worker recommends. Replacement also needs to
+know where every logical-rank shard can be obtained.
+
+```python
+class CheckpointCopy(TypedDict):
+    owner_global_rank: int
+    holder_node_id: str
+    holder_kind: Literal["owner", "peer", "durable"]
+    storage_kind: Literal["memory", "node_local", "shared", "remote"]
+    location_token: str
+    complete: bool
+    checksums_available: bool
+
+
+class CheckpointInventoryEvent(TypedDict):
+    schema_version: int
+    event_id: str
+    run_id: str
+    generation: int
+    reporter: WorkerIdentity
+    step: int
+    trust: Literal["latest", "candidate", "recovery_verified"]
+    topology_digest: str
+    copies: list[CheckpointCopy]
+```
+
+Only completed checkpoint slots may appear with `complete=True`. A
+`CANDIDATE` inventory can be retained for diagnosis but is never selected for
+conservative recovery.
+
+`location_token` is an opaque control-plane reference, not an unchecked path
+that another worker is allowed to open.
+
+### Local client protocol
+
+```python
+class ResiliencyEventSink(Protocol):
+    def publish_fault(self, event: FaultEvent) -> None: ...
+    def publish_recovery(self, event: RecoveryProposalEvent) -> None: ...
+    def publish_checkpoint(self, event: CheckpointInventoryEvent) -> None: ...
+    def acknowledge_restart(self, ack: RestartAck) -> None: ...
+```
+
+The callbacks must be bounded and must not use the training process group.
+Delivery failure is visible and causes the coordinator to use conservative
+recovery; it must not be silently treated as a healthy report.
+
+## API: torchrun to lm-resiliency
+
+Restart is a two-phase protocol:
+
+1. a `RestartIntent` quiesces accessible workers and gathers final checkpoint
+   preparation results without advancing the generation; then
+2. an immutable `RestartPlan` selects the actual checkpoint and next placement
+   from those results.
+
+This prevents a failed flush or transfer from invalidating a plan that already
+promised `LATEST_GEMINI`.
+
+### Restart intent
+
+```python
+class RestartIntent(TypedDict):
+    schema_version: int
+    intent_id: str
+    run_id: str
+    generation: int
+    incident_ids: list[str]
+    reason_code: str
+    minimum_recovery_mode: Literal["latest", "recovery_verified"]
+    suspected_node_ids: list[str]
+    prepare_deadline_unix_ms: int
+```
+
+The intent is a single-writer, compare-and-swap record for the current
+generation. It does not authorize a new worker group. Agents receiving it
+quiesce or terminate local training according to the incident, prepare eligible
+checkpoint state, and wait for either a committed plan or an explicit abort.
+
+An abort is allowed only before a plan is committed and only when resuming the
+same generation is safe. An SDC, inaccessible node, corrupted checkpoint, or
+lost worker group cannot be aborted back to normal training.
+
+### Committed restart plan
+
+Only the coordinator writes a `RestartPlan`. It is published atomically after
+checkpoint preparation finishes or times out and advances the monotonically
+increasing generation.
+
+```python
+class SlotAssignment(TypedDict):
+    logical_node_slot: int
+    node_id: str
+    first_global_rank: int
+    local_world_size: int
+
+
+class RestartPlan(TypedDict):
+    schema_version: int
+    plan_id: str
+    intent_id: str
+    run_id: str
+    from_generation: int
+    to_generation: int
+    incident_ids: list[str]
+    reason_code: str
+    recovery_mode: Literal["latest", "recovery_verified"]
+    checkpoint_source: Literal["gemini", "durable"]
+    checkpoint_step: int
+    checkpoint_id: str | None
+    checkpoint_manifest_id: str
+    slot_assignments: list[SlotAssignment]
+    quarantined_node_ids: list[str]
+    expected_world_size: int
+    topology_digest: str
+    stop_deadline_unix_ms: int
+```
+
+Before commit, the coordinator validates:
+
+- exactly `min_nodes` active logical slots are assigned;
+- every assigned node is healthy, compatible, and not quarantined;
+- each logical slot is assigned once;
+- the topology digest matches the prior generation;
+- the checkpoint is complete for every required logical rank;
+- the checkpoint trust satisfies the selected recovery mode;
+- the plan never selects `CANDIDATE`;
+- the target step is coherent across all selected shards; and
+- the plan generation is the successor of the current committed generation.
+
+### Restart context passed to workers
+
+The agent derives a rank-local context from the committed plan and writes it to
+an atomically replaced file. The worker receives only the file path:
+
+```text
+LM_RESILIENCY_RESTART_CONTEXT=/run/torchrun/<run-id>/restart-context.json
+```
+
+```python
+class RestartContext(TypedDict):
+    schema_version: int
+    plan_id: str
+    run_id: str
+    generation: int
+    node_id: str
+    logical_node_slot: int
+    global_rank: int
+    local_rank: int
+    expected_world_size: int
+    topology_digest: str
+    recovery_mode: Literal["latest", "recovery_verified"]
+    checkpoint_source: Literal["gemini", "durable"]
+    checkpoint_step: int
+    checkpoint_id: str | None
+    checkpoint_manifest_id: str
+    reason_code: str
+```
+
+`lm-resiliency` rejects startup if the context conflicts with torchrun's
+`RANK`, `LOCAL_RANK`, `WORLD_SIZE`, `TORCHELASTIC_RUN_ID`, or the framework
+topology.
+
+The context must not contain a newer, less trusted local checkpoint merely
+because it exists on the replacement host.
+
+The committed `checkpoint_step` is a pin, not a hint. On a managed restart,
+GEMINI must load exactly that step from `checkpoint_manifest_id` on every rank
+or fail. Its existing collective `find_latest()` remains useful for validating
+rank-wide availability during unmanaged recovery, but it must not silently
+substitute a different step after the coordinator commits a plan. This requires
+an additive exact-step checkpoint-manager surface used by
+`enable_resiliency(..., restart_context=restart)`:
+
+```python
+checkpoint_manager.load_exact(
+    step=restart.checkpoint_step,
+    manifest_id=restart.checkpoint_manifest_id,
+    recovery_mode=restart.recovery_mode,
+)
+```
+
+This is an implementation boundary, not an additional call required in the
+training script. A durable source is similarly pinned by `checkpoint_id` and
+step.
+
+### Prepare-for-restart command
+
+For an accessible worker group, the agent derives a local command from the
+intent:
+
+```python
+class PrepareRestart(TypedDict):
+    intent_id: str
+    generation: int
+    minimum_recovery_mode: Literal["latest", "recovery_verified"]
+    destination_token: str | None
+    deadline_unix_ms: int
+```
+
+The `lm-resiliency` client:
+
+1. stops accepting new unsafe checkpoint candidates;
+2. waits boundedly for the eligible GEMINI capture and replication state;
+3. flushes completed owner and peer slots;
+4. transfers or mirrors only checkpoint state allowed by the plan; and
+5. writes a `RestartAck`.
+
+```python
+class RestartAck(TypedDict):
+    intent_id: str
+    node_id: str
+    generation: int
+    flushed_step: int
+    inventory_event_ids: list[str]
+    transferred_owner_ranks: list[int]
+    transferred_peer_ranks: list[int]
+    success: bool
+    reason: str
+```
+
+The socket listener only validates and stages the command. It must not call
+CUDA, framework, or checkpoint operations from a background listener thread.
+The agent then requests a framework safe point or sends the configured
+catchable termination signal. GEMINI's bounded main-thread/signal path performs
+the flush and writes the acknowledgement.
+
+The agent waits only until the intent deadline and reports missing
+acknowledgements. Missing or failed preparation cannot promote
+`LATEST_GEMINI`; the coordinator must commit a plan using a complete
+recovery-verified source or fail the restart.
+
+For a crashed or unreachable node, no preparation is assumed.
+
+## API: lm-resiliency to the Framework
+
+The framework receives a platform-neutral recovery request. It does not receive
+quarantine or placement policy.
+
+```python
+@dataclass(frozen=True)
+class FrameworkRecoveryRequest:
+    run_id: str
+    generation: int
+    recovery_mode: RecoveryMode
+    checkpoint_source: Literal["gemini", "durable"]
+    checkpoint_step: int
+    checkpoint_id: str | None
+    expected_world_size: int
+    topology_digest: str
+
+
+class FrameworkRecoveryAdapter(Protocol):
+    def validate_restart(self, request: FrameworkRecoveryRequest) -> None: ...
+    def load_durable(self, request: FrameworkRecoveryRequest) -> int | None: ...
+```
+
+The proposed activation API is additive:
+
+```python
+from lm_resiliency import enable_resiliency
+from lm_resiliency.integrations.torchrun import (
+    RestartContext,
+    TorchrunOrchestrationClient,
+)
+
+restart = RestartContext.from_env()
+control = TorchrunOrchestrationClient.connect(restart)
+
+resiliency = enable_resiliency(
+    trainer,
+    orchestration=control.hooks(),
+    restart_context=restart,
+)
+trainer.train()
+```
+
+`restart_context=None` preserves the current behavior. Existing
+`load_fallback: Callable[[], int | None]` remains supported. A new
+context-aware durable loader can be added without changing the old callback.
+
+For TorchTitan, the existing adapter already captures:
+
+- model state;
+- optimizer state;
+- LR scheduler state;
+- trainer state;
+- dataloader position; and
+- the recovered training step.
+
+The adapter must additionally validate that the relaunched
+`ParallelDims/world_size` produces the committed topology digest before any
+checkpoint is loaded.
+
+## Torchrun Agent and Rendezvous Design
+
+### Node states
+
+```text
+STANDBY -> ADMITTED -> ACTIVE -> DRAINING -> QUARANTINED
+     \          \         \          \-> FAILED
+      \----------> REJECTED
+```
+
+- `STANDBY`: agent is registered; no trainer process is running.
+- `ADMITTED`: coordinator assigned a logical slot for the next generation.
+- `ACTIVE`: local workers are running for the committed generation.
+- `DRAINING`: restart is committed; bounded checkpoint preparation is running.
+- `QUARANTINED`: node cannot enter another generation for this run.
+- `FAILED`: agent or node is unreachable; its slot may be reassigned.
+
+### Job states
+
+```text
+RUNNING
+  -> DECIDING
+  -> PREPARING
+  -> COMMITTING
+  -> STOPPING
+  -> RENDEZVOUS
+  -> RECOVERING
+  -> RUNNING
+```
+
+Any state may transition to `FAILED` when there are too few eligible nodes, no
+complete trusted checkpoint, a conflicting plan, or an unrecoverable topology
+mismatch.
+
+### Coordinator
+
+The `RestartCoordinator` is the single writer for:
+
+- current generation;
+- current restart intent;
+- active slot leases;
+- standby eligibility;
+- quarantine records;
+- checkpoint manifest selection; and
+- committed restart plans.
+
+The writer may be lease-elected rather than a fixed process. All authoritative
+state must be in the strongly consistent store so another coordinator can take
+over after the lease expires without changing or duplicating an already
+committed plan.
+
+It may be implemented over the rendezvous store for a prototype, but control
+keys must be namespaced separately from worker-group bootstrap keys. Production
+deployments should use a durable external service if the rendezvous endpoint is
+not sufficiently available or persistent.
+
+### Slot-aware rendezvous
+
+`SlotAwareRendezvous` admits only nodes named by the committed plan:
+
+- standby agents block without creating trainers;
+- quarantined nodes receive a terminal rejection;
+- a replacement node receives the failed node's logical slot;
+- exactly `min_nodes` slots complete the rendezvous; and
+- returned group rank is derived from logical slot, not arrival order.
+
+This is stricter than the normal dynamic-rendezvous wait list. A random late
+node must not trigger scale-up.
+
+### Resilient elastic agent
+
+The prototype `ResilientElasticAgent` extends the local agent loop to poll the
+intent and committed generation. It:
+
+1. asks accessible workers to prepare when it observes an intent;
+2. waits in a quiesced state after acknowledgement or timeout;
+3. stops all local workers when it observes the committed plan;
+4. reports the local stop result;
+5. enters slot-aware rendezvous if admitted; and
+6. injects the rank-local `RestartContext` before starting workers.
+
+All active agents act on the same committed plan. A node-local SCOUT report
+cannot directly force only its own workers to restart.
+
+Current torchrun does not expose this policy as a stable public hook. The
+prototype will likely subclass protected agent behavior and must therefore be
+pinned and tested for each supported PyTorch minor version.
+
+The upstream target is a public interface similar to:
+
+```python
+class ElasticResiliencyPolicy(Protocol):
+    def register_agent(self, agent: AgentIdentity) -> AgentAdmission: ...
+    def poll_action(self, state: AgentState) -> AgentAction: ...
+    def prepare_worker_env(
+        self,
+        assignment: RankAssignment,
+        local_rank: int,
+    ) -> dict[str, str]: ...
+    def report_action_result(self, result: AgentActionResult) -> None: ...
+```
+
+This hook should run above process monitoring and below the CLI, so a policy can
+request a coordinated restart without pretending a healthy worker crashed.
+
+## Control-Plane Integrity
+
+- Create the local control directory with owner-only permissions and verify Unix
+  peer credentials where supported.
+- Write intent, context, and acknowledgement files with atomic replace.
+- Provision `node_id` and agent credentials outside the training worker.
+- Namespace every store key by run ID and schema version.
+- Protect the external store with deployment authentication and authorization.
+- Include the plan ID and generation in every mutable operation.
+- Reject path traversal and never expand `location_token` as a raw filesystem
+  path without resolving it through the trusted control client.
+- Treat malformed, unauthenticated, or conflicting input as unavailable
+  evidence, not as permission to continue.
+
+## Healthy-Path Cost
+
+The integration must not add a global synchronization to normal optimizer
+steps.
+
+- Fault and recovery events are emitted only when SCOUT produces actionable
+  evidence.
+- Checkpoint inventory contains metadata only and is published asynchronously
+  after a completed checkpoint transition.
+- Agent plan polling is out of process and bounded.
+- Standby agents do not allocate model state or join training collectives.
+- Checkpoint flush and transfer happen only after a restart intent.
+- Control delivery backpressure must not block the training thread
+  indefinitely.
+
+## Recovery Policy
+
+| Incident | Node action | Recovery mode |
+|---|---|---|
+| Attributed SDC on one node/GPU | Quarantine affected node conservatively | `RECOVERY_VERIFIED` |
+| Inconclusive exact replay | Do not over-attribute; operator policy may replace a broader scope | `RECOVERY_VERIFIED` |
+| Required node inaccessible | Mark failed and replace its slot | `RECOVERY_VERIFIED` |
+| Confirmed accessible compute or communication straggler | Drain and replace when policy threshold is met | `LATEST_GEMINI` if a complete generation is prepared; otherwise verified |
+| Hang with complete clean emergency replay and all ranks accessible | Restart or replace implicated scope | `LATEST_GEMINI` |
+| Hang with missing, stale, incomplete, or contradictory evidence | Restart conservatively; avoid unsupported attribution | `RECOVERY_VERIFIED` |
+| Operator-initiated healthy migration | Drain source and replace slot | `LATEST_GEMINI` if preparation succeeds |
+
+### Aggregation rules
+
+The coordinator uses all available events for the incident:
+
+- any SDC or inconclusive exact evidence forces verified recovery;
+- any inaccessible required rank forces verified recovery;
+- a latest proposal is accepted only if the checkpoint manifest proves every
+  required logical-rank shard is complete at one step;
+- conflicting steps are not merged;
+- after plan commit, workers load the exact selected step rather than
+  independently choosing a newer local generation;
+- missing reporter events do not count as agreement;
+- a checksum failure makes that copy unavailable;
+- checksum success does not prove the original GPU state was numerically
+  correct; and
+- one comparison group cannot certify the job if another group found SDC.
+
+## Checkpoint Placement and Transfer
+
+Stable logical slots are required for the fast path. GEMINI checkpoints are
+rank-sharded and peer replicas preserve the original owner rank. If torchrun
+arbitrarily renumbers ranks after replacement, a new framework topology may not
+match those shards even when `WORLD_SIZE` is unchanged.
+
+For each selected checkpoint, the coordinator builds one immutable manifest:
+
+```python
+class RankCheckpointCopies(TypedDict):
+    owner_global_rank: int
+    copies: list[CheckpointCopy]
+
+
+class RecoveryManifest(TypedDict):
+    manifest_id: str
+    run_id: str
+    source_generation: int
+    step: int
+    trust: Literal["latest", "recovery_verified"]
+    topology_digest: str
+    rank_copies: list[RankCheckpointCopies]
+```
+
+The manifest is usable only when every required rank has at least one eligible
+copy.
+
+Preferred source order:
+
+1. completed owner copy on an accessible healthy node;
+2. completed peer replica on a different healthy node;
+3. previously mirrored restart storage; or
+4. framework durable recovery-verified checkpoint.
+
+For an SDC incident, the selected generation must already be
+`RECOVERY_VERIFIED`. The current suspect state is never promoted. A stored
+verified copy on a suspect machine should be transferred only when policy
+allows it and integrity verification succeeds; a healthy peer or durable copy
+is preferred.
+
+The current `CheckpointTransfer` interface can move shards after the
+coordinator chooses source and destination endpoints. The transport never
+chooses the checkpoint or replacement node.
+
+If a failed node and every holder of its peer replicas are unavailable, GEMINI
+cannot reconstruct that rank's fast checkpoint. Recovery falls back to the
+framework durable checkpoint.
+
+## End-to-End Flows
+
+### Initial launch
+
+1. All `max_nodes` agents register stable node identities.
+2. The coordinator validates compatibility and selects exactly `min_nodes`.
+3. Selected nodes receive logical slots; the rest enter `STANDBY`.
+4. Slot-aware rendezvous assigns deterministic rank ranges.
+5. Agents start workers with generation `0`.
+6. `lm-resiliency` registers the worker identity and framework topology digest.
+
+### Accessible straggler replacement
+
+1. SCOUT emits a confirmed straggler report and latest-checkpoint proposal.
+2. The coordinator maps the reported rank to its generation and node.
+3. The coordinator opens a restart intent and provisionally reserves a
+   compatible standby for the affected logical slot.
+4. Every active agent enters `DRAINING`.
+5. Workers flush eligible GEMINI state and report transfer results.
+6. The coordinator commits a restart plan using the newest complete allowed
+   generation, or falls back to verified recovery.
+7. Agents stop all workers.
+8. The source node becomes quarantined or standby according to policy.
+9. The replacement and surviving nodes rendezvous with the same slots/ranks.
+10. Relaunched workers validate the restart context and load exactly the
+    committed rank-consistent step.
+11. TorchTitan restores the complete state and resumes.
+
+### Inaccessible node
+
+1. The agent or infrastructure marks one node unavailable.
+2. The coordinator opens an intent so surviving nodes can expose their
+   completed peer replicas.
+3. The coordinator selects `RECOVERY_VERIFIED`.
+4. The committed manifest uses peer replicas or the durable verified
+   checkpoint.
+5. A standby inherits the failed logical slot.
+6. Surviving workers are stopped and the fixed-size group is relaunched.
+7. If any required shard is unavailable, the job fails rather than mixing
+   checkpoint generations.
+
+### SDC
+
+1. SCOUT rejects the current candidate and emits attributed or inconclusive
+   evidence.
+2. The coordinator selects only `RECOVERY_VERIFIED`.
+3. The affected node is quarantined only to the scope supported by evidence and
+   deployment policy.
+4. No current or candidate checkpoint is copied into the restart manifest.
+5. The fixed-size group relaunches and loads the verified generation.
+
+## Failure Handling
+
+- **Coordinator unavailable:** do not autonomously form a new generation.
+- **Coordinator unavailable with an open intent:** remain quiesced and fail
+  after the control-plane deadline; do not resume training without an explicit
+  safe abort.
+- **Conflicting committed plans:** fail the run; never choose locally.
+- **Stale event:** ignore it and record the rejection.
+- **Missing preparation acknowledgement:** treat the node's latest state as
+  unavailable.
+- **Standby fails admission health checks:** select another standby or fail.
+- **Too few eligible nodes:** wait within policy or fail; do not silently shrink
+  the training world.
+- **Restart context mismatch:** exit before framework checkpoint loading.
+- **Checkpoint manifest incomplete:** use a complete verified durable
+  checkpoint or fail.
+- **Transfer timeout or checksum failure:** mark that copy unavailable and
+  re-plan only from the same or a more conservative trust state.
+- **Agent crash after plan commit:** another agent cannot rewrite the plan; the
+  same generation may be retried idempotently.
+
+## Packaging and Compatibility
+
+- Keep the public neutral payloads in `lm_resiliency.manager_api`.
+- Put torchrun-specific code under `lm_resiliency.integrations.torchrun`.
+- Keep TorchTitan imports lazy.
+- Importing `lm_resiliency` must not import TorchTitan or CUDA-only packages.
+- Version every wire payload independently from the Python package version.
+- Reject unknown required fields or unsupported schema versions.
+- Pin the prototype agent integration to qualified PyTorch minor versions
+  because protected agent methods are not a stable API.
+- Preserve the existing `OrchestrationHooks`, `RecoveryDecision`,
+  `SCOUTFaultReport`, and framework entry points.
+- Use PyTorch 2.13 as the initial prototype baseline, then separately qualify
+  the other PyTorch minors in the supported compatibility range.
+
+### Proposed prototype command
+
+An out-of-tree command avoids changing torchrun's existing CLI semantics:
+
+```bash
+python -m lm_resiliency.integrations.torchrun.launch \
+  --active-nnodes=8 \
+  --fleet-nnodes=10 \
+  --nproc-per-node=8 \
+  --rdzv-backend=c10d \
+  --rdzv-endpoint="${RDZV_ENDPOINT}" \
+  --rdzv-id="${JOB_ID}" \
+  --max-replacement-generations=2 \
+  --module torchtitan.train ...
+```
+
+### Upstream CLI target
+
+If PyTorch accepts a resiliency-policy hook, torchrun can preserve its current
+default and add explicit replacement-only semantics:
+
+```bash
+torchrun \
+  --nnodes=8:10 \
+  --active-nnodes=8 \
+  --standby-policy=replace-only \
+  --resiliency-policy=lm_resiliency \
+  --nproc-per-node=8 \
+  --rdzv-backend=c10d \
+  --rdzv-endpoint="${RDZV_ENDPOINT}" \
+  --rdzv-id="${JOB_ID}" \
+  --module torchtitan.train ...
+```
+
+The names are placeholders for upstream discussion. The important requirement
+is that replacement-only mode is opt-in and does not silently change the
+meaning of existing `--nnodes=min:max` jobs.
+
+## Validation Plan
+
+### Contract tests
+
+- JSON round-trip and schema-version rejection for every event and plan.
+- Stale generation, duplicate event, and conflicting-plan rejection.
+- Conservative recovery lattice across missing and conflicting proposals.
+- Rank-to-node mapping through immutable generation snapshots.
+- Quarantine by stable node ID, never by rank alone.
+- Plan validation for exact active size, unique slots, topology digest, and
+  complete checkpoint manifest.
+
+### CPU multi-process tests
+
+- Standby agents do not spawn trainer workers.
+- A new standby does not cause scale-up.
+- A committed plan stops every active local worker group.
+- A replacement inherits the same logical slot and rank range.
+- A quarantined node cannot rejoin.
+- Restart context mismatch aborts before user code initializes recovery.
+- Agent/coordinator restart preserves idempotent generation state.
+
+### Focused GPU and multi-node tests
+
+Start with `min_nodes=2`, `max_nodes=3`, and the smallest topology that
+exercises peer replication:
+
+1. kill one active node and recover its rank shards from peer replicas;
+2. replace an accessible straggler after bounded flush and transfer;
+3. inject SDC and verify rollback to the prior recovery-verified generation;
+4. make one rank's newest shard unavailable and verify global step selection
+   falls back consistently;
+5. verify bitwise model, optimizer, scheduler, RNG, and data-position recovery;
+6. repeat with TorchTitan and native PyTorch;
+7. exercise one HSDP or FSDP2 topology with stable shard coordinates; and
+8. document the remaining hardware-dependent coverage.
+
+The test must assert that no quarantined node runs a trainer process in the new
+generation and that the active world size remains exactly `min_nodes`.
+
+## Alternatives Considered
+
+### Use stock `--nnodes=min:max` and callbacks only
+
+Insufficient. It cannot keep extra nodes standby-only, preserve stable rank
+slots, or exclude a localized bad node from later rendezvous.
+
+### Implement only a custom rendezvous handler
+
+Insufficient. It can control admission, but it cannot safely ask all currently
+healthy agents to prepare and stop their workers after a SCOUT decision.
+
+### Allow the active world to shrink after a failure
+
+Deferred. It changes framework parallelism, checkpoint sharding, batch size,
+optimizer semantics, and potentially the training trajectory. It requires a
+separate elastic-topology and resharding contract.
+
+### Put placement policy inside lm-resiliency
+
+Rejected. SCOUT and GEMINI do not own scheduler state, leases, or physical
+resource lifecycle. They should provide evidence and recovery state to a
+torchrun or infrastructure manager.
+
+### Delegate everything to an external scheduler
+
+Viable for production, and the neutral manager API should continue supporting
+it. The reference design still adds value by defining the torchrun-native
+worker/agent contract and enabling local-agent standby replacement.
+
+## Phased Implementation
+
+### Phase 0: agree on contracts
+
+- Decide stable node identity and logical-slot semantics.
+- Agree on the event, inventory, manifest, plan, and restart-context schemas.
+- Decide where the single-writer coordinator runs.
+
+### Phase 1: manager-neutral data model
+
+- Add versioned event envelopes and `RestartContext`.
+- Extend checkpoint inventory without changing current callback behavior.
+- Add contract tests and conservative aggregation tests.
+
+### Phase 2: reference torchrun integration
+
+- Add the local orchestration client.
+- Add the coordinator and quarantine store.
+- Add standby-only admission and stable slot rendezvous.
+- Add a version-pinned resilient elastic agent and prototype launcher.
+
+### Phase 3: framework validation
+
+- Validate native PyTorch and TorchTitan end to end.
+- Add Megatron Core and DeepSpeed after the neutral contract is stable.
+
+### Phase 4: upstream torchrun proposal
+
+- Propose a public coordinated-restart policy hook.
+- Propose explicit replacement-only standby semantics.
+- Remove protected-method subclassing when the public hook is available.
+
+## Open Questions
+
+Recommended defaults for the first prototype:
+
+- pre-launch standby agents in the same allocation;
+- require stable logical slots and exact rank-range inheritance;
+- quarantine the whole node when one full-node torchrun local worker group is
+  the scheduling unit;
+- prefer healthy peer or durable verified copies over a suspect node;
+- keep framework durable checkpoint IDs opaque;
+- use a separate replacement-generation budget; and
+- propose the smallest upstream hooks for coordinated restart, worker
+  environment injection, and admission before proposing a broad policy API.
+
+1. **Coordinator placement:** should the first prototype use a namespaced c10d
+   rendezvous store, etcd, or a separate manager service?
+2. **Stable slots:** can all target deployments guarantee that a standby can
+   inherit the failed node's exact rank range and local device count?
+3. **Quarantine scope:** when SCOUT identifies one GPU but torchrun launches a
+   homogeneous full-node local worker group, should policy always quarantine
+   the whole node in version 1?
+4. **Verified copies on suspect hardware:** may a previously certified
+   checkpoint be transferred from a now-suspect node when its checksum passes,
+   or must recovery use only a healthy peer/durable copy?
+5. **Replacement budget:** should repeated replacement generations be bounded
+   separately by incident type, node, and whole job?
+6. **Standby lifecycle:** are standby agents pre-launched in the same scheduler
+   allocation, or must the coordinator request a new host on demand?
+7. **Durable checkpoint handoff:** should `checkpoint_id` remain framework
+   opaque, or should the restart manifest expose a common durable-checkpoint
+   URI contract?
+8. **Upstream surface:** is a general `ElasticResiliencyPolicy` acceptable to
+   torchrun, or should the first upstream change be a smaller coordinated
+   restart and worker-environment hook?
+
+## References
+
+- [GEMINI operational contract](gemini.md)
+- [SCOUT operational contract](scout.md)
+- [LM Resiliency API guide](api.md)
+- [Compatibility policy](compatibility.md)
+- [PyTorch torchrun elastic launch documentation](https://docs.pytorch.org/docs/2.13/elastic/run.html)
+- [PyTorch elastic agent documentation](https://docs.pytorch.org/docs/2.13/elastic/agent.html)
+- [PyTorch rendezvous documentation](https://docs.pytorch.org/docs/2.13/elastic/rendezvous.html)

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -341,7 +341,7 @@ Requirements:
   attribution. A direct `HealthEvent` is normalized to
   `HardwareFaultReport` without upgrading its resource granularity.
 - The coordinator resolves reported ranks through that generation's
-  `RankAssignment`.
+  `RankAssignment` and rejects any reported rank outside its committed ranges.
 - The orchestration dispatcher allocates `incident_id` once and uses it for
   both the recovery and fault callbacks. The client must not infer correlation
   from callback timing.
@@ -414,7 +414,9 @@ but is never selected for conservative recovery. Durable copies must use shared
 or remote storage and carry the opaque durable `checkpoint_id`; that ID must
 match the committed plan. Owner and peer copies do not carry a durable
 checkpoint ID. Node-local and in-memory copies remain subject to holder health
-and quarantine.
+and quarantine, and are eligible only when the inventory event was reported by
+that holder. Shared or remote copies may instead be referenced by an
+authenticated control-plane inventory.
 
 `location_token` is an opaque control-plane reference, not an unchecked path
 that another worker is allowed to open.
@@ -569,6 +571,12 @@ context conflicts with torchrun's `RANK`, `LOCAL_RANK`, `LOCAL_WORLD_SIZE`,
 `WORLD_SIZE`, `TORCHELASTIC_RUN_ID`, or the framework topology.
 `expected_world_size` must also be divisible by `local_world_size`, so a
 context cannot describe a partial logical node slot.
+
+Before inspecting checkpoint fields, the worker validates the complete context
+against the currently committed `RestartPlan` for its node. The plan ID,
+successor generation, assignment, topology, recovery mode, checkpoint pin, and
+reason must match exactly. A leftover context from an earlier plan is rejected
+even when stable ranks make every torchrun environment value identical.
 
 The context must not contain a newer, less trusted local checkpoint merely
 because it exists on the replacement host.

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -289,9 +289,10 @@ must not be allowed to choose its own quarantine identity. If no stable node
 identity is available, replacement mode should refuse to start.
 
 The trusted resource inventory maps every resource ID to both its stable node
-owner and resource kind (`gpu`, `nic`, `hca`, `link`, or `node`). Worker
-registration proves that an agent may report a resource; it does not allow the
-worker to relabel a GPU as a NIC or another resource class.
+owner, resource kind (`gpu`, `nic`, `hca`, `link`, or `node`), and the global
+rank for rank-bound endpoints. Worker registration proves that an agent may
+report a resource; it does not allow the worker to relabel a GPU as a NIC or
+attribute another local worker's GPU to its own rank.
 
 The topology digest covers at least the active world size, local worker count,
 framework parallel dimensions, logical rank-to-parallel-coordinate mapping,
@@ -564,6 +565,9 @@ Before commit, the coordinator validates:
 - the recovery mode is at least as conservative as the intent's minimum;
 - every node in the intent's suspected scope is removed from the next
   assignment;
+- every new quarantine entry is both in that suspected scope and removed from
+  the current assignment; unrelated standbys require separate trusted fault
+  evidence before quarantine;
 - exactly `min_nodes` active logical slots are assigned;
 - at least one assigned node is new to the active membership, because version
   1 uses standby admission as its healthy-group restart edge;

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -331,6 +331,9 @@ Requirements:
 - `event_id` is idempotent.
 - `incident_id` correlates the fault with recovery and checkpoint events.
 - The coordinator rejects a stale `generation`.
+- Event admission validates the reporter's node, logical slot, local worker
+  count, rank range, and topology digest against that generation's immutable
+  `RankAssignment`; worker-supplied rank arithmetic alone is insufficient.
 - The original `SCOUTFaultReport` is preserved without upgrading its
   attribution. A direct `HealthEvent` is normalized to
   `HardwareFaultReport` without upgrading its resource granularity.
@@ -377,6 +380,7 @@ know where every logical-rank shard can be obtained.
 class CheckpointCopy(TypedDict):
     owner_global_rank: int
     checkpoint_step: int
+    inventory_event_id: str
     holder_node_id: str
     holder_kind: Literal["owner", "peer", "durable"]
     storage_kind: Literal["memory", "node_local", "shared", "remote"]
@@ -399,10 +403,12 @@ class CheckpointInventoryEvent(TypedDict):
 
 Only completed checkpoint slots may appear with `complete=True`.
 `checkpoint_step` must equal the enclosing inventory event's positive `step`;
-the coordinator validates it again when assembling the recovery manifest. A
-`CANDIDATE` inventory can be retained for diagnosis but is never selected for
-conservative recovery. Durable copies must use shared or remote storage;
-node-local and in-memory copies remain subject to holder health and quarantine.
+`inventory_event_id` binds the copy to that source event, and the coordinator
+validates the complete copy record against the referenced event when assembling
+the recovery manifest. A `CANDIDATE` inventory can be retained for diagnosis
+but is never selected for conservative recovery. Durable copies must use shared
+or remote storage; node-local and in-memory copies remain subject to holder
+health and quarantine.
 
 `location_token` is an opaque control-plane reference, not an unchecked path
 that another worker is allowed to open.
@@ -500,6 +506,8 @@ Before commit, the coordinator validates:
   reason;
 - the recovery mode is at least as conservative as the intent's minimum;
 - exactly `min_nodes` active logical slots are assigned;
+- at least one assigned node is new to the active membership, because version
+  1 uses standby admission as its healthy-group restart edge;
 - every assigned node is healthy, compatible, and not quarantined;
 - each logical slot is assigned once;
 - active size, local world size, total world size, and topology digest match the
@@ -507,6 +515,8 @@ Before commit, the coordinator validates:
 - the checkpoint is complete for every required logical rank;
 - every copy belongs to the selected positive step and selected checkpoint
   source;
+- every copy exactly matches its referenced inventory event, and the source
+  inventory trust satisfies the manifest trust;
 - the checkpoint trust satisfies the selected recovery mode;
 - the plan never selects `CANDIDATE`;
 - the target step is coherent across all selected shards;
@@ -550,6 +560,8 @@ Each worker derives its expected rank as
 `first_global_rank + LOCAL_RANK`. `lm-resiliency` rejects startup if the
 context conflicts with torchrun's `RANK`, `LOCAL_RANK`, `LOCAL_WORLD_SIZE`,
 `WORLD_SIZE`, `TORCHELASTIC_RUN_ID`, or the framework topology.
+`expected_world_size` must also be divisible by `local_world_size`, so a
+context cannot describe a partial logical node slot.
 
 The context must not contain a newer, less trusted local checkpoint merely
 because it exists on the replacement host.
@@ -890,7 +902,10 @@ class RecoveryManifest(TypedDict):
 The manifest is usable only when every required rank has at least one eligible
 copy for the manifest's exact positive step and the plan's selected source.
 GEMINI plans use owner or peer copies; durable plans use durable copies. Only
-shared or remote storage is independent of holder-node availability.
+shared or remote storage is independent of holder-node availability. The
+manifest's trust label is not self-authenticating: every selected copy must
+match its referenced inventory record, and `RECOVERY_VERIFIED` manifests may
+use only recovery-verified inventory evidence.
 
 Preferred source order:
 

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -976,7 +976,10 @@ a recovery-verified manifest and recovery-verified inventory, even if the
 originating intent allowed latest recovery.
 
 An in-memory or node-local copy is selectable only when its holder remains in
-the next assignment. A departing node's transfer counters in `RestartAck` do
+the next assignment. Process-memory copies are never selectable because stock
+elastic restart destroys every worker address space, including workers on
+retained nodes. Successful preparation must publish new node-local inventory
+for the flushed bytes. A departing node's transfer counters in `RestartAck` do
 not by themselves prove that a destination has the bytes. Version 1 requires
 such transfers to materialize as authenticated shared or remote copy
 provenance before plan commit; a future local-destination transfer record may

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -352,7 +352,9 @@ Requirements:
 - `failed_ranks`, `endpoint_rank`, `dataloader_culprit_ranks`, and
   `stage_culprit_ranks` are validated together. Culprit and endpoint ranks must
   be included in `failed_ranks`; node or resource endpoint IDs must resolve to
-  the endpoint rank through the trusted assignment and resource map.
+  the endpoint rank's node through the trusted assignment and resource map.
+  Rank-bound resources must also match the trusted resource-to-rank binding;
+  node-shared NIC, HCA, and link resources need no artificial rank binding.
 - The orchestration dispatcher allocates `incident_id` once and uses it for
   both the recovery and fault callbacks. The client must not infer correlation
   from callback timing.

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -421,6 +421,33 @@ authenticated control-plane inventory.
 `location_token` is an opaque control-plane reference, not an unchecked path
 that another worker is allowed to open.
 
+Worker inventory is not checkpoint certification. The coordinator consumes a
+separate record from the trusted SCOUT/GEMINI catalog store:
+
+```python
+class CheckpointCertification(TypedDict):
+    schema_version: int
+    certification_id: str
+    run_id: str
+    source_generation: int
+    step: int
+    topology_digest: str
+    checkpoint_source: Literal["gemini", "durable"]
+    checkpoint_id: str | None
+    expected_world_size: int
+    certification_kind: Literal[
+        "dense_consensus",
+        "dynamic_candidate_promotion",
+    ]
+    inventory_event_ids: list[str]
+```
+
+This record is written only after job-wide dense acceptance or the documented
+two-cycle dynamic-catalog promotion. It is not accepted through the worker
+event sink. A worker-declared `recovery_verified` inventory is eligible only
+when a trusted certification matches its run, generation, step, topology,
+source, durable checkpoint ID, world size, and inventory event ID.
+
 ### Local client protocol
 
 ```python
@@ -633,7 +660,9 @@ The `lm-resiliency` client:
 ```python
 class RestartAck(TypedDict):
     intent_id: str
+    run_id: str
     node_id: str
+    agent_id: str
     generation: int
     flushed_step: int
     inventory_event_ids: list[str]
@@ -657,6 +686,11 @@ Previously certified recovery-verified inventory remains eligible without
 promoting unprepared latest state. Missing or failed preparation cannot promote
 `LATEST_GEMINI`; the coordinator must commit a plan using a complete
 recovery-verified source or fail the restart.
+
+The manager transport authenticates the acknowledgement sender. The
+coordinator checks the acknowledgement's run, node, and agent incarnation
+against that authenticated identity and requires the agent to match the
+inventory reporter. Payload identity fields alone are not authentication.
 
 For a crashed or unreachable node, no preparation is assumed.
 
@@ -935,6 +969,13 @@ match its referenced inventory record, and `RECOVERY_VERIFIED` manifests may
 use only recovery-verified inventory evidence. Durable recovery always requires
 a recovery-verified manifest and recovery-verified inventory, even if the
 originating intent allowed latest recovery.
+
+An in-memory or node-local copy is selectable only when its holder remains in
+the next assignment. A departing node's transfer counters in `RestartAck` do
+not by themselves prove that a destination has the bytes. Version 1 requires
+such transfers to materialize as authenticated shared or remote copy
+provenance before plan commit; a future local-destination transfer record may
+extend this without weakening the holder rule.
 
 Preferred source order:
 

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -334,6 +334,9 @@ Requirements:
 - Event admission validates the reporter's node, logical slot, local worker
   count, rank range, and topology digest against that generation's immutable
   `RankAssignment`; worker-supplied rank arithmetic alone is insufficient.
+- Event admission also binds the worker to its registered `AgentIdentity`.
+  Hardware reports are accepted only when the reported node or resource belongs
+  to that agent in the trusted scheduler or infrastructure resource map.
 - The original `SCOUTFaultReport` is preserved without upgrading its
   attribution. A direct `HealthEvent` is normalized to
   `HardwareFaultReport` without upgrading its resource granularity.
@@ -381,6 +384,7 @@ class CheckpointCopy(TypedDict):
     owner_global_rank: int
     checkpoint_step: int
     inventory_event_id: str
+    checkpoint_id: str | None
     holder_node_id: str
     holder_kind: Literal["owner", "peer", "durable"]
     storage_kind: Literal["memory", "node_local", "shared", "remote"]
@@ -407,8 +411,10 @@ Only completed checkpoint slots may appear with `complete=True`.
 validates the complete copy record against the referenced event when assembling
 the recovery manifest. A `CANDIDATE` inventory can be retained for diagnosis
 but is never selected for conservative recovery. Durable copies must use shared
-or remote storage; node-local and in-memory copies remain subject to holder
-health and quarantine.
+or remote storage and carry the opaque durable `checkpoint_id`; that ID must
+match the committed plan. Owner and peer copies do not carry a durable
+checkpoint ID. Node-local and in-memory copies remain subject to holder health
+and quarantine.
 
 `location_token` is an opaque control-plane reference, not an unchecked path
 that another worker is allowed to open.
@@ -508,6 +514,7 @@ Before commit, the coordinator validates:
 - exactly `min_nodes` active logical slots are assigned;
 - at least one assigned node is new to the active membership, because version
   1 uses standby admission as its healthy-group restart edge;
+- every surviving node retains its committed logical slot and rank range;
 - every assigned node is healthy, compatible, and not quarantined;
 - each logical slot is assigned once;
 - active size, local world size, total world size, and topology digest match the
@@ -628,8 +635,13 @@ bounded main-thread path performs the flush and writes the acknowledgement,
 after which the worker remains quiesced.
 
 The coordinator waits only until the intent deadline. Missing or failed
-preparation cannot promote `LATEST_GEMINI`; the coordinator must commit a plan
-using a complete recovery-verified source or fail the restart.
+acknowledgements make the associated latest inventory unavailable. A latest
+manifest may use an inventory event only when the reporting node returned a
+successful acknowledgement for the selected step and included that event ID.
+Previously certified recovery-verified inventory remains eligible without
+promoting unprepared latest state. Missing or failed preparation cannot promote
+`LATEST_GEMINI`; the coordinator must commit a plan using a complete
+recovery-verified source or fail the restart.
 
 For a crashed or unreachable node, no preparation is assumed.
 
@@ -905,7 +917,9 @@ GEMINI plans use owner or peer copies; durable plans use durable copies. Only
 shared or remote storage is independent of holder-node availability. The
 manifest's trust label is not self-authenticating: every selected copy must
 match its referenced inventory record, and `RECOVERY_VERIFIED` manifests may
-use only recovery-verified inventory evidence.
+use only recovery-verified inventory evidence. Durable recovery always requires
+a recovery-verified manifest and recovery-verified inventory, even if the
+originating intent allowed latest recovery.
 
 Preferred source order:
 

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -342,6 +342,10 @@ Requirements:
   `HardwareFaultReport` without upgrading its resource granularity.
 - The coordinator resolves reported ranks through that generation's
   `RankAssignment` and rejects any reported rank outside its committed ranges.
+- `failed_ranks`, `endpoint_rank`, `dataloader_culprit_ranks`, and
+  `stage_culprit_ranks` are validated together. Culprit and endpoint ranks must
+  be included in `failed_ranks`; node or resource endpoint IDs must resolve to
+  the endpoint rank through the trusted assignment and resource map.
 - The orchestration dispatcher allocates `incident_id` once and uses it for
   both the recovery and fault callbacks. The client must not infer correlation
   from callback timing.
@@ -369,6 +373,11 @@ RECOVERY_VERIFIED dominates LATEST_GEMINI
 unavailable required shard dominates locally available state
 missing or stale evidence blocks promotion to a less conservative mode
 ```
+
+A schema-v1 proposal accepts only the known failure kinds `straggler`,
+`data_stall`, `checkpoint_stall`, `hang`, `uncertain`, `sdc`, and
+`machine_unavailable`. Unknown or newly introduced kinds are rejected until a
+new schema defines their recovery semantics.
 
 A worker must never interpret its local `checkpoint_step` as the final global
 step. The coordinator selects one step from the complete job-wide inventory,
@@ -667,7 +676,7 @@ class RestartAck(TypedDict):
     agent_id: str
     generation: int
     flushed_step: int
-    inventory_event_ids: list[str]
+    inventory_event_digests: dict[str, str]  # event ID to canonical SHA-256
     transferred_owner_ranks: list[int]
     transferred_peer_ranks: list[int]
     success: bool
@@ -695,7 +704,9 @@ against that authenticated identity and requires the agent to match the
 inventory reporter. The coordinator also records receipt time outside the
 worker payload and rejects acknowledgements received after
 `prepare_deadline_unix_ms`. Payload identity fields and timestamps alone are
-not authentication.
+not authentication. For latest recovery, the acknowledgement's canonical
+inventory digest must match the exact event used by the manifest; event-ID
+reuse cannot substitute different copies after preparation.
 
 For a crashed or unreachable node, no preparation is assumed.
 
@@ -989,7 +1000,8 @@ The coordinator resolves every rank through the immutable `RankAssignment` for
 the manifest's `source_generation`. An `owner` copy must be held by the node
 that owned that rank in that generation; a `peer` copy must be held elsewhere.
 The source assignment's run, generation, topology digest, and world size must
-match the manifest and plan.
+match the manifest and plan. When source and current generations are equal,
+their assignments must be identical rather than merely share metadata.
 
 Preferred source order:
 

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -288,6 +288,11 @@ deployment inventory. A worker-provided hostname is diagnostic metadata and
 must not be allowed to choose its own quarantine identity. If no stable node
 identity is available, replacement mode should refuse to start.
 
+The trusted resource inventory maps every resource ID to both its stable node
+owner and resource kind (`gpu`, `nic`, `hca`, `link`, or `node`). Worker
+registration proves that an agent may report a resource; it does not allow the
+worker to relabel a GPU as a NIC or another resource class.
+
 The topology digest covers at least the active world size, local worker count,
 framework parallel dimensions, logical rank-to-parallel-coordinate mapping,
 checkpoint schema, and model configuration needed to interpret rank-local
@@ -336,7 +341,8 @@ Requirements:
   `RankAssignment`; worker-supplied rank arithmetic alone is insufficient.
 - Event admission also binds the worker to its registered `AgentIdentity`.
   Hardware reports are accepted only when the reported node or resource belongs
-  to that agent in the trusted scheduler or infrastructure resource map.
+  to that agent and both its node owner and resource kind match the trusted
+  scheduler or infrastructure inventory.
 - The original `SCOUTFaultReport` is preserved without upgrading its
   attribution. A direct `HealthEvent` is normalized to
   `HardwareFaultReport` without upgrading its resource granularity.

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -239,12 +239,12 @@ carry both the current rank mapping and stable infrastructure identities.
 ```python
 class AgentIdentity(TypedDict):
     run_id: str
-    node_id: str              # Stable scheduler or infrastructure identity.
-    agent_id: str             # Unique torchrun agent incarnation.
+    node_id: str  # Stable scheduler or infrastructure identity.
+    agent_id: str  # Unique torchrun agent incarnation.
     hostname: str
     local_world_size: int
-    resource_ids: list[str]   # GPU UUIDs, NICs, HCAs, or deployment IDs.
-    environment_digest: str   # Software, configuration, and capability identity.
+    resource_ids: list[str]  # GPU UUIDs, NICs, HCAs, or deployment IDs.
+    environment_digest: str  # Software, configuration, and capability identity.
 
 
 class WorkerIdentity(TypedDict):
@@ -252,7 +252,7 @@ class WorkerIdentity(TypedDict):
     generation: int
     node_id: str
     agent_id: str
-    logical_node_slot: int    # Stable for the lifetime of the training job.
+    logical_node_slot: int  # Stable for the lifetime of the training job.
     global_rank: int
     local_rank: int
     local_world_size: int

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -690,7 +690,10 @@ recovery-verified source or fail the restart.
 The manager transport authenticates the acknowledgement sender. The
 coordinator checks the acknowledgement's run, node, and agent incarnation
 against that authenticated identity and requires the agent to match the
-inventory reporter. Payload identity fields alone are not authentication.
+inventory reporter. The coordinator also records receipt time outside the
+worker payload and rejects acknowledgements received after
+`prepare_deadline_unix_ms`. Payload identity fields and timestamps alone are
+not authentication.
 
 For a crashed or unreachable node, no preparation is assumed.
 
@@ -976,6 +979,12 @@ not by themselves prove that a destination has the bytes. Version 1 requires
 such transfers to materialize as authenticated shared or remote copy
 provenance before plan commit; a future local-destination transfer record may
 extend this without weakening the holder rule.
+
+The coordinator resolves every rank through the immutable `RankAssignment` for
+the manifest's `source_generation`. An `owner` copy must be held by the node
+that owned that rank in that generation; a `peer` copy must be held elsewhere.
+The source assignment's run, generation, topology digest, and world size must
+match the manifest and plan.
 
 Preferred source order:
 

--- a/lm_resiliency/integrations/torchrun/__init__.py
+++ b/lm_resiliency/integrations/torchrun/__init__.py
@@ -1,0 +1,5 @@
+"""Internal torchrun resiliency integration.
+
+The integration is intentionally not exported until its recovery and
+rendezvous paths are complete.
+"""

--- a/lm_resiliency/integrations/torchrun/_protocol.py
+++ b/lm_resiliency/integrations/torchrun/_protocol.py
@@ -2011,9 +2011,15 @@ class RestartContext(_WireRecord):
         environment: Mapping[str, str],
         *,
         committed_plan: RestartPlan,
+        now_unix_ms: int,
     ) -> None:
         if not isinstance(committed_plan, RestartPlan):
             raise ProtocolValidationError("committed_plan: expected RestartPlan")
+        _integer(now_unix_ms, "now_unix_ms", minimum=1)
+        if committed_plan.restart_deadline_unix_ms <= now_unix_ms:
+            raise ProtocolValidationError(
+                "RestartPlan.restart_deadline_unix_ms: deadline has elapsed"
+            )
         expected_context = RestartContext.from_plan(committed_plan, self.node_id)
         if self != expected_context:
             raise ProtocolValidationError(
@@ -2909,6 +2915,10 @@ def validate_restart_plan(
         if not eligible_copies:
             raise ProtocolValidationError(
                 f"RecoveryManifest.rank_copies[{rank}]: no complete eligible copy"
+            )
+        if len(eligible_copies) != len(entry.copies):
+            raise ProtocolValidationError(
+                f"RecoveryManifest.rank_copies[{rank}]: contains an ineligible copy"
             )
 
 

--- a/lm_resiliency/integrations/torchrun/_protocol.py
+++ b/lm_resiliency/integrations/torchrun/_protocol.py
@@ -2318,6 +2318,18 @@ def validate_restart_plan(
         )
     current_nodes = set(current_assignment.slot_to_node_id.values())
     assigned_nodes = {assignment.node_id for assignment in plan.slot_assignments}
+    suspected_nodes = set(intent.suspected_node_ids)
+    unknown_suspects = sorted(suspected_nodes - current_nodes)
+    if unknown_suspects:
+        raise ProtocolValidationError(
+            "RestartIntent.suspected_node_ids: nodes are not active in the committed "
+            f"generation: {unknown_suspects!r}"
+        )
+    retained_suspects = sorted(suspected_nodes & assigned_nodes)
+    if retained_suspects:
+        raise ProtocolValidationError(
+            f"RestartPlan.slot_assignments: suspected nodes remain assigned: {retained_suspects!r}"
+        )
     current_slots_by_node = {
         node_id: slot for slot, node_id in current_assignment.slot_to_node_id.items()
     }

--- a/lm_resiliency/integrations/torchrun/_protocol.py
+++ b/lm_resiliency/integrations/torchrun/_protocol.py
@@ -2415,6 +2415,8 @@ def validate_restart_plan(
     trusted_certifications: Sequence[CheckpointCertification],
     restart_acks: Sequence[RestartAck],
     authenticated_ack_agent_ids: Mapping[str, str],
+    authenticated_ack_received_unix_ms: Mapping[str, int],
+    source_assignment: RankAssignment,
     current_assignment: RankAssignment,
     now_unix_ms: int,
     eligible_node_ids: Sequence[str],
@@ -2528,6 +2530,24 @@ def validate_restart_plan(
         raise ProtocolValidationError(
             "RecoveryManifest.topology_digest: does not match restart plan"
         )
+    if source_assignment.run_id != manifest.run_id:
+        raise ProtocolValidationError("source_assignment.run_id: does not match recovery manifest")
+    if source_assignment.generation != manifest.source_generation:
+        raise ProtocolValidationError(
+            "source_assignment.generation: does not match recovery manifest"
+        )
+    if source_assignment.topology_digest != manifest.topology_digest:
+        raise ProtocolValidationError(
+            "source_assignment.topology_digest: does not match recovery manifest"
+        )
+    source_world_size = source_assignment.active_nodes * source_assignment.local_world_size
+    if source_world_size != plan.expected_world_size:
+        raise ProtocolValidationError("source_assignment: world size does not match restart plan")
+    source_owner_by_rank = {
+        rank: source_assignment.slot_to_node_id[slot]
+        for slot, (first_rank, last_rank) in source_assignment.slot_to_rank_range.items()
+        for rank in range(first_rank, last_rank)
+    }
     if plan.recovery_mode == "recovery_verified" and manifest.trust != "recovery_verified":
         raise ProtocolValidationError(
             "RecoveryManifest.trust: verified recovery requires a verified manifest"
@@ -2581,6 +2601,16 @@ def validate_restart_plan(
         )
         for node_id, agent_id in authenticated_ack_agent_ids.items()
     }
+    if not isinstance(authenticated_ack_received_unix_ms, Mapping):
+        raise ProtocolValidationError("authenticated_ack_received_unix_ms: expected an object")
+    authenticated_ack_receipts = {
+        _string(node_id, "authenticated_ack_received_unix_ms.key"): _integer(
+            received_unix_ms,
+            f"authenticated_ack_received_unix_ms[{node_id!r}]",
+            minimum=1,
+        )
+        for node_id, received_unix_ms in authenticated_ack_received_unix_ms.items()
+    }
     ack_by_node: dict[str, RestartAck] = {}
     for index, ack in enumerate(_sequence(restart_acks, "restart_acks")):
         if not isinstance(ack, RestartAck):
@@ -2607,10 +2637,24 @@ def validate_restart_plan(
             raise ProtocolValidationError(
                 f"restart_acks[{index}].agent_id: does not match authenticated transport sender"
             )
+        received_unix_ms = authenticated_ack_receipts.get(ack.node_id)
+        if received_unix_ms is None:
+            raise ProtocolValidationError(
+                f"restart_acks[{index}]: missing authenticated receipt time"
+            )
+        if received_unix_ms > intent.prepare_deadline_unix_ms:
+            raise ProtocolValidationError(
+                f"restart_acks[{index}]: received after restart intent deadline"
+            )
         ack_by_node[ack.node_id] = ack
     if set(authenticated_ack_agents) != set(ack_by_node):
         raise ProtocolValidationError(
             "authenticated_ack_agent_ids: bindings must exactly match submitted acknowledgements"
+        )
+    if set(authenticated_ack_receipts) != set(ack_by_node):
+        raise ProtocolValidationError(
+            "authenticated_ack_received_unix_ms: receipts must exactly match "
+            "submitted acknowledgements"
         )
     entries = {entry.owner_global_rank: entry for entry in manifest.rank_copies}
     required_ranks = set(range(plan.expected_world_size))
@@ -2638,6 +2682,16 @@ def validate_restart_plan(
                 certified_inventory_event_ids,
             )
             and copy.holder_kind in compatible_holder_kinds
+            and (
+                copy.holder_kind == "durable"
+                or (
+                    copy.holder_kind == "owner"
+                    and copy.holder_node_id == source_owner_by_rank[rank]
+                )
+                or (
+                    copy.holder_kind == "peer" and copy.holder_node_id != source_owner_by_rank[rank]
+                )
+            )
             and copy.checkpoint_id == plan.checkpoint_id
             and (copy.storage_kind in {"shared", "remote"} or copy.holder_node_id in assigned_nodes)
         ]

--- a/lm_resiliency/integrations/torchrun/_protocol.py
+++ b/lm_resiliency/integrations/torchrun/_protocol.py
@@ -2560,7 +2560,11 @@ def validate_event_reporter(
                     "FaultEvent.report.endpoint_id: trusted resource kind does not match "
                     "endpoint kind"
                 )
-            elif resource_ranks.get(endpoint_id) != endpoint_rank:
+            elif endpoint_kind == "gpu" and endpoint_id not in resource_ranks:
+                raise ProtocolValidationError(
+                    "FaultEvent.report.endpoint_id: trusted GPU resource rank is missing"
+                )
+            elif endpoint_id in resource_ranks and resource_ranks[endpoint_id] != endpoint_rank:
                 raise ProtocolValidationError(
                     "FaultEvent.report.endpoint_id: trusted resource rank does not match "
                     "endpoint rank"

--- a/lm_resiliency/integrations/torchrun/_protocol.py
+++ b/lm_resiliency/integrations/torchrun/_protocol.py
@@ -580,8 +580,13 @@ class RankAssignment(_WireRecord):
 def _slot_key(value: object, path: str) -> int:
     if isinstance(value, int) and not isinstance(value, bool):
         return _integer(value, path, minimum=0)
-    if isinstance(value, str) and value.isdigit():
-        return int(value)
+    if isinstance(value, str) and value and value.isascii() and value.isdecimal():
+        try:
+            return int(value)
+        except ValueError as error:
+            raise ProtocolValidationError(
+                f"{path}: slot keys must be parseable non-negative integers"
+            ) from error
     raise ProtocolValidationError(f"{path}: slot keys must be non-negative integers")
 
 

--- a/lm_resiliency/integrations/torchrun/_protocol.py
+++ b/lm_resiliency/integrations/torchrun/_protocol.py
@@ -1242,6 +1242,144 @@ class CheckpointInventoryEvent(_WireRecord):
 
 
 @dataclass(frozen=True, slots=True)
+class CheckpointCertification(_WireRecord):
+    certification_id: str
+    run_id: str
+    source_generation: int
+    step: int
+    topology_digest: str
+    checkpoint_source: str
+    checkpoint_id: str | None
+    expected_world_size: int
+    certification_kind: str
+    inventory_event_ids: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        _string(self.certification_id, "CheckpointCertification.certification_id")
+        _string(self.run_id, "CheckpointCertification.run_id")
+        _integer(
+            self.source_generation,
+            "CheckpointCertification.source_generation",
+            minimum=0,
+        )
+        _integer(self.step, "CheckpointCertification.step", minimum=1)
+        _string(self.topology_digest, "CheckpointCertification.topology_digest")
+        _choice(
+            self.checkpoint_source,
+            "CheckpointCertification.checkpoint_source",
+            {"gemini", "durable"},
+        )
+        _optional_string(self.checkpoint_id, "CheckpointCertification.checkpoint_id")
+        if self.checkpoint_source == "durable" and self.checkpoint_id is None:
+            raise ProtocolValidationError(
+                "CheckpointCertification.checkpoint_id: durable certification requires an ID"
+            )
+        if self.checkpoint_source == "gemini" and self.checkpoint_id is not None:
+            raise ProtocolValidationError(
+                "CheckpointCertification.checkpoint_id: GEMINI certification must not set an ID"
+            )
+        _integer(
+            self.expected_world_size,
+            "CheckpointCertification.expected_world_size",
+            minimum=1,
+        )
+        _choice(
+            self.certification_kind,
+            "CheckpointCertification.certification_kind",
+            {"dense_consensus", "dynamic_candidate_promotion"},
+        )
+        event_ids = _strings(
+            self.inventory_event_ids,
+            "CheckpointCertification.inventory_event_ids",
+            unique=True,
+        )
+        if not event_ids:
+            raise ProtocolValidationError(
+                "CheckpointCertification.inventory_event_ids: at least one event is required"
+            )
+        object.__setattr__(self, "inventory_event_ids", event_ids)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "certification_id": self.certification_id,
+            "run_id": self.run_id,
+            "source_generation": self.source_generation,
+            "step": self.step,
+            "topology_digest": self.topology_digest,
+            "checkpoint_source": self.checkpoint_source,
+            "checkpoint_id": self.checkpoint_id,
+            "expected_world_size": self.expected_world_size,
+            "certification_kind": self.certification_kind,
+            "inventory_event_ids": list(self.inventory_event_ids),
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> CheckpointCertification:
+        _record_fields(
+            value,
+            path=cls.__name__,
+            required={
+                "certification_id",
+                "run_id",
+                "source_generation",
+                "step",
+                "topology_digest",
+                "checkpoint_source",
+                "checkpoint_id",
+                "expected_world_size",
+                "certification_kind",
+                "inventory_event_ids",
+            },
+        )
+        return cls(
+            certification_id=_string(
+                value["certification_id"],
+                "CheckpointCertification.certification_id",
+            ),
+            run_id=_string(value["run_id"], "CheckpointCertification.run_id"),
+            source_generation=_integer(
+                value["source_generation"],
+                "CheckpointCertification.source_generation",
+                minimum=0,
+            ),
+            step=_integer(
+                value["step"],
+                "CheckpointCertification.step",
+                minimum=1,
+            ),
+            topology_digest=_string(
+                value["topology_digest"],
+                "CheckpointCertification.topology_digest",
+            ),
+            checkpoint_source=_choice(
+                value["checkpoint_source"],
+                "CheckpointCertification.checkpoint_source",
+                {"gemini", "durable"},
+            ),
+            checkpoint_id=_optional_string(
+                value["checkpoint_id"],
+                "CheckpointCertification.checkpoint_id",
+            ),
+            expected_world_size=_integer(
+                value["expected_world_size"],
+                "CheckpointCertification.expected_world_size",
+                minimum=1,
+            ),
+            certification_kind=_choice(
+                value["certification_kind"],
+                "CheckpointCertification.certification_kind",
+                {"dense_consensus", "dynamic_candidate_promotion"},
+            ),
+            inventory_event_ids=_strings(
+                value["inventory_event_ids"],
+                "CheckpointCertification.inventory_event_ids",
+                unique=True,
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class RestartIntent(_WireRecord):
     intent_id: str
     run_id: str
@@ -1353,7 +1491,9 @@ class RestartIntent(_WireRecord):
 @dataclass(frozen=True, slots=True)
 class RestartAck(_WireRecord):
     intent_id: str
+    run_id: str
     node_id: str
+    agent_id: str
     generation: int
     flushed_step: int
     inventory_event_ids: tuple[str, ...]
@@ -1364,7 +1504,9 @@ class RestartAck(_WireRecord):
 
     def __post_init__(self) -> None:
         _string(self.intent_id, "RestartAck.intent_id")
+        _string(self.run_id, "RestartAck.run_id")
         _string(self.node_id, "RestartAck.node_id")
+        _string(self.agent_id, "RestartAck.agent_id")
         _integer(self.generation, "RestartAck.generation", minimum=0)
         _integer(self.flushed_step, "RestartAck.flushed_step", minimum=-1)
         object.__setattr__(
@@ -1407,7 +1549,9 @@ class RestartAck(_WireRecord):
         return {
             "schema_version": self.SCHEMA_VERSION,
             "intent_id": self.intent_id,
+            "run_id": self.run_id,
             "node_id": self.node_id,
+            "agent_id": self.agent_id,
             "generation": self.generation,
             "flushed_step": self.flushed_step,
             "inventory_event_ids": list(self.inventory_event_ids),
@@ -1424,7 +1568,9 @@ class RestartAck(_WireRecord):
             path=cls.__name__,
             required={
                 "intent_id",
+                "run_id",
                 "node_id",
+                "agent_id",
                 "generation",
                 "flushed_step",
                 "inventory_event_ids",
@@ -1436,7 +1582,9 @@ class RestartAck(_WireRecord):
         )
         return cls(
             intent_id=_string(value["intent_id"], "RestartAck.intent_id"),
+            run_id=_string(value["run_id"], "RestartAck.run_id"),
             node_id=_string(value["node_id"], "RestartAck.node_id"),
+            agent_id=_string(value["agent_id"], "RestartAck.agent_id"),
             generation=_integer(
                 value["generation"],
                 "RestartAck.generation",
@@ -2264,7 +2412,9 @@ def validate_restart_plan(
     manifest: RecoveryManifest,
     *,
     inventory_events: Sequence[CheckpointInventoryEvent],
+    trusted_certifications: Sequence[CheckpointCertification],
     restart_acks: Sequence[RestartAck],
+    authenticated_ack_agent_ids: Mapping[str, str],
     current_assignment: RankAssignment,
     now_unix_ms: int,
     eligible_node_ids: Sequence[str],
@@ -2397,6 +2547,40 @@ def validate_restart_plan(
                 f"inventory_events: duplicate event ID {event.event_id!r}"
             )
         inventory_by_id[event.event_id] = event
+    certification_ids: set[str] = set()
+    certified_inventory_event_ids: set[str] = set()
+    for index, certification in enumerate(
+        _sequence(trusted_certifications, "trusted_certifications")
+    ):
+        if not isinstance(certification, CheckpointCertification):
+            raise ProtocolValidationError(
+                f"trusted_certifications[{index}]: expected CheckpointCertification"
+            )
+        if certification.certification_id in certification_ids:
+            raise ProtocolValidationError(
+                "trusted_certifications: duplicate certification ID "
+                f"{certification.certification_id!r}"
+            )
+        certification_ids.add(certification.certification_id)
+        if (
+            certification.run_id == manifest.run_id
+            and certification.source_generation == manifest.source_generation
+            and certification.step == manifest.step
+            and certification.topology_digest == manifest.topology_digest
+            and certification.checkpoint_source == plan.checkpoint_source
+            and certification.checkpoint_id == plan.checkpoint_id
+            and certification.expected_world_size == plan.expected_world_size
+        ):
+            certified_inventory_event_ids.update(certification.inventory_event_ids)
+    if not isinstance(authenticated_ack_agent_ids, Mapping):
+        raise ProtocolValidationError("authenticated_ack_agent_ids: expected an object")
+    authenticated_ack_agents = {
+        _string(node_id, "authenticated_ack_agent_ids.key"): _string(
+            agent_id,
+            f"authenticated_ack_agent_ids[{node_id!r}]",
+        )
+        for node_id, agent_id in authenticated_ack_agent_ids.items()
+    }
     ack_by_node: dict[str, RestartAck] = {}
     for index, ack in enumerate(_sequence(restart_acks, "restart_acks")):
         if not isinstance(ack, RestartAck):
@@ -2407,6 +2591,10 @@ def validate_restart_plan(
             raise ProtocolValidationError(
                 f"restart_acks[{index}].intent_id: does not match restart intent"
             )
+        if ack.run_id != intent.run_id:
+            raise ProtocolValidationError(
+                f"restart_acks[{index}].run_id: does not match restart intent"
+            )
         if ack.generation != intent.generation:
             raise ProtocolValidationError(
                 f"restart_acks[{index}].generation: does not match restart intent"
@@ -2415,7 +2603,15 @@ def validate_restart_plan(
             raise ProtocolValidationError(
                 f"restart_acks[{index}].node_id: is not active in the committed generation"
             )
+        if authenticated_ack_agents.get(ack.node_id) != ack.agent_id:
+            raise ProtocolValidationError(
+                f"restart_acks[{index}].agent_id: does not match authenticated transport sender"
+            )
         ack_by_node[ack.node_id] = ack
+    if set(authenticated_ack_agents) != set(ack_by_node):
+        raise ProtocolValidationError(
+            "authenticated_ack_agent_ids: bindings must exactly match submitted acknowledgements"
+        )
     entries = {entry.owner_global_rank: entry for entry in manifest.rank_copies}
     required_ranks = set(range(plan.expected_world_size))
     if set(entries) != required_ranks:
@@ -2439,13 +2635,11 @@ def validate_restart_plan(
                 manifest,
                 inventory_by_id,
                 ack_by_node,
+                certified_inventory_event_ids,
             )
             and copy.holder_kind in compatible_holder_kinds
             and copy.checkpoint_id == plan.checkpoint_id
-            and (
-                copy.storage_kind in {"shared", "remote"}
-                or (copy.holder_node_id in eligible and copy.holder_node_id not in quarantined)
-            )
+            and (copy.storage_kind in {"shared", "remote"} or copy.holder_node_id in assigned_nodes)
         ]
         if not eligible_copies:
             raise ProtocolValidationError(
@@ -2458,6 +2652,7 @@ def _copy_has_trusted_inventory_provenance(
     manifest: RecoveryManifest,
     inventory_by_id: Mapping[str, CheckpointInventoryEvent],
     ack_by_node: Mapping[str, RestartAck],
+    certified_inventory_event_ids: set[str],
 ) -> bool:
     event = inventory_by_id.get(copy.inventory_event_id)
     if event is None:
@@ -2479,11 +2674,12 @@ def _copy_has_trusted_inventory_provenance(
     ):
         return False
     if manifest.trust != "latest":
-        return True
+        return event.event_id in certified_inventory_event_ids
     ack = ack_by_node.get(event.reporter.node_id)
     return (
         ack is not None
         and ack.success
+        and ack.agent_id == event.reporter.agent_id
         and ack.flushed_step == manifest.step
         and event.event_id in ack.inventory_event_ids
     )
@@ -2491,6 +2687,7 @@ def _copy_has_trusted_inventory_provenance(
 
 __all__ = [
     "AgentIdentity",
+    "CheckpointCertification",
     "CheckpointCopy",
     "CheckpointInventoryEvent",
     "FaultEvent",

--- a/lm_resiliency/integrations/torchrun/_protocol.py
+++ b/lm_resiliency/integrations/torchrun/_protocol.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import math
 from collections.abc import Mapping, Sequence
@@ -1252,7 +1253,7 @@ class CheckpointCertification(_WireRecord):
     checkpoint_id: str | None
     expected_world_size: int
     certification_kind: str
-    inventory_event_ids: tuple[str, ...]
+    inventory_event_digests: Mapping[str, str]
 
     def __post_init__(self) -> None:
         _string(self.certification_id, "CheckpointCertification.certification_id")
@@ -1288,16 +1289,29 @@ class CheckpointCertification(_WireRecord):
             "CheckpointCertification.certification_kind",
             {"dense_consensus", "dynamic_candidate_promotion"},
         )
-        event_ids = _strings(
-            self.inventory_event_ids,
-            "CheckpointCertification.inventory_event_ids",
-            unique=True,
-        )
-        if not event_ids:
+        if not isinstance(self.inventory_event_digests, Mapping):
             raise ProtocolValidationError(
-                "CheckpointCertification.inventory_event_ids: at least one event is required"
+                "CheckpointCertification.inventory_event_digests: expected an object"
             )
-        object.__setattr__(self, "inventory_event_ids", event_ids)
+        event_digests = {
+            _string(
+                event_id,
+                "CheckpointCertification.inventory_event_digests.key",
+            ): _sha256_digest(
+                digest,
+                f"CheckpointCertification.inventory_event_digests[{event_id!r}]",
+            )
+            for event_id, digest in self.inventory_event_digests.items()
+        }
+        if not event_digests:
+            raise ProtocolValidationError(
+                "CheckpointCertification.inventory_event_digests: at least one event is required"
+            )
+        object.__setattr__(
+            self,
+            "inventory_event_digests",
+            MappingProxyType(dict(sorted(event_digests.items()))),
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -1311,7 +1325,7 @@ class CheckpointCertification(_WireRecord):
             "checkpoint_id": self.checkpoint_id,
             "expected_world_size": self.expected_world_size,
             "certification_kind": self.certification_kind,
-            "inventory_event_ids": list(self.inventory_event_ids),
+            "inventory_event_digests": dict(self.inventory_event_digests),
         }
 
     @classmethod
@@ -1329,7 +1343,7 @@ class CheckpointCertification(_WireRecord):
                 "checkpoint_id",
                 "expected_world_size",
                 "certification_kind",
-                "inventory_event_ids",
+                "inventory_event_digests",
             },
         )
         return cls(
@@ -1371,12 +1385,27 @@ class CheckpointCertification(_WireRecord):
                 "CheckpointCertification.certification_kind",
                 {"dense_consensus", "dynamic_candidate_promotion"},
             ),
-            inventory_event_ids=_strings(
-                value["inventory_event_ids"],
-                "CheckpointCertification.inventory_event_ids",
-                unique=True,
+            inventory_event_digests=_require_mapping(
+                value["inventory_event_digests"],
+                "CheckpointCertification.inventory_event_digests",
             ),
         )
+
+
+def _sha256_digest(value: object, path: str) -> str:
+    digest = _string(value, path)
+    if len(digest) != 64 or any(character not in "0123456789abcdef" for character in digest):
+        raise ProtocolValidationError(f"{path}: expected a lowercase SHA-256 digest")
+    return digest
+
+
+def checkpoint_inventory_digest(event: CheckpointInventoryEvent) -> str:
+    """Return the canonical digest stored by trusted checkpoint certification."""
+    if not isinstance(event, CheckpointInventoryEvent):
+        raise ProtocolValidationError(
+            "checkpoint_inventory_digest.event: expected CheckpointInventoryEvent"
+        )
+    return hashlib.sha256(event.to_json().encode("utf-8")).hexdigest()
 
 
 @dataclass(frozen=True, slots=True)
@@ -2568,7 +2597,7 @@ def validate_restart_plan(
             )
         inventory_by_id[event.event_id] = event
     certification_ids: set[str] = set()
-    certified_inventory_event_ids: set[str] = set()
+    certified_inventory_event_digests: dict[str, str] = {}
     for index, certification in enumerate(
         _sequence(trusted_certifications, "trusted_certifications")
     ):
@@ -2591,7 +2620,14 @@ def validate_restart_plan(
             and certification.checkpoint_id == plan.checkpoint_id
             and certification.expected_world_size == plan.expected_world_size
         ):
-            certified_inventory_event_ids.update(certification.inventory_event_ids)
+            for event_id, digest in certification.inventory_event_digests.items():
+                previous_digest = certified_inventory_event_digests.get(event_id)
+                if previous_digest is not None and previous_digest != digest:
+                    raise ProtocolValidationError(
+                        "trusted_certifications: conflicting digests for inventory event "
+                        f"{event_id!r}"
+                    )
+                certified_inventory_event_digests[event_id] = digest
     if not isinstance(authenticated_ack_agent_ids, Mapping):
         raise ProtocolValidationError("authenticated_ack_agent_ids: expected an object")
     authenticated_ack_agents = {
@@ -2679,7 +2715,7 @@ def validate_restart_plan(
                 manifest,
                 inventory_by_id,
                 ack_by_node,
-                certified_inventory_event_ids,
+                certified_inventory_event_digests,
             )
             and copy.holder_kind in compatible_holder_kinds
             and (
@@ -2706,7 +2742,7 @@ def _copy_has_trusted_inventory_provenance(
     manifest: RecoveryManifest,
     inventory_by_id: Mapping[str, CheckpointInventoryEvent],
     ack_by_node: Mapping[str, RestartAck],
-    certified_inventory_event_ids: set[str],
+    certified_inventory_event_digests: Mapping[str, str],
 ) -> bool:
     event = inventory_by_id.get(copy.inventory_event_id)
     if event is None:
@@ -2728,7 +2764,9 @@ def _copy_has_trusted_inventory_provenance(
     ):
         return False
     if manifest.trust != "latest":
-        return event.event_id in certified_inventory_event_ids
+        return certified_inventory_event_digests.get(event.event_id) == checkpoint_inventory_digest(
+            event
+        )
     ack = ack_by_node.get(event.reporter.node_id)
     return (
         ack is not None
@@ -2757,6 +2795,7 @@ __all__ = [
     "RestartPlan",
     "SlotAssignment",
     "WorkerIdentity",
+    "checkpoint_inventory_digest",
     "validate_restart_plan",
     "validate_event_reporter",
     "validate_worker_identity",

--- a/lm_resiliency/integrations/torchrun/_protocol.py
+++ b/lm_resiliency/integrations/torchrun/_protocol.py
@@ -1,0 +1,2137 @@
+"""Strict internal wire records for torchrun standby replacement."""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, ClassVar, Literal, TypeVar
+
+RecoveryModeValue = Literal["latest", "recovery_verified"]
+CheckpointSource = Literal["gemini", "durable"]
+CheckpointTrust = Literal["latest", "candidate", "recovery_verified"]
+RecoveryManifestTrust = Literal["latest", "recovery_verified"]
+
+_T = TypeVar("_T", bound="_WireRecord")
+
+
+class ProtocolValidationError(ValueError):
+    """Raised when an untrusted torchrun protocol record is invalid."""
+
+
+class _WireRecord:
+    SCHEMA_VERSION: ClassVar[int] = 1
+
+    def to_dict(self) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def to_json(self) -> str:
+        return json.dumps(
+            self.to_dict(),
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+
+    @classmethod
+    def from_json(cls: type[_T], encoded: str | bytes | bytearray) -> _T:
+        try:
+            value = json.loads(encoded)
+        except (TypeError, ValueError) as error:
+            raise ProtocolValidationError(f"{cls.__name__}: invalid JSON") from error
+        return cls.from_dict(_require_mapping(value, cls.__name__))  # type: ignore[attr-defined]
+
+
+def _require_mapping(value: object, path: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ProtocolValidationError(f"{path}: expected an object")
+    if not all(isinstance(key, str) for key in value):
+        raise ProtocolValidationError(f"{path}: object keys must be strings")
+    return value
+
+
+def _record_fields(
+    value: Mapping[str, Any],
+    *,
+    path: str,
+    required: set[str],
+    optional: set[str] | None = None,
+    schema_version: int = 1,
+) -> None:
+    optional = optional or set()
+    actual_schema = value.get("schema_version")
+    if isinstance(actual_schema, bool) or actual_schema != schema_version:
+        raise ProtocolValidationError(
+            f"{path}.schema_version: unsupported value {actual_schema!r}; expected {schema_version}"
+        )
+    expected = required | optional | {"schema_version"}
+    missing = required - set(value)
+    unknown = set(value) - expected
+    if missing:
+        raise ProtocolValidationError(f"{path}: missing fields {sorted(missing)!r}")
+    if unknown:
+        raise ProtocolValidationError(f"{path}: unknown fields {sorted(unknown)!r}")
+
+
+def _string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ProtocolValidationError(f"{path}: expected a non-empty string")
+    return value
+
+
+def _optional_string(value: object, path: str) -> str | None:
+    if value is None:
+        return None
+    return _string(value, path)
+
+
+def _integer(value: object, path: str, *, minimum: int | None = None) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ProtocolValidationError(f"{path}: expected an integer")
+    if minimum is not None and value < minimum:
+        raise ProtocolValidationError(f"{path}: expected a value >= {minimum}")
+    return value
+
+
+def _boolean(value: object, path: str) -> bool:
+    if not isinstance(value, bool):
+        raise ProtocolValidationError(f"{path}: expected a boolean")
+    return value
+
+
+def _choice(value: object, path: str, choices: set[str]) -> str:
+    selected = _string(value, path)
+    if selected not in choices:
+        raise ProtocolValidationError(
+            f"{path}: unsupported value {selected!r}; expected one of {sorted(choices)!r}"
+        )
+    return selected
+
+
+def _sequence(value: object, path: str) -> Sequence[Any]:
+    if isinstance(value, (str, bytes, bytearray)) or not isinstance(value, Sequence):
+        raise ProtocolValidationError(f"{path}: expected an array")
+    return value
+
+
+def _strings(value: object, path: str, *, unique: bool = False) -> tuple[str, ...]:
+    result = tuple(
+        _string(item, f"{path}[{index}]") for index, item in enumerate(_sequence(value, path))
+    )
+    if unique and len(result) != len(set(result)):
+        raise ProtocolValidationError(f"{path}: values must be unique")
+    return result
+
+
+def _integers(
+    value: object,
+    path: str,
+    *,
+    minimum: int | None = None,
+    unique: bool = False,
+) -> tuple[int, ...]:
+    result = tuple(
+        _integer(item, f"{path}[{index}]", minimum=minimum)
+        for index, item in enumerate(_sequence(value, path))
+    )
+    if unique and len(result) != len(set(result)):
+        raise ProtocolValidationError(f"{path}: values must be unique")
+    return result
+
+
+def _freeze_json(value: object, path: str) -> object:
+    if value is None or isinstance(value, (bool, str)):
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ProtocolValidationError(f"{path}: floating-point values must be finite")
+        return value
+    if isinstance(value, Mapping):
+        if not all(isinstance(key, str) for key in value):
+            raise ProtocolValidationError(f"{path}: object keys must be strings")
+        return MappingProxyType(
+            {key: _freeze_json(item, f"{path}.{key}") for key, item in value.items()}
+        )
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return tuple(_freeze_json(item, f"{path}[{index}]") for index, item in enumerate(value))
+    raise ProtocolValidationError(f"{path}: value is not JSON-serializable")
+
+
+def _thaw_json(value: object) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _thaw_json(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw_json(item) for item in value]
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class AgentIdentity(_WireRecord):
+    run_id: str
+    node_id: str
+    agent_id: str
+    hostname: str
+    local_world_size: int
+    resource_ids: tuple[str, ...]
+    environment_digest: str
+
+    def __post_init__(self) -> None:
+        _string(self.run_id, "AgentIdentity.run_id")
+        _string(self.node_id, "AgentIdentity.node_id")
+        _string(self.agent_id, "AgentIdentity.agent_id")
+        _string(self.hostname, "AgentIdentity.hostname")
+        _integer(self.local_world_size, "AgentIdentity.local_world_size", minimum=1)
+        object.__setattr__(
+            self,
+            "resource_ids",
+            _strings(self.resource_ids, "AgentIdentity.resource_ids", unique=True),
+        )
+        _string(self.environment_digest, "AgentIdentity.environment_digest")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "run_id": self.run_id,
+            "node_id": self.node_id,
+            "agent_id": self.agent_id,
+            "hostname": self.hostname,
+            "local_world_size": self.local_world_size,
+            "resource_ids": list(self.resource_ids),
+            "environment_digest": self.environment_digest,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> AgentIdentity:
+        _record_fields(
+            value,
+            path=cls.__name__,
+            required={
+                "run_id",
+                "node_id",
+                "agent_id",
+                "hostname",
+                "local_world_size",
+                "resource_ids",
+                "environment_digest",
+            },
+        )
+        return cls(
+            run_id=_string(value["run_id"], "AgentIdentity.run_id"),
+            node_id=_string(value["node_id"], "AgentIdentity.node_id"),
+            agent_id=_string(value["agent_id"], "AgentIdentity.agent_id"),
+            hostname=_string(value["hostname"], "AgentIdentity.hostname"),
+            local_world_size=_integer(
+                value["local_world_size"],
+                "AgentIdentity.local_world_size",
+                minimum=1,
+            ),
+            resource_ids=_strings(
+                value["resource_ids"],
+                "AgentIdentity.resource_ids",
+                unique=True,
+            ),
+            environment_digest=_string(
+                value["environment_digest"],
+                "AgentIdentity.environment_digest",
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerIdentity(_WireRecord):
+    run_id: str
+    generation: int
+    node_id: str
+    agent_id: str
+    logical_node_slot: int
+    global_rank: int
+    local_rank: int
+    local_world_size: int
+    hostname: str
+    gpu_uuid: str | None
+    topology_digest: str
+
+    def __post_init__(self) -> None:
+        _string(self.run_id, "WorkerIdentity.run_id")
+        _integer(self.generation, "WorkerIdentity.generation", minimum=0)
+        _string(self.node_id, "WorkerIdentity.node_id")
+        _string(self.agent_id, "WorkerIdentity.agent_id")
+        _integer(self.logical_node_slot, "WorkerIdentity.logical_node_slot", minimum=0)
+        _integer(self.global_rank, "WorkerIdentity.global_rank", minimum=0)
+        _integer(self.local_rank, "WorkerIdentity.local_rank", minimum=0)
+        _integer(self.local_world_size, "WorkerIdentity.local_world_size", minimum=1)
+        if self.local_rank >= self.local_world_size:
+            raise ProtocolValidationError(
+                "WorkerIdentity.local_rank: must be smaller than local_world_size"
+            )
+        _string(self.hostname, "WorkerIdentity.hostname")
+        _optional_string(self.gpu_uuid, "WorkerIdentity.gpu_uuid")
+        _string(self.topology_digest, "WorkerIdentity.topology_digest")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "run_id": self.run_id,
+            "generation": self.generation,
+            "node_id": self.node_id,
+            "agent_id": self.agent_id,
+            "logical_node_slot": self.logical_node_slot,
+            "global_rank": self.global_rank,
+            "local_rank": self.local_rank,
+            "local_world_size": self.local_world_size,
+            "hostname": self.hostname,
+            "gpu_uuid": self.gpu_uuid,
+            "topology_digest": self.topology_digest,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> WorkerIdentity:
+        _record_fields(
+            value,
+            path=cls.__name__,
+            required={
+                "run_id",
+                "generation",
+                "node_id",
+                "agent_id",
+                "logical_node_slot",
+                "global_rank",
+                "local_rank",
+                "local_world_size",
+                "hostname",
+                "gpu_uuid",
+                "topology_digest",
+            },
+        )
+        return cls(
+            run_id=_string(value["run_id"], "WorkerIdentity.run_id"),
+            generation=_integer(
+                value["generation"],
+                "WorkerIdentity.generation",
+                minimum=0,
+            ),
+            node_id=_string(value["node_id"], "WorkerIdentity.node_id"),
+            agent_id=_string(value["agent_id"], "WorkerIdentity.agent_id"),
+            logical_node_slot=_integer(
+                value["logical_node_slot"],
+                "WorkerIdentity.logical_node_slot",
+                minimum=0,
+            ),
+            global_rank=_integer(
+                value["global_rank"],
+                "WorkerIdentity.global_rank",
+                minimum=0,
+            ),
+            local_rank=_integer(
+                value["local_rank"],
+                "WorkerIdentity.local_rank",
+                minimum=0,
+            ),
+            local_world_size=_integer(
+                value["local_world_size"],
+                "WorkerIdentity.local_world_size",
+                minimum=1,
+            ),
+            hostname=_string(value["hostname"], "WorkerIdentity.hostname"),
+            gpu_uuid=_optional_string(value["gpu_uuid"], "WorkerIdentity.gpu_uuid"),
+            topology_digest=_string(
+                value["topology_digest"],
+                "WorkerIdentity.topology_digest",
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SlotAssignment:
+    logical_node_slot: int
+    node_id: str
+    first_global_rank: int
+    local_world_size: int
+
+    def __post_init__(self) -> None:
+        _integer(self.logical_node_slot, "SlotAssignment.logical_node_slot", minimum=0)
+        _string(self.node_id, "SlotAssignment.node_id")
+        _integer(self.first_global_rank, "SlotAssignment.first_global_rank", minimum=0)
+        _integer(self.local_world_size, "SlotAssignment.local_world_size", minimum=1)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "logical_node_slot": self.logical_node_slot,
+            "node_id": self.node_id,
+            "first_global_rank": self.first_global_rank,
+            "local_world_size": self.local_world_size,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> SlotAssignment:
+        required = {
+            "logical_node_slot",
+            "node_id",
+            "first_global_rank",
+            "local_world_size",
+        }
+        missing = required - set(value)
+        unknown = set(value) - required
+        if missing:
+            raise ProtocolValidationError(f"SlotAssignment: missing fields {sorted(missing)!r}")
+        if unknown:
+            raise ProtocolValidationError(f"SlotAssignment: unknown fields {sorted(unknown)!r}")
+        return cls(
+            logical_node_slot=_integer(
+                value["logical_node_slot"],
+                "SlotAssignment.logical_node_slot",
+                minimum=0,
+            ),
+            node_id=_string(value["node_id"], "SlotAssignment.node_id"),
+            first_global_rank=_integer(
+                value["first_global_rank"],
+                "SlotAssignment.first_global_rank",
+                minimum=0,
+            ),
+            local_world_size=_integer(
+                value["local_world_size"],
+                "SlotAssignment.local_world_size",
+                minimum=1,
+            ),
+        )
+
+
+def _assignments(
+    value: object,
+    path: str,
+    *,
+    require_nonempty: bool = True,
+) -> tuple[SlotAssignment, ...]:
+    assignments = tuple(
+        item
+        if isinstance(item, SlotAssignment)
+        else SlotAssignment.from_dict(_require_mapping(item, f"{path}[{index}]"))
+        for index, item in enumerate(_sequence(value, path))
+    )
+    if require_nonempty and not assignments:
+        raise ProtocolValidationError(f"{path}: at least one assignment is required")
+    slots = [assignment.logical_node_slot for assignment in assignments]
+    if len(slots) != len(set(slots)):
+        raise ProtocolValidationError(f"{path}: logical slots must be unique")
+    if slots and set(slots) != set(range(len(slots))):
+        raise ProtocolValidationError(f"{path}: logical slots must be dense from zero")
+    node_ids = [assignment.node_id for assignment in assignments]
+    if len(node_ids) != len(set(node_ids)):
+        raise ProtocolValidationError(f"{path}: assigned node IDs must be unique")
+    local_sizes = {assignment.local_world_size for assignment in assignments}
+    if len(local_sizes) > 1:
+        raise ProtocolValidationError(f"{path}: all assignments must use one local world size")
+    if assignments:
+        local_world_size = assignments[0].local_world_size
+        for assignment in assignments:
+            expected = assignment.logical_node_slot * local_world_size
+            if assignment.first_global_rank != expected:
+                raise ProtocolValidationError(
+                    f"{path}: slot {assignment.logical_node_slot} must start at rank {expected}"
+                )
+    return tuple(sorted(assignments, key=lambda item: item.logical_node_slot))
+
+
+@dataclass(frozen=True, slots=True)
+class RankAssignment(_WireRecord):
+    run_id: str
+    generation: int
+    active_nodes: int
+    local_world_size: int
+    slot_to_node_id: Mapping[int, str]
+    slot_to_rank_range: Mapping[int, tuple[int, int]]
+    topology_digest: str
+
+    def __post_init__(self) -> None:
+        _string(self.run_id, "RankAssignment.run_id")
+        _integer(self.generation, "RankAssignment.generation", minimum=0)
+        _integer(self.active_nodes, "RankAssignment.active_nodes", minimum=1)
+        _integer(self.local_world_size, "RankAssignment.local_world_size", minimum=1)
+        node_map = _normalize_slot_node_map(
+            self.slot_to_node_id,
+            "RankAssignment.slot_to_node_id",
+        )
+        range_map = _normalize_slot_range_map(
+            self.slot_to_rank_range,
+            "RankAssignment.slot_to_rank_range",
+        )
+        expected_slots = set(range(self.active_nodes))
+        if set(node_map) != expected_slots or set(range_map) != expected_slots:
+            raise ProtocolValidationError(
+                "RankAssignment: node and rank maps must contain every active slot"
+            )
+        if len(set(node_map.values())) != len(node_map):
+            raise ProtocolValidationError("RankAssignment.slot_to_node_id: node IDs must be unique")
+        for slot, rank_range in range_map.items():
+            expected = (
+                slot * self.local_world_size,
+                (slot + 1) * self.local_world_size,
+            )
+            if rank_range != expected:
+                raise ProtocolValidationError(
+                    f"RankAssignment.slot_to_rank_range[{slot}]: expected {expected!r}"
+                )
+        object.__setattr__(self, "slot_to_node_id", MappingProxyType(node_map))
+        object.__setattr__(self, "slot_to_rank_range", MappingProxyType(range_map))
+        _string(self.topology_digest, "RankAssignment.topology_digest")
+
+    @classmethod
+    def from_assignments(
+        cls,
+        *,
+        run_id: str,
+        generation: int,
+        assignments: Sequence[SlotAssignment],
+        topology_digest: str,
+    ) -> RankAssignment:
+        normalized = _assignments(assignments, "RankAssignment.assignments")
+        local_world_size = normalized[0].local_world_size
+        return cls(
+            run_id=run_id,
+            generation=generation,
+            active_nodes=len(normalized),
+            local_world_size=local_world_size,
+            slot_to_node_id={
+                assignment.logical_node_slot: assignment.node_id for assignment in normalized
+            },
+            slot_to_rank_range={
+                assignment.logical_node_slot: (
+                    assignment.first_global_rank,
+                    assignment.first_global_rank + assignment.local_world_size,
+                )
+                for assignment in normalized
+            },
+            topology_digest=topology_digest,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "run_id": self.run_id,
+            "generation": self.generation,
+            "active_nodes": self.active_nodes,
+            "local_world_size": self.local_world_size,
+            "slot_to_node_id": {
+                str(slot): node_id for slot, node_id in self.slot_to_node_id.items()
+            },
+            "slot_to_rank_range": {
+                str(slot): list(rank_range) for slot, rank_range in self.slot_to_rank_range.items()
+            },
+            "topology_digest": self.topology_digest,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> RankAssignment:
+        _record_fields(
+            value,
+            path=cls.__name__,
+            required={
+                "run_id",
+                "generation",
+                "active_nodes",
+                "local_world_size",
+                "slot_to_node_id",
+                "slot_to_rank_range",
+                "topology_digest",
+            },
+        )
+        return cls(
+            run_id=_string(value["run_id"], "RankAssignment.run_id"),
+            generation=_integer(
+                value["generation"],
+                "RankAssignment.generation",
+                minimum=0,
+            ),
+            active_nodes=_integer(
+                value["active_nodes"],
+                "RankAssignment.active_nodes",
+                minimum=1,
+            ),
+            local_world_size=_integer(
+                value["local_world_size"],
+                "RankAssignment.local_world_size",
+                minimum=1,
+            ),
+            slot_to_node_id=_parse_slot_node_map(
+                value["slot_to_node_id"],
+                "RankAssignment.slot_to_node_id",
+            ),
+            slot_to_rank_range=_parse_slot_range_map(
+                value["slot_to_rank_range"],
+                "RankAssignment.slot_to_rank_range",
+            ),
+            topology_digest=_string(
+                value["topology_digest"],
+                "RankAssignment.topology_digest",
+            ),
+        )
+
+
+def _slot_key(value: object, path: str) -> int:
+    if isinstance(value, int) and not isinstance(value, bool):
+        return _integer(value, path, minimum=0)
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    raise ProtocolValidationError(f"{path}: slot keys must be non-negative integers")
+
+
+def _normalize_slot_node_map(
+    value: object,
+    path: str,
+) -> dict[int, str]:
+    if not isinstance(value, Mapping):
+        raise ProtocolValidationError(f"{path}: expected an object")
+    mapping = value
+    result: dict[int, str] = {}
+    for raw_slot, node_id in mapping.items():
+        slot = _slot_key(raw_slot, f"{path}.key")
+        if slot in result:
+            raise ProtocolValidationError(f"{path}: duplicate slot {slot}")
+        result[slot] = _string(node_id, f"{path}[{slot}]")
+    return dict(sorted(result.items()))
+
+
+def _parse_slot_node_map(value: object, path: str) -> dict[int, str]:
+    return _normalize_slot_node_map(value, path)
+
+
+def _normalize_slot_range_map(
+    value: object,
+    path: str,
+) -> dict[int, tuple[int, int]]:
+    if not isinstance(value, Mapping):
+        raise ProtocolValidationError(f"{path}: expected an object")
+    mapping = value
+    result: dict[int, tuple[int, int]] = {}
+    for raw_slot, raw_range in mapping.items():
+        slot = _slot_key(raw_slot, f"{path}.key")
+        if slot in result:
+            raise ProtocolValidationError(f"{path}: duplicate slot {slot}")
+        values = _integers(raw_range, f"{path}[{slot}]", minimum=0)
+        if len(values) != 2 or values[1] <= values[0]:
+            raise ProtocolValidationError(
+                f"{path}[{slot}]: expected a non-empty half-open rank range"
+            )
+        result[slot] = (values[0], values[1])
+    return dict(sorted(result.items()))
+
+
+def _parse_slot_range_map(value: object, path: str) -> dict[int, tuple[int, int]]:
+    return _normalize_slot_range_map(value, path)
+
+
+@dataclass(frozen=True, slots=True)
+class HardwareFaultReport:
+    kind: Literal["hardware"]
+    resource_kind: str
+    resource_id: str
+    metric: str
+    value: float
+    severity: Literal["fatal"]
+    message: str
+
+    def __post_init__(self) -> None:
+        if self.kind != "hardware":
+            raise ProtocolValidationError("HardwareFaultReport.kind: expected 'hardware'")
+        _choice(
+            self.resource_kind,
+            "HardwareFaultReport.resource_kind",
+            {"gpu", "node", "nic", "hca", "link"},
+        )
+        _string(self.resource_id, "HardwareFaultReport.resource_id")
+        _string(self.metric, "HardwareFaultReport.metric")
+        if isinstance(self.value, bool) or not isinstance(self.value, (int, float)):
+            raise ProtocolValidationError("HardwareFaultReport.value: expected a number")
+        if not math.isfinite(float(self.value)):
+            raise ProtocolValidationError("HardwareFaultReport.value: must be finite")
+        if self.severity != "fatal":
+            raise ProtocolValidationError("HardwareFaultReport.severity: expected 'fatal'")
+        _string(self.message, "HardwareFaultReport.message")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "resource_kind": self.resource_kind,
+            "resource_id": self.resource_id,
+            "metric": self.metric,
+            "value": self.value,
+            "severity": self.severity,
+            "message": self.message,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> HardwareFaultReport:
+        required = {
+            "kind",
+            "resource_kind",
+            "resource_id",
+            "metric",
+            "value",
+            "severity",
+            "message",
+        }
+        missing = required - set(value)
+        unknown = set(value) - required
+        if missing:
+            raise ProtocolValidationError(
+                f"HardwareFaultReport: missing fields {sorted(missing)!r}"
+            )
+        if unknown:
+            raise ProtocolValidationError(
+                f"HardwareFaultReport: unknown fields {sorted(unknown)!r}"
+            )
+        raw_value = value["value"]
+        if isinstance(raw_value, bool) or not isinstance(raw_value, (int, float)):
+            raise ProtocolValidationError("HardwareFaultReport.value: expected a number")
+        return cls(
+            kind=_choice(value["kind"], "HardwareFaultReport.kind", {"hardware"}),  # type: ignore[arg-type]
+            resource_kind=_choice(
+                value["resource_kind"],
+                "HardwareFaultReport.resource_kind",
+                {"gpu", "node", "nic", "hca", "link"},
+            ),
+            resource_id=_string(
+                value["resource_id"],
+                "HardwareFaultReport.resource_id",
+            ),
+            metric=_string(value["metric"], "HardwareFaultReport.metric"),
+            value=float(raw_value),
+            severity=_choice(  # type: ignore[arg-type]
+                value["severity"],
+                "HardwareFaultReport.severity",
+                {"fatal"},
+            ),
+            message=_string(value["message"], "HardwareFaultReport.message"),
+        )
+
+
+def _fault_report(value: object, path: str) -> Mapping[str, Any]:
+    if isinstance(value, HardwareFaultReport):
+        normalized: Mapping[str, Any] = value.to_dict()
+    else:
+        normalized = _require_mapping(value, path)
+        kind = _string(normalized.get("kind"), f"{path}.kind")
+        if kind == "hardware":
+            normalized = HardwareFaultReport.from_dict(normalized).to_dict()
+        elif "failed_ranks" in normalized:
+            _integers(
+                normalized["failed_ranks"],
+                f"{path}.failed_ranks",
+                minimum=0,
+                unique=True,
+            )
+    frozen = _freeze_json(normalized, path)
+    assert isinstance(frozen, Mapping)
+    return frozen
+
+
+@dataclass(frozen=True, slots=True)
+class FaultEvent(_WireRecord):
+    event_id: str
+    incident_id: str
+    run_id: str
+    generation: int
+    reporter: WorkerIdentity
+    optimizer_step: int
+    report: Mapping[str, Any] | HardwareFaultReport
+
+    def __post_init__(self) -> None:
+        _string(self.event_id, "FaultEvent.event_id")
+        _string(self.incident_id, "FaultEvent.incident_id")
+        _string(self.run_id, "FaultEvent.run_id")
+        _integer(self.generation, "FaultEvent.generation", minimum=0)
+        if not isinstance(self.reporter, WorkerIdentity):
+            raise ProtocolValidationError("FaultEvent.reporter: expected WorkerIdentity")
+        if self.reporter.run_id != self.run_id:
+            raise ProtocolValidationError("FaultEvent: reporter run_id does not match event")
+        if self.reporter.generation != self.generation:
+            raise ProtocolValidationError("FaultEvent: reporter generation does not match event")
+        _integer(self.optimizer_step, "FaultEvent.optimizer_step", minimum=0)
+        object.__setattr__(self, "report", _fault_report(self.report, "FaultEvent.report"))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "event_id": self.event_id,
+            "incident_id": self.incident_id,
+            "run_id": self.run_id,
+            "generation": self.generation,
+            "reporter": self.reporter.to_dict(),
+            "optimizer_step": self.optimizer_step,
+            "report": _thaw_json(self.report),
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> FaultEvent:
+        _record_fields(
+            value,
+            path=cls.__name__,
+            required={
+                "event_id",
+                "incident_id",
+                "run_id",
+                "generation",
+                "reporter",
+                "optimizer_step",
+                "report",
+            },
+        )
+        return cls(
+            event_id=_string(value["event_id"], "FaultEvent.event_id"),
+            incident_id=_string(value["incident_id"], "FaultEvent.incident_id"),
+            run_id=_string(value["run_id"], "FaultEvent.run_id"),
+            generation=_integer(
+                value["generation"],
+                "FaultEvent.generation",
+                minimum=0,
+            ),
+            reporter=WorkerIdentity.from_dict(
+                _require_mapping(value["reporter"], "FaultEvent.reporter")
+            ),
+            optimizer_step=_integer(
+                value["optimizer_step"],
+                "FaultEvent.optimizer_step",
+                minimum=0,
+            ),
+            report=_require_mapping(value["report"], "FaultEvent.report"),
+        )
+
+
+def _recovery_decision(value: object, path: str) -> Mapping[str, Any]:
+    mapping = _require_mapping(value, path)
+    fields = {
+        "failure_kind",
+        "recovery_mode",
+        "checkpoint_source",
+        "checkpoint_step",
+        "checkpoint_id",
+        "all_ranks_accessible",
+        "available",
+        "reason",
+    }
+    missing = fields - set(mapping)
+    unknown = set(mapping) - fields
+    if missing:
+        raise ProtocolValidationError(f"{path}: missing fields {sorted(missing)!r}")
+    if unknown:
+        raise ProtocolValidationError(f"{path}: unknown fields {sorted(unknown)!r}")
+    normalized = {
+        "failure_kind": _string(mapping["failure_kind"], f"{path}.failure_kind"),
+        "recovery_mode": _choice(
+            mapping["recovery_mode"],
+            f"{path}.recovery_mode",
+            {"latest", "recovery_verified"},
+        ),
+        "checkpoint_source": _choice(
+            mapping["checkpoint_source"],
+            f"{path}.checkpoint_source",
+            {"gemini", "durable", "none"},
+        ),
+        "checkpoint_step": _integer(
+            mapping["checkpoint_step"],
+            f"{path}.checkpoint_step",
+            minimum=-1,
+        ),
+        "checkpoint_id": _optional_string(
+            mapping["checkpoint_id"],
+            f"{path}.checkpoint_id",
+        ),
+        "all_ranks_accessible": _boolean(
+            mapping["all_ranks_accessible"],
+            f"{path}.all_ranks_accessible",
+        ),
+        "available": _boolean(mapping["available"], f"{path}.available"),
+        "reason": _string(mapping["reason"], f"{path}.reason"),
+    }
+    available = normalized["available"]
+    checkpoint_step = normalized["checkpoint_step"]
+    checkpoint_source = normalized["checkpoint_source"]
+    checkpoint_id = normalized["checkpoint_id"]
+    if available:
+        if checkpoint_step <= 0 or checkpoint_source == "none":
+            raise ProtocolValidationError(
+                f"{path}: available decisions require a positive step and source"
+            )
+    elif checkpoint_source != "none" or checkpoint_step > 0 or checkpoint_id is not None:
+        raise ProtocolValidationError(f"{path}: unavailable decisions must not select a checkpoint")
+    if checkpoint_source == "durable" and checkpoint_id is None:
+        raise ProtocolValidationError(f"{path}: durable decisions require checkpoint_id")
+    if checkpoint_source != "durable" and checkpoint_id is not None:
+        raise ProtocolValidationError(f"{path}: checkpoint_id is only valid for durable decisions")
+    frozen = _freeze_json(normalized, path)
+    assert isinstance(frozen, Mapping)
+    return frozen
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryProposalEvent(_WireRecord):
+    event_id: str
+    incident_id: str
+    run_id: str
+    generation: int
+    reporter: WorkerIdentity
+    decision: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        _string(self.event_id, "RecoveryProposalEvent.event_id")
+        _string(self.incident_id, "RecoveryProposalEvent.incident_id")
+        _string(self.run_id, "RecoveryProposalEvent.run_id")
+        _integer(self.generation, "RecoveryProposalEvent.generation", minimum=0)
+        if not isinstance(self.reporter, WorkerIdentity):
+            raise ProtocolValidationError("RecoveryProposalEvent.reporter: expected WorkerIdentity")
+        if self.reporter.run_id != self.run_id:
+            raise ProtocolValidationError(
+                "RecoveryProposalEvent: reporter run_id does not match event"
+            )
+        if self.reporter.generation != self.generation:
+            raise ProtocolValidationError(
+                "RecoveryProposalEvent: reporter generation does not match event"
+            )
+        object.__setattr__(
+            self,
+            "decision",
+            _recovery_decision(self.decision, "RecoveryProposalEvent.decision"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "event_id": self.event_id,
+            "incident_id": self.incident_id,
+            "run_id": self.run_id,
+            "generation": self.generation,
+            "reporter": self.reporter.to_dict(),
+            "decision": _thaw_json(self.decision),
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> RecoveryProposalEvent:
+        _record_fields(
+            value,
+            path=cls.__name__,
+            required={
+                "event_id",
+                "incident_id",
+                "run_id",
+                "generation",
+                "reporter",
+                "decision",
+            },
+        )
+        return cls(
+            event_id=_string(
+                value["event_id"],
+                "RecoveryProposalEvent.event_id",
+            ),
+            incident_id=_string(
+                value["incident_id"],
+                "RecoveryProposalEvent.incident_id",
+            ),
+            run_id=_string(value["run_id"], "RecoveryProposalEvent.run_id"),
+            generation=_integer(
+                value["generation"],
+                "RecoveryProposalEvent.generation",
+                minimum=0,
+            ),
+            reporter=WorkerIdentity.from_dict(
+                _require_mapping(
+                    value["reporter"],
+                    "RecoveryProposalEvent.reporter",
+                )
+            ),
+            decision=_require_mapping(
+                value["decision"],
+                "RecoveryProposalEvent.decision",
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CheckpointCopy:
+    owner_global_rank: int
+    holder_node_id: str
+    holder_kind: str
+    storage_kind: str
+    location_token: str
+    complete: bool
+    checksums_available: bool
+
+    def __post_init__(self) -> None:
+        _integer(self.owner_global_rank, "CheckpointCopy.owner_global_rank", minimum=0)
+        _string(self.holder_node_id, "CheckpointCopy.holder_node_id")
+        _choice(
+            self.holder_kind,
+            "CheckpointCopy.holder_kind",
+            {"owner", "peer", "durable"},
+        )
+        _choice(
+            self.storage_kind,
+            "CheckpointCopy.storage_kind",
+            {"memory", "node_local", "shared", "remote"},
+        )
+        _string(self.location_token, "CheckpointCopy.location_token")
+        _boolean(self.complete, "CheckpointCopy.complete")
+        _boolean(self.checksums_available, "CheckpointCopy.checksums_available")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "owner_global_rank": self.owner_global_rank,
+            "holder_node_id": self.holder_node_id,
+            "holder_kind": self.holder_kind,
+            "storage_kind": self.storage_kind,
+            "location_token": self.location_token,
+            "complete": self.complete,
+            "checksums_available": self.checksums_available,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> CheckpointCopy:
+        required = {
+            "owner_global_rank",
+            "holder_node_id",
+            "holder_kind",
+            "storage_kind",
+            "location_token",
+            "complete",
+            "checksums_available",
+        }
+        missing = required - set(value)
+        unknown = set(value) - required
+        if missing:
+            raise ProtocolValidationError(f"CheckpointCopy: missing fields {sorted(missing)!r}")
+        if unknown:
+            raise ProtocolValidationError(f"CheckpointCopy: unknown fields {sorted(unknown)!r}")
+        return cls(
+            owner_global_rank=_integer(
+                value["owner_global_rank"],
+                "CheckpointCopy.owner_global_rank",
+                minimum=0,
+            ),
+            holder_node_id=_string(
+                value["holder_node_id"],
+                "CheckpointCopy.holder_node_id",
+            ),
+            holder_kind=_choice(
+                value["holder_kind"],
+                "CheckpointCopy.holder_kind",
+                {"owner", "peer", "durable"},
+            ),
+            storage_kind=_choice(
+                value["storage_kind"],
+                "CheckpointCopy.storage_kind",
+                {"memory", "node_local", "shared", "remote"},
+            ),
+            location_token=_string(
+                value["location_token"],
+                "CheckpointCopy.location_token",
+            ),
+            complete=_boolean(value["complete"], "CheckpointCopy.complete"),
+            checksums_available=_boolean(
+                value["checksums_available"],
+                "CheckpointCopy.checksums_available",
+            ),
+        )
+
+
+def _checkpoint_copies(value: object, path: str) -> tuple[CheckpointCopy, ...]:
+    copies = tuple(
+        item
+        if isinstance(item, CheckpointCopy)
+        else CheckpointCopy.from_dict(_require_mapping(item, f"{path}[{index}]"))
+        for index, item in enumerate(_sequence(value, path))
+    )
+    identities = [
+        (
+            copy.owner_global_rank,
+            copy.holder_node_id,
+            copy.holder_kind,
+            copy.storage_kind,
+            copy.location_token,
+        )
+        for copy in copies
+    ]
+    if len(identities) != len(set(identities)):
+        raise ProtocolValidationError(f"{path}: duplicate checkpoint copies")
+    return copies
+
+
+@dataclass(frozen=True, slots=True)
+class CheckpointInventoryEvent(_WireRecord):
+    event_id: str
+    run_id: str
+    generation: int
+    reporter: WorkerIdentity
+    step: int
+    trust: str
+    topology_digest: str
+    copies: tuple[CheckpointCopy, ...]
+
+    def __post_init__(self) -> None:
+        _string(self.event_id, "CheckpointInventoryEvent.event_id")
+        _string(self.run_id, "CheckpointInventoryEvent.run_id")
+        _integer(self.generation, "CheckpointInventoryEvent.generation", minimum=0)
+        if not isinstance(self.reporter, WorkerIdentity):
+            raise ProtocolValidationError(
+                "CheckpointInventoryEvent.reporter: expected WorkerIdentity"
+            )
+        if self.reporter.run_id != self.run_id:
+            raise ProtocolValidationError(
+                "CheckpointInventoryEvent: reporter run_id does not match event"
+            )
+        if self.reporter.generation != self.generation:
+            raise ProtocolValidationError(
+                "CheckpointInventoryEvent: reporter generation does not match event"
+            )
+        _integer(self.step, "CheckpointInventoryEvent.step", minimum=0)
+        _choice(
+            self.trust,
+            "CheckpointInventoryEvent.trust",
+            {"latest", "candidate", "recovery_verified"},
+        )
+        _string(self.topology_digest, "CheckpointInventoryEvent.topology_digest")
+        if self.topology_digest != self.reporter.topology_digest:
+            raise ProtocolValidationError(
+                "CheckpointInventoryEvent: reporter topology digest does not match event"
+            )
+        object.__setattr__(
+            self,
+            "copies",
+            _checkpoint_copies(self.copies, "CheckpointInventoryEvent.copies"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "event_id": self.event_id,
+            "run_id": self.run_id,
+            "generation": self.generation,
+            "reporter": self.reporter.to_dict(),
+            "step": self.step,
+            "trust": self.trust,
+            "topology_digest": self.topology_digest,
+            "copies": [copy.to_dict() for copy in self.copies],
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> CheckpointInventoryEvent:
+        _record_fields(
+            value,
+            path=cls.__name__,
+            required={
+                "event_id",
+                "run_id",
+                "generation",
+                "reporter",
+                "step",
+                "trust",
+                "topology_digest",
+                "copies",
+            },
+        )
+        return cls(
+            event_id=_string(
+                value["event_id"],
+                "CheckpointInventoryEvent.event_id",
+            ),
+            run_id=_string(value["run_id"], "CheckpointInventoryEvent.run_id"),
+            generation=_integer(
+                value["generation"],
+                "CheckpointInventoryEvent.generation",
+                minimum=0,
+            ),
+            reporter=WorkerIdentity.from_dict(
+                _require_mapping(
+                    value["reporter"],
+                    "CheckpointInventoryEvent.reporter",
+                )
+            ),
+            step=_integer(
+                value["step"],
+                "CheckpointInventoryEvent.step",
+                minimum=0,
+            ),
+            trust=_choice(
+                value["trust"],
+                "CheckpointInventoryEvent.trust",
+                {"latest", "candidate", "recovery_verified"},
+            ),
+            topology_digest=_string(
+                value["topology_digest"],
+                "CheckpointInventoryEvent.topology_digest",
+            ),
+            copies=_checkpoint_copies(
+                value["copies"],
+                "CheckpointInventoryEvent.copies",
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RestartIntent(_WireRecord):
+    intent_id: str
+    run_id: str
+    generation: int
+    incident_ids: tuple[str, ...]
+    reason_code: str
+    minimum_recovery_mode: str
+    suspected_node_ids: tuple[str, ...]
+    prepare_deadline_unix_ms: int
+
+    def __post_init__(self) -> None:
+        _string(self.intent_id, "RestartIntent.intent_id")
+        _string(self.run_id, "RestartIntent.run_id")
+        _integer(self.generation, "RestartIntent.generation", minimum=0)
+        object.__setattr__(
+            self,
+            "incident_ids",
+            _strings(self.incident_ids, "RestartIntent.incident_ids", unique=True),
+        )
+        if not self.incident_ids:
+            raise ProtocolValidationError(
+                "RestartIntent.incident_ids: at least one incident is required"
+            )
+        _string(self.reason_code, "RestartIntent.reason_code")
+        _choice(
+            self.minimum_recovery_mode,
+            "RestartIntent.minimum_recovery_mode",
+            {"latest", "recovery_verified"},
+        )
+        object.__setattr__(
+            self,
+            "suspected_node_ids",
+            _strings(
+                self.suspected_node_ids,
+                "RestartIntent.suspected_node_ids",
+                unique=True,
+            ),
+        )
+        _integer(
+            self.prepare_deadline_unix_ms,
+            "RestartIntent.prepare_deadline_unix_ms",
+            minimum=1,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "intent_id": self.intent_id,
+            "run_id": self.run_id,
+            "generation": self.generation,
+            "incident_ids": list(self.incident_ids),
+            "reason_code": self.reason_code,
+            "minimum_recovery_mode": self.minimum_recovery_mode,
+            "suspected_node_ids": list(self.suspected_node_ids),
+            "prepare_deadline_unix_ms": self.prepare_deadline_unix_ms,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> RestartIntent:
+        _record_fields(
+            value,
+            path=cls.__name__,
+            required={
+                "intent_id",
+                "run_id",
+                "generation",
+                "incident_ids",
+                "reason_code",
+                "minimum_recovery_mode",
+                "suspected_node_ids",
+                "prepare_deadline_unix_ms",
+            },
+        )
+        return cls(
+            intent_id=_string(value["intent_id"], "RestartIntent.intent_id"),
+            run_id=_string(value["run_id"], "RestartIntent.run_id"),
+            generation=_integer(
+                value["generation"],
+                "RestartIntent.generation",
+                minimum=0,
+            ),
+            incident_ids=_strings(
+                value["incident_ids"],
+                "RestartIntent.incident_ids",
+                unique=True,
+            ),
+            reason_code=_string(
+                value["reason_code"],
+                "RestartIntent.reason_code",
+            ),
+            minimum_recovery_mode=_choice(
+                value["minimum_recovery_mode"],
+                "RestartIntent.minimum_recovery_mode",
+                {"latest", "recovery_verified"},
+            ),
+            suspected_node_ids=_strings(
+                value["suspected_node_ids"],
+                "RestartIntent.suspected_node_ids",
+                unique=True,
+            ),
+            prepare_deadline_unix_ms=_integer(
+                value["prepare_deadline_unix_ms"],
+                "RestartIntent.prepare_deadline_unix_ms",
+                minimum=1,
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RestartAck(_WireRecord):
+    intent_id: str
+    node_id: str
+    generation: int
+    flushed_step: int
+    inventory_event_ids: tuple[str, ...]
+    transferred_owner_ranks: tuple[int, ...]
+    transferred_peer_ranks: tuple[int, ...]
+    success: bool
+    reason: str
+
+    def __post_init__(self) -> None:
+        _string(self.intent_id, "RestartAck.intent_id")
+        _string(self.node_id, "RestartAck.node_id")
+        _integer(self.generation, "RestartAck.generation", minimum=0)
+        _integer(self.flushed_step, "RestartAck.flushed_step", minimum=-1)
+        object.__setattr__(
+            self,
+            "inventory_event_ids",
+            _strings(
+                self.inventory_event_ids,
+                "RestartAck.inventory_event_ids",
+                unique=True,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "transferred_owner_ranks",
+            _integers(
+                self.transferred_owner_ranks,
+                "RestartAck.transferred_owner_ranks",
+                minimum=0,
+                unique=True,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "transferred_peer_ranks",
+            _integers(
+                self.transferred_peer_ranks,
+                "RestartAck.transferred_peer_ranks",
+                minimum=0,
+                unique=True,
+            ),
+        )
+        _boolean(self.success, "RestartAck.success")
+        _string(self.reason, "RestartAck.reason")
+        if self.success and self.flushed_step < 0:
+            raise ProtocolValidationError(
+                "RestartAck.flushed_step: successful acknowledgements require a step"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "intent_id": self.intent_id,
+            "node_id": self.node_id,
+            "generation": self.generation,
+            "flushed_step": self.flushed_step,
+            "inventory_event_ids": list(self.inventory_event_ids),
+            "transferred_owner_ranks": list(self.transferred_owner_ranks),
+            "transferred_peer_ranks": list(self.transferred_peer_ranks),
+            "success": self.success,
+            "reason": self.reason,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> RestartAck:
+        _record_fields(
+            value,
+            path=cls.__name__,
+            required={
+                "intent_id",
+                "node_id",
+                "generation",
+                "flushed_step",
+                "inventory_event_ids",
+                "transferred_owner_ranks",
+                "transferred_peer_ranks",
+                "success",
+                "reason",
+            },
+        )
+        return cls(
+            intent_id=_string(value["intent_id"], "RestartAck.intent_id"),
+            node_id=_string(value["node_id"], "RestartAck.node_id"),
+            generation=_integer(
+                value["generation"],
+                "RestartAck.generation",
+                minimum=0,
+            ),
+            flushed_step=_integer(
+                value["flushed_step"],
+                "RestartAck.flushed_step",
+                minimum=-1,
+            ),
+            inventory_event_ids=_strings(
+                value["inventory_event_ids"],
+                "RestartAck.inventory_event_ids",
+                unique=True,
+            ),
+            transferred_owner_ranks=_integers(
+                value["transferred_owner_ranks"],
+                "RestartAck.transferred_owner_ranks",
+                minimum=0,
+                unique=True,
+            ),
+            transferred_peer_ranks=_integers(
+                value["transferred_peer_ranks"],
+                "RestartAck.transferred_peer_ranks",
+                minimum=0,
+                unique=True,
+            ),
+            success=_boolean(value["success"], "RestartAck.success"),
+            reason=_string(value["reason"], "RestartAck.reason"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RestartPlan(_WireRecord):
+    plan_id: str
+    intent_id: str
+    run_id: str
+    from_generation: int
+    to_generation: int
+    incident_ids: tuple[str, ...]
+    reason_code: str
+    recovery_mode: str
+    checkpoint_source: str
+    checkpoint_step: int
+    checkpoint_id: str | None
+    checkpoint_manifest_id: str
+    slot_assignments: tuple[SlotAssignment, ...]
+    quarantined_node_ids: tuple[str, ...]
+    expected_world_size: int
+    topology_digest: str
+    restart_deadline_unix_ms: int
+
+    def __post_init__(self) -> None:
+        _string(self.plan_id, "RestartPlan.plan_id")
+        _string(self.intent_id, "RestartPlan.intent_id")
+        _string(self.run_id, "RestartPlan.run_id")
+        _integer(self.from_generation, "RestartPlan.from_generation", minimum=0)
+        _integer(self.to_generation, "RestartPlan.to_generation", minimum=1)
+        if self.to_generation != self.from_generation + 1:
+            raise ProtocolValidationError(
+                "RestartPlan.to_generation: must be the successor generation"
+            )
+        object.__setattr__(
+            self,
+            "incident_ids",
+            _strings(self.incident_ids, "RestartPlan.incident_ids", unique=True),
+        )
+        if not self.incident_ids:
+            raise ProtocolValidationError(
+                "RestartPlan.incident_ids: at least one incident is required"
+            )
+        _string(self.reason_code, "RestartPlan.reason_code")
+        _choice(
+            self.recovery_mode,
+            "RestartPlan.recovery_mode",
+            {"latest", "recovery_verified"},
+        )
+        _choice(
+            self.checkpoint_source,
+            "RestartPlan.checkpoint_source",
+            {"gemini", "durable"},
+        )
+        _integer(self.checkpoint_step, "RestartPlan.checkpoint_step", minimum=0)
+        _optional_string(self.checkpoint_id, "RestartPlan.checkpoint_id")
+        if self.checkpoint_source == "durable" and self.checkpoint_id is None:
+            raise ProtocolValidationError(
+                "RestartPlan.checkpoint_id: durable recovery requires an ID"
+            )
+        if self.checkpoint_source == "gemini" and self.checkpoint_id is not None:
+            raise ProtocolValidationError(
+                "RestartPlan.checkpoint_id: GEMINI recovery must not set an ID"
+            )
+        _string(
+            self.checkpoint_manifest_id,
+            "RestartPlan.checkpoint_manifest_id",
+        )
+        assignments = _assignments(
+            self.slot_assignments,
+            "RestartPlan.slot_assignments",
+        )
+        object.__setattr__(self, "slot_assignments", assignments)
+        object.__setattr__(
+            self,
+            "quarantined_node_ids",
+            _strings(
+                self.quarantined_node_ids,
+                "RestartPlan.quarantined_node_ids",
+                unique=True,
+            ),
+        )
+        assigned_nodes = {assignment.node_id for assignment in assignments}
+        overlap = assigned_nodes & set(self.quarantined_node_ids)
+        if overlap:
+            raise ProtocolValidationError(
+                f"RestartPlan: quarantined nodes cannot be assigned: {sorted(overlap)!r}"
+            )
+        _integer(
+            self.expected_world_size,
+            "RestartPlan.expected_world_size",
+            minimum=1,
+        )
+        calculated_world_size = sum(assignment.local_world_size for assignment in assignments)
+        if self.expected_world_size != calculated_world_size:
+            raise ProtocolValidationError(
+                "RestartPlan.expected_world_size: does not match slot assignments"
+            )
+        _string(self.topology_digest, "RestartPlan.topology_digest")
+        _integer(
+            self.restart_deadline_unix_ms,
+            "RestartPlan.restart_deadline_unix_ms",
+            minimum=1,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "plan_id": self.plan_id,
+            "intent_id": self.intent_id,
+            "run_id": self.run_id,
+            "from_generation": self.from_generation,
+            "to_generation": self.to_generation,
+            "incident_ids": list(self.incident_ids),
+            "reason_code": self.reason_code,
+            "recovery_mode": self.recovery_mode,
+            "checkpoint_source": self.checkpoint_source,
+            "checkpoint_step": self.checkpoint_step,
+            "checkpoint_id": self.checkpoint_id,
+            "checkpoint_manifest_id": self.checkpoint_manifest_id,
+            "slot_assignments": [assignment.to_dict() for assignment in self.slot_assignments],
+            "quarantined_node_ids": list(self.quarantined_node_ids),
+            "expected_world_size": self.expected_world_size,
+            "topology_digest": self.topology_digest,
+            "restart_deadline_unix_ms": self.restart_deadline_unix_ms,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> RestartPlan:
+        _record_fields(
+            value,
+            path=cls.__name__,
+            required={
+                "plan_id",
+                "intent_id",
+                "run_id",
+                "from_generation",
+                "to_generation",
+                "incident_ids",
+                "reason_code",
+                "recovery_mode",
+                "checkpoint_source",
+                "checkpoint_step",
+                "checkpoint_id",
+                "checkpoint_manifest_id",
+                "slot_assignments",
+                "quarantined_node_ids",
+                "expected_world_size",
+                "topology_digest",
+                "restart_deadline_unix_ms",
+            },
+        )
+        return cls(
+            plan_id=_string(value["plan_id"], "RestartPlan.plan_id"),
+            intent_id=_string(value["intent_id"], "RestartPlan.intent_id"),
+            run_id=_string(value["run_id"], "RestartPlan.run_id"),
+            from_generation=_integer(
+                value["from_generation"],
+                "RestartPlan.from_generation",
+                minimum=0,
+            ),
+            to_generation=_integer(
+                value["to_generation"],
+                "RestartPlan.to_generation",
+                minimum=1,
+            ),
+            incident_ids=_strings(
+                value["incident_ids"],
+                "RestartPlan.incident_ids",
+                unique=True,
+            ),
+            reason_code=_string(value["reason_code"], "RestartPlan.reason_code"),
+            recovery_mode=_choice(
+                value["recovery_mode"],
+                "RestartPlan.recovery_mode",
+                {"latest", "recovery_verified"},
+            ),
+            checkpoint_source=_choice(
+                value["checkpoint_source"],
+                "RestartPlan.checkpoint_source",
+                {"gemini", "durable"},
+            ),
+            checkpoint_step=_integer(
+                value["checkpoint_step"],
+                "RestartPlan.checkpoint_step",
+                minimum=0,
+            ),
+            checkpoint_id=_optional_string(
+                value["checkpoint_id"],
+                "RestartPlan.checkpoint_id",
+            ),
+            checkpoint_manifest_id=_string(
+                value["checkpoint_manifest_id"],
+                "RestartPlan.checkpoint_manifest_id",
+            ),
+            slot_assignments=_assignments(
+                value["slot_assignments"],
+                "RestartPlan.slot_assignments",
+            ),
+            quarantined_node_ids=_strings(
+                value["quarantined_node_ids"],
+                "RestartPlan.quarantined_node_ids",
+                unique=True,
+            ),
+            expected_world_size=_integer(
+                value["expected_world_size"],
+                "RestartPlan.expected_world_size",
+                minimum=1,
+            ),
+            topology_digest=_string(
+                value["topology_digest"],
+                "RestartPlan.topology_digest",
+            ),
+            restart_deadline_unix_ms=_integer(
+                value["restart_deadline_unix_ms"],
+                "RestartPlan.restart_deadline_unix_ms",
+                minimum=1,
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RestartContext(_WireRecord):
+    plan_id: str
+    run_id: str
+    generation: int
+    node_id: str
+    logical_node_slot: int
+    first_global_rank: int
+    local_world_size: int
+    expected_world_size: int
+    topology_digest: str
+    recovery_mode: str
+    checkpoint_source: str
+    checkpoint_step: int
+    checkpoint_id: str | None
+    checkpoint_manifest_id: str
+    reason_code: str
+
+    def __post_init__(self) -> None:
+        _string(self.plan_id, "RestartContext.plan_id")
+        _string(self.run_id, "RestartContext.run_id")
+        _integer(self.generation, "RestartContext.generation", minimum=0)
+        _string(self.node_id, "RestartContext.node_id")
+        _integer(
+            self.logical_node_slot,
+            "RestartContext.logical_node_slot",
+            minimum=0,
+        )
+        _integer(
+            self.first_global_rank,
+            "RestartContext.first_global_rank",
+            minimum=0,
+        )
+        _integer(
+            self.local_world_size,
+            "RestartContext.local_world_size",
+            minimum=1,
+        )
+        expected_first_rank = self.logical_node_slot * self.local_world_size
+        if self.first_global_rank != expected_first_rank:
+            raise ProtocolValidationError(
+                "RestartContext.first_global_rank: does not match logical slot"
+            )
+        _integer(
+            self.expected_world_size,
+            "RestartContext.expected_world_size",
+            minimum=1,
+        )
+        if self.first_global_rank + self.local_world_size > self.expected_world_size:
+            raise ProtocolValidationError(
+                "RestartContext: local rank range exceeds expected world size"
+            )
+        _string(self.topology_digest, "RestartContext.topology_digest")
+        _choice(
+            self.recovery_mode,
+            "RestartContext.recovery_mode",
+            {"latest", "recovery_verified"},
+        )
+        _choice(
+            self.checkpoint_source,
+            "RestartContext.checkpoint_source",
+            {"gemini", "durable"},
+        )
+        _integer(self.checkpoint_step, "RestartContext.checkpoint_step", minimum=0)
+        _optional_string(self.checkpoint_id, "RestartContext.checkpoint_id")
+        if self.checkpoint_source == "durable" and self.checkpoint_id is None:
+            raise ProtocolValidationError(
+                "RestartContext.checkpoint_id: durable recovery requires an ID"
+            )
+        if self.checkpoint_source == "gemini" and self.checkpoint_id is not None:
+            raise ProtocolValidationError(
+                "RestartContext.checkpoint_id: GEMINI recovery must not set an ID"
+            )
+        _string(
+            self.checkpoint_manifest_id,
+            "RestartContext.checkpoint_manifest_id",
+        )
+        _string(self.reason_code, "RestartContext.reason_code")
+
+    @classmethod
+    def from_plan(cls, plan: RestartPlan, node_id: str) -> RestartContext:
+        assignment = next(
+            (assignment for assignment in plan.slot_assignments if assignment.node_id == node_id),
+            None,
+        )
+        if assignment is None:
+            raise ProtocolValidationError(
+                f"RestartContext: node {node_id!r} is not assigned by the plan"
+            )
+        return cls(
+            plan_id=plan.plan_id,
+            run_id=plan.run_id,
+            generation=plan.to_generation,
+            node_id=assignment.node_id,
+            logical_node_slot=assignment.logical_node_slot,
+            first_global_rank=assignment.first_global_rank,
+            local_world_size=assignment.local_world_size,
+            expected_world_size=plan.expected_world_size,
+            topology_digest=plan.topology_digest,
+            recovery_mode=plan.recovery_mode,
+            checkpoint_source=plan.checkpoint_source,
+            checkpoint_step=plan.checkpoint_step,
+            checkpoint_id=plan.checkpoint_id,
+            checkpoint_manifest_id=plan.checkpoint_manifest_id,
+            reason_code=plan.reason_code,
+        )
+
+    def validate_worker_environment(self, environment: Mapping[str, str]) -> None:
+        required = {
+            "RANK",
+            "LOCAL_RANK",
+            "LOCAL_WORLD_SIZE",
+            "WORLD_SIZE",
+            "TORCHELASTIC_RUN_ID",
+        }
+        missing = required - set(environment)
+        if missing:
+            raise ProtocolValidationError(
+                f"RestartContext.environment: missing fields {sorted(missing)!r}"
+            )
+        local_rank = _environment_integer(
+            environment["LOCAL_RANK"],
+            "LOCAL_RANK",
+            minimum=0,
+        )
+        if local_rank >= self.local_world_size:
+            raise ProtocolValidationError(
+                "RestartContext.environment: LOCAL_RANK exceeds local world size"
+            )
+        expected = {
+            "RANK": self.first_global_rank + local_rank,
+            "LOCAL_WORLD_SIZE": self.local_world_size,
+            "WORLD_SIZE": self.expected_world_size,
+        }
+        for key, expected_value in expected.items():
+            actual = _environment_integer(environment[key], key, minimum=0)
+            if actual != expected_value:
+                raise ProtocolValidationError(
+                    f"RestartContext.environment: {key}={actual} does not match "
+                    f"expected {expected_value}"
+                )
+        if environment["TORCHELASTIC_RUN_ID"] != self.run_id:
+            raise ProtocolValidationError(
+                "RestartContext.environment: TORCHELASTIC_RUN_ID does not match run_id"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "plan_id": self.plan_id,
+            "run_id": self.run_id,
+            "generation": self.generation,
+            "node_id": self.node_id,
+            "logical_node_slot": self.logical_node_slot,
+            "first_global_rank": self.first_global_rank,
+            "local_world_size": self.local_world_size,
+            "expected_world_size": self.expected_world_size,
+            "topology_digest": self.topology_digest,
+            "recovery_mode": self.recovery_mode,
+            "checkpoint_source": self.checkpoint_source,
+            "checkpoint_step": self.checkpoint_step,
+            "checkpoint_id": self.checkpoint_id,
+            "checkpoint_manifest_id": self.checkpoint_manifest_id,
+            "reason_code": self.reason_code,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> RestartContext:
+        _record_fields(
+            value,
+            path=cls.__name__,
+            required={
+                "plan_id",
+                "run_id",
+                "generation",
+                "node_id",
+                "logical_node_slot",
+                "first_global_rank",
+                "local_world_size",
+                "expected_world_size",
+                "topology_digest",
+                "recovery_mode",
+                "checkpoint_source",
+                "checkpoint_step",
+                "checkpoint_id",
+                "checkpoint_manifest_id",
+                "reason_code",
+            },
+        )
+        return cls(
+            plan_id=_string(value["plan_id"], "RestartContext.plan_id"),
+            run_id=_string(value["run_id"], "RestartContext.run_id"),
+            generation=_integer(
+                value["generation"],
+                "RestartContext.generation",
+                minimum=0,
+            ),
+            node_id=_string(value["node_id"], "RestartContext.node_id"),
+            logical_node_slot=_integer(
+                value["logical_node_slot"],
+                "RestartContext.logical_node_slot",
+                minimum=0,
+            ),
+            first_global_rank=_integer(
+                value["first_global_rank"],
+                "RestartContext.first_global_rank",
+                minimum=0,
+            ),
+            local_world_size=_integer(
+                value["local_world_size"],
+                "RestartContext.local_world_size",
+                minimum=1,
+            ),
+            expected_world_size=_integer(
+                value["expected_world_size"],
+                "RestartContext.expected_world_size",
+                minimum=1,
+            ),
+            topology_digest=_string(
+                value["topology_digest"],
+                "RestartContext.topology_digest",
+            ),
+            recovery_mode=_choice(
+                value["recovery_mode"],
+                "RestartContext.recovery_mode",
+                {"latest", "recovery_verified"},
+            ),
+            checkpoint_source=_choice(
+                value["checkpoint_source"],
+                "RestartContext.checkpoint_source",
+                {"gemini", "durable"},
+            ),
+            checkpoint_step=_integer(
+                value["checkpoint_step"],
+                "RestartContext.checkpoint_step",
+                minimum=0,
+            ),
+            checkpoint_id=_optional_string(
+                value["checkpoint_id"],
+                "RestartContext.checkpoint_id",
+            ),
+            checkpoint_manifest_id=_string(
+                value["checkpoint_manifest_id"],
+                "RestartContext.checkpoint_manifest_id",
+            ),
+            reason_code=_string(
+                value["reason_code"],
+                "RestartContext.reason_code",
+            ),
+        )
+
+
+def _environment_integer(value: object, name: str, *, minimum: int) -> int:
+    if not isinstance(value, str):
+        raise ProtocolValidationError(f"RestartContext.environment: {name} must be a string")
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise ProtocolValidationError(
+            f"RestartContext.environment: {name} must be an integer"
+        ) from error
+    return _integer(parsed, f"RestartContext.environment.{name}", minimum=minimum)
+
+
+@dataclass(frozen=True, slots=True)
+class RankCheckpointCopies:
+    owner_global_rank: int
+    copies: tuple[CheckpointCopy, ...]
+
+    def __post_init__(self) -> None:
+        _integer(
+            self.owner_global_rank,
+            "RankCheckpointCopies.owner_global_rank",
+            minimum=0,
+        )
+        copies = _checkpoint_copies(self.copies, "RankCheckpointCopies.copies")
+        for copy in copies:
+            if copy.owner_global_rank != self.owner_global_rank:
+                raise ProtocolValidationError(
+                    "RankCheckpointCopies: copy owner does not match entry owner"
+                )
+        object.__setattr__(self, "copies", copies)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "owner_global_rank": self.owner_global_rank,
+            "copies": [copy.to_dict() for copy in self.copies],
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> RankCheckpointCopies:
+        required = {"owner_global_rank", "copies"}
+        missing = required - set(value)
+        unknown = set(value) - required
+        if missing:
+            raise ProtocolValidationError(
+                f"RankCheckpointCopies: missing fields {sorted(missing)!r}"
+            )
+        if unknown:
+            raise ProtocolValidationError(
+                f"RankCheckpointCopies: unknown fields {sorted(unknown)!r}"
+            )
+        return cls(
+            owner_global_rank=_integer(
+                value["owner_global_rank"],
+                "RankCheckpointCopies.owner_global_rank",
+                minimum=0,
+            ),
+            copies=_checkpoint_copies(
+                value["copies"],
+                "RankCheckpointCopies.copies",
+            ),
+        )
+
+
+def _rank_checkpoint_copies(
+    value: object,
+    path: str,
+) -> tuple[RankCheckpointCopies, ...]:
+    entries = tuple(
+        item
+        if isinstance(item, RankCheckpointCopies)
+        else RankCheckpointCopies.from_dict(_require_mapping(item, f"{path}[{index}]"))
+        for index, item in enumerate(_sequence(value, path))
+    )
+    owner_ranks = [entry.owner_global_rank for entry in entries]
+    if len(owner_ranks) != len(set(owner_ranks)):
+        raise ProtocolValidationError(f"{path}: owner ranks must be unique")
+    return tuple(sorted(entries, key=lambda item: item.owner_global_rank))
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryManifest(_WireRecord):
+    manifest_id: str
+    run_id: str
+    source_generation: int
+    step: int
+    trust: str
+    topology_digest: str
+    rank_copies: tuple[RankCheckpointCopies, ...]
+
+    def __post_init__(self) -> None:
+        _string(self.manifest_id, "RecoveryManifest.manifest_id")
+        _string(self.run_id, "RecoveryManifest.run_id")
+        _integer(
+            self.source_generation,
+            "RecoveryManifest.source_generation",
+            minimum=0,
+        )
+        _integer(self.step, "RecoveryManifest.step", minimum=0)
+        _choice(
+            self.trust,
+            "RecoveryManifest.trust",
+            {"latest", "recovery_verified"},
+        )
+        _string(self.topology_digest, "RecoveryManifest.topology_digest")
+        object.__setattr__(
+            self,
+            "rank_copies",
+            _rank_checkpoint_copies(
+                self.rank_copies,
+                "RecoveryManifest.rank_copies",
+            ),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "manifest_id": self.manifest_id,
+            "run_id": self.run_id,
+            "source_generation": self.source_generation,
+            "step": self.step,
+            "trust": self.trust,
+            "topology_digest": self.topology_digest,
+            "rank_copies": [entry.to_dict() for entry in self.rank_copies],
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> RecoveryManifest:
+        _record_fields(
+            value,
+            path=cls.__name__,
+            required={
+                "manifest_id",
+                "run_id",
+                "source_generation",
+                "step",
+                "trust",
+                "topology_digest",
+                "rank_copies",
+            },
+        )
+        return cls(
+            manifest_id=_string(
+                value["manifest_id"],
+                "RecoveryManifest.manifest_id",
+            ),
+            run_id=_string(value["run_id"], "RecoveryManifest.run_id"),
+            source_generation=_integer(
+                value["source_generation"],
+                "RecoveryManifest.source_generation",
+                minimum=0,
+            ),
+            step=_integer(value["step"], "RecoveryManifest.step", minimum=0),
+            trust=_choice(
+                value["trust"],
+                "RecoveryManifest.trust",
+                {"latest", "recovery_verified"},
+            ),
+            topology_digest=_string(
+                value["topology_digest"],
+                "RecoveryManifest.topology_digest",
+            ),
+            rank_copies=_rank_checkpoint_copies(
+                value["rank_copies"],
+                "RecoveryManifest.rank_copies",
+            ),
+        )
+
+
+def validate_restart_plan(
+    plan: RestartPlan,
+    manifest: RecoveryManifest,
+    *,
+    current_generation: int,
+    expected_active_nodes: int,
+    expected_topology_digest: str,
+    eligible_node_ids: Sequence[str],
+    quarantined_node_ids: Sequence[str] = (),
+) -> None:
+    """Validate that one immutable plan is safe to expose through rendezvous."""
+    if plan.from_generation != current_generation:
+        raise ProtocolValidationError(
+            "RestartPlan.from_generation: does not match the committed generation"
+        )
+    if len(plan.slot_assignments) != expected_active_nodes:
+        raise ProtocolValidationError(
+            "RestartPlan.slot_assignments: active node count does not match policy"
+        )
+    if plan.topology_digest != expected_topology_digest:
+        raise ProtocolValidationError(
+            "RestartPlan.topology_digest: does not match the committed topology"
+        )
+    eligible = set(_strings(eligible_node_ids, "eligible_node_ids", unique=True))
+    quarantined = set(_strings(quarantined_node_ids, "quarantined_node_ids", unique=True)) | set(
+        plan.quarantined_node_ids
+    )
+    assigned = {assignment.node_id for assignment in plan.slot_assignments}
+    unavailable = assigned - eligible
+    if unavailable:
+        raise ProtocolValidationError(
+            f"RestartPlan: assigned nodes are not eligible: {sorted(unavailable)!r}"
+        )
+    unsafe = assigned & quarantined
+    if unsafe:
+        raise ProtocolValidationError(
+            f"RestartPlan: assigned nodes are quarantined: {sorted(unsafe)!r}"
+        )
+    if manifest.manifest_id != plan.checkpoint_manifest_id:
+        raise ProtocolValidationError("RecoveryManifest.manifest_id: does not match restart plan")
+    if manifest.run_id != plan.run_id:
+        raise ProtocolValidationError("RecoveryManifest.run_id: does not match restart plan")
+    if manifest.source_generation > plan.from_generation:
+        raise ProtocolValidationError(
+            "RecoveryManifest.source_generation: cannot be newer than the failed generation"
+        )
+    if manifest.step != plan.checkpoint_step:
+        raise ProtocolValidationError("RecoveryManifest.step: does not match restart plan")
+    if manifest.topology_digest != plan.topology_digest:
+        raise ProtocolValidationError(
+            "RecoveryManifest.topology_digest: does not match restart plan"
+        )
+    if plan.recovery_mode == "recovery_verified" and manifest.trust != "recovery_verified":
+        raise ProtocolValidationError(
+            "RecoveryManifest.trust: verified recovery requires a verified manifest"
+        )
+    entries = {entry.owner_global_rank: entry for entry in manifest.rank_copies}
+    required_ranks = set(range(plan.expected_world_size))
+    if set(entries) != required_ranks:
+        missing = sorted(required_ranks - set(entries))
+        extra = sorted(set(entries) - required_ranks)
+        raise ProtocolValidationError(
+            f"RecoveryManifest.rank_copies: rank coverage mismatch; "
+            f"missing={missing!r}, extra={extra!r}"
+        )
+    for rank, entry in entries.items():
+        eligible_copies = [
+            copy
+            for copy in entry.copies
+            if copy.complete
+            and (
+                copy.holder_kind == "durable"
+                or (copy.holder_node_id in eligible and copy.holder_node_id not in quarantined)
+            )
+        ]
+        if not eligible_copies:
+            raise ProtocolValidationError(
+                f"RecoveryManifest.rank_copies[{rank}]: no complete eligible copy"
+            )
+
+
+__all__ = [
+    "AgentIdentity",
+    "CheckpointCopy",
+    "CheckpointInventoryEvent",
+    "FaultEvent",
+    "HardwareFaultReport",
+    "ProtocolValidationError",
+    "RankAssignment",
+    "RankCheckpointCopies",
+    "RecoveryManifest",
+    "RecoveryProposalEvent",
+    "RestartAck",
+    "RestartContext",
+    "RestartIntent",
+    "RestartPlan",
+    "SlotAssignment",
+    "WorkerIdentity",
+    "validate_restart_plan",
+]

--- a/lm_resiliency/integrations/torchrun/_protocol.py
+++ b/lm_resiliency/integrations/torchrun/_protocol.py
@@ -2718,6 +2718,7 @@ def validate_restart_plan(
                 certified_inventory_event_digests,
             )
             and copy.holder_kind in compatible_holder_kinds
+            and copy.storage_kind in {"node_local", "shared", "remote"}
             and (
                 copy.holder_kind == "durable"
                 or (

--- a/lm_resiliency/integrations/torchrun/_protocol.py
+++ b/lm_resiliency/integrations/torchrun/_protocol.py
@@ -268,6 +268,11 @@ class WorkerIdentity(_WireRecord):
             raise ProtocolValidationError(
                 "WorkerIdentity.local_rank: must be smaller than local_world_size"
             )
+        expected_global_rank = self.logical_node_slot * self.local_world_size + self.local_rank
+        if self.global_rank != expected_global_rank:
+            raise ProtocolValidationError(
+                "WorkerIdentity.global_rank: does not match logical slot and local rank"
+            )
         _string(self.hostname, "WorkerIdentity.hostname")
         _optional_string(self.gpu_uuid, "WorkerIdentity.gpu_uuid")
         _string(self.topology_digest, "WorkerIdentity.topology_digest")
@@ -851,6 +856,15 @@ def _recovery_decision(value: object, path: str) -> Mapping[str, Any]:
     checkpoint_step = normalized["checkpoint_step"]
     checkpoint_source = normalized["checkpoint_source"]
     checkpoint_id = normalized["checkpoint_id"]
+    failure_kind = normalized["failure_kind"]
+    recovery_mode = normalized["recovery_mode"]
+    all_ranks_accessible = normalized["all_ranks_accessible"]
+    if (
+        not all_ranks_accessible or failure_kind in {"sdc", "machine_unavailable"}
+    ) and recovery_mode != "recovery_verified":
+        raise ProtocolValidationError(
+            f"{path}.recovery_mode: unsafe failures require recovery_verified"
+        )
     if available:
         if checkpoint_step <= 0 or checkpoint_source == "none":
             raise ProtocolValidationError(
@@ -953,6 +967,7 @@ class RecoveryProposalEvent(_WireRecord):
 @dataclass(frozen=True, slots=True)
 class CheckpointCopy:
     owner_global_rank: int
+    checkpoint_step: int
     holder_node_id: str
     holder_kind: str
     storage_kind: str
@@ -962,6 +977,7 @@ class CheckpointCopy:
 
     def __post_init__(self) -> None:
         _integer(self.owner_global_rank, "CheckpointCopy.owner_global_rank", minimum=0)
+        _integer(self.checkpoint_step, "CheckpointCopy.checkpoint_step", minimum=1)
         _string(self.holder_node_id, "CheckpointCopy.holder_node_id")
         _choice(
             self.holder_kind,
@@ -973,6 +989,13 @@ class CheckpointCopy:
             "CheckpointCopy.storage_kind",
             {"memory", "node_local", "shared", "remote"},
         )
+        if self.holder_kind == "durable" and self.storage_kind not in {
+            "shared",
+            "remote",
+        }:
+            raise ProtocolValidationError(
+                "CheckpointCopy.storage_kind: durable copies must use shared or remote storage"
+            )
         _string(self.location_token, "CheckpointCopy.location_token")
         _boolean(self.complete, "CheckpointCopy.complete")
         _boolean(self.checksums_available, "CheckpointCopy.checksums_available")
@@ -980,6 +1003,7 @@ class CheckpointCopy:
     def to_dict(self) -> dict[str, Any]:
         return {
             "owner_global_rank": self.owner_global_rank,
+            "checkpoint_step": self.checkpoint_step,
             "holder_node_id": self.holder_node_id,
             "holder_kind": self.holder_kind,
             "storage_kind": self.storage_kind,
@@ -992,6 +1016,7 @@ class CheckpointCopy:
     def from_dict(cls, value: Mapping[str, Any]) -> CheckpointCopy:
         required = {
             "owner_global_rank",
+            "checkpoint_step",
             "holder_node_id",
             "holder_kind",
             "storage_kind",
@@ -1010,6 +1035,11 @@ class CheckpointCopy:
                 value["owner_global_rank"],
                 "CheckpointCopy.owner_global_rank",
                 minimum=0,
+            ),
+            checkpoint_step=_integer(
+                value["checkpoint_step"],
+                "CheckpointCopy.checkpoint_step",
+                minimum=1,
             ),
             holder_node_id=_string(
                 value["holder_node_id"],
@@ -1047,6 +1077,7 @@ def _checkpoint_copies(value: object, path: str) -> tuple[CheckpointCopy, ...]:
     identities = [
         (
             copy.owner_global_rank,
+            copy.checkpoint_step,
             copy.holder_node_id,
             copy.holder_kind,
             copy.storage_kind,
@@ -1086,7 +1117,7 @@ class CheckpointInventoryEvent(_WireRecord):
             raise ProtocolValidationError(
                 "CheckpointInventoryEvent: reporter generation does not match event"
             )
-        _integer(self.step, "CheckpointInventoryEvent.step", minimum=0)
+        _integer(self.step, "CheckpointInventoryEvent.step", minimum=1)
         _choice(
             self.trust,
             "CheckpointInventoryEvent.trust",
@@ -1097,11 +1128,18 @@ class CheckpointInventoryEvent(_WireRecord):
             raise ProtocolValidationError(
                 "CheckpointInventoryEvent: reporter topology digest does not match event"
             )
-        object.__setattr__(
-            self,
-            "copies",
-            _checkpoint_copies(self.copies, "CheckpointInventoryEvent.copies"),
+        copies = _checkpoint_copies(
+            self.copies,
+            "CheckpointInventoryEvent.copies",
         )
+        mismatched_steps = sorted(
+            {copy.checkpoint_step for copy in copies if copy.checkpoint_step != self.step}
+        )
+        if mismatched_steps:
+            raise ProtocolValidationError(
+                "CheckpointInventoryEvent.copies: copy steps do not match event step"
+            )
+        object.__setattr__(self, "copies", copies)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -1152,7 +1190,7 @@ class CheckpointInventoryEvent(_WireRecord):
             step=_integer(
                 value["step"],
                 "CheckpointInventoryEvent.step",
-                minimum=0,
+                minimum=1,
             ),
             trust=_choice(
                 value["trust"],
@@ -1448,7 +1486,7 @@ class RestartPlan(_WireRecord):
             "RestartPlan.checkpoint_source",
             {"gemini", "durable"},
         )
-        _integer(self.checkpoint_step, "RestartPlan.checkpoint_step", minimum=0)
+        _integer(self.checkpoint_step, "RestartPlan.checkpoint_step", minimum=1)
         _optional_string(self.checkpoint_id, "RestartPlan.checkpoint_id")
         if self.checkpoint_source == "durable" and self.checkpoint_id is None:
             raise ProtocolValidationError(
@@ -1579,7 +1617,7 @@ class RestartPlan(_WireRecord):
             checkpoint_step=_integer(
                 value["checkpoint_step"],
                 "RestartPlan.checkpoint_step",
-                minimum=0,
+                minimum=1,
             ),
             checkpoint_id=_optional_string(
                 value["checkpoint_id"],
@@ -1678,7 +1716,7 @@ class RestartContext(_WireRecord):
             "RestartContext.checkpoint_source",
             {"gemini", "durable"},
         )
-        _integer(self.checkpoint_step, "RestartContext.checkpoint_step", minimum=0)
+        _integer(self.checkpoint_step, "RestartContext.checkpoint_step", minimum=1)
         _optional_string(self.checkpoint_id, "RestartContext.checkpoint_id")
         if self.checkpoint_source == "durable" and self.checkpoint_id is None:
             raise ProtocolValidationError(
@@ -1850,7 +1888,7 @@ class RestartContext(_WireRecord):
             checkpoint_step=_integer(
                 value["checkpoint_step"],
                 "RestartContext.checkpoint_step",
-                minimum=0,
+                minimum=1,
             ),
             checkpoint_id=_optional_string(
                 value["checkpoint_id"],
@@ -1964,21 +2002,30 @@ class RecoveryManifest(_WireRecord):
             "RecoveryManifest.source_generation",
             minimum=0,
         )
-        _integer(self.step, "RecoveryManifest.step", minimum=0)
+        _integer(self.step, "RecoveryManifest.step", minimum=1)
         _choice(
             self.trust,
             "RecoveryManifest.trust",
             {"latest", "recovery_verified"},
         )
         _string(self.topology_digest, "RecoveryManifest.topology_digest")
-        object.__setattr__(
-            self,
-            "rank_copies",
-            _rank_checkpoint_copies(
-                self.rank_copies,
-                "RecoveryManifest.rank_copies",
-            ),
+        rank_copies = _rank_checkpoint_copies(
+            self.rank_copies,
+            "RecoveryManifest.rank_copies",
         )
+        mismatched_steps = sorted(
+            {
+                copy.checkpoint_step
+                for entry in rank_copies
+                for copy in entry.copies
+                if copy.checkpoint_step != self.step
+            }
+        )
+        if mismatched_steps:
+            raise ProtocolValidationError(
+                "RecoveryManifest.rank_copies: copy steps do not match manifest step"
+            )
+        object.__setattr__(self, "rank_copies", rank_copies)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -2018,7 +2065,7 @@ class RecoveryManifest(_WireRecord):
                 "RecoveryManifest.source_generation",
                 minimum=0,
             ),
-            step=_integer(value["step"], "RecoveryManifest.step", minimum=0),
+            step=_integer(value["step"], "RecoveryManifest.step", minimum=1),
             trust=_choice(
                 value["trust"],
                 "RecoveryManifest.trust",
@@ -2037,24 +2084,57 @@ class RecoveryManifest(_WireRecord):
 
 def validate_restart_plan(
     plan: RestartPlan,
+    intent: RestartIntent,
     manifest: RecoveryManifest,
     *,
-    current_generation: int,
-    expected_active_nodes: int,
-    expected_topology_digest: str,
+    current_assignment: RankAssignment,
+    now_unix_ms: int,
     eligible_node_ids: Sequence[str],
     quarantined_node_ids: Sequence[str] = (),
 ) -> None:
     """Validate that one immutable plan is safe to expose through rendezvous."""
-    if plan.from_generation != current_generation:
+    _integer(now_unix_ms, "now_unix_ms", minimum=1)
+    if plan.restart_deadline_unix_ms <= now_unix_ms:
+        raise ProtocolValidationError("RestartPlan.restart_deadline_unix_ms: deadline has elapsed")
+    if plan.intent_id != intent.intent_id:
+        raise ProtocolValidationError("RestartPlan.intent_id: does not match restart intent")
+    if plan.run_id != intent.run_id or plan.run_id != current_assignment.run_id:
         raise ProtocolValidationError(
-            "RestartPlan.from_generation: does not match the committed generation"
+            "RestartPlan.run_id: does not match intent and committed assignment"
         )
-    if len(plan.slot_assignments) != expected_active_nodes:
+    if (
+        plan.from_generation != intent.generation
+        or plan.from_generation != current_assignment.generation
+    ):
         raise ProtocolValidationError(
-            "RestartPlan.slot_assignments: active node count does not match policy"
+            "RestartPlan.from_generation: does not match intent and committed assignment"
         )
-    if plan.topology_digest != expected_topology_digest:
+    if plan.incident_ids != intent.incident_ids:
+        raise ProtocolValidationError("RestartPlan.incident_ids: do not match restart intent")
+    if plan.reason_code != intent.reason_code:
+        raise ProtocolValidationError("RestartPlan.reason_code: does not match restart intent")
+    if (
+        intent.minimum_recovery_mode == "recovery_verified"
+        and plan.recovery_mode != "recovery_verified"
+    ):
+        raise ProtocolValidationError(
+            "RestartPlan.recovery_mode: weaker than restart intent minimum"
+        )
+    if len(plan.slot_assignments) != current_assignment.active_nodes:
+        raise ProtocolValidationError(
+            "RestartPlan.slot_assignments: active node count does not match committed assignment"
+        )
+    plan_local_world_size = plan.slot_assignments[0].local_world_size
+    if plan_local_world_size != current_assignment.local_world_size:
+        raise ProtocolValidationError(
+            "RestartPlan.slot_assignments: local world size does not match committed assignment"
+        )
+    committed_world_size = current_assignment.active_nodes * current_assignment.local_world_size
+    if plan.expected_world_size != committed_world_size:
+        raise ProtocolValidationError(
+            "RestartPlan.expected_world_size: does not match committed assignment"
+        )
+    if plan.topology_digest != current_assignment.topology_digest:
         raise ProtocolValidationError(
             "RestartPlan.topology_digest: does not match the committed topology"
         )
@@ -2101,12 +2181,17 @@ def validate_restart_plan(
             f"missing={missing!r}, extra={extra!r}"
         )
     for rank, entry in entries.items():
+        compatible_holder_kinds = (
+            {"durable"} if plan.checkpoint_source == "durable" else {"owner", "peer"}
+        )
         eligible_copies = [
             copy
             for copy in entry.copies
             if copy.complete
+            and copy.checkpoint_step == manifest.step
+            and copy.holder_kind in compatible_holder_kinds
             and (
-                copy.holder_kind == "durable"
+                copy.storage_kind in {"shared", "remote"}
                 or (copy.holder_node_id in eligible and copy.holder_node_id not in quarantined)
             )
         ]

--- a/lm_resiliency/integrations/torchrun/_protocol.py
+++ b/lm_resiliency/integrations/torchrun/_protocol.py
@@ -969,6 +969,7 @@ class CheckpointCopy:
     owner_global_rank: int
     checkpoint_step: int
     inventory_event_id: str
+    checkpoint_id: str | None
     holder_node_id: str
     holder_kind: str
     storage_kind: str
@@ -980,6 +981,7 @@ class CheckpointCopy:
         _integer(self.owner_global_rank, "CheckpointCopy.owner_global_rank", minimum=0)
         _integer(self.checkpoint_step, "CheckpointCopy.checkpoint_step", minimum=1)
         _string(self.inventory_event_id, "CheckpointCopy.inventory_event_id")
+        _optional_string(self.checkpoint_id, "CheckpointCopy.checkpoint_id")
         _string(self.holder_node_id, "CheckpointCopy.holder_node_id")
         _choice(
             self.holder_kind,
@@ -998,6 +1000,14 @@ class CheckpointCopy:
             raise ProtocolValidationError(
                 "CheckpointCopy.storage_kind: durable copies must use shared or remote storage"
             )
+        if self.holder_kind == "durable" and self.checkpoint_id is None:
+            raise ProtocolValidationError(
+                "CheckpointCopy.checkpoint_id: durable copies require a checkpoint ID"
+            )
+        if self.holder_kind != "durable" and self.checkpoint_id is not None:
+            raise ProtocolValidationError(
+                "CheckpointCopy.checkpoint_id: only durable copies may carry a checkpoint ID"
+            )
         _string(self.location_token, "CheckpointCopy.location_token")
         _boolean(self.complete, "CheckpointCopy.complete")
         _boolean(self.checksums_available, "CheckpointCopy.checksums_available")
@@ -1007,6 +1017,7 @@ class CheckpointCopy:
             "owner_global_rank": self.owner_global_rank,
             "checkpoint_step": self.checkpoint_step,
             "inventory_event_id": self.inventory_event_id,
+            "checkpoint_id": self.checkpoint_id,
             "holder_node_id": self.holder_node_id,
             "holder_kind": self.holder_kind,
             "storage_kind": self.storage_kind,
@@ -1021,6 +1032,7 @@ class CheckpointCopy:
             "owner_global_rank",
             "checkpoint_step",
             "inventory_event_id",
+            "checkpoint_id",
             "holder_node_id",
             "holder_kind",
             "storage_kind",
@@ -1048,6 +1060,10 @@ class CheckpointCopy:
             inventory_event_id=_string(
                 value["inventory_event_id"],
                 "CheckpointCopy.inventory_event_id",
+            ),
+            checkpoint_id=_optional_string(
+                value["checkpoint_id"],
+                "CheckpointCopy.checkpoint_id",
             ),
             holder_node_id=_string(
                 value["holder_node_id"],
@@ -1087,6 +1103,7 @@ def _checkpoint_copies(value: object, path: str) -> tuple[CheckpointCopy, ...]:
             copy.owner_global_rank,
             copy.checkpoint_step,
             copy.inventory_event_id,
+            copy.checkpoint_id,
             copy.holder_node_id,
             copy.holder_kind,
             copy.storage_kind,
@@ -2139,8 +2156,11 @@ def validate_worker_identity(
 def validate_event_reporter(
     event: FaultEvent | RecoveryProposalEvent | CheckpointInventoryEvent,
     assignment: RankAssignment,
+    *,
+    agent_identity: AgentIdentity,
+    resource_to_node_id: Mapping[str, str],
 ) -> None:
-    """Validate a report's worker identity at coordinator admission."""
+    """Validate a report against committed rank and infrastructure identities."""
     if not isinstance(
         event,
         (FaultEvent, RecoveryProposalEvent, CheckpointInventoryEvent),
@@ -2149,6 +2169,63 @@ def validate_event_reporter(
             "event: expected a fault, recovery, or checkpoint inventory event"
         )
     validate_worker_identity(event.reporter, assignment)
+    if not isinstance(agent_identity, AgentIdentity):
+        raise ProtocolValidationError("agent_identity: expected AgentIdentity")
+    reporter = event.reporter
+    if agent_identity.run_id != reporter.run_id:
+        raise ProtocolValidationError("AgentIdentity.run_id: does not match event reporter")
+    if agent_identity.node_id != reporter.node_id:
+        raise ProtocolValidationError("AgentIdentity.node_id: does not match event reporter")
+    if agent_identity.agent_id != reporter.agent_id:
+        raise ProtocolValidationError("AgentIdentity.agent_id: does not match event reporter")
+    if agent_identity.hostname != reporter.hostname:
+        raise ProtocolValidationError("AgentIdentity.hostname: does not match event reporter")
+    if agent_identity.local_world_size != reporter.local_world_size:
+        raise ProtocolValidationError(
+            "AgentIdentity.local_world_size: does not match event reporter"
+        )
+    if not isinstance(resource_to_node_id, Mapping):
+        raise ProtocolValidationError("resource_to_node_id: expected an object")
+    resource_owners = {
+        _string(resource_id, "resource_to_node_id.key"): _string(
+            node_id,
+            f"resource_to_node_id[{resource_id!r}]",
+        )
+        for resource_id, node_id in resource_to_node_id.items()
+    }
+    if reporter.gpu_uuid is not None:
+        if reporter.gpu_uuid not in agent_identity.resource_ids:
+            raise ProtocolValidationError(
+                "WorkerIdentity.gpu_uuid: is not registered to the reporting agent"
+            )
+        if resource_owners.get(reporter.gpu_uuid) != reporter.node_id:
+            raise ProtocolValidationError(
+                "WorkerIdentity.gpu_uuid: trusted resource owner does not match reporter"
+            )
+    if not isinstance(event, FaultEvent) or event.report.get("kind") != "hardware":
+        return
+    resource_kind = _choice(
+        event.report.get("resource_kind"),
+        "FaultEvent.report.resource_kind",
+        {"gpu", "node", "nic", "hca", "link"},
+    )
+    resource_id = _string(
+        event.report.get("resource_id"),
+        "FaultEvent.report.resource_id",
+    )
+    if resource_kind == "node":
+        if resource_id != reporter.node_id:
+            raise ProtocolValidationError(
+                "FaultEvent.report.resource_id: node fault does not identify the reporter's node"
+            )
+    elif resource_id not in agent_identity.resource_ids:
+        raise ProtocolValidationError(
+            "FaultEvent.report.resource_id: resource is not registered to the reporting agent"
+        )
+    if resource_owners.get(resource_id) != reporter.node_id:
+        raise ProtocolValidationError(
+            "FaultEvent.report.resource_id: trusted resource owner does not match reporter"
+        )
 
 
 def validate_restart_plan(
@@ -2157,6 +2234,7 @@ def validate_restart_plan(
     manifest: RecoveryManifest,
     *,
     inventory_events: Sequence[CheckpointInventoryEvent],
+    restart_acks: Sequence[RestartAck],
     current_assignment: RankAssignment,
     now_unix_ms: int,
     eligible_node_ids: Sequence[str],
@@ -2210,6 +2288,22 @@ def validate_restart_plan(
         )
     current_nodes = set(current_assignment.slot_to_node_id.values())
     assigned_nodes = {assignment.node_id for assignment in plan.slot_assignments}
+    current_slots_by_node = {
+        node_id: slot for slot, node_id in current_assignment.slot_to_node_id.items()
+    }
+    planned_slots_by_node = {
+        assignment.node_id: assignment.logical_node_slot for assignment in plan.slot_assignments
+    }
+    moved_survivors = sorted(
+        node_id
+        for node_id in current_nodes & assigned_nodes
+        if current_slots_by_node[node_id] != planned_slots_by_node[node_id]
+    )
+    if moved_survivors:
+        raise ProtocolValidationError(
+            "RestartPlan.slot_assignments: surviving nodes changed logical slots: "
+            f"{moved_survivors!r}"
+        )
     if assigned_nodes == current_nodes:
         raise ProtocolValidationError(
             "RestartPlan.slot_assignments: version 1 requires at least one replacement node"
@@ -2246,6 +2340,10 @@ def validate_restart_plan(
         raise ProtocolValidationError(
             "RecoveryManifest.trust: verified recovery requires a verified manifest"
         )
+    if plan.checkpoint_source == "durable" and manifest.trust != "recovery_verified":
+        raise ProtocolValidationError(
+            "RecoveryManifest.trust: durable recovery requires a verified manifest"
+        )
     inventory_by_id: dict[str, CheckpointInventoryEvent] = {}
     for index, event in enumerate(_sequence(inventory_events, "inventory_events")):
         if not isinstance(event, CheckpointInventoryEvent):
@@ -2257,6 +2355,25 @@ def validate_restart_plan(
                 f"inventory_events: duplicate event ID {event.event_id!r}"
             )
         inventory_by_id[event.event_id] = event
+    ack_by_node: dict[str, RestartAck] = {}
+    for index, ack in enumerate(_sequence(restart_acks, "restart_acks")):
+        if not isinstance(ack, RestartAck):
+            raise ProtocolValidationError(f"restart_acks[{index}]: expected RestartAck")
+        if ack.node_id in ack_by_node:
+            raise ProtocolValidationError(f"restart_acks: duplicate node ID {ack.node_id!r}")
+        if ack.intent_id != intent.intent_id:
+            raise ProtocolValidationError(
+                f"restart_acks[{index}].intent_id: does not match restart intent"
+            )
+        if ack.generation != intent.generation:
+            raise ProtocolValidationError(
+                f"restart_acks[{index}].generation: does not match restart intent"
+            )
+        if ack.node_id not in current_nodes:
+            raise ProtocolValidationError(
+                f"restart_acks[{index}].node_id: is not active in the committed generation"
+            )
+        ack_by_node[ack.node_id] = ack
     entries = {entry.owner_global_rank: entry for entry in manifest.rank_copies}
     required_ranks = set(range(plan.expected_world_size))
     if set(entries) != required_ranks:
@@ -2279,8 +2396,10 @@ def validate_restart_plan(
                 copy,
                 manifest,
                 inventory_by_id,
+                ack_by_node,
             )
             and copy.holder_kind in compatible_holder_kinds
+            and copy.checkpoint_id == plan.checkpoint_id
             and (
                 copy.storage_kind in {"shared", "remote"}
                 or (copy.holder_node_id in eligible and copy.holder_node_id not in quarantined)
@@ -2296,6 +2415,7 @@ def _copy_has_trusted_inventory_provenance(
     copy: CheckpointCopy,
     manifest: RecoveryManifest,
     inventory_by_id: Mapping[str, CheckpointInventoryEvent],
+    ack_by_node: Mapping[str, RestartAck],
 ) -> bool:
     event = inventory_by_id.get(copy.inventory_event_id)
     if event is None:
@@ -2309,7 +2429,17 @@ def _copy_has_trusted_inventory_provenance(
         or (manifest.trust == "recovery_verified" and event.trust != "recovery_verified")
     ):
         return False
-    return copy in event.copies
+    if copy not in event.copies:
+        return False
+    if manifest.trust != "latest":
+        return True
+    ack = ack_by_node.get(event.reporter.node_id)
+    return (
+        ack is not None
+        and ack.success
+        and ack.flushed_step == manifest.step
+        and event.event_id in ack.inventory_event_ids
+    )
 
 
 __all__ = [

--- a/lm_resiliency/integrations/torchrun/_protocol.py
+++ b/lm_resiliency/integrations/torchrun/_protocol.py
@@ -2381,6 +2381,7 @@ def validate_event_reporter(
     agent_identity: AgentIdentity,
     resource_to_node_id: Mapping[str, str],
     resource_to_kind: Mapping[str, str],
+    resource_to_global_rank: Mapping[str, int],
 ) -> None:
     """Validate a report against committed rank and infrastructure identities."""
     if not isinstance(
@@ -2425,6 +2426,16 @@ def validate_event_reporter(
         )
         for resource_id, resource_kind in resource_to_kind.items()
     }
+    if not isinstance(resource_to_global_rank, Mapping):
+        raise ProtocolValidationError("resource_to_global_rank: expected an object")
+    resource_ranks = {
+        _string(resource_id, "resource_to_global_rank.key"): _integer(
+            global_rank,
+            f"resource_to_global_rank[{resource_id!r}]",
+            minimum=0,
+        )
+        for resource_id, global_rank in resource_to_global_rank.items()
+    }
     if reporter.gpu_uuid is not None:
         if reporter.gpu_uuid not in agent_identity.resource_ids:
             raise ProtocolValidationError(
@@ -2437,6 +2448,10 @@ def validate_event_reporter(
         if resource_kinds.get(reporter.gpu_uuid) != "gpu":
             raise ProtocolValidationError(
                 "WorkerIdentity.gpu_uuid: trusted resource kind is not gpu"
+            )
+        if resource_ranks.get(reporter.gpu_uuid) != reporter.global_rank:
+            raise ProtocolValidationError(
+                "WorkerIdentity.gpu_uuid: trusted resource rank does not match reporter"
             )
     if isinstance(event, FaultEvent):
         rank_to_node = {
@@ -2534,6 +2549,11 @@ def validate_event_reporter(
                     "FaultEvent.report.endpoint_id: trusted resource kind does not match "
                     "endpoint kind"
                 )
+            elif resource_ranks.get(endpoint_id) != endpoint_rank:
+                raise ProtocolValidationError(
+                    "FaultEvent.report.endpoint_id: trusted resource rank does not match "
+                    "endpoint rank"
+                )
     if not isinstance(event, FaultEvent) or event.report.get("kind") != "hardware":
         return
     resource_kind = _choice(
@@ -2561,6 +2581,10 @@ def validate_event_reporter(
     if resource_kinds.get(resource_id) != resource_kind:
         raise ProtocolValidationError(
             "FaultEvent.report.resource_id: trusted resource kind does not match report"
+        )
+    if resource_kind == "gpu" and resource_ranks.get(resource_id) != reporter.global_rank:
+        raise ProtocolValidationError(
+            "FaultEvent.report.resource_id: trusted GPU rank does not match reporter"
         )
 
 
@@ -2659,6 +2683,20 @@ def validate_restart_plan(
     if assigned_nodes == current_nodes:
         raise ProtocolValidationError(
             "RestartPlan.slot_assignments: version 1 requires at least one replacement node"
+        )
+    removed_nodes = current_nodes - assigned_nodes
+    plan_quarantined_nodes = set(plan.quarantined_node_ids)
+    unsupported_quarantine = sorted(plan_quarantined_nodes - suspected_nodes)
+    if unsupported_quarantine:
+        raise ProtocolValidationError(
+            "RestartPlan.quarantined_node_ids: nodes are not in the intent's suspected "
+            f"scope: {unsupported_quarantine!r}"
+        )
+    unremoved_quarantine = sorted(plan_quarantined_nodes - removed_nodes)
+    if unremoved_quarantine:
+        raise ProtocolValidationError(
+            "RestartPlan.quarantined_node_ids: nodes were not removed from the current "
+            f"assignment: {unremoved_quarantine!r}"
         )
     eligible = set(_strings(eligible_node_ids, "eligible_node_ids", unique=True))
     quarantined = set(_strings(quarantined_node_ids, "quarantined_node_ids", unique=True)) | set(

--- a/lm_resiliency/integrations/torchrun/_protocol.py
+++ b/lm_resiliency/integrations/torchrun/_protocol.py
@@ -826,7 +826,19 @@ def _recovery_decision(value: object, path: str) -> Mapping[str, Any]:
     if unknown:
         raise ProtocolValidationError(f"{path}: unknown fields {sorted(unknown)!r}")
     normalized = {
-        "failure_kind": _string(mapping["failure_kind"], f"{path}.failure_kind"),
+        "failure_kind": _choice(
+            mapping["failure_kind"],
+            f"{path}.failure_kind",
+            {
+                "checkpoint_stall",
+                "data_stall",
+                "hang",
+                "machine_unavailable",
+                "sdc",
+                "straggler",
+                "uncertain",
+            },
+        ),
         "recovery_mode": _choice(
             mapping["recovery_mode"],
             f"{path}.recovery_mode",
@@ -1525,7 +1537,7 @@ class RestartAck(_WireRecord):
     agent_id: str
     generation: int
     flushed_step: int
-    inventory_event_ids: tuple[str, ...]
+    inventory_event_digests: Mapping[str, str]
     transferred_owner_ranks: tuple[int, ...]
     transferred_peer_ranks: tuple[int, ...]
     success: bool
@@ -1538,13 +1550,24 @@ class RestartAck(_WireRecord):
         _string(self.agent_id, "RestartAck.agent_id")
         _integer(self.generation, "RestartAck.generation", minimum=0)
         _integer(self.flushed_step, "RestartAck.flushed_step", minimum=-1)
+        if not isinstance(self.inventory_event_digests, Mapping):
+            raise ProtocolValidationError("RestartAck.inventory_event_digests: expected an object")
         object.__setattr__(
             self,
-            "inventory_event_ids",
-            _strings(
-                self.inventory_event_ids,
-                "RestartAck.inventory_event_ids",
-                unique=True,
+            "inventory_event_digests",
+            MappingProxyType(
+                dict(
+                    sorted(
+                        (
+                            _string(event_id, "RestartAck.inventory_event_digests.key"),
+                            _sha256_digest(
+                                digest,
+                                f"RestartAck.inventory_event_digests[{event_id!r}]",
+                            ),
+                        )
+                        for event_id, digest in self.inventory_event_digests.items()
+                    )
+                )
             ),
         )
         object.__setattr__(
@@ -1583,7 +1606,7 @@ class RestartAck(_WireRecord):
             "agent_id": self.agent_id,
             "generation": self.generation,
             "flushed_step": self.flushed_step,
-            "inventory_event_ids": list(self.inventory_event_ids),
+            "inventory_event_digests": dict(self.inventory_event_digests),
             "transferred_owner_ranks": list(self.transferred_owner_ranks),
             "transferred_peer_ranks": list(self.transferred_peer_ranks),
             "success": self.success,
@@ -1602,7 +1625,7 @@ class RestartAck(_WireRecord):
                 "agent_id",
                 "generation",
                 "flushed_step",
-                "inventory_event_ids",
+                "inventory_event_digests",
                 "transferred_owner_ranks",
                 "transferred_peer_ranks",
                 "success",
@@ -1624,10 +1647,9 @@ class RestartAck(_WireRecord):
                 "RestartAck.flushed_step",
                 minimum=-1,
             ),
-            inventory_event_ids=_strings(
-                value["inventory_event_ids"],
-                "RestartAck.inventory_event_ids",
-                unique=True,
+            inventory_event_digests=_require_mapping(
+                value["inventory_event_digests"],
+                "RestartAck.inventory_event_digests",
             ),
             transferred_owner_ranks=_integers(
                 value["transferred_owner_ranks"],
@@ -2391,24 +2413,97 @@ def validate_event_reporter(
             raise ProtocolValidationError(
                 "WorkerIdentity.gpu_uuid: trusted resource owner does not match reporter"
             )
-    if isinstance(event, FaultEvent) and "failed_ranks" in event.report:
-        reported_ranks = _integers(
-            event.report["failed_ranks"],
-            "FaultEvent.report.failed_ranks",
-            minimum=0,
-            unique=True,
-        )
-        assigned_ranks = {
-            rank
-            for first_rank, last_rank in assignment.slot_to_rank_range.values()
+    if isinstance(event, FaultEvent):
+        rank_to_node = {
+            rank: assignment.slot_to_node_id[slot]
+            for slot, (first_rank, last_rank) in assignment.slot_to_rank_range.items()
             for rank in range(first_rank, last_rank)
         }
-        unknown_ranks = sorted(set(reported_ranks) - assigned_ranks)
-        if unknown_ranks:
-            raise ProtocolValidationError(
-                "FaultEvent.report.failed_ranks: ranks are not active in the committed "
-                f"assignment: {unknown_ranks!r}"
+        failed_ranks = (
+            _integers(
+                event.report["failed_ranks"],
+                "FaultEvent.report.failed_ranks",
+                minimum=0,
+                unique=True,
             )
+            if "failed_ranks" in event.report
+            else ()
+        )
+
+        def validate_attributed_ranks(field: str) -> tuple[int, ...]:
+            ranks = _integers(
+                event.report[field],
+                f"FaultEvent.report.{field}",
+                minimum=0,
+                unique=True,
+            )
+            unknown_ranks = sorted(set(ranks) - set(rank_to_node))
+            if unknown_ranks:
+                raise ProtocolValidationError(
+                    f"FaultEvent.report.{field}: ranks are not active in the committed "
+                    f"assignment: {unknown_ranks!r}"
+                )
+            outside_failed = sorted(set(ranks) - set(failed_ranks))
+            if outside_failed:
+                raise ProtocolValidationError(
+                    f"FaultEvent.report.{field}: ranks are not present in failed_ranks: "
+                    f"{outside_failed!r}"
+                )
+            return ranks
+
+        if failed_ranks:
+            validate_attributed_ranks("failed_ranks")
+        for field in ("dataloader_culprit_ranks", "stage_culprit_ranks"):
+            if field in event.report:
+                validate_attributed_ranks(field)
+        endpoint_fields = {
+            field
+            for field in ("endpoint_kind", "endpoint_id", "endpoint_rank")
+            if field in event.report
+        }
+        if endpoint_fields and endpoint_fields != {
+            "endpoint_kind",
+            "endpoint_id",
+            "endpoint_rank",
+        }:
+            raise ProtocolValidationError(
+                "FaultEvent.report: endpoint_kind, endpoint_id, and endpoint_rank "
+                "must be provided together"
+            )
+        if endpoint_fields:
+            endpoint_rank = _integer(
+                event.report["endpoint_rank"],
+                "FaultEvent.report.endpoint_rank",
+                minimum=0,
+            )
+            if endpoint_rank not in rank_to_node:
+                raise ProtocolValidationError(
+                    "FaultEvent.report.endpoint_rank: rank is not active in the "
+                    "committed assignment"
+                )
+            if endpoint_rank not in failed_ranks:
+                raise ProtocolValidationError(
+                    "FaultEvent.report.endpoint_rank: rank is not present in failed_ranks"
+                )
+            endpoint_kind = _string(
+                event.report["endpoint_kind"],
+                "FaultEvent.report.endpoint_kind",
+            )
+            endpoint_id = _string(
+                event.report["endpoint_id"],
+                "FaultEvent.report.endpoint_id",
+            )
+            endpoint_node_id = rank_to_node[endpoint_rank]
+            if endpoint_kind == "node":
+                if endpoint_id != endpoint_node_id:
+                    raise ProtocolValidationError(
+                        "FaultEvent.report.endpoint_id: does not match endpoint rank's node"
+                    )
+            elif resource_owners.get(endpoint_id) != endpoint_node_id:
+                raise ProtocolValidationError(
+                    "FaultEvent.report.endpoint_id: trusted resource owner does not match "
+                    "endpoint rank"
+                )
     if not isinstance(event, FaultEvent) or event.report.get("kind") != "hardware":
         return
     resource_kind = _choice(
@@ -2568,6 +2663,13 @@ def validate_restart_plan(
     if source_assignment.topology_digest != manifest.topology_digest:
         raise ProtocolValidationError(
             "source_assignment.topology_digest: does not match recovery manifest"
+        )
+    if (
+        source_assignment.generation == current_assignment.generation
+        and source_assignment != current_assignment
+    ):
+        raise ProtocolValidationError(
+            "source_assignment: conflicts with the committed assignment for this generation"
         )
     source_world_size = source_assignment.active_nodes * source_assignment.local_world_size
     if source_world_size != plan.expected_world_size:
@@ -2774,7 +2876,7 @@ def _copy_has_trusted_inventory_provenance(
         and ack.success
         and ack.agent_id == event.reporter.agent_id
         and ack.flushed_step == manifest.step
-        and event.event_id in ack.inventory_event_ids
+        and ack.inventory_event_digests.get(event.event_id) == checkpoint_inventory_digest(event)
     )
 
 

--- a/lm_resiliency/integrations/torchrun/_protocol.py
+++ b/lm_resiliency/integrations/torchrun/_protocol.py
@@ -968,6 +968,7 @@ class RecoveryProposalEvent(_WireRecord):
 class CheckpointCopy:
     owner_global_rank: int
     checkpoint_step: int
+    inventory_event_id: str
     holder_node_id: str
     holder_kind: str
     storage_kind: str
@@ -978,6 +979,7 @@ class CheckpointCopy:
     def __post_init__(self) -> None:
         _integer(self.owner_global_rank, "CheckpointCopy.owner_global_rank", minimum=0)
         _integer(self.checkpoint_step, "CheckpointCopy.checkpoint_step", minimum=1)
+        _string(self.inventory_event_id, "CheckpointCopy.inventory_event_id")
         _string(self.holder_node_id, "CheckpointCopy.holder_node_id")
         _choice(
             self.holder_kind,
@@ -1004,6 +1006,7 @@ class CheckpointCopy:
         return {
             "owner_global_rank": self.owner_global_rank,
             "checkpoint_step": self.checkpoint_step,
+            "inventory_event_id": self.inventory_event_id,
             "holder_node_id": self.holder_node_id,
             "holder_kind": self.holder_kind,
             "storage_kind": self.storage_kind,
@@ -1017,6 +1020,7 @@ class CheckpointCopy:
         required = {
             "owner_global_rank",
             "checkpoint_step",
+            "inventory_event_id",
             "holder_node_id",
             "holder_kind",
             "storage_kind",
@@ -1040,6 +1044,10 @@ class CheckpointCopy:
                 value["checkpoint_step"],
                 "CheckpointCopy.checkpoint_step",
                 minimum=1,
+            ),
+            inventory_event_id=_string(
+                value["inventory_event_id"],
+                "CheckpointCopy.inventory_event_id",
             ),
             holder_node_id=_string(
                 value["holder_node_id"],
@@ -1078,6 +1086,7 @@ def _checkpoint_copies(value: object, path: str) -> tuple[CheckpointCopy, ...]:
         (
             copy.owner_global_rank,
             copy.checkpoint_step,
+            copy.inventory_event_id,
             copy.holder_node_id,
             copy.holder_kind,
             copy.storage_kind,
@@ -1138,6 +1147,13 @@ class CheckpointInventoryEvent(_WireRecord):
         if mismatched_steps:
             raise ProtocolValidationError(
                 "CheckpointInventoryEvent.copies: copy steps do not match event step"
+            )
+        mismatched_event_ids = sorted(
+            {copy.inventory_event_id for copy in copies if copy.inventory_event_id != self.event_id}
+        )
+        if mismatched_event_ids:
+            raise ProtocolValidationError(
+                "CheckpointInventoryEvent.copies: provenance does not match event ID"
             )
         object.__setattr__(self, "copies", copies)
 
@@ -1701,6 +1717,10 @@ class RestartContext(_WireRecord):
             "RestartContext.expected_world_size",
             minimum=1,
         )
+        if self.expected_world_size % self.local_world_size != 0:
+            raise ProtocolValidationError(
+                "RestartContext.expected_world_size: must contain complete local worker slots"
+            )
         if self.first_global_rank + self.local_world_size > self.expected_world_size:
             raise ProtocolValidationError(
                 "RestartContext: local rank range exceeds expected world size"
@@ -2082,11 +2102,61 @@ class RecoveryManifest(_WireRecord):
         )
 
 
+def validate_worker_identity(
+    identity: WorkerIdentity,
+    assignment: RankAssignment,
+) -> None:
+    """Bind a worker-supplied identity to one committed rank assignment."""
+    if identity.run_id != assignment.run_id:
+        raise ProtocolValidationError("WorkerIdentity.run_id: does not match committed assignment")
+    if identity.generation != assignment.generation:
+        raise ProtocolValidationError(
+            "WorkerIdentity.generation: does not match committed assignment"
+        )
+    if identity.topology_digest != assignment.topology_digest:
+        raise ProtocolValidationError(
+            "WorkerIdentity.topology_digest: does not match committed assignment"
+        )
+    expected_node_id = assignment.slot_to_node_id.get(identity.logical_node_slot)
+    if expected_node_id is None:
+        raise ProtocolValidationError(
+            "WorkerIdentity.logical_node_slot: is not active in committed assignment"
+        )
+    if identity.node_id != expected_node_id:
+        raise ProtocolValidationError("WorkerIdentity.node_id: does not match committed assignment")
+    if identity.local_world_size != assignment.local_world_size:
+        raise ProtocolValidationError(
+            "WorkerIdentity.local_world_size: does not match committed assignment"
+        )
+    first_rank, last_rank = assignment.slot_to_rank_range[identity.logical_node_slot]
+    expected_global_rank = first_rank + identity.local_rank
+    if identity.global_rank != expected_global_rank or identity.global_rank >= last_rank:
+        raise ProtocolValidationError(
+            "WorkerIdentity.global_rank: does not match committed rank range"
+        )
+
+
+def validate_event_reporter(
+    event: FaultEvent | RecoveryProposalEvent | CheckpointInventoryEvent,
+    assignment: RankAssignment,
+) -> None:
+    """Validate a report's worker identity at coordinator admission."""
+    if not isinstance(
+        event,
+        (FaultEvent, RecoveryProposalEvent, CheckpointInventoryEvent),
+    ):
+        raise ProtocolValidationError(
+            "event: expected a fault, recovery, or checkpoint inventory event"
+        )
+    validate_worker_identity(event.reporter, assignment)
+
+
 def validate_restart_plan(
     plan: RestartPlan,
     intent: RestartIntent,
     manifest: RecoveryManifest,
     *,
+    inventory_events: Sequence[CheckpointInventoryEvent],
     current_assignment: RankAssignment,
     now_unix_ms: int,
     eligible_node_ids: Sequence[str],
@@ -2138,17 +2208,22 @@ def validate_restart_plan(
         raise ProtocolValidationError(
             "RestartPlan.topology_digest: does not match the committed topology"
         )
+    current_nodes = set(current_assignment.slot_to_node_id.values())
+    assigned_nodes = {assignment.node_id for assignment in plan.slot_assignments}
+    if assigned_nodes == current_nodes:
+        raise ProtocolValidationError(
+            "RestartPlan.slot_assignments: version 1 requires at least one replacement node"
+        )
     eligible = set(_strings(eligible_node_ids, "eligible_node_ids", unique=True))
     quarantined = set(_strings(quarantined_node_ids, "quarantined_node_ids", unique=True)) | set(
         plan.quarantined_node_ids
     )
-    assigned = {assignment.node_id for assignment in plan.slot_assignments}
-    unavailable = assigned - eligible
+    unavailable = assigned_nodes - eligible
     if unavailable:
         raise ProtocolValidationError(
             f"RestartPlan: assigned nodes are not eligible: {sorted(unavailable)!r}"
         )
-    unsafe = assigned & quarantined
+    unsafe = assigned_nodes & quarantined
     if unsafe:
         raise ProtocolValidationError(
             f"RestartPlan: assigned nodes are quarantined: {sorted(unsafe)!r}"
@@ -2171,6 +2246,17 @@ def validate_restart_plan(
         raise ProtocolValidationError(
             "RecoveryManifest.trust: verified recovery requires a verified manifest"
         )
+    inventory_by_id: dict[str, CheckpointInventoryEvent] = {}
+    for index, event in enumerate(_sequence(inventory_events, "inventory_events")):
+        if not isinstance(event, CheckpointInventoryEvent):
+            raise ProtocolValidationError(
+                f"inventory_events[{index}]: expected CheckpointInventoryEvent"
+            )
+        if event.event_id in inventory_by_id:
+            raise ProtocolValidationError(
+                f"inventory_events: duplicate event ID {event.event_id!r}"
+            )
+        inventory_by_id[event.event_id] = event
     entries = {entry.owner_global_rank: entry for entry in manifest.rank_copies}
     required_ranks = set(range(plan.expected_world_size))
     if set(entries) != required_ranks:
@@ -2189,6 +2275,11 @@ def validate_restart_plan(
             for copy in entry.copies
             if copy.complete
             and copy.checkpoint_step == manifest.step
+            and _copy_has_trusted_inventory_provenance(
+                copy,
+                manifest,
+                inventory_by_id,
+            )
             and copy.holder_kind in compatible_holder_kinds
             and (
                 copy.storage_kind in {"shared", "remote"}
@@ -2199,6 +2290,26 @@ def validate_restart_plan(
             raise ProtocolValidationError(
                 f"RecoveryManifest.rank_copies[{rank}]: no complete eligible copy"
             )
+
+
+def _copy_has_trusted_inventory_provenance(
+    copy: CheckpointCopy,
+    manifest: RecoveryManifest,
+    inventory_by_id: Mapping[str, CheckpointInventoryEvent],
+) -> bool:
+    event = inventory_by_id.get(copy.inventory_event_id)
+    if event is None:
+        return False
+    if (
+        event.run_id != manifest.run_id
+        or event.generation != manifest.source_generation
+        or event.step != manifest.step
+        or event.topology_digest != manifest.topology_digest
+        or event.trust == "candidate"
+        or (manifest.trust == "recovery_verified" and event.trust != "recovery_verified")
+    ):
+        return False
+    return copy in event.copies
 
 
 __all__ = [
@@ -2219,4 +2330,6 @@ __all__ = [
     "SlotAssignment",
     "WorkerIdentity",
     "validate_restart_plan",
+    "validate_event_reporter",
+    "validate_worker_identity",
 ]

--- a/lm_resiliency/integrations/torchrun/_protocol.py
+++ b/lm_resiliency/integrations/torchrun/_protocol.py
@@ -650,10 +650,11 @@ class HardwareFaultReport:
         )
         _string(self.resource_id, "HardwareFaultReport.resource_id")
         _string(self.metric, "HardwareFaultReport.metric")
-        if isinstance(self.value, bool) or not isinstance(self.value, (int, float)):
-            raise ProtocolValidationError("HardwareFaultReport.value: expected a number")
-        if not math.isfinite(float(self.value)):
-            raise ProtocolValidationError("HardwareFaultReport.value: must be finite")
+        object.__setattr__(
+            self,
+            "value",
+            _finite_float(self.value, "HardwareFaultReport.value"),
+        )
         if self.severity != "fatal":
             raise ProtocolValidationError("HardwareFaultReport.severity: expected 'fatal'")
         _string(self.message, "HardwareFaultReport.message")
@@ -690,9 +691,6 @@ class HardwareFaultReport:
             raise ProtocolValidationError(
                 f"HardwareFaultReport: unknown fields {sorted(unknown)!r}"
             )
-        raw_value = value["value"]
-        if isinstance(raw_value, bool) or not isinstance(raw_value, (int, float)):
-            raise ProtocolValidationError("HardwareFaultReport.value: expected a number")
         return cls(
             kind=_choice(value["kind"], "HardwareFaultReport.kind", {"hardware"}),  # type: ignore[arg-type]
             resource_kind=_choice(
@@ -705,7 +703,7 @@ class HardwareFaultReport:
                 "HardwareFaultReport.resource_id",
             ),
             metric=_string(value["metric"], "HardwareFaultReport.metric"),
-            value=float(raw_value),
+            value=_finite_float(value["value"], "HardwareFaultReport.value"),
             severity=_choice(  # type: ignore[arg-type]
                 value["severity"],
                 "HardwareFaultReport.severity",
@@ -713,6 +711,18 @@ class HardwareFaultReport:
             ),
             message=_string(value["message"], "HardwareFaultReport.message"),
         )
+
+
+def _finite_float(value: object, path: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ProtocolValidationError(f"{path}: expected a number")
+    try:
+        normalized = float(value)
+    except (OverflowError, ValueError) as error:
+        raise ProtocolValidationError(f"{path}: must be a finite float") from error
+    if not math.isfinite(normalized):
+        raise ProtocolValidationError(f"{path}: must be finite")
+    return normalized
 
 
 def _fault_report(value: object, path: str) -> Mapping[str, Any]:
@@ -2370,6 +2380,7 @@ def validate_event_reporter(
     *,
     agent_identity: AgentIdentity,
     resource_to_node_id: Mapping[str, str],
+    resource_to_kind: Mapping[str, str],
 ) -> None:
     """Validate a report against committed rank and infrastructure identities."""
     if not isinstance(
@@ -2404,6 +2415,16 @@ def validate_event_reporter(
         )
         for resource_id, node_id in resource_to_node_id.items()
     }
+    if not isinstance(resource_to_kind, Mapping):
+        raise ProtocolValidationError("resource_to_kind: expected an object")
+    resource_kinds = {
+        _string(resource_id, "resource_to_kind.key"): _choice(
+            resource_kind,
+            f"resource_to_kind[{resource_id!r}]",
+            {"gpu", "node", "nic", "hca", "link"},
+        )
+        for resource_id, resource_kind in resource_to_kind.items()
+    }
     if reporter.gpu_uuid is not None:
         if reporter.gpu_uuid not in agent_identity.resource_ids:
             raise ProtocolValidationError(
@@ -2412,6 +2433,10 @@ def validate_event_reporter(
         if resource_owners.get(reporter.gpu_uuid) != reporter.node_id:
             raise ProtocolValidationError(
                 "WorkerIdentity.gpu_uuid: trusted resource owner does not match reporter"
+            )
+        if resource_kinds.get(reporter.gpu_uuid) != "gpu":
+            raise ProtocolValidationError(
+                "WorkerIdentity.gpu_uuid: trusted resource kind is not gpu"
             )
     if isinstance(event, FaultEvent):
         rank_to_node = {
@@ -2504,6 +2529,11 @@ def validate_event_reporter(
                     "FaultEvent.report.endpoint_id: trusted resource owner does not match "
                     "endpoint rank"
                 )
+            elif resource_kinds.get(endpoint_id) != endpoint_kind:
+                raise ProtocolValidationError(
+                    "FaultEvent.report.endpoint_id: trusted resource kind does not match "
+                    "endpoint kind"
+                )
     if not isinstance(event, FaultEvent) or event.report.get("kind") != "hardware":
         return
     resource_kind = _choice(
@@ -2527,6 +2557,10 @@ def validate_event_reporter(
     if resource_owners.get(resource_id) != reporter.node_id:
         raise ProtocolValidationError(
             "FaultEvent.report.resource_id: trusted resource owner does not match reporter"
+        )
+    if resource_kinds.get(resource_id) != resource_kind:
+        raise ProtocolValidationError(
+            "FaultEvent.report.resource_id: trusted resource kind does not match report"
         )
 
 

--- a/lm_resiliency/integrations/torchrun/_protocol.py
+++ b/lm_resiliency/integrations/torchrun/_protocol.py
@@ -1797,7 +1797,19 @@ class RestartContext(_WireRecord):
             reason_code=plan.reason_code,
         )
 
-    def validate_worker_environment(self, environment: Mapping[str, str]) -> None:
+    def validate_worker_environment(
+        self,
+        environment: Mapping[str, str],
+        *,
+        committed_plan: RestartPlan,
+    ) -> None:
+        if not isinstance(committed_plan, RestartPlan):
+            raise ProtocolValidationError("committed_plan: expected RestartPlan")
+        expected_context = RestartContext.from_plan(committed_plan, self.node_id)
+        if self != expected_context:
+            raise ProtocolValidationError(
+                "RestartContext: does not match the currently committed restart plan"
+            )
         required = {
             "RANK",
             "LOCAL_RANK",
@@ -2202,6 +2214,24 @@ def validate_event_reporter(
             raise ProtocolValidationError(
                 "WorkerIdentity.gpu_uuid: trusted resource owner does not match reporter"
             )
+    if isinstance(event, FaultEvent) and "failed_ranks" in event.report:
+        reported_ranks = _integers(
+            event.report["failed_ranks"],
+            "FaultEvent.report.failed_ranks",
+            minimum=0,
+            unique=True,
+        )
+        assigned_ranks = {
+            rank
+            for first_rank, last_rank in assignment.slot_to_rank_range.values()
+            for rank in range(first_rank, last_rank)
+        }
+        unknown_ranks = sorted(set(reported_ranks) - assigned_ranks)
+        if unknown_ranks:
+            raise ProtocolValidationError(
+                "FaultEvent.report.failed_ranks: ranks are not active in the committed "
+                f"assignment: {unknown_ranks!r}"
+            )
     if not isinstance(event, FaultEvent) or event.report.get("kind") != "hardware":
         return
     resource_kind = _choice(
@@ -2430,6 +2460,11 @@ def _copy_has_trusted_inventory_provenance(
     ):
         return False
     if copy not in event.copies:
+        return False
+    if (
+        copy.storage_kind in {"memory", "node_local"}
+        and copy.holder_node_id != event.reporter.node_id
+    ):
         return False
     if manifest.trust != "latest":
         return True

--- a/tests/unit/test_torchrun_protocol.py
+++ b/tests/unit/test_torchrun_protocol.py
@@ -1,0 +1,385 @@
+"""Contract tests for internal torchrun standby-replacement records."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._protocol import (
+    AgentIdentity,
+    CheckpointCopy,
+    CheckpointInventoryEvent,
+    FaultEvent,
+    HardwareFaultReport,
+    ProtocolValidationError,
+    RankAssignment,
+    RankCheckpointCopies,
+    RecoveryManifest,
+    RecoveryProposalEvent,
+    RestartAck,
+    RestartContext,
+    RestartIntent,
+    RestartPlan,
+    SlotAssignment,
+    WorkerIdentity,
+    validate_restart_plan,
+)
+
+RUN_ID = "training-run"
+TOPOLOGY_DIGEST = "topology-sha256"
+
+
+def _assignments() -> tuple[SlotAssignment, ...]:
+    return (
+        SlotAssignment(
+            logical_node_slot=0,
+            node_id="node-a",
+            first_global_rank=0,
+            local_world_size=2,
+        ),
+        SlotAssignment(
+            logical_node_slot=1,
+            node_id="node-spare",
+            first_global_rank=2,
+            local_world_size=2,
+        ),
+    )
+
+
+def _worker() -> WorkerIdentity:
+    return WorkerIdentity(
+        run_id=RUN_ID,
+        generation=4,
+        node_id="node-a",
+        agent_id="agent-a",
+        logical_node_slot=0,
+        global_rank=0,
+        local_rank=0,
+        local_world_size=2,
+        hostname="host-a",
+        gpu_uuid="GPU-0",
+        topology_digest=TOPOLOGY_DIGEST,
+    )
+
+
+def _plan(*, recovery_mode: str = "latest") -> RestartPlan:
+    return RestartPlan(
+        plan_id="plan-5",
+        intent_id="intent-4",
+        run_id=RUN_ID,
+        from_generation=4,
+        to_generation=5,
+        incident_ids=("incident-a",),
+        reason_code="replace_straggler",
+        recovery_mode=recovery_mode,
+        checkpoint_source="gemini",
+        checkpoint_step=40,
+        checkpoint_id=None,
+        checkpoint_manifest_id="manifest-40",
+        slot_assignments=_assignments(),
+        quarantined_node_ids=("node-b",),
+        expected_world_size=4,
+        topology_digest=TOPOLOGY_DIGEST,
+        restart_deadline_unix_ms=2_000_000_000_000,
+    )
+
+
+def _copy(
+    rank: int,
+    *,
+    holder_node_id: str,
+    holder_kind: str = "owner",
+    complete: bool = True,
+) -> CheckpointCopy:
+    return CheckpointCopy(
+        owner_global_rank=rank,
+        holder_node_id=holder_node_id,
+        holder_kind=holder_kind,
+        storage_kind="remote" if holder_kind == "durable" else "memory",
+        location_token=f"copy-{rank}-{holder_node_id}",
+        complete=complete,
+        checksums_available=True,
+    )
+
+
+def _manifest(
+    *,
+    trust: str = "latest",
+    ranks: tuple[int, ...] = (0, 1, 2, 3),
+    incomplete_rank: int | None = None,
+    holder_overrides: dict[int, str] | None = None,
+) -> RecoveryManifest:
+    holder_overrides = holder_overrides or {}
+    return RecoveryManifest(
+        manifest_id="manifest-40",
+        run_id=RUN_ID,
+        source_generation=4,
+        step=40,
+        trust=trust,
+        topology_digest=TOPOLOGY_DIGEST,
+        rank_copies=tuple(
+            RankCheckpointCopies(
+                owner_global_rank=rank,
+                copies=(
+                    _copy(
+                        rank,
+                        holder_node_id=holder_overrides.get(
+                            rank,
+                            "node-a" if rank < 2 else "node-spare",
+                        ),
+                        complete=rank != incomplete_rank,
+                    ),
+                ),
+            )
+            for rank in ranks
+        ),
+    )
+
+
+def _records():
+    worker = _worker()
+    plan = _plan()
+    assignments = _assignments()
+    hardware_report = HardwareFaultReport(
+        kind="hardware",
+        resource_kind="gpu",
+        resource_id="GPU-0",
+        metric="uncorrectable_ecc",
+        value=1.0,
+        severity="fatal",
+        message="fatal ECC",
+    )
+    return (
+        AgentIdentity(
+            run_id=RUN_ID,
+            node_id="node-a",
+            agent_id="agent-a",
+            hostname="host-a",
+            local_world_size=2,
+            resource_ids=("GPU-0", "GPU-1"),
+            environment_digest="environment-sha256",
+        ),
+        worker,
+        RankAssignment.from_assignments(
+            run_id=RUN_ID,
+            generation=4,
+            assignments=assignments,
+            topology_digest=TOPOLOGY_DIGEST,
+        ),
+        FaultEvent(
+            event_id="fault-a",
+            incident_id="incident-a",
+            run_id=RUN_ID,
+            generation=4,
+            reporter=worker,
+            optimizer_step=41,
+            report=hardware_report,
+        ),
+        RecoveryProposalEvent(
+            event_id="recovery-a",
+            incident_id="incident-a",
+            run_id=RUN_ID,
+            generation=4,
+            reporter=worker,
+            decision={
+                "failure_kind": "straggler",
+                "recovery_mode": "latest",
+                "checkpoint_source": "gemini",
+                "checkpoint_step": 40,
+                "checkpoint_id": None,
+                "all_ranks_accessible": True,
+                "available": True,
+                "reason": "accessible_straggler",
+            },
+        ),
+        CheckpointInventoryEvent(
+            event_id="inventory-a",
+            run_id=RUN_ID,
+            generation=4,
+            reporter=worker,
+            step=40,
+            trust="latest",
+            topology_digest=TOPOLOGY_DIGEST,
+            copies=(_copy(0, holder_node_id="node-a"),),
+        ),
+        RestartIntent(
+            intent_id="intent-4",
+            run_id=RUN_ID,
+            generation=4,
+            incident_ids=("incident-a",),
+            reason_code="replace_straggler",
+            minimum_recovery_mode="latest",
+            suspected_node_ids=("node-b",),
+            prepare_deadline_unix_ms=2_000_000_000_000,
+        ),
+        RestartAck(
+            intent_id="intent-4",
+            node_id="node-a",
+            generation=4,
+            flushed_step=40,
+            inventory_event_ids=("inventory-a",),
+            transferred_owner_ranks=(0, 1),
+            transferred_peer_ranks=(2, 3),
+            success=True,
+            reason="prepared",
+        ),
+        plan,
+        RestartContext.from_plan(plan, "node-spare"),
+        _manifest(),
+    )
+
+
+@pytest.mark.parametrize("record", _records(), ids=lambda value: type(value).__name__)
+def test_wire_records_round_trip_json(record):
+    restored = type(record).from_json(record.to_json())
+
+    assert restored == record
+    assert json.loads(record.to_json()) == record.to_dict()
+
+
+def test_wire_records_reject_unknown_schema_and_fields():
+    value = _plan().to_dict()
+    value["schema_version"] = 99
+
+    with pytest.raises(ProtocolValidationError, match="unsupported value"):
+        RestartPlan.from_dict(value)
+
+    value = _plan().to_dict()
+    value["unexpected"] = True
+
+    with pytest.raises(ProtocolValidationError, match="unknown fields"):
+        RestartPlan.from_dict(value)
+
+
+def test_event_payloads_are_deeply_immutable_copies():
+    report = {
+        "kind": "straggler",
+        "failed_ranks": [0],
+        "evidence": {"groups": ["dp"]},
+    }
+    event = FaultEvent(
+        event_id="fault-a",
+        incident_id="incident-a",
+        run_id=RUN_ID,
+        generation=4,
+        reporter=_worker(),
+        optimizer_step=41,
+        report=report,
+    )
+
+    report["failed_ranks"].append(1)
+    report["evidence"]["groups"].append("tp")
+
+    assert event.to_dict()["report"] == {
+        "kind": "straggler",
+        "failed_ranks": [0],
+        "evidence": {"groups": ["dp"]},
+    }
+
+
+def test_rank_assignment_requires_dense_slots_and_stable_rank_ranges():
+    with pytest.raises(ProtocolValidationError, match="dense from zero"):
+        RankAssignment.from_assignments(
+            run_id=RUN_ID,
+            generation=4,
+            assignments=(
+                SlotAssignment(
+                    logical_node_slot=1,
+                    node_id="node-a",
+                    first_global_rank=2,
+                    local_world_size=2,
+                ),
+            ),
+            topology_digest=TOPOLOGY_DIGEST,
+        )
+
+    with pytest.raises(ProtocolValidationError, match="must start at rank 2"):
+        replace(
+            _plan(),
+            slot_assignments=(
+                _assignments()[0],
+                SlotAssignment(
+                    logical_node_slot=1,
+                    node_id="node-spare",
+                    first_global_rank=4,
+                    local_world_size=2,
+                ),
+            ),
+        )
+
+
+def test_restart_plan_and_complete_manifest_validate():
+    validate_restart_plan(
+        _plan(),
+        _manifest(),
+        current_generation=4,
+        expected_active_nodes=2,
+        expected_topology_digest=TOPOLOGY_DIGEST,
+        eligible_node_ids=("node-a", "node-spare"),
+    )
+
+
+@pytest.mark.parametrize(
+    ("manifest", "message"),
+    [
+        (_manifest(ranks=(0, 1, 2)), "rank coverage mismatch"),
+        (_manifest(incomplete_rank=2), "no complete eligible copy"),
+        (
+            _manifest(holder_overrides={2: "node-b"}),
+            "no complete eligible copy",
+        ),
+    ],
+)
+def test_restart_plan_rejects_incomplete_or_quarantined_manifest(manifest, message):
+    with pytest.raises(ProtocolValidationError, match=message):
+        validate_restart_plan(
+            _plan(),
+            manifest,
+            current_generation=4,
+            expected_active_nodes=2,
+            expected_topology_digest=TOPOLOGY_DIGEST,
+            eligible_node_ids=("node-a", "node-spare", "node-b"),
+        )
+
+
+def test_verified_recovery_rejects_latest_manifest():
+    with pytest.raises(ProtocolValidationError, match="verified manifest"):
+        validate_restart_plan(
+            _plan(recovery_mode="recovery_verified"),
+            _manifest(trust="latest"),
+            current_generation=4,
+            expected_active_nodes=2,
+            expected_topology_digest=TOPOLOGY_DIGEST,
+            eligible_node_ids=("node-a", "node-spare"),
+        )
+
+
+def test_candidate_cannot_become_recovery_manifest():
+    with pytest.raises(ProtocolValidationError, match="unsupported value"):
+        _manifest(trust="candidate")
+
+
+def test_restart_context_validates_worker_environment():
+    context = RestartContext.from_plan(_plan(), "node-spare")
+    environment = {
+        "RANK": "3",
+        "LOCAL_RANK": "1",
+        "LOCAL_WORLD_SIZE": "2",
+        "WORLD_SIZE": "4",
+        "TORCHELASTIC_RUN_ID": RUN_ID,
+    }
+
+    context.validate_worker_environment(environment)
+
+    with pytest.raises(ProtocolValidationError, match="RANK=2"):
+        context.validate_worker_environment({**environment, "RANK": "2"})
+
+    with pytest.raises(ProtocolValidationError, match="TORCHELASTIC_RUN_ID"):
+        context.validate_worker_environment({**environment, "TORCHELASTIC_RUN_ID": "stale-run"})
+
+
+def test_restart_context_rejects_unassigned_node():
+    with pytest.raises(ProtocolValidationError, match="is not assigned"):
+        RestartContext.from_plan(_plan(), "node-unknown")

--- a/tests/unit/test_torchrun_protocol.py
+++ b/tests/unit/test_torchrun_protocol.py
@@ -9,6 +9,7 @@ import pytest
 
 from lm_resiliency.integrations.torchrun._protocol import (
     AgentIdentity,
+    CheckpointCertification,
     CheckpointCopy,
     CheckpointInventoryEvent,
     FaultEvent,
@@ -165,13 +166,16 @@ def _copy(
 def _ack(
     *,
     node_id: str = "node-a",
+    agent_id: str = "agent-a",
     flushed_step: int = 40,
     inventory_event_ids: tuple[str, ...] = ("inventory-a",),
     success: bool = True,
 ) -> RestartAck:
     return RestartAck(
         intent_id="intent-4",
+        run_id=RUN_ID,
         node_id=node_id,
+        agent_id=agent_id,
         generation=4,
         flushed_step=flushed_step if success else -1,
         inventory_event_ids=inventory_event_ids,
@@ -226,19 +230,44 @@ def _inventory_event(
     manifest: RecoveryManifest,
     *,
     trust: str | None = None,
+    reporter: WorkerIdentity | None = None,
 ) -> CheckpointInventoryEvent:
     return CheckpointInventoryEvent(
         event_id="inventory-a",
         run_id=manifest.run_id,
         generation=manifest.source_generation,
         reporter=replace(
-            _worker(),
+            reporter or _worker(),
             generation=manifest.source_generation,
         ),
         step=manifest.step,
         trust=trust or manifest.trust,
         topology_digest=manifest.topology_digest,
         copies=tuple(copy for rank_copies in manifest.rank_copies for copy in rank_copies.copies),
+    )
+
+
+def _certification(
+    plan: RestartPlan,
+    manifest: RecoveryManifest,
+) -> CheckpointCertification:
+    return CheckpointCertification(
+        certification_id=f"certification-{manifest.step}",
+        run_id=manifest.run_id,
+        source_generation=manifest.source_generation,
+        step=manifest.step,
+        topology_digest=manifest.topology_digest,
+        checkpoint_source=plan.checkpoint_source,
+        checkpoint_id=plan.checkpoint_id,
+        expected_world_size=plan.expected_world_size,
+        certification_kind="dense_consensus",
+        inventory_event_ids=tuple(
+            dict.fromkeys(
+                copy.inventory_event_id
+                for rank_copies in manifest.rank_copies
+                for copy in rank_copies.copies
+            )
+        ),
     )
 
 
@@ -249,19 +278,33 @@ def _validate(
     intent: RestartIntent | None = None,
     current_assignment: RankAssignment | None = None,
     inventory_events: tuple[CheckpointInventoryEvent, ...] | None = None,
+    trusted_certifications: tuple[CheckpointCertification, ...] | None = None,
     restart_acks: tuple[RestartAck, ...] | None = None,
+    authenticated_ack_agent_ids: dict[str, str] | None = None,
     now_unix_ms: int = 1_900_000_000_000,
     eligible_node_ids: tuple[str, ...] = ("node-a", "node-spare"),
 ) -> None:
+    selected_plan = plan or _plan()
     selected_manifest = manifest or _manifest()
+    selected_acks = (_ack(),) if restart_acks is None else restart_acks
     validate_restart_plan(
-        plan or _plan(),
+        selected_plan,
         intent or _intent(),
         selected_manifest,
         inventory_events=(
             (_inventory_event(selected_manifest),) if inventory_events is None else inventory_events
         ),
-        restart_acks=(_ack(),) if restart_acks is None else restart_acks,
+        trusted_certifications=(
+            (_certification(selected_plan, selected_manifest),)
+            if trusted_certifications is None and selected_manifest.trust == "recovery_verified"
+            else (() if trusted_certifications is None else trusted_certifications)
+        ),
+        restart_acks=selected_acks,
+        authenticated_ack_agent_ids=(
+            {ack.node_id: ack.agent_id for ack in selected_acks}
+            if authenticated_ack_agent_ids is None
+            else authenticated_ack_agent_ids
+        ),
         current_assignment=current_assignment or _current_assignment(),
         now_unix_ms=now_unix_ms,
         eligible_node_ids=eligible_node_ids,
@@ -325,6 +368,10 @@ def _records():
             trust="latest",
             topology_digest=TOPOLOGY_DIGEST,
             copies=(_copy(0, holder_node_id="node-a"),),
+        ),
+        _certification(
+            _plan(recovery_mode="recovery_verified"),
+            _manifest(trust="recovery_verified"),
         ),
         _intent(),
         _ack(),
@@ -458,6 +505,18 @@ def test_restart_plan_rejects_uncertified_manifest_trust():
         )
 
 
+def test_verified_inventory_requires_trusted_catalog_certification():
+    manifest = _manifest(trust="recovery_verified")
+
+    with pytest.raises(ProtocolValidationError, match="no complete eligible copy"):
+        _validate(
+            plan=_plan(recovery_mode="recovery_verified"),
+            intent=_intent(minimum_recovery_mode="recovery_verified"),
+            manifest=manifest,
+            trusted_certifications=(),
+        )
+
+
 def test_restart_plan_requires_inventory_provenance_for_every_copy():
     with pytest.raises(ProtocolValidationError, match="no complete eligible copy"):
         _validate(inventory_events=())
@@ -484,6 +543,46 @@ def test_restart_plan_rejects_local_copy_reported_by_another_node():
             manifest=_manifest(
                 holder_overrides={0: "node-spare"},
             ),
+        )
+
+
+def test_restart_plan_rejects_local_copy_on_departing_holder():
+    departing_worker = replace(
+        _worker(),
+        node_id="node-b",
+        agent_id="agent-b",
+        logical_node_slot=1,
+        global_rank=2,
+        hostname="host-b",
+        gpu_uuid="GPU-2",
+    )
+    manifest = _manifest(
+        holder_overrides={
+            0: "node-b",
+            1: "node-b",
+            2: "node-b",
+            3: "node-b",
+        },
+    )
+
+    with pytest.raises(ProtocolValidationError, match="no complete eligible copy"):
+        _validate(
+            plan=replace(_plan(), quarantined_node_ids=()),
+            manifest=manifest,
+            inventory_events=(
+                _inventory_event(
+                    manifest,
+                    reporter=departing_worker,
+                ),
+            ),
+            restart_acks=(
+                _ack(
+                    node_id="node-b",
+                    agent_id="agent-b",
+                ),
+            ),
+            authenticated_ack_agent_ids={"node-b": "agent-b"},
+            eligible_node_ids=("node-a", "node-b", "node-spare"),
         )
 
 
@@ -931,6 +1030,13 @@ def test_durable_recovery_rejects_latest_manifest_even_in_latest_mode():
 def test_latest_recovery_requires_successful_preparation_ack(restart_acks):
     with pytest.raises(ProtocolValidationError, match="no complete eligible copy"):
         _validate(restart_acks=restart_acks)
+
+
+def test_restart_ack_must_match_authenticated_agent():
+    with pytest.raises(ProtocolValidationError, match="authenticated transport sender"):
+        _validate(
+            authenticated_ack_agent_ids={"node-a": "agent-other"},
+        )
 
 
 def test_candidate_cannot_become_recovery_manifest():

--- a/tests/unit/test_torchrun_protocol.py
+++ b/tests/unit/test_torchrun_protocol.py
@@ -64,7 +64,36 @@ def _worker() -> WorkerIdentity:
     )
 
 
-def _plan(*, recovery_mode: str = "latest") -> RestartPlan:
+def _intent(*, minimum_recovery_mode: str = "latest") -> RestartIntent:
+    return RestartIntent(
+        intent_id="intent-4",
+        run_id=RUN_ID,
+        generation=4,
+        incident_ids=("incident-a",),
+        reason_code="replace_straggler",
+        minimum_recovery_mode=minimum_recovery_mode,
+        suspected_node_ids=("node-b",),
+        prepare_deadline_unix_ms=2_000_000_000_000,
+    )
+
+
+def _current_assignment() -> RankAssignment:
+    return RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=4,
+        assignments=(
+            _assignments()[0],
+            replace(_assignments()[1], node_id="node-b"),
+        ),
+        topology_digest=TOPOLOGY_DIGEST,
+    )
+
+
+def _plan(
+    *,
+    recovery_mode: str = "latest",
+    checkpoint_source: str = "gemini",
+) -> RestartPlan:
     return RestartPlan(
         plan_id="plan-5",
         intent_id="intent-4",
@@ -74,9 +103,9 @@ def _plan(*, recovery_mode: str = "latest") -> RestartPlan:
         incident_ids=("incident-a",),
         reason_code="replace_straggler",
         recovery_mode=recovery_mode,
-        checkpoint_source="gemini",
+        checkpoint_source=checkpoint_source,
         checkpoint_step=40,
-        checkpoint_id=None,
+        checkpoint_id="durable-40" if checkpoint_source == "durable" else None,
         checkpoint_manifest_id="manifest-40",
         slot_assignments=_assignments(),
         quarantined_node_ids=("node-b",),
@@ -91,13 +120,16 @@ def _copy(
     *,
     holder_node_id: str,
     holder_kind: str = "owner",
+    checkpoint_step: int = 40,
+    storage_kind: str | None = None,
     complete: bool = True,
 ) -> CheckpointCopy:
     return CheckpointCopy(
         owner_global_rank=rank,
+        checkpoint_step=checkpoint_step,
         holder_node_id=holder_node_id,
         holder_kind=holder_kind,
-        storage_kind="remote" if holder_kind == "durable" else "memory",
+        storage_kind=storage_kind or ("remote" if holder_kind == "durable" else "memory"),
         location_token=f"copy-{rank}-{holder_node_id}",
         complete=complete,
         checksums_available=True,
@@ -107,6 +139,8 @@ def _copy(
 def _manifest(
     *,
     trust: str = "latest",
+    holder_kind: str = "owner",
+    checkpoint_step: int = 40,
     ranks: tuple[int, ...] = (0, 1, 2, 3),
     incomplete_rank: int | None = None,
     holder_overrides: dict[int, str] | None = None,
@@ -129,12 +163,33 @@ def _manifest(
                             rank,
                             "node-a" if rank < 2 else "node-spare",
                         ),
+                        holder_kind=holder_kind,
+                        checkpoint_step=checkpoint_step,
                         complete=rank != incomplete_rank,
                     ),
                 ),
             )
             for rank in ranks
         ),
+    )
+
+
+def _validate(
+    plan: RestartPlan | None = None,
+    manifest: RecoveryManifest | None = None,
+    *,
+    intent: RestartIntent | None = None,
+    current_assignment: RankAssignment | None = None,
+    now_unix_ms: int = 1_900_000_000_000,
+    eligible_node_ids: tuple[str, ...] = ("node-a", "node-spare"),
+) -> None:
+    validate_restart_plan(
+        plan or _plan(),
+        intent or _intent(),
+        manifest or _manifest(),
+        current_assignment=current_assignment or _current_assignment(),
+        now_unix_ms=now_unix_ms,
+        eligible_node_ids=eligible_node_ids,
     )
 
 
@@ -204,16 +259,7 @@ def _records():
             topology_digest=TOPOLOGY_DIGEST,
             copies=(_copy(0, holder_node_id="node-a"),),
         ),
-        RestartIntent(
-            intent_id="intent-4",
-            run_id=RUN_ID,
-            generation=4,
-            incident_ids=("incident-a",),
-            reason_code="replace_straggler",
-            minimum_recovery_mode="latest",
-            suspected_node_ids=("node-b",),
-            prepare_deadline_unix_ms=2_000_000_000_000,
-        ),
+        _intent(),
         RestartAck(
             intent_id="intent-4",
             node_id="node-a",
@@ -311,14 +357,7 @@ def test_rank_assignment_requires_dense_slots_and_stable_rank_ranges():
 
 
 def test_restart_plan_and_complete_manifest_validate():
-    validate_restart_plan(
-        _plan(),
-        _manifest(),
-        current_generation=4,
-        expected_active_nodes=2,
-        expected_topology_digest=TOPOLOGY_DIGEST,
-        eligible_node_ids=("node-a", "node-spare"),
-    )
+    _validate()
 
 
 @pytest.mark.parametrize(
@@ -334,25 +373,187 @@ def test_restart_plan_and_complete_manifest_validate():
 )
 def test_restart_plan_rejects_incomplete_or_quarantined_manifest(manifest, message):
     with pytest.raises(ProtocolValidationError, match=message):
-        validate_restart_plan(
-            _plan(),
-            manifest,
-            current_generation=4,
-            expected_active_nodes=2,
-            expected_topology_digest=TOPOLOGY_DIGEST,
+        _validate(
+            manifest=manifest,
             eligible_node_ids=("node-a", "node-spare", "node-b"),
+        )
+
+
+def test_recovery_manifest_rejects_checkpoint_copies_from_another_step():
+    with pytest.raises(ProtocolValidationError, match="copy steps do not match"):
+        _manifest(checkpoint_step=39)
+
+
+@pytest.mark.parametrize(
+    ("plan", "manifest"),
+    [
+        (_plan(checkpoint_source="durable"), _manifest(holder_kind="owner")),
+        (_plan(checkpoint_source="gemini"), _manifest(holder_kind="durable")),
+    ],
+)
+def test_restart_plan_rejects_copies_from_the_wrong_source(plan, manifest):
+    with pytest.raises(ProtocolValidationError, match="no complete eligible copy"):
+        _validate(plan=plan, manifest=manifest)
+
+
+def test_restart_plan_accepts_remote_durable_copies():
+    _validate(
+        plan=_plan(
+            recovery_mode="recovery_verified",
+            checkpoint_source="durable",
+        ),
+        manifest=_manifest(
+            trust="recovery_verified",
+            holder_kind="durable",
+            holder_overrides={
+                0: "durable-store",
+                1: "durable-store",
+                2: "durable-store",
+                3: "durable-store",
+            },
+        ),
+    )
+
+
+def test_restart_plan_requires_complete_remote_or_shared_durable_copies():
+    with pytest.raises(ProtocolValidationError, match="shared or remote"):
+        _copy(
+            0,
+            holder_node_id="node-a",
+            holder_kind="durable",
+            storage_kind="node_local",
+        )
+
+
+def test_restart_plan_enforces_intent_fencing_and_minimum_recovery_mode():
+    intent = _intent(minimum_recovery_mode="recovery_verified")
+
+    with pytest.raises(ProtocolValidationError, match="weaker than restart intent"):
+        _validate(intent=intent)
+
+
+@pytest.mark.parametrize(
+    ("plan", "message"),
+    [
+        (replace(_plan(), intent_id="other-intent"), "intent_id"),
+        (replace(_plan(), run_id="other-run"), "run_id"),
+        (
+            replace(_plan(), from_generation=3, to_generation=4),
+            "from_generation",
+        ),
+        (
+            replace(_plan(), incident_ids=("other-incident",)),
+            "incident_ids",
+        ),
+        (replace(_plan(), reason_code="other-reason"), "reason_code"),
+    ],
+)
+def test_restart_plan_rejects_intent_fence_mismatch(plan, message):
+    with pytest.raises(ProtocolValidationError, match=message):
+        _validate(plan=plan)
+
+
+def test_restart_plan_rejects_expired_deadline():
+    with pytest.raises(ProtocolValidationError, match="deadline has elapsed"):
+        _validate(now_unix_ms=2_000_000_000_000)
+
+
+def test_restart_plan_preserves_committed_world_size():
+    smaller_plan = replace(
+        _plan(),
+        slot_assignments=(
+            SlotAssignment(
+                logical_node_slot=0,
+                node_id="node-a",
+                first_global_rank=0,
+                local_world_size=1,
+            ),
+            SlotAssignment(
+                logical_node_slot=1,
+                node_id="node-spare",
+                first_global_rank=1,
+                local_world_size=1,
+            ),
+        ),
+        expected_world_size=2,
+    )
+
+    with pytest.raises(ProtocolValidationError, match="local world size"):
+        _validate(
+            plan=smaller_plan,
+            manifest=_manifest(ranks=(0, 1)),
+        )
+
+
+def test_worker_identity_rejects_inconsistent_global_rank():
+    with pytest.raises(ProtocolValidationError, match="does not match logical slot"):
+        replace(_worker(), global_rank=3)
+
+
+@pytest.mark.parametrize(
+    ("failure_kind", "all_ranks_accessible"),
+    [("sdc", True), ("machine_unavailable", True), ("hang", False)],
+)
+def test_recovery_proposal_rejects_latest_for_unsafe_failures(
+    failure_kind,
+    all_ranks_accessible,
+):
+    with pytest.raises(ProtocolValidationError, match="require recovery_verified"):
+        RecoveryProposalEvent(
+            event_id="recovery-unsafe",
+            incident_id="incident-a",
+            run_id=RUN_ID,
+            generation=4,
+            reporter=_worker(),
+            decision={
+                "failure_kind": failure_kind,
+                "recovery_mode": "latest",
+                "checkpoint_source": "gemini",
+                "checkpoint_step": 40,
+                "checkpoint_id": None,
+                "all_ranks_accessible": all_ranks_accessible,
+                "available": True,
+                "reason": "unsafe",
+            },
+        )
+
+
+def test_checkpoint_records_reject_step_zero():
+    with pytest.raises(ProtocolValidationError, match="value >= 1"):
+        replace(_plan(), checkpoint_step=0)
+
+    with pytest.raises(ProtocolValidationError, match="value >= 1"):
+        replace(_manifest(), step=0)
+
+    with pytest.raises(ProtocolValidationError, match="value >= 1"):
+        _copy(0, holder_node_id="node-a", checkpoint_step=0)
+
+
+def test_checkpoint_inventory_rejects_copy_from_another_step():
+    with pytest.raises(ProtocolValidationError, match="copy steps do not match"):
+        CheckpointInventoryEvent(
+            event_id="inventory-mixed",
+            run_id=RUN_ID,
+            generation=4,
+            reporter=_worker(),
+            step=40,
+            trust="latest",
+            topology_digest=TOPOLOGY_DIGEST,
+            copies=(
+                _copy(
+                    0,
+                    holder_node_id="node-a",
+                    checkpoint_step=39,
+                ),
+            ),
         )
 
 
 def test_verified_recovery_rejects_latest_manifest():
     with pytest.raises(ProtocolValidationError, match="verified manifest"):
-        validate_restart_plan(
-            _plan(recovery_mode="recovery_verified"),
-            _manifest(trust="latest"),
-            current_generation=4,
-            expected_active_nodes=2,
-            expected_topology_digest=TOPOLOGY_DIGEST,
-            eligible_node_ids=("node-a", "node-spare"),
+        _validate(
+            plan=_plan(recovery_mode="recovery_verified"),
+            manifest=_manifest(trust="latest"),
         )
 
 

--- a/tests/unit/test_torchrun_protocol.py
+++ b/tests/unit/test_torchrun_protocol.py
@@ -169,9 +169,14 @@ def _ack(
     node_id: str = "node-a",
     agent_id: str = "agent-a",
     flushed_step: int = 40,
-    inventory_event_ids: tuple[str, ...] = ("inventory-a",),
+    inventory_event_digests: dict[str, str] | None = None,
     success: bool = True,
 ) -> RestartAck:
+    if inventory_event_digests is None:
+        event = _inventory_event(_manifest())
+        inventory_event_digests = {
+            event.event_id: checkpoint_inventory_digest(event),
+        }
     return RestartAck(
         intent_id="intent-4",
         run_id=RUN_ID,
@@ -179,7 +184,7 @@ def _ack(
         agent_id=agent_id,
         generation=4,
         flushed_step=flushed_step if success else -1,
-        inventory_event_ids=inventory_event_ids,
+        inventory_event_digests=inventory_event_digests,
         transferred_owner_ranks=(0, 1),
         transferred_peer_ranks=(2, 3),
         success=success,
@@ -583,6 +588,39 @@ def test_certification_binds_immutable_inventory_contents():
         )
 
 
+def test_restart_ack_binds_immutable_inventory_contents():
+    original_manifest = _manifest()
+    original_event = _inventory_event(original_manifest)
+    altered_manifest = replace(
+        original_manifest,
+        rank_copies=tuple(
+            replace(
+                rank_copies,
+                copies=tuple(
+                    replace(copy, location_token="substituted-location")
+                    if copy.owner_global_rank == 0
+                    else copy
+                    for copy in rank_copies.copies
+                ),
+            )
+            for rank_copies in original_manifest.rank_copies
+        ),
+    )
+
+    with pytest.raises(ProtocolValidationError, match="no complete eligible copy"):
+        _validate(
+            manifest=altered_manifest,
+            inventory_events=(_inventory_event(altered_manifest),),
+            restart_acks=(
+                _ack(
+                    inventory_event_digests={
+                        original_event.event_id: checkpoint_inventory_digest(original_event),
+                    }
+                ),
+            ),
+        )
+
+
 def test_restart_plan_requires_inventory_provenance_for_every_copy():
     with pytest.raises(ProtocolValidationError, match="no complete eligible copy"):
         _validate(inventory_events=())
@@ -636,21 +674,23 @@ def test_restart_plan_rejects_local_copy_on_departing_holder():
             3: "owner",
         },
     )
+    departing_event = _inventory_event(
+        manifest,
+        reporter=departing_worker,
+    )
 
     with pytest.raises(ProtocolValidationError, match="no complete eligible copy"):
         _validate(
             plan=replace(_plan(), quarantined_node_ids=()),
             manifest=manifest,
-            inventory_events=(
-                _inventory_event(
-                    manifest,
-                    reporter=departing_worker,
-                ),
-            ),
+            inventory_events=(departing_event,),
             restart_acks=(
                 _ack(
                     node_id="node-b",
                     agent_id="agent-b",
+                    inventory_event_digests={
+                        departing_event.event_id: checkpoint_inventory_digest(departing_event),
+                    },
                 ),
             ),
             authenticated_ack_agent_ids={"node-b": "agent-b"},
@@ -897,6 +937,31 @@ def test_restart_plan_preserves_committed_world_size():
         )
 
 
+def test_source_assignment_cannot_conflict_with_current_generation():
+    conflicting_source = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=4,
+        assignments=(
+            SlotAssignment(
+                logical_node_slot=0,
+                node_id="node-spare",
+                first_global_rank=0,
+                local_world_size=2,
+            ),
+            SlotAssignment(
+                logical_node_slot=1,
+                node_id="node-b",
+                first_global_rank=2,
+                local_world_size=2,
+            ),
+        ),
+        topology_digest=TOPOLOGY_DIGEST,
+    )
+
+    with pytest.raises(ProtocolValidationError, match="conflicts with the committed assignment"):
+        _validate(source_assignment=conflicting_source)
+
+
 def test_worker_identity_rejects_inconsistent_global_rank():
     with pytest.raises(ProtocolValidationError, match="does not match logical slot"):
         replace(_worker(), global_rank=3)
@@ -1021,6 +1086,63 @@ def test_fault_report_rejects_rank_outside_committed_assignment():
 
 
 @pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("dataloader_culprit_ranks", [3], "not present in failed_ranks"),
+        ("stage_culprit_ranks", [999], "not active"),
+    ],
+)
+def test_fault_report_validates_all_rank_attribution_fields(field, value, message):
+    event = FaultEvent(
+        event_id="fault-attribution",
+        incident_id="incident-a",
+        run_id=RUN_ID,
+        generation=4,
+        reporter=_worker(),
+        optimizer_step=41,
+        report={
+            "kind": "data_stall",
+            "failed_ranks": [0],
+            field: value,
+        },
+    )
+
+    with pytest.raises(ProtocolValidationError, match=message):
+        validate_event_reporter(
+            event,
+            _current_assignment(),
+            agent_identity=_agent(),
+            resource_to_node_id={"GPU-0": "node-a"},
+        )
+
+
+def test_fault_report_endpoint_must_match_failed_rank_and_node():
+    event = FaultEvent(
+        event_id="fault-endpoint",
+        incident_id="incident-a",
+        run_id=RUN_ID,
+        generation=4,
+        reporter=_worker(),
+        optimizer_step=41,
+        report={
+            "kind": "straggler",
+            "failed_ranks": [0],
+            "endpoint_kind": "node",
+            "endpoint_id": "node-b",
+            "endpoint_rank": 0,
+        },
+    )
+
+    with pytest.raises(ProtocolValidationError, match="endpoint rank's node"):
+        validate_event_reporter(
+            event,
+            _current_assignment(),
+            agent_identity=_agent(),
+            resource_to_node_id={"GPU-0": "node-a"},
+        )
+
+
+@pytest.mark.parametrize(
     ("failure_kind", "all_ranks_accessible"),
     [("sdc", True), ("machine_unavailable", True), ("hang", False)],
 )
@@ -1044,6 +1166,27 @@ def test_recovery_proposal_rejects_latest_for_unsafe_failures(
                 "all_ranks_accessible": all_ranks_accessible,
                 "available": True,
                 "reason": "unsafe",
+            },
+        )
+
+
+def test_recovery_proposal_rejects_unknown_failure_kind():
+    with pytest.raises(ProtocolValidationError, match="unsupported value"):
+        RecoveryProposalEvent(
+            event_id="recovery-unknown",
+            incident_id="incident-a",
+            run_id=RUN_ID,
+            generation=4,
+            reporter=_worker(),
+            decision={
+                "failure_kind": "stragler",
+                "recovery_mode": "latest",
+                "checkpoint_source": "gemini",
+                "checkpoint_step": 40,
+                "checkpoint_id": None,
+                "all_ranks_accessible": True,
+                "available": True,
+                "reason": "unknown failure kind",
             },
         )
 
@@ -1110,7 +1253,7 @@ def test_durable_recovery_rejects_latest_manifest_even_in_latest_mode():
         (),
         (_ack(success=False),),
         (_ack(flushed_step=39),),
-        (_ack(inventory_event_ids=("inventory-other",)),),
+        (_ack(inventory_event_digests={"inventory-other": "0" * 64}),),
     ],
 )
 def test_latest_recovery_requires_successful_preparation_ack(restart_acks):

--- a/tests/unit/test_torchrun_protocol.py
+++ b/tests/unit/test_torchrun_protocol.py
@@ -1001,6 +1001,7 @@ def test_event_reporter_must_match_committed_rank_assignment():
             assignment,
             agent_identity=_agent(),
             resource_to_node_id={"GPU-0": "node-a"},
+            resource_to_kind={"GPU-0": "gpu"},
         )
 
 
@@ -1032,6 +1033,10 @@ def test_hardware_report_resource_must_match_registered_owner():
                 "GPU-0": "node-a",
                 "GPU-1": "node-b",
             },
+            resource_to_kind={
+                "GPU-0": "gpu",
+                "GPU-1": "gpu",
+            },
         )
 
 
@@ -1062,7 +1067,71 @@ def test_hardware_report_accepts_registered_resource_on_reporter_node():
             "GPU-0": "node-a",
             "GPU-1": "node-a",
         },
+        resource_to_kind={
+            "GPU-0": "gpu",
+            "GPU-1": "gpu",
+        },
     )
+
+
+def test_hardware_report_resource_kind_must_match_trusted_inventory():
+    event = FaultEvent(
+        event_id="fault-resource-kind",
+        incident_id="incident-a",
+        run_id=RUN_ID,
+        generation=4,
+        reporter=_worker(),
+        optimizer_step=41,
+        report=HardwareFaultReport(
+            kind="hardware",
+            resource_kind="nic",
+            resource_id="GPU-1",
+            metric="link_down",
+            value=1.0,
+            severity="fatal",
+            message="reported with the wrong resource kind",
+        ),
+    )
+
+    with pytest.raises(ProtocolValidationError, match="resource kind"):
+        validate_event_reporter(
+            event,
+            _current_assignment(),
+            agent_identity=_agent(),
+            resource_to_node_id={
+                "GPU-0": "node-a",
+                "GPU-1": "node-a",
+            },
+            resource_to_kind={
+                "GPU-0": "gpu",
+                "GPU-1": "gpu",
+            },
+        )
+
+
+def test_hardware_report_rejects_oversized_numeric_metric():
+    event = FaultEvent(
+        event_id="fault-oversized-metric",
+        incident_id="incident-a",
+        run_id=RUN_ID,
+        generation=4,
+        reporter=_worker(),
+        optimizer_step=41,
+        report=HardwareFaultReport(
+            kind="hardware",
+            resource_kind="gpu",
+            resource_id="GPU-0",
+            metric="counter",
+            value=1.0,
+            severity="fatal",
+            message="oversized metric",
+        ),
+    )
+    payload = event.to_dict()
+    payload["report"]["value"] = 10**1000
+
+    with pytest.raises(ProtocolValidationError, match="finite float"):
+        FaultEvent.from_json(json.dumps(payload))
 
 
 def test_fault_report_rejects_rank_outside_committed_assignment():
@@ -1082,6 +1151,7 @@ def test_fault_report_rejects_rank_outside_committed_assignment():
             _current_assignment(),
             agent_identity=_agent(),
             resource_to_node_id={"GPU-0": "node-a"},
+            resource_to_kind={"GPU-0": "gpu"},
         )
 
 
@@ -1113,6 +1183,7 @@ def test_fault_report_validates_all_rank_attribution_fields(field, value, messag
             _current_assignment(),
             agent_identity=_agent(),
             resource_to_node_id={"GPU-0": "node-a"},
+            resource_to_kind={"GPU-0": "gpu"},
         )
 
 
@@ -1139,6 +1210,7 @@ def test_fault_report_endpoint_must_match_failed_rank_and_node():
             _current_assignment(),
             agent_identity=_agent(),
             resource_to_node_id={"GPU-0": "node-a"},
+            resource_to_kind={"GPU-0": "gpu"},
         )
 
 

--- a/tests/unit/test_torchrun_protocol.py
+++ b/tests/unit/test_torchrun_protocol.py
@@ -641,6 +641,43 @@ def test_restart_plan_requires_exact_inventory_copy_match():
         )
 
 
+def test_restart_plan_rejects_ineligible_copy_alongside_eligible_copy():
+    base_manifest = _manifest()
+    inventory = _inventory_event(base_manifest)
+    manifest = replace(
+        base_manifest,
+        rank_copies=tuple(
+            replace(
+                entry,
+                copies=entry.copies
+                + (
+                    replace(
+                        entry.copies[0],
+                        inventory_event_id="inventory-unproven",
+                        location_token="unproven-copy",
+                    ),
+                ),
+            )
+            if entry.owner_global_rank == 0
+            else entry
+            for entry in base_manifest.rank_copies
+        ),
+    )
+
+    with pytest.raises(ProtocolValidationError, match="contains an ineligible copy"):
+        _validate(
+            manifest=manifest,
+            inventory_events=(inventory,),
+            restart_acks=(
+                _ack(
+                    inventory_event_digests={
+                        inventory.event_id: checkpoint_inventory_digest(inventory),
+                    }
+                ),
+            ),
+        )
+
+
 def test_restart_plan_rejects_local_copy_reported_by_another_node():
     with pytest.raises(ProtocolValidationError, match="no complete eligible copy"):
         _validate(
@@ -1425,18 +1462,43 @@ def test_restart_context_validates_worker_environment():
         "TORCHELASTIC_RUN_ID": RUN_ID,
     }
 
-    context.validate_worker_environment(environment, committed_plan=_plan())
+    context.validate_worker_environment(
+        environment,
+        committed_plan=_plan(),
+        now_unix_ms=1_900_000_000_000,
+    )
 
     with pytest.raises(ProtocolValidationError, match="RANK=2"):
         context.validate_worker_environment(
             {**environment, "RANK": "2"},
             committed_plan=_plan(),
+            now_unix_ms=1_900_000_000_000,
         )
 
     with pytest.raises(ProtocolValidationError, match="TORCHELASTIC_RUN_ID"):
         context.validate_worker_environment(
             {**environment, "TORCHELASTIC_RUN_ID": "stale-run"},
             committed_plan=_plan(),
+            now_unix_ms=1_900_000_000_000,
+        )
+
+
+def test_restart_context_rejects_expired_committed_plan():
+    plan = _plan()
+    context = RestartContext.from_plan(plan, "node-spare")
+    environment = {
+        "RANK": "3",
+        "LOCAL_RANK": "1",
+        "LOCAL_WORLD_SIZE": "2",
+        "WORLD_SIZE": "4",
+        "TORCHELASTIC_RUN_ID": RUN_ID,
+    }
+
+    with pytest.raises(ProtocolValidationError, match="deadline has elapsed"):
+        context.validate_worker_environment(
+            environment,
+            committed_plan=plan,
+            now_unix_ms=plan.restart_deadline_unix_ms,
         )
 
 
@@ -1461,6 +1523,7 @@ def test_restart_context_must_match_current_committed_plan():
         stale_context.validate_worker_environment(
             environment,
             committed_plan=current_plan,
+            now_unix_ms=1_900_000_000_000,
         )
 
 

--- a/tests/unit/test_torchrun_protocol.py
+++ b/tests/unit/test_torchrun_protocol.py
@@ -66,6 +66,18 @@ def _worker() -> WorkerIdentity:
     )
 
 
+def _agent() -> AgentIdentity:
+    return AgentIdentity(
+        run_id=RUN_ID,
+        node_id="node-a",
+        agent_id="agent-a",
+        hostname="host-a",
+        local_world_size=2,
+        resource_ids=("GPU-0", "GPU-1"),
+        environment_digest="environment-sha256",
+    )
+
+
 def _intent(*, minimum_recovery_mode: str = "latest") -> RestartIntent:
     return RestartIntent(
         intent_id="intent-4",
@@ -125,18 +137,44 @@ def _copy(
     checkpoint_step: int = 40,
     inventory_event_id: str = "inventory-a",
     storage_kind: str | None = None,
+    checkpoint_id: str | None = None,
     complete: bool = True,
 ) -> CheckpointCopy:
     return CheckpointCopy(
         owner_global_rank=rank,
         checkpoint_step=checkpoint_step,
         inventory_event_id=inventory_event_id,
+        checkpoint_id=(
+            checkpoint_id
+            if checkpoint_id is not None
+            else ("durable-40" if holder_kind == "durable" else None)
+        ),
         holder_node_id=holder_node_id,
         holder_kind=holder_kind,
         storage_kind=storage_kind or ("remote" if holder_kind == "durable" else "memory"),
         location_token=f"copy-{rank}-{holder_node_id}",
         complete=complete,
         checksums_available=True,
+    )
+
+
+def _ack(
+    *,
+    node_id: str = "node-a",
+    flushed_step: int = 40,
+    inventory_event_ids: tuple[str, ...] = ("inventory-a",),
+    success: bool = True,
+) -> RestartAck:
+    return RestartAck(
+        intent_id="intent-4",
+        node_id=node_id,
+        generation=4,
+        flushed_step=flushed_step if success else -1,
+        inventory_event_ids=inventory_event_ids,
+        transferred_owner_ranks=(0, 1),
+        transferred_peer_ranks=(2, 3),
+        success=success,
+        reason="prepared" if success else "preparation failed",
     )
 
 
@@ -148,6 +186,7 @@ def _manifest(
     ranks: tuple[int, ...] = (0, 1, 2, 3),
     incomplete_rank: int | None = None,
     holder_overrides: dict[int, str] | None = None,
+    durable_checkpoint_id: str = "durable-40",
 ) -> RecoveryManifest:
     holder_overrides = holder_overrides or {}
     return RecoveryManifest(
@@ -169,6 +208,7 @@ def _manifest(
                         ),
                         holder_kind=holder_kind,
                         checkpoint_step=checkpoint_step,
+                        checkpoint_id=(durable_checkpoint_id if holder_kind == "durable" else None),
                         complete=rank != incomplete_rank,
                     ),
                 ),
@@ -205,6 +245,7 @@ def _validate(
     intent: RestartIntent | None = None,
     current_assignment: RankAssignment | None = None,
     inventory_events: tuple[CheckpointInventoryEvent, ...] | None = None,
+    restart_acks: tuple[RestartAck, ...] | None = None,
     now_unix_ms: int = 1_900_000_000_000,
     eligible_node_ids: tuple[str, ...] = ("node-a", "node-spare"),
 ) -> None:
@@ -216,6 +257,7 @@ def _validate(
         inventory_events=(
             (_inventory_event(selected_manifest),) if inventory_events is None else inventory_events
         ),
+        restart_acks=(_ack(),) if restart_acks is None else restart_acks,
         current_assignment=current_assignment or _current_assignment(),
         now_unix_ms=now_unix_ms,
         eligible_node_ids=eligible_node_ids,
@@ -236,15 +278,7 @@ def _records():
         message="fatal ECC",
     )
     return (
-        AgentIdentity(
-            run_id=RUN_ID,
-            node_id="node-a",
-            agent_id="agent-a",
-            hostname="host-a",
-            local_world_size=2,
-            resource_ids=("GPU-0", "GPU-1"),
-            environment_digest="environment-sha256",
-        ),
+        _agent(),
         worker,
         RankAssignment.from_assignments(
             run_id=RUN_ID,
@@ -289,17 +323,7 @@ def _records():
             copies=(_copy(0, holder_node_id="node-a"),),
         ),
         _intent(),
-        RestartAck(
-            intent_id="intent-4",
-            node_id="node-a",
-            generation=4,
-            flushed_step=40,
-            inventory_event_ids=("inventory-a",),
-            transferred_owner_ranks=(0, 1),
-            transferred_peer_ranks=(2, 3),
-            success=True,
-            reason="prepared",
-        ),
+        _ack(),
         plan,
         RestartContext.from_plan(plan, "node-spare"),
         _manifest(),
@@ -473,7 +497,10 @@ def test_checkpoint_inventory_rejects_mismatched_provenance_id():
 @pytest.mark.parametrize(
     ("plan", "manifest"),
     [
-        (_plan(checkpoint_source="durable"), _manifest(holder_kind="owner")),
+        (
+            _plan(checkpoint_source="durable"),
+            _manifest(trust="recovery_verified", holder_kind="owner"),
+        ),
         (_plan(checkpoint_source="gemini"), _manifest(holder_kind="durable")),
     ],
 )
@@ -499,6 +526,39 @@ def test_restart_plan_accepts_remote_durable_copies():
             },
         ),
     )
+
+
+def test_restart_plan_binds_durable_copies_to_checkpoint_id():
+    with pytest.raises(ProtocolValidationError, match="no complete eligible copy"):
+        _validate(
+            plan=_plan(
+                recovery_mode="recovery_verified",
+                checkpoint_source="durable",
+            ),
+            manifest=_manifest(
+                trust="recovery_verified",
+                holder_kind="durable",
+                durable_checkpoint_id="durable-other",
+                holder_overrides={
+                    0: "durable-store",
+                    1: "durable-store",
+                    2: "durable-store",
+                    3: "durable-store",
+                },
+            ),
+        )
+
+
+def test_durable_checkpoint_copy_requires_checkpoint_id():
+    with pytest.raises(ProtocolValidationError, match="require a checkpoint ID"):
+        replace(
+            _copy(
+                0,
+                holder_node_id="durable-store",
+                holder_kind="durable",
+            ),
+            checkpoint_id=None,
+        )
 
 
 def test_restart_plan_requires_complete_remote_or_shared_durable_copies():
@@ -559,6 +619,29 @@ def test_restart_plan_requires_a_replacement_node():
             plan=unchanged_plan,
             eligible_node_ids=("node-a", "node-b"),
         )
+
+
+def test_restart_plan_preserves_surviving_nodes_logical_slots():
+    shifted_plan = replace(
+        _plan(),
+        slot_assignments=(
+            SlotAssignment(
+                logical_node_slot=0,
+                node_id="node-spare",
+                first_global_rank=0,
+                local_world_size=2,
+            ),
+            SlotAssignment(
+                logical_node_slot=1,
+                node_id="node-a",
+                first_global_rank=2,
+                local_world_size=2,
+            ),
+        ),
+    )
+
+    with pytest.raises(ProtocolValidationError, match="changed logical slots"):
+        _validate(plan=shifted_plan)
 
 
 def test_restart_plan_preserves_committed_world_size():
@@ -622,7 +705,73 @@ def test_event_reporter_must_match_committed_rank_assignment():
         validate_worker_identity(contradictory_worker, assignment)
 
     with pytest.raises(ProtocolValidationError, match="local_world_size"):
-        validate_event_reporter(event, assignment)
+        validate_event_reporter(
+            event,
+            assignment,
+            agent_identity=_agent(),
+            resource_to_node_id={"GPU-0": "node-a"},
+        )
+
+
+def test_hardware_report_resource_must_match_registered_owner():
+    event = FaultEvent(
+        event_id="fault-resource",
+        incident_id="incident-a",
+        run_id=RUN_ID,
+        generation=4,
+        reporter=_worker(),
+        optimizer_step=41,
+        report=HardwareFaultReport(
+            kind="hardware",
+            resource_kind="gpu",
+            resource_id="GPU-1",
+            metric="uncorrectable_ecc",
+            value=1.0,
+            severity="fatal",
+            message="fatal ECC",
+        ),
+    )
+
+    with pytest.raises(ProtocolValidationError, match="trusted resource owner"):
+        validate_event_reporter(
+            event,
+            _current_assignment(),
+            agent_identity=_agent(),
+            resource_to_node_id={
+                "GPU-0": "node-a",
+                "GPU-1": "node-b",
+            },
+        )
+
+
+def test_hardware_report_accepts_registered_resource_on_reporter_node():
+    event = FaultEvent(
+        event_id="fault-resource",
+        incident_id="incident-a",
+        run_id=RUN_ID,
+        generation=4,
+        reporter=_worker(),
+        optimizer_step=41,
+        report=HardwareFaultReport(
+            kind="hardware",
+            resource_kind="gpu",
+            resource_id="GPU-1",
+            metric="uncorrectable_ecc",
+            value=1.0,
+            severity="fatal",
+            message="fatal ECC",
+        ),
+    )
+
+    validate_event_reporter(
+        event,
+        _current_assignment(),
+        agent_identity=_agent(),
+        resource_to_node_id={
+            "GPU-0": "node-a",
+            "GPU-1": "node-a",
+        },
+    )
 
 
 @pytest.mark.parametrize(
@@ -690,6 +839,37 @@ def test_verified_recovery_rejects_latest_manifest():
             plan=_plan(recovery_mode="recovery_verified"),
             manifest=_manifest(trust="latest"),
         )
+
+
+def test_durable_recovery_rejects_latest_manifest_even_in_latest_mode():
+    with pytest.raises(ProtocolValidationError, match="durable recovery requires"):
+        _validate(
+            plan=_plan(checkpoint_source="durable"),
+            manifest=_manifest(
+                trust="latest",
+                holder_kind="durable",
+                holder_overrides={
+                    0: "durable-store",
+                    1: "durable-store",
+                    2: "durable-store",
+                    3: "durable-store",
+                },
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    "restart_acks",
+    [
+        (),
+        (_ack(success=False),),
+        (_ack(flushed_step=39),),
+        (_ack(inventory_event_ids=("inventory-other",)),),
+    ],
+)
+def test_latest_recovery_requires_successful_preparation_ack(restart_acks):
+    with pytest.raises(ProtocolValidationError, match="no complete eligible copy"):
+        _validate(restart_acks=restart_acks)
 
 
 def test_candidate_cannot_become_recovery_manifest():

--- a/tests/unit/test_torchrun_protocol.py
+++ b/tests/unit/test_torchrun_protocol.py
@@ -24,7 +24,9 @@ from lm_resiliency.integrations.torchrun._protocol import (
     RestartPlan,
     SlotAssignment,
     WorkerIdentity,
+    validate_event_reporter,
     validate_restart_plan,
+    validate_worker_identity,
 )
 
 RUN_ID = "training-run"
@@ -121,12 +123,14 @@ def _copy(
     holder_node_id: str,
     holder_kind: str = "owner",
     checkpoint_step: int = 40,
+    inventory_event_id: str = "inventory-a",
     storage_kind: str | None = None,
     complete: bool = True,
 ) -> CheckpointCopy:
     return CheckpointCopy(
         owner_global_rank=rank,
         checkpoint_step=checkpoint_step,
+        inventory_event_id=inventory_event_id,
         holder_node_id=holder_node_id,
         holder_kind=holder_kind,
         storage_kind=storage_kind or ("remote" if holder_kind == "durable" else "memory"),
@@ -174,19 +178,44 @@ def _manifest(
     )
 
 
+def _inventory_event(
+    manifest: RecoveryManifest,
+    *,
+    trust: str | None = None,
+) -> CheckpointInventoryEvent:
+    return CheckpointInventoryEvent(
+        event_id="inventory-a",
+        run_id=manifest.run_id,
+        generation=manifest.source_generation,
+        reporter=replace(
+            _worker(),
+            generation=manifest.source_generation,
+        ),
+        step=manifest.step,
+        trust=trust or manifest.trust,
+        topology_digest=manifest.topology_digest,
+        copies=tuple(copy for rank_copies in manifest.rank_copies for copy in rank_copies.copies),
+    )
+
+
 def _validate(
     plan: RestartPlan | None = None,
     manifest: RecoveryManifest | None = None,
     *,
     intent: RestartIntent | None = None,
     current_assignment: RankAssignment | None = None,
+    inventory_events: tuple[CheckpointInventoryEvent, ...] | None = None,
     now_unix_ms: int = 1_900_000_000_000,
     eligible_node_ids: tuple[str, ...] = ("node-a", "node-spare"),
 ) -> None:
+    selected_manifest = manifest or _manifest()
     validate_restart_plan(
         plan or _plan(),
         intent or _intent(),
-        manifest or _manifest(),
+        selected_manifest,
+        inventory_events=(
+            (_inventory_event(selected_manifest),) if inventory_events is None else inventory_events
+        ),
         current_assignment=current_assignment or _current_assignment(),
         now_unix_ms=now_unix_ms,
         eligible_node_ids=eligible_node_ids,
@@ -384,6 +413,63 @@ def test_recovery_manifest_rejects_checkpoint_copies_from_another_step():
         _manifest(checkpoint_step=39)
 
 
+def test_restart_plan_rejects_uncertified_manifest_trust():
+    manifest = _manifest(trust="recovery_verified")
+
+    with pytest.raises(ProtocolValidationError, match="no complete eligible copy"):
+        _validate(
+            plan=_plan(recovery_mode="recovery_verified"),
+            intent=_intent(minimum_recovery_mode="recovery_verified"),
+            manifest=manifest,
+            inventory_events=(
+                _inventory_event(
+                    manifest,
+                    trust="candidate",
+                ),
+            ),
+        )
+
+
+def test_restart_plan_requires_inventory_provenance_for_every_copy():
+    with pytest.raises(ProtocolValidationError, match="no complete eligible copy"):
+        _validate(inventory_events=())
+
+
+def test_restart_plan_requires_exact_inventory_copy_match():
+    manifest = _manifest()
+    inventory = _inventory_event(manifest)
+    altered_copies = tuple(
+        replace(copy, location_token="altered-location") if copy.owner_global_rank == 0 else copy
+        for copy in inventory.copies
+    )
+
+    with pytest.raises(ProtocolValidationError, match="no complete eligible copy"):
+        _validate(
+            manifest=manifest,
+            inventory_events=(replace(inventory, copies=altered_copies),),
+        )
+
+
+def test_checkpoint_inventory_rejects_mismatched_provenance_id():
+    with pytest.raises(ProtocolValidationError, match="provenance does not match"):
+        CheckpointInventoryEvent(
+            event_id="inventory-b",
+            run_id=RUN_ID,
+            generation=4,
+            reporter=_worker(),
+            step=40,
+            trust="latest",
+            topology_digest=TOPOLOGY_DIGEST,
+            copies=(
+                _copy(
+                    0,
+                    holder_node_id="node-a",
+                    inventory_event_id="inventory-a",
+                ),
+            ),
+        )
+
+
 @pytest.mark.parametrize(
     ("plan", "manifest"),
     [
@@ -458,6 +544,23 @@ def test_restart_plan_rejects_expired_deadline():
         _validate(now_unix_ms=2_000_000_000_000)
 
 
+def test_restart_plan_requires_a_replacement_node():
+    unchanged_plan = replace(
+        _plan(),
+        slot_assignments=(
+            _assignments()[0],
+            replace(_assignments()[1], node_id="node-b"),
+        ),
+        quarantined_node_ids=(),
+    )
+
+    with pytest.raises(ProtocolValidationError, match="replacement node"):
+        _validate(
+            plan=unchanged_plan,
+            eligible_node_ids=("node-a", "node-b"),
+        )
+
+
 def test_restart_plan_preserves_committed_world_size():
     smaller_plan = replace(
         _plan(),
@@ -488,6 +591,38 @@ def test_restart_plan_preserves_committed_world_size():
 def test_worker_identity_rejects_inconsistent_global_rank():
     with pytest.raises(ProtocolValidationError, match="does not match logical slot"):
         replace(_worker(), global_rank=3)
+
+
+def test_event_reporter_must_match_committed_rank_assignment():
+    assignment = _current_assignment()
+    contradictory_worker = WorkerIdentity(
+        run_id=RUN_ID,
+        generation=4,
+        node_id="node-b",
+        agent_id="agent-b",
+        logical_node_slot=1,
+        global_rank=1,
+        local_rank=0,
+        local_world_size=1,
+        hostname="host-b",
+        gpu_uuid="GPU-2",
+        topology_digest=TOPOLOGY_DIGEST,
+    )
+    event = FaultEvent(
+        event_id="fault-contradictory",
+        incident_id="incident-a",
+        run_id=RUN_ID,
+        generation=4,
+        reporter=contradictory_worker,
+        optimizer_step=41,
+        report={"kind": "straggler", "failed_ranks": [1]},
+    )
+
+    with pytest.raises(ProtocolValidationError, match="local_world_size"):
+        validate_worker_identity(contradictory_worker, assignment)
+
+    with pytest.raises(ProtocolValidationError, match="local_world_size"):
+        validate_event_reporter(event, assignment)
 
 
 @pytest.mark.parametrize(
@@ -579,6 +714,13 @@ def test_restart_context_validates_worker_environment():
 
     with pytest.raises(ProtocolValidationError, match="TORCHELASTIC_RUN_ID"):
         context.validate_worker_environment({**environment, "TORCHELASTIC_RUN_ID": "stale-run"})
+
+
+def test_restart_context_rejects_partial_local_worker_slot():
+    context = RestartContext.from_plan(_plan(), "node-a")
+
+    with pytest.raises(ProtocolValidationError, match="complete local worker slots"):
+        replace(context, expected_world_size=3)
 
 
 def test_restart_context_rejects_unassigned_node():

--- a/tests/unit/test_torchrun_protocol.py
+++ b/tests/unit/test_torchrun_protocol.py
@@ -189,14 +189,23 @@ def _ack(
 def _manifest(
     *,
     trust: str = "latest",
-    holder_kind: str = "owner",
+    holder_kind: str | None = None,
     checkpoint_step: int = 40,
     ranks: tuple[int, ...] = (0, 1, 2, 3),
     incomplete_rank: int | None = None,
     holder_overrides: dict[int, str] | None = None,
+    holder_kind_overrides: dict[int, str] | None = None,
     durable_checkpoint_id: str = "durable-40",
 ) -> RecoveryManifest:
     holder_overrides = holder_overrides or {}
+    holder_kind_overrides = holder_kind_overrides or {}
+
+    def rank_holder_kind(rank: int) -> str:
+        return holder_kind_overrides.get(
+            rank,
+            holder_kind or ("owner" if rank < 2 else "peer"),
+        )
+
     return RecoveryManifest(
         manifest_id="manifest-40",
         run_id=RUN_ID,
@@ -214,9 +223,11 @@ def _manifest(
                             rank,
                             "node-a",
                         ),
-                        holder_kind=holder_kind,
+                        holder_kind=rank_holder_kind(rank),
                         checkpoint_step=checkpoint_step,
-                        checkpoint_id=(durable_checkpoint_id if holder_kind == "durable" else None),
+                        checkpoint_id=(
+                            durable_checkpoint_id if rank_holder_kind(rank) == "durable" else None
+                        ),
                         complete=rank != incomplete_rank,
                     ),
                 ),
@@ -281,15 +292,18 @@ def _validate(
     trusted_certifications: tuple[CheckpointCertification, ...] | None = None,
     restart_acks: tuple[RestartAck, ...] | None = None,
     authenticated_ack_agent_ids: dict[str, str] | None = None,
+    authenticated_ack_received_unix_ms: dict[str, int] | None = None,
+    source_assignment: RankAssignment | None = None,
     now_unix_ms: int = 1_900_000_000_000,
     eligible_node_ids: tuple[str, ...] = ("node-a", "node-spare"),
 ) -> None:
     selected_plan = plan or _plan()
+    selected_intent = intent or _intent()
     selected_manifest = manifest or _manifest()
     selected_acks = (_ack(),) if restart_acks is None else restart_acks
     validate_restart_plan(
         selected_plan,
-        intent or _intent(),
+        selected_intent,
         selected_manifest,
         inventory_events=(
             (_inventory_event(selected_manifest),) if inventory_events is None else inventory_events
@@ -305,6 +319,12 @@ def _validate(
             if authenticated_ack_agent_ids is None
             else authenticated_ack_agent_ids
         ),
+        authenticated_ack_received_unix_ms=(
+            {ack.node_id: selected_intent.prepare_deadline_unix_ms - 1 for ack in selected_acks}
+            if authenticated_ack_received_unix_ms is None
+            else authenticated_ack_received_unix_ms
+        ),
+        source_assignment=source_assignment or _current_assignment(),
         current_assignment=current_assignment or _current_assignment(),
         now_unix_ms=now_unix_ms,
         eligible_node_ids=eligible_node_ids,
@@ -563,6 +583,12 @@ def test_restart_plan_rejects_local_copy_on_departing_holder():
             2: "node-b",
             3: "node-b",
         },
+        holder_kind_overrides={
+            0: "peer",
+            1: "peer",
+            2: "owner",
+            3: "owner",
+        },
     )
 
     with pytest.raises(ProtocolValidationError, match="no complete eligible copy"):
@@ -583,6 +609,13 @@ def test_restart_plan_rejects_local_copy_on_departing_holder():
             ),
             authenticated_ack_agent_ids={"node-b": "agent-b"},
             eligible_node_ids=("node-a", "node-b", "node-spare"),
+        )
+
+
+def test_restart_plan_rejects_owner_copy_held_by_another_node():
+    with pytest.raises(ProtocolValidationError, match="no complete eligible copy"):
+        _validate(
+            manifest=_manifest(holder_kind="owner"),
         )
 
 
@@ -1036,6 +1069,13 @@ def test_restart_ack_must_match_authenticated_agent():
     with pytest.raises(ProtocolValidationError, match="authenticated transport sender"):
         _validate(
             authenticated_ack_agent_ids={"node-a": "agent-other"},
+        )
+
+
+def test_restart_ack_must_arrive_by_prepare_deadline():
+    with pytest.raises(ProtocolValidationError, match="received after"):
+        _validate(
+            authenticated_ack_received_unix_ms={"node-a": 2_000_000_000_001},
         )
 
 

--- a/tests/unit/test_torchrun_protocol.py
+++ b/tests/unit/test_torchrun_protocol.py
@@ -78,7 +78,11 @@ def _agent() -> AgentIdentity:
     )
 
 
-def _intent(*, minimum_recovery_mode: str = "latest") -> RestartIntent:
+def _intent(
+    *,
+    minimum_recovery_mode: str = "latest",
+    suspected_node_ids: tuple[str, ...] = ("node-b",),
+) -> RestartIntent:
     return RestartIntent(
         intent_id="intent-4",
         run_id=RUN_ID,
@@ -86,7 +90,7 @@ def _intent(*, minimum_recovery_mode: str = "latest") -> RestartIntent:
         incident_ids=("incident-a",),
         reason_code="replace_straggler",
         minimum_recovery_mode=minimum_recovery_mode,
-        suspected_node_ids=("node-b",),
+        suspected_node_ids=suspected_node_ids,
         prepare_deadline_unix_ms=2_000_000_000_000,
     )
 
@@ -626,6 +630,7 @@ def test_restart_plan_requires_a_replacement_node():
     with pytest.raises(ProtocolValidationError, match="replacement node"):
         _validate(
             plan=unchanged_plan,
+            intent=_intent(suspected_node_ids=()),
             eligible_node_ids=("node-a", "node-b"),
         )
 
@@ -651,6 +656,33 @@ def test_restart_plan_preserves_surviving_nodes_logical_slots():
 
     with pytest.raises(ProtocolValidationError, match="changed logical slots"):
         _validate(plan=shifted_plan)
+
+
+def test_restart_plan_removes_every_node_suspected_by_intent():
+    wrong_replacement = replace(
+        _plan(),
+        slot_assignments=(
+            SlotAssignment(
+                logical_node_slot=0,
+                node_id="node-spare",
+                first_global_rank=0,
+                local_world_size=2,
+            ),
+            SlotAssignment(
+                logical_node_slot=1,
+                node_id="node-b",
+                first_global_rank=2,
+                local_world_size=2,
+            ),
+        ),
+        quarantined_node_ids=(),
+    )
+
+    with pytest.raises(ProtocolValidationError, match="suspected nodes remain assigned"):
+        _validate(
+            plan=wrong_replacement,
+            eligible_node_ids=("node-b", "node-spare"),
+        )
 
 
 def test_restart_plan_preserves_committed_world_size():

--- a/tests/unit/test_torchrun_protocol.py
+++ b/tests/unit/test_torchrun_protocol.py
@@ -496,6 +496,15 @@ def test_rank_assignment_requires_dense_slots_and_stable_rank_ranges():
         )
 
 
+@pytest.mark.parametrize("invalid_slot", ["²", "1" * 5_000])
+def test_rank_assignment_rejects_unparseable_slot_keys(invalid_slot):
+    value = _current_assignment().to_dict()
+    value["slot_to_node_id"][invalid_slot] = value["slot_to_node_id"].pop("0")
+
+    with pytest.raises(ProtocolValidationError, match="slot keys"):
+        RankAssignment.from_dict(value)
+
+
 def test_restart_plan_and_complete_manifest_validate():
     _validate()
 

--- a/tests/unit/test_torchrun_protocol.py
+++ b/tests/unit/test_torchrun_protocol.py
@@ -1323,6 +1323,67 @@ def test_fault_report_resource_endpoint_must_match_specific_rank():
         )
 
 
+def test_fault_report_gpu_endpoint_requires_rank_binding():
+    event = FaultEvent(
+        event_id="fault-unbound-gpu-endpoint",
+        incident_id="incident-a",
+        run_id=RUN_ID,
+        generation=4,
+        reporter=_worker(),
+        optimizer_step=41,
+        report={
+            "kind": "straggler",
+            "failed_ranks": [0],
+            "endpoint_kind": "gpu",
+            "endpoint_id": "GPU-1",
+            "endpoint_rank": 0,
+        },
+    )
+
+    with pytest.raises(ProtocolValidationError, match="GPU resource rank is missing"):
+        validate_event_reporter(
+            event,
+            _current_assignment(),
+            agent_identity=_agent(),
+            resource_to_node_id={"GPU-0": "node-a", "GPU-1": "node-a"},
+            resource_to_kind={"GPU-0": "gpu", "GPU-1": "gpu"},
+            resource_to_global_rank={"GPU-0": 0},
+        )
+
+
+def test_fault_report_accepts_node_shared_endpoint_without_rank_binding():
+    event = FaultEvent(
+        event_id="fault-shared-resource-endpoint",
+        incident_id="incident-a",
+        run_id=RUN_ID,
+        generation=4,
+        reporter=_worker(),
+        optimizer_step=41,
+        report={
+            "kind": "straggler",
+            "failed_ranks": [0],
+            "endpoint_kind": "nic",
+            "endpoint_id": "NIC-node-a",
+            "endpoint_rank": 0,
+        },
+    )
+
+    validate_event_reporter(
+        event,
+        _current_assignment(),
+        agent_identity=_agent(),
+        resource_to_node_id={
+            "GPU-0": "node-a",
+            "NIC-node-a": "node-a",
+        },
+        resource_to_kind={
+            "GPU-0": "gpu",
+            "NIC-node-a": "nic",
+        },
+        resource_to_global_rank={"GPU-0": 0},
+    )
+
+
 @pytest.mark.parametrize(
     ("failure_kind", "all_ranks_accessible"),
     [("sdc", True), ("machine_unavailable", True), ("hang", False)],

--- a/tests/unit/test_torchrun_protocol.py
+++ b/tests/unit/test_torchrun_protocol.py
@@ -25,6 +25,7 @@ from lm_resiliency.integrations.torchrun._protocol import (
     RestartPlan,
     SlotAssignment,
     WorkerIdentity,
+    checkpoint_inventory_digest,
     validate_event_reporter,
     validate_restart_plan,
     validate_worker_identity,
@@ -261,6 +262,7 @@ def _inventory_event(
 def _certification(
     plan: RestartPlan,
     manifest: RecoveryManifest,
+    inventory_events: tuple[CheckpointInventoryEvent, ...],
 ) -> CheckpointCertification:
     return CheckpointCertification(
         certification_id=f"certification-{manifest.step}",
@@ -272,13 +274,9 @@ def _certification(
         checkpoint_id=plan.checkpoint_id,
         expected_world_size=plan.expected_world_size,
         certification_kind="dense_consensus",
-        inventory_event_ids=tuple(
-            dict.fromkeys(
-                copy.inventory_event_id
-                for rank_copies in manifest.rank_copies
-                for copy in rank_copies.copies
-            )
-        ),
+        inventory_event_digests={
+            event.event_id: checkpoint_inventory_digest(event) for event in inventory_events
+        },
     )
 
 
@@ -301,15 +299,22 @@ def _validate(
     selected_intent = intent or _intent()
     selected_manifest = manifest or _manifest()
     selected_acks = (_ack(),) if restart_acks is None else restart_acks
+    selected_inventory_events = (
+        (_inventory_event(selected_manifest),) if inventory_events is None else inventory_events
+    )
     validate_restart_plan(
         selected_plan,
         selected_intent,
         selected_manifest,
-        inventory_events=(
-            (_inventory_event(selected_manifest),) if inventory_events is None else inventory_events
-        ),
+        inventory_events=selected_inventory_events,
         trusted_certifications=(
-            (_certification(selected_plan, selected_manifest),)
+            (
+                _certification(
+                    selected_plan,
+                    selected_manifest,
+                    selected_inventory_events,
+                ),
+            )
             if trusted_certifications is None and selected_manifest.trust == "recovery_verified"
             else (() if trusted_certifications is None else trusted_certifications)
         ),
@@ -392,6 +397,7 @@ def _records():
         _certification(
             _plan(recovery_mode="recovery_verified"),
             _manifest(trust="recovery_verified"),
+            (_inventory_event(_manifest(trust="recovery_verified")),),
         ),
         _intent(),
         _ack(),
@@ -534,6 +540,41 @@ def test_verified_inventory_requires_trusted_catalog_certification():
             intent=_intent(minimum_recovery_mode="recovery_verified"),
             manifest=manifest,
             trusted_certifications=(),
+        )
+
+
+def test_certification_binds_immutable_inventory_contents():
+    plan = _plan(recovery_mode="recovery_verified")
+    original_manifest = _manifest(trust="recovery_verified")
+    original_event = _inventory_event(original_manifest)
+    certification = _certification(
+        plan,
+        original_manifest,
+        (original_event,),
+    )
+    altered_manifest = replace(
+        original_manifest,
+        rank_copies=tuple(
+            replace(
+                rank_copies,
+                copies=tuple(
+                    replace(copy, location_token="substituted-location")
+                    if copy.owner_global_rank == 0
+                    else copy
+                    for copy in rank_copies.copies
+                ),
+            )
+            for rank_copies in original_manifest.rank_copies
+        ),
+    )
+
+    with pytest.raises(ProtocolValidationError, match="no complete eligible copy"):
+        _validate(
+            plan=plan,
+            intent=_intent(minimum_recovery_mode="recovery_verified"),
+            manifest=altered_manifest,
+            inventory_events=(_inventory_event(altered_manifest),),
+            trusted_certifications=(certification,),
         )
 
 

--- a/tests/unit/test_torchrun_protocol.py
+++ b/tests/unit/test_torchrun_protocol.py
@@ -204,7 +204,7 @@ def _manifest(
                         rank,
                         holder_node_id=holder_overrides.get(
                             rank,
-                            "node-a" if rank < 2 else "node-spare",
+                            "node-a",
                         ),
                         holder_kind=holder_kind,
                         checkpoint_step=checkpoint_step,
@@ -471,6 +471,15 @@ def test_restart_plan_requires_exact_inventory_copy_match():
         _validate(
             manifest=manifest,
             inventory_events=(replace(inventory, copies=altered_copies),),
+        )
+
+
+def test_restart_plan_rejects_local_copy_reported_by_another_node():
+    with pytest.raises(ProtocolValidationError, match="no complete eligible copy"):
+        _validate(
+            manifest=_manifest(
+                holder_overrides={0: "node-spare"},
+            ),
         )
 
 
@@ -774,6 +783,26 @@ def test_hardware_report_accepts_registered_resource_on_reporter_node():
     )
 
 
+def test_fault_report_rejects_rank_outside_committed_assignment():
+    event = FaultEvent(
+        event_id="fault-rank",
+        incident_id="incident-a",
+        run_id=RUN_ID,
+        generation=4,
+        reporter=_worker(),
+        optimizer_step=41,
+        report={"kind": "straggler", "failed_ranks": [999]},
+    )
+
+    with pytest.raises(ProtocolValidationError, match="not active"):
+        validate_event_reporter(
+            event,
+            _current_assignment(),
+            agent_identity=_agent(),
+            resource_to_node_id={"GPU-0": "node-a"},
+        )
+
+
 @pytest.mark.parametrize(
     ("failure_kind", "all_ranks_accessible"),
     [("sdc", True), ("machine_unavailable", True), ("hang", False)],
@@ -887,13 +916,43 @@ def test_restart_context_validates_worker_environment():
         "TORCHELASTIC_RUN_ID": RUN_ID,
     }
 
-    context.validate_worker_environment(environment)
+    context.validate_worker_environment(environment, committed_plan=_plan())
 
     with pytest.raises(ProtocolValidationError, match="RANK=2"):
-        context.validate_worker_environment({**environment, "RANK": "2"})
+        context.validate_worker_environment(
+            {**environment, "RANK": "2"},
+            committed_plan=_plan(),
+        )
 
     with pytest.raises(ProtocolValidationError, match="TORCHELASTIC_RUN_ID"):
-        context.validate_worker_environment({**environment, "TORCHELASTIC_RUN_ID": "stale-run"})
+        context.validate_worker_environment(
+            {**environment, "TORCHELASTIC_RUN_ID": "stale-run"},
+            committed_plan=_plan(),
+        )
+
+
+def test_restart_context_must_match_current_committed_plan():
+    stale_context = RestartContext.from_plan(_plan(), "node-spare")
+    current_plan = replace(
+        _plan(),
+        plan_id="plan-6",
+        from_generation=5,
+        to_generation=6,
+        recovery_mode="recovery_verified",
+    )
+    environment = {
+        "RANK": "3",
+        "LOCAL_RANK": "1",
+        "LOCAL_WORLD_SIZE": "2",
+        "WORLD_SIZE": "4",
+        "TORCHELASTIC_RUN_ID": RUN_ID,
+    }
+
+    with pytest.raises(ProtocolValidationError, match="currently committed"):
+        stale_context.validate_worker_environment(
+            environment,
+            committed_plan=current_plan,
+        )
 
 
 def test_restart_context_rejects_partial_local_worker_slot():

--- a/tests/unit/test_torchrun_protocol.py
+++ b/tests/unit/test_torchrun_protocol.py
@@ -910,6 +910,16 @@ def test_restart_plan_removes_every_node_suspected_by_intent():
         )
 
 
+def test_restart_plan_quarantines_only_policy_approved_removed_nodes():
+    with pytest.raises(ProtocolValidationError, match="not in the intent's suspected scope"):
+        _validate(
+            plan=replace(
+                _plan(),
+                quarantined_node_ids=("node-b", "node-c"),
+            ),
+        )
+
+
 def test_restart_plan_preserves_committed_world_size():
     smaller_plan = replace(
         _plan(),
@@ -1002,6 +1012,7 @@ def test_event_reporter_must_match_committed_rank_assignment():
             agent_identity=_agent(),
             resource_to_node_id={"GPU-0": "node-a"},
             resource_to_kind={"GPU-0": "gpu"},
+            resource_to_global_rank={"GPU-0": 0},
         )
 
 
@@ -1037,6 +1048,10 @@ def test_hardware_report_resource_must_match_registered_owner():
                 "GPU-0": "gpu",
                 "GPU-1": "gpu",
             },
+            resource_to_global_rank={
+                "GPU-0": 0,
+                "GPU-1": 1,
+            },
         )
 
 
@@ -1051,7 +1066,7 @@ def test_hardware_report_accepts_registered_resource_on_reporter_node():
         report=HardwareFaultReport(
             kind="hardware",
             resource_kind="gpu",
-            resource_id="GPU-1",
+            resource_id="GPU-0",
             metric="uncorrectable_ecc",
             value=1.0,
             severity="fatal",
@@ -1070,6 +1085,10 @@ def test_hardware_report_accepts_registered_resource_on_reporter_node():
         resource_to_kind={
             "GPU-0": "gpu",
             "GPU-1": "gpu",
+        },
+        resource_to_global_rank={
+            "GPU-0": 0,
+            "GPU-1": 1,
         },
     )
 
@@ -1105,6 +1124,10 @@ def test_hardware_report_resource_kind_must_match_trusted_inventory():
             resource_to_kind={
                 "GPU-0": "gpu",
                 "GPU-1": "gpu",
+            },
+            resource_to_global_rank={
+                "GPU-0": 0,
+                "GPU-1": 1,
             },
         )
 
@@ -1152,6 +1175,7 @@ def test_fault_report_rejects_rank_outside_committed_assignment():
             agent_identity=_agent(),
             resource_to_node_id={"GPU-0": "node-a"},
             resource_to_kind={"GPU-0": "gpu"},
+            resource_to_global_rank={"GPU-0": 0},
         )
 
 
@@ -1184,6 +1208,7 @@ def test_fault_report_validates_all_rank_attribution_fields(field, value, messag
             agent_identity=_agent(),
             resource_to_node_id={"GPU-0": "node-a"},
             resource_to_kind={"GPU-0": "gpu"},
+            resource_to_global_rank={"GPU-0": 0},
         )
 
 
@@ -1211,6 +1236,44 @@ def test_fault_report_endpoint_must_match_failed_rank_and_node():
             agent_identity=_agent(),
             resource_to_node_id={"GPU-0": "node-a"},
             resource_to_kind={"GPU-0": "gpu"},
+            resource_to_global_rank={"GPU-0": 0},
+        )
+
+
+def test_fault_report_resource_endpoint_must_match_specific_rank():
+    event = FaultEvent(
+        event_id="fault-resource-endpoint",
+        incident_id="incident-a",
+        run_id=RUN_ID,
+        generation=4,
+        reporter=_worker(),
+        optimizer_step=41,
+        report={
+            "kind": "straggler",
+            "failed_ranks": [0],
+            "endpoint_kind": "gpu",
+            "endpoint_id": "GPU-1",
+            "endpoint_rank": 0,
+        },
+    )
+
+    with pytest.raises(ProtocolValidationError, match="resource rank"):
+        validate_event_reporter(
+            event,
+            _current_assignment(),
+            agent_identity=_agent(),
+            resource_to_node_id={
+                "GPU-0": "node-a",
+                "GPU-1": "node-a",
+            },
+            resource_to_kind={
+                "GPU-0": "gpu",
+                "GPU-1": "gpu",
+            },
+            resource_to_global_rank={
+                "GPU-0": 0,
+                "GPU-1": 1,
+            },
         )
 
 

--- a/tests/unit/test_torchrun_protocol.py
+++ b/tests/unit/test_torchrun_protocol.py
@@ -196,6 +196,7 @@ def _manifest(
     incomplete_rank: int | None = None,
     holder_overrides: dict[int, str] | None = None,
     holder_kind_overrides: dict[int, str] | None = None,
+    storage_kind: str | None = None,
     durable_checkpoint_id: str = "durable-40",
 ) -> RecoveryManifest:
     holder_overrides = holder_overrides or {}
@@ -226,6 +227,10 @@ def _manifest(
                         ),
                         holder_kind=rank_holder_kind(rank),
                         checkpoint_step=checkpoint_step,
+                        storage_kind=(
+                            storage_kind
+                            or ("remote" if rank_holder_kind(rank) == "durable" else "node_local")
+                        ),
                         checkpoint_id=(
                             durable_checkpoint_id if rank_holder_kind(rank) == "durable" else None
                         ),
@@ -650,6 +655,13 @@ def test_restart_plan_rejects_local_copy_on_departing_holder():
             ),
             authenticated_ack_agent_ids={"node-b": "agent-b"},
             eligible_node_ids=("node-a", "node-b", "node-spare"),
+        )
+
+
+def test_restart_plan_rejects_process_memory_copies():
+    with pytest.raises(ProtocolValidationError, match="no complete eligible copy"):
+        _validate(
+            manifest=_manifest(storage_kind="memory"),
         )
 
 


### PR DESCRIPTION
## Problem

Stock `torchrun --nnodes=min:max` provides elastic membership, not a fixed-size active group with replacement-only standby nodes, stable logical slots, quarantine, and checkpoint-fenced recovery.

## Implementation

- Document an out-of-tree design using an existing `RendezvousHandler` plugin, the stock `LocalElasticAgent`, and an LM Resiliency coordinator.
- Add internal, versioned immutable records for identities, fault and recovery events, checkpoint inventories, restart intents/plans/contexts, rank assignments, and recovery manifests.
- Reject unknown schemas and fields, stale or inconsistent generations, unstable rank mappings, quarantined assignments, incomplete rank coverage, and insufficient checkpoint trust.
- Keep the integration internal: this PR does not register a `torchrun.handlers` entry point or activate runtime behavior.

## Compatibility

The package root and current orchestration APIs are unchanged. Optional framework imports remain lazy. Runtime coordinator and rendezvous integration will be added in later PRs.

## Validation

- `CUDA_VISIBLE_DEVICES='' .venv/bin/python -m pytest -q tests/unit/test_torchrun_protocol.py tests/unit/test_orchestration_api.py tests/unit/test_recovery_decision.py` (43 passed)
- `.venv/bin/ruff check lm_resiliency/integrations/torchrun tests/unit/test_torchrun_protocol.py`
- `.venv/bin/ruff format --check lm_resiliency/integrations/torchrun tests/unit/test_torchrun_protocol.py`
- `git diff --check`