### PR TITLE
[CI/Release] Add trusted two-GPU qualification

### DIFF
--- a/.github/workflows/gpu-qualification.yml
+++ b/.github/workflows/gpu-qualification.yml
@@ -1,0 +1,67 @@
+name: GPU Qualification
+
+on:
+  schedule:
+    - cron: "17 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gpu-qualification-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  core-gpu:
+    name: Core GPU qualification
+    runs-on: [self-hosted, linux, x64, gpu, lm-resiliency]
+    timeout-minutes: 60
+
+    env:
+      NUMPY_VERSION: "2.5.1"
+      TORCH_INDEX_URL: https://download.pytorch.org/whl/cu130
+      TORCH_VERSION: "2.13.0"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install qualified runtime
+        run: |
+          python -m pip install \
+            --index-url "$TORCH_INDEX_URL" \
+            --only-binary=:all: \
+            "torch==$TORCH_VERSION"
+          python -m pip install "numpy==$NUMPY_VERSION" "setuptools>=83"
+          python -m pip install --no-deps -e .
+          python -m pip check
+
+      - name: Run two-GPU qualification
+        run: |
+          python tests/validation/run_gpu_qualification.py \
+            --artifact-dir "$RUNNER_TEMP/gpu-qualification" \
+            --minimum-gpus 2
+
+      - name: Publish job summary
+        if: always()
+        run: |
+          if test -f "$RUNNER_TEMP/gpu-qualification/summary.md"; then
+            cat "$RUNNER_TEMP/gpu-qualification/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload qualification evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gpu-qualification-${{ github.sha }}
+          path: ${{ runner.temp }}/gpu-qualification
+          if-no-files-found: error
+          retention-days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 ### Added
 
 - A runnable CPU quick-start example with a complete native PyTorch training loop and GEMINI checkpoint resume.
