### PR TITLE
[Feature] Add CODEOWNERS and document maintainership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,28 @@
+# Repository-wide fallback ownership.
+* @zhuangwang93 @lmresiliencydev
+
+# Core resiliency subsystems.
+/lm_resiliency/checkpointing/ @zhuangwang93 @lmresiliencydev
+/lm_resiliency/detection/ @zhuangwang93 @lmresiliencydev
+/lm_resiliency/integrations/ @zhuangwang93 @lmresiliencydev
+/lm_resiliency/orchestration.py @zhuangwang93 @lmresiliencydev
+/lm_resiliency/recovery.py @zhuangwang93 @lmresiliencydev
+/lm_resiliency/handle.py @zhuangwang93 @lmresiliencydev
+/lm_resiliency/__init__.py @zhuangwang93 @lmresiliencydev
+
+# Tests and validation contracts.
+/tests/ @zhuangwang93 @lmresiliencydev
+
+# Public documentation and compatibility contracts.
+/docs/ @zhuangwang93 @lmresiliencydev
+/README.md @zhuangwang93 @lmresiliencydev
+/ROADMAP.md @zhuangwang93 @lmresiliencydev
+/CHANGELOG.md @zhuangwang93 @lmresiliencydev
+/pyproject.toml @zhuangwang93 @lmresiliencydev
+
+# Repository governance, CI, release, and security surfaces.
+/.github/ @zhuangwang93 @lmresiliencydev
+/SECURITY.md @zhuangwang93 @lmresiliencydev
+/CODE_OF_CONDUCT.md @zhuangwang93 @lmresiliencydev
+/CONTRIBUTING.md @zhuangwang93 @lmresiliencydev
+/MAINTAINERS.md @zhuangwang93 @lmresiliencydev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,7 @@ An optional subsystem tag may follow the type, such as `[Bugfix][SCOUT] Reject a
 Describe the problem, implementation, compatibility impact, and validation performed.
 Update public documentation and contract tests when changing supported behavior or import paths.
 Preserve backward compatibility for stable interfaces as defined in [Compatibility](docs/compatibility.md).
+Use [MAINTAINERS.md](MAINTAINERS.md) and `.github/CODEOWNERS` to identify the current owners for affected contracts and review surfaces.
 Identify copied or adapted code and include its license, copyright notice, source URL, and source revision.
 Do not commit credentials, private keys, customer data, model data, generated environments, build products, or local validation artifacts.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,34 @@
+# Maintainers
+
+LM Resiliency currently uses joint maintainership rather than separate subsystem teams.
+
+## Current maintainers
+
+- `@zhuangwang93`
+- `@lmresiliencydev`
+
+Both maintainers are listed as code owners for the repository's current critical surfaces. This keeps review routing explicit without implying a specialization split that does not yet exist.
+
+## Ownership map
+
+| Surface | Current owners | Review focus |
+|---|---|---|
+| GEMINI checkpointing and recovery | `@zhuangwang93`, `@lmresiliencydev` | checkpoint coherence, persistence, recovery selection, resource cleanup |
+| SCOUT detection and localization | `@zhuangwang93`, `@lmresiliencydev` | replay safety, consensus, localization semantics, fail-safe behavior |
+| Framework integrations | `@zhuangwang93`, `@lmresiliencydev` | framework lifecycle, topology mapping, optional imports, compatibility |
+| Public API and orchestration | `@zhuangwang93`, `@lmresiliencydev` | stable interfaces, manager contracts, backward compatibility |
+| Tests and validation | `@zhuangwang93`, `@lmresiliencydev` | regression coverage, reproducibility, qualification boundaries |
+| Documentation and compatibility | `@zhuangwang93`, `@lmresiliencydev` | release alignment, supported-version claims, user-facing contracts |
+| CI, release, governance, and security metadata | `@zhuangwang93`, `@lmresiliencydev` | branch/release safety, workflow permissions, reporting and policy surfaces |
+
+## Review and fallback policy
+
+`CODEOWNERS` is used to route review requests. Code-owner review is not a substitute for the repository's branch rules, CI checks, or required conversation resolution.
+
+When a change spans multiple surfaces, request review from the owners of every affected contract. If an owner is temporarily unavailable, keep the pull request open and document which review is outstanding rather than bypassing validation. If ownership becomes a recurring bottleneck, update this file and `CODEOWNERS` in the same pull request to assign another trusted maintainer.
+
+Security vulnerabilities must follow [SECURITY.md](SECURITY.md) and must not be disclosed in public review threads.
+
+## Changing ownership
+
+Ownership changes require a focused pull request that updates both `MAINTAINERS.md` and `.github/CODEOWNERS`. The pull request should explain the new responsibility boundary and verify that representative paths request the intended reviewer(s).


### PR DESCRIPTION
## Summary

Add explicit review ownership and a documented maintainership map for the repository.

Closes #17.

## Related issues

Closes #17.

## Changes

- Add `.github/CODEOWNERS` with repository-wide fallback ownership and explicit critical-path entries.
- Add `MAINTAINERS.md` describing current joint ownership across GEMINI, SCOUT, integrations, public APIs, tests/validation, documentation, and CI/release/security surfaces.
- Document review fallback and the process for changing ownership without silently bypassing validation.
- Link the maintainership policy from `CONTRIBUTING.md`.

## Compatibility

No runtime, package, framework, or topology behavior changes. This only changes repository review routing and governance documentation.

## Validation

- Reviewed CODEOWNERS patterns against the current repository layout.
- Verified both current reviewer accounts are named on repository-wide and critical-path ownership entries.
- Verified `CONTRIBUTING.md` links to the new maintainership policy.

GPU or distributed validation is not applicable.

## Documentation

Adds `MAINTAINERS.md` and updates contributor guidance.

## Checklist

- [x] The pull request is focused on one coherent change.
- [x] I added or updated tests for changed behavior, or explained why tests are not required.
- [x] I ran the relevant CPU checks from `CONTRIBUTING.md`, or documented why runtime CPU checks are not applicable to this metadata-only change.
- [x] I ran relevant distributed or GPU validation, or documented why it was not required or available.
- [x] I updated public documentation, examples, and compatibility notes, or explained why they are not required.
- [x] I preserved stable API compatibility or documented the compatibility impact.
- [x] I removed credentials, private data, generated environments, and local validation artifacts.
- [x] I identified copied or adapted code and preserved required attribution and licensing; no copied or adapted code is included.