### PR TITLE
[CI/Release] Harden release publishing and artifact promotion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,14 @@ jobs:
             python: "3.10"
             numpy: "1.26.4"
             torch: "2.10.0"
+          - name: python-3.11-torch-2.11
+            python: "3.11"
+            numpy: "1.26.4"
+            torch: "2.11.0"
+          - name: torch-2.12
+            python: "3.12"
+            numpy: "2.5.1"
+            torch: "2.12.0"
           - name: primary
             python: "3.12"
             numpy: "2.5.1"
@@ -171,3 +179,26 @@ jobs:
           name: distributions
           path: dist/*
           if-no-files-found: error
+
+  required:
+    name: CI Required
+    if: always()
+    needs:
+      - quality
+      - unit
+      - package
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Verify required CI
+        env:
+          QUALITY_RESULT: ${{ needs.quality.result }}
+          UNIT_RESULT: ${{ needs.unit.result }}
+          PACKAGE_RESULT: ${{ needs.package.result }}
+        run: |
+          printf 'quality=%s\nunit=%s\npackage=%s\n' \
+            "$QUALITY_RESULT" "$UNIT_RESULT" "$PACKAGE_RESULT"
+          test "$QUALITY_RESULT" = "success"
+          test "$UNIT_RESULT" = "success"
+          test "$PACKAGE_RESULT" = "success"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,14 +9,74 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  build:
-    name: Build release artifacts
+  validate-source:
+    name: Validate release source
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 25
+
+    env:
+      DEFAULT_BRANCH: main
+      NUMPY_VERSION: "2.5.1"
+      TORCH_VERSION: "2.13.0"
 
     steps:
-      - name: Check out repository
+      - name: Check out exact revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify production tag and default-branch ancestry
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          version=$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
+          test "$GITHUB_REF_NAME" = "v$version"
+          tag_commit=$(git rev-list -n 1 "$GITHUB_REF_NAME")
+          test "$tag_commit" = "$(git rev-parse HEAD)"
+          git fetch --no-tags origin "$DEFAULT_BRANCH"
+          git merge-base --is-ancestor "$tag_commit" "origin/$DEFAULT_BRANCH"
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install pinned supported runtime
+        run: |
+          python -m pip install \
+            --index-url https://download.pytorch.org/whl/cpu \
+            --only-binary=:all: \
+            "torch==$TORCH_VERSION"
+          python -m pip install \
+            "numpy==$NUMPY_VERSION" \
+            "pytest==9.1.1" \
+            "pytest-timeout==2.4.0" \
+            "setuptools==84.0.0"
+          python -m pip install --no-deps -e .
+          python -m pip check
+
+      - name: Run release CPU suite
+        env:
+          CUDA_VISIBLE_DEVICES: ""
+        run: python -m pytest -q
+
+  build:
+    name: Build identified release artifacts
+    needs: validate-source
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+
+    steps:
+      - name: Check out exact revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -26,29 +86,114 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Verify tag matches package version
+      - name: Build with pinned toolchain
+        run: |
+          python -m pip install \
+            "build==1.5.0" \
+            "setuptools==84.0.0" \
+            "twine==6.2.0"
+          python -m build --no-isolation
+          python -m twine check dist/*.whl dist/*.tar.gz
+          python scripts/release_artifacts.py create \
+            --dist dist \
+            --repository "$GITHUB_REPOSITORY" \
+            --commit "$GITHUB_SHA" \
+            --ref "$GITHUB_REF"
+
+      - name: Attest wheel and source distribution
         if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          version=$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
-          test "$GITHUB_REF_NAME" = "v$version"
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: |
+            dist/*.whl
+            dist/*.tar.gz
 
-      - name: Build and check distributions
-        run: |
-          python -m pip install "build>=1.2,<2" "twine>=6,<7"
-          python -m build
-          python -m twine check dist/*
-
-      - name: Upload distributions
+      - name: Upload identified release artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-distributions
           path: dist/*
           if-no-files-found: error
 
-  publish-testpypi:
-    name: Publish to TestPyPI
-    if: github.event_name == 'workflow_dispatch'
+  validate-artifacts:
+    name: Validate exact release artifacts
     needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out exact revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Download identified release artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-distributions
+          path: dist
+
+      - name: Verify artifact manifest and digests
+        run: |
+          python scripts/release_artifacts.py verify \
+            --dist dist \
+            --repository "$GITHUB_REPOSITORY" \
+            --commit "$GITHUB_SHA" \
+            --ref "$GITHUB_REF"
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Test clean installation of exact wheel
+        run: |
+          smoke_env="$RUNNER_TEMP/lm-resiliency-release-smoke"
+          python -m venv "$smoke_env"
+          "$smoke_env/bin/python" -m pip install \
+            --index-url https://download.pytorch.org/whl/cpu \
+            --only-binary=:all: \
+            "torch==2.13.0"
+          "$smoke_env/bin/python" -m pip install "numpy==2.5.1" "setuptools==84.0.0"
+          "$smoke_env/bin/python" -m pip install --no-deps dist/*.whl
+          "$smoke_env/bin/python" -m pip check
+          cd "$RUNNER_TEMP"
+          "$smoke_env/bin/python" -c \
+            'import lm_resiliency, sys; optional = {"deepspeed", "megatron", "torchtitan", "triton"}; assert not optional.intersection(sys.modules); print(lm_resiliency.__file__)'
+          "$smoke_env/bin/python" "$GITHUB_WORKSPACE/examples/quickstart.py" \
+            --steps 2 \
+            --interval 1 \
+            --checkpoint-dir "$RUNNER_TEMP/release-quickstart"
+
+      - name: Audit exact wheel environment
+        run: |
+          python -m pip install "pip-audit==2.10.1"
+          smoke_env="$RUNNER_TEMP/lm-resiliency-release-smoke"
+          runtime_requirements="$RUNNER_TEMP/lm-resiliency-release-requirements.txt"
+          "$smoke_env/bin/python" -m pip freeze |
+            sed -E -e '/^lm-resiliency/d' -e 's/^(torch==[^+]+)\+cpu$/\1/' \
+              > "$runtime_requirements"
+          python -m pip_audit \
+            --requirement "$runtime_requirements" \
+            --no-deps \
+            --disable-pip \
+            --strict \
+            --progress-spinner off \
+            --desc off
+
+      - name: Verify build provenance
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for artifact in dist/*.whl dist/*.tar.gz; do
+            gh attestation verify "$artifact" --repo "$GITHUB_REPOSITORY"
+          done
+
+  publish-testpypi:
+    name: Publish exact artifacts to TestPyPI
+    if: github.event_name == 'workflow_dispatch'
+    needs: [build, validate-artifacts]
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     environment:
@@ -58,16 +203,24 @@ jobs:
       id-token: write
 
     steps:
-      - name: Download distributions
+      - name: Download identified release artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-distributions
           path: dist
 
-      - name: Publish distributions
+      - name: Recheck artifact digests
+        run: |
+          cd dist
+          sha256sum --check SHA256SUMS
+          mkdir ../publish
+          cp -- *.whl *.tar.gz ../publish/
+
+      - name: Publish wheel and source distribution
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
+          packages-dir: publish
 
   test-testpypi:
     name: Test TestPyPI installation
@@ -77,7 +230,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - name: Check out repository
+      - name: Check out exact revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -87,13 +240,13 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install supported runtime
+      - name: Install pinned supported runtime
         run: |
           python -m pip install \
             --index-url https://download.pytorch.org/whl/cpu \
             --only-binary=:all: \
             "torch==2.13.0"
-          python -m pip install "numpy==2.5.1" "setuptools>=83"
+          python -m pip install "numpy==2.5.1" "setuptools==84.0.0"
 
       - name: Install and import staged package
         run: |
@@ -105,7 +258,7 @@ jobs:
               "lm-resiliency==$version"; then
               break
             fi
-            if [ "$attempt" -eq 12 ]; then
+            if test "$attempt" -eq 12; then
               exit 1
             fi
             sleep 10
@@ -115,9 +268,9 @@ jobs:
           python -c "import lm_resiliency; print(lm_resiliency.__file__)"
 
   publish-pypi:
-    name: Publish to PyPI
+    name: Publish exact artifacts to PyPI
     if: startsWith(github.ref, 'refs/tags/')
-    needs: build
+    needs: [build, validate-artifacts]
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     environment:
@@ -127,17 +280,26 @@ jobs:
       id-token: write
 
     steps:
-      - name: Download distributions
+      - name: Download identified release artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-distributions
           path: dist
 
-      - name: Publish distributions
+      - name: Recheck artifact digests
+        run: |
+          cd dist
+          sha256sum --check SHA256SUMS
+          mkdir ../publish
+          cp -- *.whl *.tar.gz ../publish/
+
+      - name: Publish wheel and source distribution
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          packages-dir: publish
 
   github-release:
-    name: Publish GitHub release
+    name: Publish immutable GitHub release
     if: startsWith(github.ref, 'refs/tags/')
     needs: publish-pypi
     runs-on: ubuntu-24.04
@@ -146,18 +308,30 @@ jobs:
       contents: write
 
     steps:
-      - name: Download distributions
+      - name: Download identified release artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-distributions
           path: dist
 
-      - name: Create GitHub release
+      - name: Recheck artifact digests
+        run: cd dist && sha256sum --check SHA256SUMS
+
+      - name: Draft, populate, and publish release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release create "$GITHUB_REF_NAME" dist/* \
             --repo "$GITHUB_REPOSITORY" \
             --verify-tag \
+            --draft \
             --title "lm-resiliency $GITHUB_REF_NAME" \
             --generate-notes
+          gh release edit "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --draft=false
+          gh release verify "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY"
+          for artifact in dist/*; do
+            gh release verify-asset "$GITHUB_REF_NAME" "$artifact" \
+              --repo "$GITHUB_REPOSITORY"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,7 +269,7 @@ jobs:
 
   publish-pypi:
     name: Publish exact artifacts to PyPI
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     needs: [build, validate-artifacts]
     runs-on: ubuntu-24.04
     timeout-minutes: 10
@@ -293,6 +293,19 @@ jobs:
           mkdir ../publish
           cp -- *.whl *.tar.gz ../publish/
 
+      - name: Recheck release tag target
+        run: |
+          tag_ref="refs/tags/$GITHUB_REF_NAME"
+          remote_commit=$(
+            git ls-remote "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git" \
+              "$tag_ref" "$tag_ref^{}" |
+              awk '$2 ~ /\^\{\}$/ { peeled=$1 } $2 !~ /\^\{\}$/ { direct=$1 } END { print peeled ? peeled : direct }'
+          )
+          manifest_commit=$(jq -r '.commit_sha // empty' dist/release-manifest.json)
+          test -n "$remote_commit"
+          test "$remote_commit" = "$manifest_commit"
+          test "$manifest_commit" = "$GITHUB_SHA"
+
       - name: Publish wheel and source distribution
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
@@ -300,7 +313,7 @@ jobs:
 
   github-release:
     name: Publish immutable GitHub release
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     needs: publish-pypi
     runs-on: ubuntu-24.04
     timeout-minutes: 10
@@ -316,6 +329,19 @@ jobs:
 
       - name: Recheck artifact digests
         run: cd dist && sha256sum --check SHA256SUMS
+
+      - name: Recheck release tag target
+        run: |
+          tag_ref="refs/tags/$GITHUB_REF_NAME"
+          remote_commit=$(
+            git ls-remote "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git" \
+              "$tag_ref" "$tag_ref^{}" |
+              awk '$2 ~ /\^\{\}$/ { peeled=$1 } $2 !~ /\^\{\}$/ { direct=$1 } END { print peeled ? peeled : direct }'
+          )
+          manifest_commit=$(jq -r '.commit_sha // empty' dist/release-manifest.json)
+          test -n "$remote_commit"
+          test "$remote_commit" = "$manifest_commit"
+          test "$manifest_commit" = "$GITHUB_SHA"
 
       - name: Draft, populate, and publish release
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 ### Changed
 
 - Quick Start installs the core package from PyPI before introducing optional framework integrations.
+- Release publishing now requires a protected default-branch tag, revalidates source and exact artifact digests, uses a pinned build/audit toolchain, emits build provenance, and publishes draft-populated immutable GitHub releases.
 
 ## [0.1.0] - 2026-08-12
 
@@ -30,4 +31,4 @@ The project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 
 Accumulate user-visible changes under `Unreleased`.
 Before tagging a release, move those entries under the new version, replace `Pending` with the release date, and update the versions in `pyproject.toml` and `CITATION.cff`.
-Release artifacts are built and published by the [Release workflow](.github/workflows/release.yml).
+Release artifacts are built and published by the [Release workflow](.github/workflows/release.yml) under the documented [release process](docs/release.md).

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,38 @@
+# Release Process
+
+Production releases use one identified wheel and source distribution from build through validation, PyPI publication, and the immutable GitHub release.
+
+## Repository Controls
+
+- The active `release tag protection` ruleset matches `refs/tags/v*`. Only organization administrators can create, update, or delete matching tags; non-fast-forward tag changes are blocked.
+- Repository release immutability is enabled for releases created after `v0.1.0`. Published release tags and assets cannot be changed. The `v0.1.0` release predates this setting and remains outside the immutable-release guarantee.
+- PyPI publication uses the protected `pypi` environment and OIDC trusted publishing. TestPyPI uses its separate protected environment.
+
+## Production Release
+
+1. Merge the release changes through protected `main` and wait for required CI and review policy.
+2. Update `pyproject.toml`, `CITATION.cff`, and this changelog to the same version.
+3. An organization administrator creates and pushes `v<version>` at the intended `main` commit. Do not reuse or move a release tag.
+4. The release workflow verifies that the tag matches `pyproject.toml`, resolves to the checked-out commit, and is an ancestor of current `origin/main`.
+5. The workflow reruns the pinned primary CPU suite, builds with a pinned toolchain, and writes `release-manifest.json` and `SHA256SUMS` for the wheel and source distribution.
+6. The exact downloaded artifacts pass manifest verification, clean installation, Quick Start, `pip check`, dependency audit, and GitHub build-provenance verification.
+7. After protected-environment approval, the same artifact bundle is published to PyPI.
+8. The workflow creates a draft GitHub release, attaches every artifact plus its manifest and checksums, publishes it, then verifies the immutable release and each local asset.
+
+The workflow fails before production publication if any tag, revision, version, digest, artifact membership, validation, audit, provenance, environment approval, or immutable-release check fails.
+
+## TestPyPI
+
+A trusted maintainer can dispatch the same workflow on a selected revision. It builds and validates an identified artifact bundle, publishes it to TestPyPI after environment approval, and verifies a clean installation. Manual dispatch never enters the production PyPI or GitHub release jobs because those jobs require a `refs/tags/v*` event.
+
+## Verification
+
+Consumers can verify a future immutable release and a downloaded asset with GitHub CLI:
+
+```bash
+gh release verify vX.Y.Z --repo LMResiliency/lm-resiliency
+gh release verify-asset vX.Y.Z ./lm_resiliency-X.Y.Z-py3-none-any.whl \
+  --repo LMResiliency/lm-resiliency
+gh attestation verify ./lm_resiliency-X.Y.Z-py3-none-any.whl \
+  --repo LMResiliency/lm-resiliency
+```

--- a/docs/release.md
+++ b/docs/release.md
@@ -16,10 +16,10 @@ Production releases use one identified wheel and source distribution from build 
 4. The release workflow verifies that the tag matches `pyproject.toml`, resolves to the checked-out commit, and is an ancestor of current `origin/main`.
 5. The workflow reruns the pinned primary CPU suite, builds with a pinned toolchain, and writes `release-manifest.json` and `SHA256SUMS` for the wheel and source distribution.
 6. The exact downloaded artifacts pass manifest verification, clean installation, Quick Start, `pip check`, dependency audit, and GitHub build-provenance verification.
-7. After protected-environment approval, the same artifact bundle is published to PyPI.
-8. The workflow creates a draft GitHub release, attaches every artifact plus its manifest and checksums, publishes it, then verifies the immutable release and each local asset.
+7. After protected-environment approval, the workflow re-resolves the remote tag against the identified commit and publishes the same artifact bundle to PyPI.
+8. The workflow rechecks the tag again, creates a draft GitHub release, attaches every artifact plus its manifest and checksums, publishes it, then verifies the immutable release and each local asset.
 
-The workflow fails before production publication if any tag, revision, version, digest, artifact membership, validation, audit, provenance, environment approval, or immutable-release check fails.
+The workflow blocks PyPI publication when any source, tag, revision, version, digest, artifact-membership, validation, audit, provenance, or environment-approval check fails. GitHub release creation and immutable-asset verification necessarily follow PyPI publication; a failure in that final job leaves the workflow failed and requires operator intervention because published PyPI files cannot be rolled back.
 
 ## TestPyPI
 

--- a/scripts/release_artifacts.py
+++ b/scripts/release_artifacts.py
@@ -1,0 +1,179 @@
+"""Create and verify the digest manifest reused by every release job."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import tomllib
+
+_SCHEMA_VERSION = 1
+_ARTIFACT_PATTERNS = ("*.whl", "*.tar.gz")
+_MANIFEST_NAME = "release-manifest.json"
+_CHECKSUMS_NAME = "SHA256SUMS"
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _project() -> tuple[str, str]:
+    with (_REPOSITORY_ROOT / "pyproject.toml").open("rb") as handle:
+        project = tomllib.load(handle)["project"]
+    return project["name"], project["version"]
+
+
+def _artifacts(dist: Path) -> list[Path]:
+    artifacts = sorted({path for pattern in _ARTIFACT_PATTERNS for path in dist.glob(pattern)})
+    if not artifacts:
+        raise ValueError(f"no wheel or source distribution found in {dist}")
+    return artifacts
+
+
+def create_manifest(
+    dist: Path,
+    *,
+    repository: str,
+    commit: str,
+    ref: str,
+) -> dict[str, Any]:
+    """Write one manifest and checksum list for the built distributions."""
+    dist = dist.resolve()
+    project_name, version = _project()
+    artifacts = [
+        {
+            "name": path.name,
+            "size": path.stat().st_size,
+            "sha256": _sha256(path),
+        }
+        for path in _artifacts(dist)
+    ]
+    manifest = {
+        "schema_version": _SCHEMA_VERSION,
+        "project": project_name,
+        "version": version,
+        "repository": repository,
+        "commit_sha": commit,
+        "ref": ref,
+        "artifacts": artifacts,
+    }
+    (dist / _MANIFEST_NAME).write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (dist / _CHECKSUMS_NAME).write_text(
+        "".join(f"{artifact['sha256']}  {artifact['name']}\n" for artifact in artifacts),
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def verify_manifest(
+    dist: Path,
+    *,
+    repository: str,
+    commit: str,
+    ref: str,
+) -> dict[str, Any]:
+    """Reject any identity, membership, size, or digest drift in downloaded artifacts."""
+    dist = dist.resolve()
+    manifest_path = dist / _MANIFEST_NAME
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError) as error:
+        raise ValueError(f"invalid or missing {manifest_path}") from error
+
+    expected_keys = {
+        "schema_version",
+        "project",
+        "version",
+        "repository",
+        "commit_sha",
+        "ref",
+        "artifacts",
+    }
+    if not isinstance(manifest, dict) or set(manifest) != expected_keys:
+        raise ValueError("release manifest has unexpected or missing fields")
+    project_name, version = _project()
+    expected_identity = {
+        "schema_version": _SCHEMA_VERSION,
+        "project": project_name,
+        "version": version,
+        "repository": repository,
+        "commit_sha": commit,
+        "ref": ref,
+    }
+    for key, expected in expected_identity.items():
+        if manifest[key] != expected:
+            raise ValueError(f"release manifest {key} is {manifest[key]!r}, expected {expected!r}")
+
+    records = manifest["artifacts"]
+    if not isinstance(records, list) or not records:
+        raise ValueError("release manifest artifacts must be a non-empty list")
+    if any(
+        not isinstance(record, dict)
+        or set(record) != {"name", "size", "sha256"}
+        or not isinstance(record["name"], str)
+        or not isinstance(record["size"], int)
+        or not isinstance(record["sha256"], str)
+        for record in records
+    ):
+        raise ValueError("release artifact record has invalid fields")
+    expected_names = {path.name for path in _artifacts(dist)}
+    record_names = {record["name"] for record in records}
+    if record_names != expected_names or len(records) != len(expected_names):
+        raise ValueError("release artifact membership does not match the manifest")
+
+    checksum_lines = []
+    for record in records:
+        path = dist / record["name"]
+        if path.stat().st_size != record["size"]:
+            raise ValueError(f"release artifact size mismatch for {path.name}")
+        digest = _sha256(path)
+        if digest != record["sha256"]:
+            raise ValueError(f"release artifact digest mismatch for {path.name}")
+        checksum_lines.append(f"{digest}  {path.name}\n")
+
+    checksums = dist / _CHECKSUMS_NAME
+    if checksums.read_text(encoding="utf-8") != "".join(checksum_lines):
+        raise ValueError(f"{_CHECKSUMS_NAME} does not match the release manifest")
+    return manifest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("create", "verify"))
+    parser.add_argument("--dist", type=Path, required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--ref", required=True)
+    args = parser.parse_args()
+
+    kwargs = {
+        "repository": args.repository,
+        "commit": args.commit,
+        "ref": args.ref,
+    }
+    try:
+        if args.command == "create":
+            value = create_manifest(args.dist, **kwargs)
+        else:
+            value = verify_manifest(args.dist, **kwargs)
+    except (OSError, TypeError, ValueError) as error:
+        print(f"release artifact validation failed: {error}", file=sys.stderr)
+        return 1
+    print(json.dumps(value, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_release_artifacts.py
+++ b/tests/unit/test_release_artifacts.py
@@ -2,14 +2,24 @@
 
 from __future__ import annotations
 
+import importlib
 import json
+import sys
+from pathlib import Path
 
 import pytest
 
-from scripts import release_artifacts
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 
 
-def test_release_manifest_round_trip(tmp_path):
+@pytest.fixture
+def release_artifacts():
+    if sys.version_info < (3, 11):
+        pytest.skip("release tooling runs on Python 3.12 and uses standard-library tomllib")
+    return importlib.import_module("scripts.release_artifacts")
+
+
+def test_release_manifest_round_trip(tmp_path, release_artifacts):
     (tmp_path / "lm_resiliency-0.1.0-py3-none-any.whl").write_bytes(b"wheel")
     (tmp_path / "lm_resiliency-0.1.0.tar.gz").write_bytes(b"sdist")
 
@@ -34,7 +44,7 @@ def test_release_manifest_round_trip(tmp_path):
     assert (tmp_path / "SHA256SUMS").read_text().count("\n") == 2
 
 
-def test_release_manifest_rejects_digest_drift(tmp_path):
+def test_release_manifest_rejects_digest_drift(tmp_path, release_artifacts):
     wheel = tmp_path / "lm_resiliency-0.1.0-py3-none-any.whl"
     wheel.write_bytes(b"wheel")
     release_artifacts.create_manifest(
@@ -54,7 +64,7 @@ def test_release_manifest_rejects_digest_drift(tmp_path):
         )
 
 
-def test_release_manifest_rejects_identity_drift(tmp_path):
+def test_release_manifest_rejects_identity_drift(tmp_path, release_artifacts):
     (tmp_path / "lm_resiliency-0.1.0.tar.gz").write_bytes(b"sdist")
     release_artifacts.create_manifest(
         tmp_path,
@@ -74,3 +84,11 @@ def test_release_manifest_rejects_identity_drift(tmp_path):
             commit="a" * 40,
             ref="refs/tags/v0.1.0",
         )
+
+
+def test_production_release_jobs_require_tag_push_and_recheck_target():
+    workflow = (_REPOSITORY_ROOT / ".github" / "workflows" / "release.yml").read_text()
+
+    production_condition = "if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')"
+    assert workflow.count(production_condition) == 2
+    assert workflow.count("- name: Recheck release tag target") == 2

--- a/tests/unit/test_release_artifacts.py
+++ b/tests/unit/test_release_artifacts.py
@@ -1,0 +1,76 @@
+"""Tests for release artifact identity manifests."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts import release_artifacts
+
+
+def test_release_manifest_round_trip(tmp_path):
+    (tmp_path / "lm_resiliency-0.1.0-py3-none-any.whl").write_bytes(b"wheel")
+    (tmp_path / "lm_resiliency-0.1.0.tar.gz").write_bytes(b"sdist")
+
+    created = release_artifacts.create_manifest(
+        tmp_path,
+        repository="LMResiliency/lm-resiliency",
+        commit="a" * 40,
+        ref="refs/tags/v0.1.0",
+    )
+    verified = release_artifacts.verify_manifest(
+        tmp_path,
+        repository="LMResiliency/lm-resiliency",
+        commit="a" * 40,
+        ref="refs/tags/v0.1.0",
+    )
+
+    assert verified == created
+    assert [record["name"] for record in verified["artifacts"]] == [
+        "lm_resiliency-0.1.0-py3-none-any.whl",
+        "lm_resiliency-0.1.0.tar.gz",
+    ]
+    assert (tmp_path / "SHA256SUMS").read_text().count("\n") == 2
+
+
+def test_release_manifest_rejects_digest_drift(tmp_path):
+    wheel = tmp_path / "lm_resiliency-0.1.0-py3-none-any.whl"
+    wheel.write_bytes(b"wheel")
+    release_artifacts.create_manifest(
+        tmp_path,
+        repository="LMResiliency/lm-resiliency",
+        commit="a" * 40,
+        ref="refs/tags/v0.1.0",
+    )
+    wheel.write_bytes(b"tampered")
+
+    with pytest.raises(ValueError, match="size mismatch"):
+        release_artifacts.verify_manifest(
+            tmp_path,
+            repository="LMResiliency/lm-resiliency",
+            commit="a" * 40,
+            ref="refs/tags/v0.1.0",
+        )
+
+
+def test_release_manifest_rejects_identity_drift(tmp_path):
+    (tmp_path / "lm_resiliency-0.1.0.tar.gz").write_bytes(b"sdist")
+    release_artifacts.create_manifest(
+        tmp_path,
+        repository="LMResiliency/lm-resiliency",
+        commit="a" * 40,
+        ref="refs/tags/v0.1.0",
+    )
+    manifest_path = tmp_path / "release-manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["commit_sha"] = "b" * 40
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(ValueError, match="commit_sha"):
+        release_artifacts.verify_manifest(
+            tmp_path,
+            repository="LMResiliency/lm-resiliency",
+            commit="a" * 40,
+            ref="refs/tags/v0.1.0",
+        )


### PR DESCRIPTION
Closes #21.

## Summary

- protect production release source by verifying the versioned tag and its ancestry from `main`
- build once with a pinned toolchain and promote the exact identified wheel/sdist through validation and publication
- add SHA-256 manifest verification, clean-install/quick-start checks, dependency audit, and GitHub build provenance
- populate a draft GitHub release before publishing, then verify the immutable release and every asset
- document the protected tag and immutable-release process

Repository controls applied alongside this PR:
- active `refs/tags/v*` tag ruleset restricting tag creation, mutation, and deletion to organization administrators
- immutable releases enabled for future releases

## Validation

- `ruff check .`
- `pre-commit run --all-files`
- `actionlint .github/workflows/release.yml`
- `pytest -q tests/unit/test_release_artifacts.py` (3 passed)
- sandbox-compatible suite (591 passed)
- exact no-isolation wheel/sdist build
- `twine check`
- release manifest create/verify and `sha256sum --check`

The complete local suite reached 599 passes; 40 tests requiring POSIX shared memory were blocked by the macOS execution sandbox and remain covered by Linux CI.