+- A scheduled and maintainer-dispatched two-GPU qualification workflow with machine-readable revision, environment, topology, command, log, and checksum evidence.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ### Fast checkpoint recovery and fault localization for distributed LLM pre-training
 
 [![16 GPU Feature Tests](https://img.shields.io/badge/16_GPU_Feature_Tests-passing-brightgreen.svg)](docs/validation.md#release-baseline)
+[![GPU Qualification](https://github.com/LMResiliency/lm-resiliency/actions/workflows/gpu-qualification.yml/badge.svg?branch=main)](https://github.com/LMResiliency/lm-resiliency/actions/workflows/gpu-qualification.yml)
 [![pip](https://img.shields.io/pypi/v/lm-resiliency?color=blue)](https://pypi.org/project/lm-resiliency/)
 [![PyTorch 2.10–2.13](https://img.shields.io/badge/PyTorch-2.10--2.13-EE4C2C.svg)](https://pytorch.org/)
 [![TorchTitan 0.2.2](https://img.shields.io/badge/TorchTitan-0.2.2-EE4C2C.svg)](https://github.com/pytorch/torchtitan)

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -5,6 +5,12 @@ Date: 2026-08-13 UTC.
 This report summarizes the release-candidate validation evidence for GEMINI and SCOUT.
 Focused integration programs use deterministic training workloads and fault injection to verify checkpoint equivalence, exact fault localization, candidate exclusion, and framework topology handling.
 
+## Automated Qualification Status
+
+The [GPU Qualification workflow](https://github.com/LMResiliency/lm-resiliency/actions/workflows/gpu-qualification.yml) runs weekly and on trusted maintainer dispatch using a two-GPU self-hosted runner. The workflow badge in the README links to the last run, including its exact revision and completion date. Each run also uploads a machine-readable summary, environment and topology inventory, exact commands, per-command logs, and SHA-256 checksums.
+
+This frequent tier exercises single-GPU trajectory-equivalent recovery plus two-rank Gloo/NCCL replay, synchronized RNG, FSDP2 checkpoint recovery, and process-exit cleanup. It does not replace the larger release-qualification campaigns documented below. Self-hosted runner provisioning and isolation requirements are documented in the [test guide](../tests/README.md#automated-gpu-qualification).
+
 ## Release Baseline
 
 | Check | Result |

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,3 +19,19 @@ python -m pytest -q
 Distributed programs document their required `torchrun` command in the module docstring.
 Production-loop integration is exercised directly through `examples/production_loops/` with `--inject-fault`.
 MoE validation is manual because it depends on specific GPU, Triton, Megatron Core, and Transformer Engine environments.
+
+## Automated GPU Qualification
+
+The scheduled and maintainer-dispatched [GPU Qualification workflow](../.github/workflows/gpu-qualification.yml) runs a two-GPU, one-host trusted tier on a self-hosted runner. It covers trajectory-equivalent checkpoint recovery, Gloo/NCCL replay, synchronized dropout RNG, structured invocation replay, FSDP2 local-shard checkpoint recovery, and automatic exit cleanup.
+
+The runner must be an isolated Linux x64 host with at least two visible CUDA GPUs and the labels `self-hosted`, `linux`, `x64`, `gpu`, and `lm-resiliency`. The workflow is deliberately not triggered by pull requests, so untrusted fork code cannot execute on the privileged runner. Prefer an ephemeral runner image and do not attach production credentials or writable production storage.
+
+Every run uploads `environment.json`, `commands.txt`, per-command logs, `summary.json`, `summary.md`, and SHA-256 checksums under an artifact named for the exact commit. Run the same tier manually with:
+
+```bash
+python tests/validation/run_gpu_qualification.py \
+  --artifact-dir /tmp/lm-resiliency-gpu-qualification \
+  --minimum-gpus 2
+```
+
+Eight/sixteen-GPU, multi-node, optional-framework, and MoE campaigns remain release qualification rather than part of this frequent tier.

--- a/tests/unit/test_gpu_qualification.py
+++ b/tests/unit/test_gpu_qualification.py
@@ -1,0 +1,58 @@
+"""Tests for the automated GPU qualification evidence harness."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from tests.validation import run_gpu_qualification
+
+
+def test_gpu_qualification_commands_cover_core_two_gpu_paths(tmp_path):
+    commands = dict(run_gpu_qualification._commands(tmp_path))
+
+    assert set(commands) == {
+        "recovery-equivalence",
+        "replay-and-collectives",
+        "fsdp2-checkpoint-recovery",
+        "automatic-exit-cleanup",
+    }
+    assert "--nproc-per-node=2" in commands["replay-and-collectives"]
+    assert "--nproc-per-node=2" in commands["fsdp2-checkpoint-recovery"]
+    case_index = commands["automatic-exit-cleanup"].index("--case")
+    assert commands["automatic-exit-cleanup"][case_index + 1] == "pytorch"
+
+
+def test_gpu_qualification_writes_failure_evidence_without_required_gpus(tmp_path, monkeypatch):
+    artifact_dir = tmp_path / "evidence"
+    monkeypatch.setattr(
+        run_gpu_qualification,
+        "_environment",
+        lambda: {
+            "cuda_available": False,
+            "device_count": 0,
+            "devices": [],
+        },
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_gpu_qualification.py",
+            "--artifact-dir",
+            str(artifact_dir),
+            "--minimum-gpus",
+            "2",
+        ],
+    )
+
+    assert run_gpu_qualification.main() == 1
+    summary = json.loads((artifact_dir / "summary.json").read_text())
+    assert summary["schema_version"] == 1
+    assert summary["status"] == "failed"
+    assert summary["topology"] == {"hosts": 1, "required_gpus": 2, "visible_gpus": 0}
+    assert summary["error"] == "requires at least 2 CUDA GPUs; found 0"
+    assert (artifact_dir / "environment.json").exists()
+    assert (artifact_dir / "commands.txt").exists()
+    assert (artifact_dir / "summary.md").exists()
+    assert (artifact_dir / "checksums.txt").exists()

--- a/tests/validation/run_gpu_qualification.py
+++ b/tests/validation/run_gpu_qualification.py
@@ -1,0 +1,291 @@
+"""Run the smallest trusted GPU qualification tier and publish JSON evidence."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import platform
+import shlex
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import torch
+
+_SCHEMA_VERSION = 1
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _timestamp() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def _nvidia_smi() -> dict[str, Any]:
+    command = [
+        "nvidia-smi",
+        "--query-gpu=index,name,uuid,driver_version,memory.total",
+        "--format=csv,noheader,nounits",
+    ]
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as error:
+        return {"command": command, "error": f"{type(error).__name__}: {error}"}
+    return {
+        "command": command,
+        "returncode": completed.returncode,
+        "stdout": completed.stdout.strip(),
+        "stderr": completed.stderr.strip(),
+    }
+
+
+def _environment() -> dict[str, Any]:
+    cuda_available = torch.cuda.is_available()
+    device_count = torch.cuda.device_count() if cuda_available else 0
+    devices = []
+    for index in range(device_count):
+        properties = torch.cuda.get_device_properties(index)
+        devices.append(
+            {
+                "index": index,
+                "name": properties.name,
+                "total_memory_bytes": properties.total_memory,
+                "compute_capability": [properties.major, properties.minor],
+            }
+        )
+    nccl_version = torch.cuda.nccl.version() if cuda_available else None
+    return {
+        "captured_at": _timestamp(),
+        "host": platform.node(),
+        "platform": platform.platform(),
+        "python": sys.version,
+        "python_executable": sys.executable,
+        "torch": torch.__version__,
+        "cuda_available": cuda_available,
+        "cuda_runtime": torch.version.cuda,
+        "nccl": list(nccl_version) if isinstance(nccl_version, tuple) else nccl_version,
+        "device_count": device_count,
+        "devices": devices,
+        "nvidia_smi": _nvidia_smi(),
+        "runner": {
+            "name": os.environ.get("RUNNER_NAME"),
+            "os": os.environ.get("RUNNER_OS"),
+            "arch": os.environ.get("RUNNER_ARCH"),
+        },
+    }
+
+
+def _commands(artifact_dir: Path) -> list[tuple[str, list[str]]]:
+    python = sys.executable
+    return [
+        (
+            "recovery-equivalence",
+            [python, "tests/integration/core/test_recovery_equivalence.py"],
+        ),
+        (
+            "replay-and-collectives",
+            [
+                python,
+                "-m",
+                "torch.distributed.run",
+                "--standalone",
+                "--nproc-per-node=2",
+                "tests/integration/core/test_replay_harness.py",
+                "no-sdc",
+                "dropout-rng",
+                "structured",
+            ],
+        ),
+        (
+            "fsdp2-checkpoint-recovery",
+            [
+                python,
+                "-m",
+                "torch.distributed.run",
+                "--standalone",
+                "--nproc-per-node=2",
+                "tests/integration/core/test_gemini_dtensor.py",
+            ],
+        ),
+        (
+            "automatic-exit-cleanup",
+            [
+                python,
+                "tests/integration/frameworks/test_exit_cleanup.py",
+                "--case",
+                "pytorch",
+                "--artifact-dir",
+                str(artifact_dir / "exit-cleanup"),
+            ],
+        ),
+    ]
+
+
+def _run_command(
+    name: str,
+    command: list[str],
+    artifact_dir: Path,
+    environment: dict[str, str],
+) -> dict[str, Any]:
+    log_path = artifact_dir / f"{name}.log"
+    started_at = _timestamp()
+    started = time.monotonic()
+    print(f"::group::{name}: {shlex.join(command)}", flush=True)
+    with log_path.open("w", encoding="utf-8") as log:
+        process = subprocess.Popen(
+            command,
+            cwd=_REPOSITORY_ROOT,
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        assert process.stdout is not None
+        for line in process.stdout:
+            print(line, end="", flush=True)
+            log.write(line)
+        returncode = process.wait()
+    print("::endgroup::", flush=True)
+    return {
+        "name": name,
+        "command": command,
+        "started_at": started_at,
+        "completed_at": _timestamp(),
+        "duration_seconds": round(time.monotonic() - started, 3),
+        "returncode": returncode,
+        "status": "passed" if returncode == 0 else "failed",
+        "log": log_path.name,
+        "log_sha256": _sha256(log_path),
+    }
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_summary_markdown(path: Path, summary: dict[str, Any]) -> None:
+    lines = [
+        "## GPU qualification",
+        "",
+        f"- Status: **{summary['status']}**",
+        f"- Commit: `{summary['commit_sha']}`",
+        f"- Completed: `{summary['completed_at']}`",
+        f"- Topology: `{summary['topology']['hosts']} host / "
+        f"{summary['topology']['visible_gpus']} visible GPUs`",
+        "",
+        "| Check | Result | Duration |",
+        "|---|---|---:|",
+    ]
+    for result in summary["results"]:
+        lines.append(
+            f"| `{result['name']}` | {result['status']} | {result['duration_seconds']:.3f}s |"
+        )
+    if summary.get("error"):
+        lines.extend(["", f"Error: `{summary['error']}`"])
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_checksums(artifact_dir: Path) -> None:
+    lines = []
+    for path in sorted(item for item in artifact_dir.rglob("*") if item.is_file()):
+        if path.name == "checksums.txt":
+            continue
+        lines.append(f"{_sha256(path)}  {path.relative_to(artifact_dir)}")
+    (artifact_dir / "checksums.txt").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--artifact-dir", type=Path, required=True)
+    parser.add_argument("--minimum-gpus", type=int, default=2)
+    args = parser.parse_args()
+    if args.minimum_gpus < 1:
+        parser.error("--minimum-gpus must be positive")
+
+    artifact_dir = args.artifact_dir.resolve()
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    environment = _environment()
+    _write_json(artifact_dir / "environment.json", environment)
+
+    command_specs = _commands(artifact_dir)
+    (artifact_dir / "commands.txt").write_text(
+        "\n".join(shlex.join(command) for _, command in command_specs) + "\n",
+        encoding="utf-8",
+    )
+    summary: dict[str, Any] = {
+        "schema_version": _SCHEMA_VERSION,
+        "repository": os.environ.get("GITHUB_REPOSITORY"),
+        "commit_sha": os.environ.get("GITHUB_SHA") or _git_revision(),
+        "ref": os.environ.get("GITHUB_REF"),
+        "event": os.environ.get("GITHUB_EVENT_NAME"),
+        "started_at": _timestamp(),
+        "completed_at": None,
+        "status": "running",
+        "topology": {
+            "hosts": 1,
+            "required_gpus": args.minimum_gpus,
+            "visible_gpus": environment["device_count"],
+        },
+        "results": [],
+    }
+
+    if not environment["cuda_available"] or environment["device_count"] < args.minimum_gpus:
+        summary["status"] = "failed"
+        summary["error"] = (
+            f"requires at least {args.minimum_gpus} CUDA GPUs; found {environment['device_count']}"
+        )
+    else:
+        command_environment = os.environ.copy()
+        root = str(_REPOSITORY_ROOT)
+        command_environment["PYTHONPATH"] = os.pathsep.join(
+            part for part in (root, command_environment.get("PYTHONPATH")) if part
+        )
+        for name, command in command_specs:
+            result = _run_command(name, command, artifact_dir, command_environment)
+            summary["results"].append(result)
+            _write_json(artifact_dir / "summary.json", summary)
+        summary["status"] = (
+            "passed"
+            if all(result["status"] == "passed" for result in summary["results"])
+            else "failed"
+        )
+
+    summary["completed_at"] = _timestamp()
+    _write_json(artifact_dir / "summary.json", summary)
+    _write_summary_markdown(artifact_dir / "summary.md", summary)
+    _write_checksums(artifact_dir)
+    return 0 if summary["status"] == "passed" else 1
+
+
+def _git_revision() -> str | None:
+    completed = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=_REPOSITORY_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip() if completed.returncode == 0 else None
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Add a weekly and maintainer-dispatched two-GPU qualification tier for core GEMINI/SCOUT correctness paths, together with revision-bound machine-readable evidence.

Addresses the repository implementation portion of #18. A compatible self-hosted runner still needs to be provisioned before the first live GPU run, so this PR does not close the issue.

## Changes

- Add a trusted-only `GPU Qualification` workflow with no pull-request trigger and read-only repository permissions.
- Target an isolated self-hosted Linux x64 runner labeled `gpu` and `lm-resiliency` with at least two visible CUDA GPUs.
- Run trajectory-equivalent recovery, two-rank Gloo/NCCL replay, synchronized dropout RNG, structured invocation replay, FSDP2 local-shard checkpoint recovery, and automatic process-exit cleanup.
- Emit `environment.json`, exact commands, per-command logs, `summary.json`, a job summary, and SHA-256 checksums tied to the exact commit.
- Upload evidence artifacts even when a qualification command fails.
- Add a workflow status badge plus runner security, reproduction, scope, and limitation documentation.

## Security and operational impact

The workflow runs only on a weekly schedule from the default branch or through trusted maintainer dispatch. Fork PRs cannot execute code on the privileged self-hosted runner. Runner provisioning should use an isolated/ephemeral host without production credentials or writable production storage.

No compatible runner is currently registered in the repository. After merge, provision a runner with labels `self-hosted`, `linux`, `x64`, `gpu`, and `lm-resiliency`; then manually dispatch the first qualification and retain its artifact as baseline evidence.

## Validation

- `pytest -q tests/unit/test_gpu_qualification.py` — 2 passed.
- CPU suite excluding the four sandbox-incompatible POSIX shared-memory files — 588 passed.
- CPU execution of the evidence harness correctly failed closed with zero GPUs and produced schema-valid environment, command, summary, Markdown, and checksum artifacts.
- `ruff check .` and `ruff format --check .` — passed.
- `pre-commit run --all-files` — passed.
- `actionlint` — passed with the two documented custom self-hosted labels.

Actual two-GPU execution remains outstanding until the self-hosted runner is provisioned.