### PR TITLE
[CI/Release] Add stable required CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,3 +179,26 @@ jobs:
           name: distributions
           path: dist/*
           if-no-files-found: error
+
+  required:
+    name: CI Required
+    if: always()
+    needs:
+      - quality
+      - unit
+      - package
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Verify required CI
+        env:
+          QUALITY_RESULT: ${{ needs.quality.result }}
+          UNIT_RESULT: ${{ needs.unit.result }}
+          PACKAGE_RESULT: ${{ needs.package.result }}
+        run: |
+          printf 'quality=%s\nunit=%s\npackage=%s\n' \
+            "$QUALITY_RESULT" "$UNIT_RESULT" "$PACKAGE_RESULT"
+          test "$QUALITY_RESULT" = "success"
+          test "$UNIT_RESULT" = "success"
+          test "$PACKAGE_RESULT" = "success"


### PR DESCRIPTION
## Summary

Add a single stable `CI Required` GitHub Actions job that aggregates the existing quality, unit-matrix, and package jobs.

This prevents branch protection from depending directly on individual matrix job names. Adding, removing, or renaming a unit-matrix entry will no longer strand older pull requests with required checks that can never be emitted by their older workflow revision.

## Related issues

No issue is required; this is a focused CI/branch-protection reliability fix prompted by required checks remaining pending on older open PRs after the compatibility matrix expanded.

## Changes

- Add a `CI Required` job to `.github/workflows/ci.yml`.
- Run the gate with `if: always()` after `quality`, the complete `unit` matrix, and `package` finish.
- Fail the gate unless all three upstream job groups report `success`.
- Keep every existing quality, compatibility-matrix, and package job unchanged.

The currently open PR branches were also synchronized at the CI-file level so they emit the two compatibility jobs and `CI Required`; PR #36 preserves its intentional shared tool-version constraints.

## Compatibility

No runtime or public API impact. This changes only GitHub Actions/branch-protection integration.

## Validation

```text
Command: Compare main...agent/stable-ci-required-gate
Result: 1 commit, 1 changed file, +23/-0. The only mainline change is the new aggregate CI job.

Expected behavior:
- `CI Required` succeeds only when Quality, every Unit matrix entry, and Package succeed.
- `CI Required` still runs and fails if any required upstream job fails or is cancelled.
- Future matrix expansion does not require adding another branch-protection check name.
```

GitHub Actions on this PR provides the end-to-end validation of the new gate.

Distributed or GPU validation is not applicable because this only aggregates existing CPU/package CI results.

## Documentation

No user-facing documentation change is required. After this PR is merged and `CI Required` has successfully appeared on `main`, the repository ruleset should be changed to require only `CI Required` instead of the six individual CI job names.

## Checklist

- [x] The pull request is focused on one coherent change.
- [x] I added or updated tests for changed behavior, or explained why tests are not required.
- [x] I ran the relevant CPU checks from `CONTRIBUTING.md`, or documented why runtime CPU checks are not applicable to this workflow-only change.
- [x] I ran relevant distributed or GPU validation, or documented why it was not required or available.
- [x] I updated public documentation, examples, and compatibility notes, or explained why they are not required.
- [x] I preserved stable API compatibility or documented the compatibility impact.
- [x] I removed credentials, private data, generated environments, and local validation artifacts.
- [x] I identified copied or adapted code and preserved required attribution and licensing; no copied or adapted code is included.