### PR TITLE
[CI/Release] Grant PR write permission to Codex re-review workflow

### DIFF
--- a/.github/workflows/codex-rereview.yml
+++ b/.github/workflows/codex-rereview.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   issues: write
+  pull-requests: write
 
 jobs:
   request_codex_review:


### PR DESCRIPTION
## Summary

Allow the existing Codex re-review workflow to post `@codex review` comments on pull requests after new commits are pushed.

The workflow currently triggers correctly on `pull_request_target: synchronize`, but both observed runs fail when creating the PR timeline comment with `403 Resource not accessible by integration`. This PR makes only the requested permission change by adding `pull-requests: write` to the workflow token permissions.

## Related issues

No issue is needed; this is a focused fix for the failing `Trigger Codex re-review / Request Codex review (pull_request_target)` workflow observed on PR #12 and PR #30.

## Changes

- Add `pull-requests: write` under `.github/workflows/codex-rereview.yml` permissions.
- Leave the event trigger, comment body, shell command, runner, and all other workflow behavior unchanged.

## Compatibility

No compatibility impact. Public APIs, checkpoint formats, framework versions, distributed topology, and manager contracts are unchanged.

## Validation

```text
Command: Compare main...agent/codex-rereview-pr-permission
Result: 1 commit, 1 changed file, +1/-0; the only diff is adding `pull-requests: write`.

Observed failing command:
POST /repos/LMResiliency/lm-resiliency/issues/<PR>/comments
Result before this fix: HTTP 403 `Resource not accessible by integration` on both PR #12 and PR #30.
```

End-to-end validation requires the fixed workflow to be present on `main`; after merge, push a new commit to an open PR and verify the workflow posts `@codex review` successfully.

Distributed or GPU validation is not applicable because this is a workflow-permission-only change.

## Documentation

No documentation change is required; this PR only corrects GitHub Actions permissions for existing repository automation.

## Checklist

- [x] The pull request is focused on one coherent change.
- [x] I added or updated tests for changed behavior, or explained why tests are not required.
- [x] I ran the relevant CPU checks from `CONTRIBUTING.md`, or documented why runtime CPU checks are not applicable to this workflow-only change.
- [x] I ran relevant distributed or GPU validation, or documented why it was not required or available.
- [x] I updated public documentation, examples, and compatibility notes, or explained why they are not required.
- [x] I preserved stable API compatibility or documented the compatibility impact.
- [x] I removed credentials, private data, generated environments, and local validation artifacts.
- [x] I identified copied or adapted code and preserved required attribution and licensing; no copied or adapted code is included.