### PR TITLE
[Bugfix] Align Quick Start source and example revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,35 +39,24 @@
 
 ## Quick Start
 
-### Install
+The runnable example is newer than the current `0.1.0` release, so keep the package source and example on the same repository revision for this Quick Start:
 
 ```bash
+git clone https://github.com/LMResiliency/lm-resiliency.git
+cd lm-resiliency
 python3.12 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip
-python -m pip install lm-resiliency
-```
-
-Install `[torchtitan]`, `[megatron]`, `[deepspeed]`, or `[all]` when integrating one of those frameworks.
-
-### Run a tiny end-to-end loop
-
-Clone the examples from the exact release tag that matches the installed PyPI package, then run the CPU quick start with plain Python:
-
-```bash
-LM_RESILIENCY_VERSION="$(
-  python -c 'from importlib.metadata import version; print(version("lm-resiliency"))'
-)"
-git clone --depth 1 \
-  --branch "v${LM_RESILIENCY_VERSION}" \
-  https://github.com/LMResiliency/lm-resiliency.git
-python lm-resiliency/examples/quickstart.py \
+python -m pip install -e .
+python examples/quickstart.py \
   --checkpoint-dir /tmp/lm-resiliency-quickstart/checkpoints
 ```
 
 The example trains a tiny causal LM through a complete forward, backward, and optimizer loop while GEMINI saves recovery state.
 Run it again with `--steps 6` to resume from the saved checkpoint.
 See [Examples](examples/README.md) for the recovery command and distributed production loops that exercise SCOUT.
+
+For integrations that do not need the repository examples, install the latest published package directly with `python -m pip install lm-resiliency`, adding `[torchtitan]`, `[megatron]`, `[deepspeed]`, or `[all]` as needed.
 
 ### Add resiliency to Megatron Core
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,15 @@ Install `[torchtitan]`, `[megatron]`, `[deepspeed]`, or `[all]` when integrating
 
 ### Run a tiny end-to-end loop
 
-Clone the examples and run the CPU quick start with plain Python:
+Clone the examples from the exact release tag that matches the installed PyPI package, then run the CPU quick start with plain Python:
 
 ```bash
-git clone --depth 1 https://github.com/LMResiliency/lm-resiliency.git
+LM_RESILIENCY_VERSION="$(
+  python -c 'from importlib.metadata import version; print(version("lm-resiliency"))'
+)"
+git clone --depth 1 \
+  --branch "v${LM_RESILIENCY_VERSION}" \
+  https://github.com/LMResiliency/lm-resiliency.git
 python lm-resiliency/examples/quickstart.py \
   --checkpoint-dir /tmp/lm-resiliency-quickstart/checkpoints
 ```

--- a/tests/unit/test_readme_quickstart.py
+++ b/tests/unit/test_readme_quickstart.py
@@ -1,5 +1,8 @@
-from pathlib import Path
+"""README Quick Start contract tests."""
 
+from __future__ import annotations
+
+from pathlib import Path
 
 ROOT = Path(__file__).parents[2]
 README = ROOT / "README.md"

--- a/tests/unit/test_readme_quickstart.py
+++ b/tests/unit/test_readme_quickstart.py
@@ -17,4 +17,4 @@ def test_quickstart_keeps_source_and_example_on_same_revision():
     assert "git clone https://github.com/LMResiliency/lm-resiliency.git" in quickstart
     assert "python -m pip install -e ." in quickstart
     assert "python examples/quickstart.py" in quickstart
-    assert "--branch \"v${LM_RESILIENCY_VERSION}\"" not in quickstart
+    assert '--branch "v${LM_RESILIENCY_VERSION}"' not in quickstart

--- a/tests/unit/test_readme_quickstart.py
+++ b/tests/unit/test_readme_quickstart.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+README = ROOT / "README.md"
+
+
+def test_release_quickstart_clones_installed_version_tag():
+    readme = README.read_text()
+
+    assert 'version("lm-resiliency")' in readme
+    assert '--branch "v${LM_RESILIENCY_VERSION}"' in readme
+    assert "git clone --depth 1 https://github.com/LMResiliency/lm-resiliency.git" not in readme

--- a/tests/unit/test_readme_quickstart.py
+++ b/tests/unit/test_readme_quickstart.py
@@ -8,9 +8,13 @@ ROOT = Path(__file__).parents[2]
 README = ROOT / "README.md"
 
 
-def test_release_quickstart_clones_installed_version_tag():
+def test_quickstart_keeps_source_and_example_on_same_revision():
     readme = README.read_text()
+    quickstart = readme.split("## Quick Start", maxsplit=1)[1].split(
+        "### Add resiliency to Megatron Core", maxsplit=1
+    )[0]
 
-    assert 'version("lm-resiliency")' in readme
-    assert '--branch "v${LM_RESILIENCY_VERSION}"' in readme
-    assert "git clone --depth 1 https://github.com/LMResiliency/lm-resiliency.git" not in readme
+    assert "git clone https://github.com/LMResiliency/lm-resiliency.git" in quickstart
+    assert "python -m pip install -e ." in quickstart
+    assert "python examples/quickstart.py" in quickstart
+    assert "--branch \"v${LM_RESILIENCY_VERSION}\"" not in quickstart


### PR DESCRIPTION
## Summary

Keep the runnable Quick Start package source and example on the same repository revision instead of mixing a released PyPI wheel with a moving or older example tree.

Closes #25.

## Related issues

Closes #25.

## Changes

- Make the runnable Quick Start clone the repository and install that checkout with `python -m pip install -e .` before running `examples/quickstart.py`.
- Explain that the example is newer than the current `0.1.0` release, so pinning the example to `v0.1.0` would be non-runnable.
- Keep a separate direct PyPI-install recommendation for integrations that do not need repository examples.
- Add a README contract test requiring the Quick Start clone, editable install, and example to stay on one source revision.

## Compatibility

No runtime API or framework behavior changes. The Quick Start no longer combines package code from one revision with example code from another revision.

## Validation

- `tests/unit/test_readme_quickstart.py` checks that the runnable Quick Start clones the repository, installs that checkout, runs its local example, and does not reintroduce the invalid `v0.1.0` example pin.
- The change is single-process CPU/documentation only; no GPU or distributed validation is required.

GitHub CI provides the authoritative test run.

## Documentation

Updates the README Quick Start and clarifies the distinction between the source-aligned runnable example and direct PyPI installation.

## Checklist

- [x] The pull request is focused on one coherent change.
- [x] I added or updated tests for changed behavior, or explained why tests are not required.
- [x] I ran the relevant CPU checks from `CONTRIBUTING.md`, or documented that GitHub CI is the authoritative run for this documentation-contract change.
- [x] I ran relevant distributed or GPU validation, or documented why it was not required or available.
- [x] I updated public documentation, examples, and compatibility notes, or explained why they are not required.
- [x] I preserved stable API compatibility or documented the compatibility impact.
- [x] I removed credentials, private data, generated environments, and local validation artifacts.
- [x] I identified copied or adapted code and preserved required attribution and licensing; no copied or adapted code is included.