### PR TITLE
[Perf] Add healthy-path regression benchmarks

### DIFF
--- a/.github/workflows/gpu-qualification.yml
+++ b/.github/workflows/gpu-qualification.yml
@@ -50,11 +50,22 @@ jobs:
             --artifact-dir "$RUNNER_TEMP/gpu-qualification" \
             --minimum-gpus 2
 
+      - name: Run healthy-path performance regression
+        run: |
+          python benchmarks/run_healthy_path.py \
+            --device cuda \
+            --world-size 2 \
+            --output-dir "$RUNNER_TEMP/gpu-qualification/healthy-path" \
+            --enforce
+
       - name: Publish job summary
         if: always()
         run: |
           if test -f "$RUNNER_TEMP/gpu-qualification/summary.md"; then
             cat "$RUNNER_TEMP/gpu-qualification/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if test -f "$RUNNER_TEMP/gpu-qualification/healthy-path/summary.md"; then
+            cat "$RUNNER_TEMP/gpu-qualification/healthy-path/summary.md" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Upload qualification evidence

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@
 
 - **SDC-safe recovery-verified checkpoint:** SCOUT certifies recovery checkpoints and excludes candidates affected by recurring SDC, preventing corrupted state from being selected during recovery.
 - **Localize latent and permanent failures at runtime:** SCOUT identifies affected ranks, GPUs, nodes, communication endpoints, peer groups, or telemetry-reported physical devices, including failures observed while the training job is blocked.
-- **Minimize rollback:** GEMINI saves complete training state to CPU memory at high frequency with no measurable training-throughput loss, reducing lost computation after a failure.
+- **Minimize rollback:** Historical validation measured no training-throughput loss from GEMINI in its published workload. GEMINI saves complete training state to CPU memory at high frequency, reducing lost computation after a failure; see the [benchmark methodology](benchmarks/README.md).
 - **Retrieve checkpoints quickly:** GEMINI restores nearby state from memory, a surviving peer, or node-local storage, minimizing checkpoint retrieval time and global-storage reads.
-- **Keep protection lightweight:** SCOUT incurs less than 1% amortized overhead during training for runtime failure localization.
+- **Keep protection lightweight:** Historical validation measured less than 1% amortized SCOUT overhead in its published workload; scheduled current-package regressions are guarded by the [benchmark methodology](benchmarks/README.md) and its qualification boundaries.
 - **No framework fork:** `lm-resiliency` integrates with PyTorch, TorchTitan, Megatron Core, and DeepSpeed through automatic adapters and one public entry point.
 - **No training-loop rewrite:** `lm-resiliency` attaches hooks at framework initialization and leaves the existing training loop unchanged.
 - **Bring your own launcher:** Users can integrate `lm-resiliency` with `torchrun`, Slurm, Kubernetes, or custom managers through platform-neutral APIs.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,6 +1,6 @@
 # Healthy-Path Benchmarks
 
-The native-PyTorch benchmark runs baseline, GEMINI-only, SCOUT-only, and combined modes in fresh `torchrun` processes. It records the exact revision, Python/PyTorch/CUDA environment, topology dimensions, workload and seed, checkpoint size and cadence, pinning and replication settings, replay cadence, throughput, p50/p95 step latency, and peak host/GPU memory.
+The native-PyTorch benchmark runs baseline, GEMINI-only, SCOUT-only, and combined modes in fresh `torchrun` processes. It records the exact revision, Python/PyTorch/CUDA environment, topology dimensions, workload and seed, checkpoint size and cadence, pinning and replication settings, replay cadence, throughput, job-level p50/p95 step latency, and peak host/GPU memory. Job latency uses the slowest rank at each step. SCOUT modes report parent and OOB-daemon peak host memory separately and as a combined per-rank peak.
 
 Run a two-GPU comparison:
 
@@ -13,6 +13,8 @@ python benchmarks/run_healthy_path.py \
 ```
 
 The controller writes one JSON record per mode plus `summary.json`, `summary.md`, `commands.json`, and SHA-256 checksums. Thresholds live in [thresholds.json](thresholds.json). They are stability alarms for this small representative workload, not replacements for the historical workload-specific percentages in the project documentation. The two-peer SCOUT cases measure healthy-path cost but do not qualify exact fault attribution, which requires at least three equivalent peers.
+
+GEMINI uses pairwise replication and therefore requires an even world size above one. Odd world sizes remain valid for baseline/SCOUT-only comparisons when those modes are selected explicitly.
 
 For a fast CPU harness smoke without a performance claim:
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,34 @@
+# Healthy-Path Benchmarks
+
+The native-PyTorch benchmark runs baseline, GEMINI-only, SCOUT-only, and combined modes in fresh `torchrun` processes. It records the exact revision, Python/PyTorch/CUDA environment, topology dimensions, workload and seed, checkpoint size and cadence, pinning and replication settings, replay cadence, throughput, p50/p95 step latency, and peak host/GPU memory.
+
+Run a two-GPU comparison:
+
+```bash
+python benchmarks/run_healthy_path.py \
+  --device cuda \
+  --world-size 2 \
+  --output-dir /tmp/lm-resiliency-benchmark \
+  --enforce
+```
+
+The controller writes one JSON record per mode plus `summary.json`, `summary.md`, `commands.json`, and SHA-256 checksums. Thresholds live in [thresholds.json](thresholds.json). They are stability alarms for this small representative workload, not replacements for the historical workload-specific percentages in the project documentation. The two-peer SCOUT cases measure healthy-path cost but do not qualify exact fault attribution, which requires at least three equivalent peers.
+
+For a fast CPU harness smoke without a performance claim:
+
+```bash
+python benchmarks/run_healthy_path.py \
+  --device cpu \
+  --world-size 1 \
+  --modes baseline gemini \
+  --steps 3 \
+  --warmup-steps 1 \
+  --hidden-size 32 \
+  --layers 2 \
+  --heads 4 \
+  --sequence-length 8 \
+  --batch-size 2 \
+  --output-dir /tmp/lm-resiliency-benchmark-smoke
+```
+
+Do not compare results across different hardware, framework versions, workload shapes, or topology records. Scheduled regression decisions compare all modes within one isolated run on the same runner.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -25,6 +25,7 @@ python benchmarks/run_healthy_path.py \
   --modes baseline gemini \
   --steps 3 \
   --warmup-steps 1 \
+  --interval 1 \
   --hidden-size 32 \
   --layers 2 \
   --heads 4 \

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Reproducible performance benchmarks for lm-resiliency."""

--- a/benchmarks/healthy_path.py
+++ b/benchmarks/healthy_path.py
@@ -197,6 +197,15 @@ def _oob_daemon_peak_rss_bytes(handle: Any) -> int | None:
     return _process_peak_rss_bytes(getattr(service, "pid", None))
 
 
+def _wait_for_oob_daemon(handle: Any) -> None:
+    replay_harness = getattr(handle, "replay_harness", None)
+    service = getattr(replay_harness, "_oob_service", None)
+    wait_until_ready = getattr(service, "wait_until_ready", None)
+    if not callable(wait_until_ready):
+        raise RuntimeError("SCOUT benchmark could not access its OOB daemon readiness signal")
+    wait_until_ready()
+
+
 def _git_revision() -> str | None:
     completed = subprocess.run(
         ["git", "rev-parse", "HEAD"],
@@ -205,6 +214,27 @@ def _git_revision() -> str | None:
         text=True,
     )
     return completed.stdout.strip() if completed.returncode == 0 else None
+
+
+def _git_worktree_dirty() -> bool | None:
+    completed = subprocess.run(
+        ["git", "status", "--porcelain", "--untracked-files=normal"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return bool(completed.stdout.strip()) if completed.returncode == 0 else None
+
+
+def _recorded_worktree_dirty() -> bool | None:
+    recorded = os.environ.get("LM_BENCHMARK_WORKTREE_DIRTY")
+    if recorded is None:
+        return _git_worktree_dirty()
+    if recorded == "1":
+        return True
+    if recorded == "0":
+        return False
+    return None
 
 
 def _run(args: argparse.Namespace) -> dict[str, Any]:
@@ -237,6 +267,7 @@ def _run(args: argparse.Namespace) -> dict[str, Any]:
 
     enable_checkpoint = args.mode in {"gemini", "combined"}
     enable_detection = args.mode in {"scout", "combined"}
+    effective_pin_memory = enable_checkpoint and device.type == "cuda" and args.pin_memory
     checkpoint_replication_jump = replication_jump(world_size) if enable_checkpoint else 1
     handle = None
     if enable_checkpoint or enable_detection:
@@ -252,7 +283,7 @@ def _run(args: argparse.Namespace) -> dict[str, Any]:
                 replication_jump=checkpoint_replication_jump,
                 replication_chunk_size=args.replication_chunk_size,
                 disk_flush_interval=0,
-                pin_memory=device.type == "cuda" and args.pin_memory,
+                pin_memory=effective_pin_memory,
             ),
             replay=ReplayHarnessConfig(
                 check_interval=args.interval,
@@ -273,6 +304,8 @@ def _run(args: argparse.Namespace) -> dict[str, Any]:
 
         if handle is not None and handle.ckpt_manager is not None:
             handle.ckpt_manager.maybe_wait()
+        if enable_detection:
+            _wait_for_oob_daemon(handle)
         dist.barrier()
         if device.type == "cuda":
             torch.cuda.synchronize(device)
@@ -307,6 +340,7 @@ def _run(args: argparse.Namespace) -> dict[str, Any]:
         )
         rank_result = {
             "rank": rank,
+            "device_name": torch.cuda.get_device_name(device) if device.type == "cuda" else None,
             "duration_seconds": measured_seconds,
             "step_times_ms": step_times_ms,
             "peak_parent_host_memory_bytes": peak_parent_host_memory_bytes,
@@ -323,12 +357,19 @@ def _run(args: argparse.Namespace) -> dict[str, Any]:
         if rank != 0:
             return {}
         complete_results = [result for result in rank_results if result is not None]
+        device_names = [result["device_name"] for result in complete_results]
+        if device.type == "cuda" and len(set(device_names)) != 1:
+            raise RuntimeError(
+                "healthy-path qualification requires equivalent GPU models on every rank: "
+                f"{device_names}"
+            )
         job_step_times = aggregate_step_latencies(complete_results)
         max_duration = max(result["duration_seconds"] for result in complete_results)
         tokens = args.steps * args.batch_size * args.sequence_length * world_size
         return {
             "schema_version": 1,
             "commit_sha": os.environ.get("GITHUB_SHA") or _git_revision(),
+            "worktree_dirty": _recorded_worktree_dirty(),
             "mode": args.mode,
             "environment": {
                 "host": platform.node(),
@@ -337,7 +378,8 @@ def _run(args: argparse.Namespace) -> dict[str, Any]:
                 "torch": torch.__version__,
                 "cuda_runtime": torch.version.cuda,
                 "device": args.device,
-                "device_name": torch.cuda.get_device_name(0) if device.type == "cuda" else None,
+                "device_name": device_names[0] if device.type == "cuda" else None,
+                "device_names_by_rank": device_names,
             },
             "topology": {
                 "hosts": 1,
@@ -365,7 +407,7 @@ def _run(args: argparse.Namespace) -> dict[str, Any]:
             "protection": {
                 "checkpoint_interval": args.interval if enable_checkpoint else None,
                 "replay_interval": args.interval if enable_detection else None,
-                "pin_memory": args.pin_memory if enable_checkpoint else None,
+                "pin_memory": effective_pin_memory if enable_checkpoint else None,
                 "replication": enable_checkpoint and world_size > 1,
                 "replication_chunk_size": (
                     args.replication_chunk_size if enable_checkpoint else None

--- a/benchmarks/healthy_path.py
+++ b/benchmarks/healthy_path.py
@@ -89,6 +89,27 @@ def percentile(values: list[float], quantile: float) -> float:
     return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction
 
 
+def replication_jump(world_size: int) -> int:
+    """Return the pairwise GEMINI replication jump for a supported world size."""
+    if world_size < 1:
+        raise ValueError("world size must be positive")
+    if world_size > 1 and world_size % 2:
+        raise ValueError("GEMINI healthy-path modes require an even world size")
+    return max(1, world_size // 2)
+
+
+def aggregate_step_latencies(rank_results: list[dict[str, Any]]) -> list[float]:
+    """Collapse rank timings to the slowest latency for each synchronous step."""
+    sample_counts = {len(result["step_times_ms"]) for result in rank_results}
+    if len(sample_counts) != 1:
+        raise ValueError("all ranks must report the same number of timed steps")
+    sample_count = sample_counts.pop() if sample_counts else 0
+    return [
+        max(float(result["step_times_ms"][offset]) for result in rank_results)
+        for offset in range(sample_count)
+    ]
+
+
 def _tokens(
     rank: int,
     step: int,
@@ -154,6 +175,28 @@ def _max_rss_bytes() -> int:
     return value if sys.platform == "darwin" else value * 1024
 
 
+def _process_peak_rss_bytes(pid: int | None, *, proc_root: Path = Path("/proc")) -> int | None:
+    """Read Linux's peak resident set for a live SCOUT daemon."""
+    if pid is None:
+        return None
+    try:
+        status = (proc_root / str(pid) / "status").read_text()
+    except OSError:
+        return None
+    for line in status.splitlines():
+        if line.startswith("VmHWM:"):
+            fields = line.split()
+            if len(fields) == 3 and fields[2] == "kB":
+                return int(fields[1]) * 1024
+    return None
+
+
+def _oob_daemon_peak_rss_bytes(handle: Any) -> int | None:
+    replay_harness = getattr(handle, "replay_harness", None)
+    service = getattr(replay_harness, "_oob_service", None)
+    return _process_peak_rss_bytes(getattr(service, "pid", None))
+
+
 def _git_revision() -> str | None:
     completed = subprocess.run(
         ["git", "rev-parse", "HEAD"],
@@ -194,6 +237,7 @@ def _run(args: argparse.Namespace) -> dict[str, Any]:
 
     enable_checkpoint = args.mode in {"gemini", "combined"}
     enable_detection = args.mode in {"scout", "combined"}
+    checkpoint_replication_jump = replication_jump(world_size) if enable_checkpoint else 1
     handle = None
     if enable_checkpoint or enable_detection:
         handle = enable_resiliency(
@@ -205,7 +249,7 @@ def _run(args: argparse.Namespace) -> dict[str, Any]:
             checkpoint=InMemoryCkptConfig(
                 enable=enable_checkpoint,
                 interval=args.interval,
-                replication_jump=max(1, world_size // 2),
+                replication_jump=checkpoint_replication_jump,
                 replication_chunk_size=args.replication_chunk_size,
                 disk_flush_interval=0,
                 pin_memory=device.type == "cuda" and args.pin_memory,
@@ -257,11 +301,18 @@ def _run(args: argparse.Namespace) -> dict[str, Any]:
         measured_seconds = time.perf_counter() - measured_started
         dist.barrier()
 
+        peak_parent_host_memory_bytes = _max_rss_bytes()
+        peak_oob_host_memory_bytes = (
+            _oob_daemon_peak_rss_bytes(handle) if enable_detection else None
+        )
         rank_result = {
             "rank": rank,
             "duration_seconds": measured_seconds,
             "step_times_ms": step_times_ms,
-            "peak_host_memory_bytes": _max_rss_bytes(),
+            "peak_parent_host_memory_bytes": peak_parent_host_memory_bytes,
+            "peak_oob_host_memory_bytes": peak_oob_host_memory_bytes,
+            "peak_host_memory_bytes": peak_parent_host_memory_bytes
+            + (peak_oob_host_memory_bytes or 0),
             "peak_gpu_memory_bytes": (
                 torch.cuda.max_memory_allocated(device) if device.type == "cuda" else None
             ),
@@ -272,7 +323,7 @@ def _run(args: argparse.Namespace) -> dict[str, Any]:
         if rank != 0:
             return {}
         complete_results = [result for result in rank_results if result is not None]
-        all_step_times = [value for result in complete_results for value in result["step_times_ms"]]
+        job_step_times = aggregate_step_latencies(complete_results)
         max_duration = max(result["duration_seconds"] for result in complete_results)
         tokens = args.steps * args.batch_size * args.sequence_length * world_size
         return {
@@ -327,8 +378,24 @@ def _run(args: argparse.Namespace) -> dict[str, Any]:
             },
             "metrics": {
                 "throughput_tokens_per_second": tokens / max_duration,
-                "step_latency_p50_ms": percentile(all_step_times, 0.50),
-                "step_latency_p95_ms": percentile(all_step_times, 0.95),
+                "step_latency_p50_ms": percentile(job_step_times, 0.50),
+                "step_latency_p95_ms": percentile(job_step_times, 0.95),
+                "step_latencies_ms": job_step_times,
+                "peak_parent_host_memory_bytes": max(
+                    result["peak_parent_host_memory_bytes"] for result in complete_results
+                ),
+                "peak_oob_host_memory_bytes": (
+                    max(
+                        result["peak_oob_host_memory_bytes"]
+                        for result in complete_results
+                        if result["peak_oob_host_memory_bytes"] is not None
+                    )
+                    if any(
+                        result["peak_oob_host_memory_bytes"] is not None
+                        for result in complete_results
+                    )
+                    else None
+                ),
                 "peak_host_memory_bytes": max(
                     result["peak_host_memory_bytes"] for result in complete_results
                 ),

--- a/benchmarks/healthy_path.py
+++ b/benchmarks/healthy_path.py
@@ -1,0 +1,389 @@
+"""Measure native-PyTorch healthy-path overhead for one protection mode."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import resource
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.nn.parallel import DistributedDataParallel
+
+from lm_resiliency import InMemoryCkptConfig, ReplayHarnessConfig, enable_resiliency
+
+VOCABULARY_SIZE = 256
+
+
+class CausalBlock(nn.Module):
+    def __init__(self, hidden_size: int, heads: int) -> None:
+        super().__init__()
+        self.attention_norm = nn.LayerNorm(hidden_size)
+        self.attention = nn.MultiheadAttention(
+            hidden_size,
+            heads,
+            dropout=0.0,
+            batch_first=True,
+        )
+        self.mlp_norm = nn.LayerNorm(hidden_size)
+        self.mlp = nn.Sequential(
+            nn.Linear(hidden_size, hidden_size * 4),
+            nn.GELU(),
+            nn.Linear(hidden_size * 4, hidden_size),
+        )
+
+    def forward(self, hidden: torch.Tensor, causal_mask: torch.Tensor) -> torch.Tensor:
+        normalized = self.attention_norm(hidden)
+        attended, _ = self.attention(
+            normalized,
+            normalized,
+            normalized,
+            attn_mask=causal_mask,
+            need_weights=False,
+        )
+        hidden = hidden + attended
+        return hidden + self.mlp(self.mlp_norm(hidden))
+
+
+class TinyCausalLM(nn.Module):
+    def __init__(self, *, hidden_size: int, layers: int, heads: int) -> None:
+        super().__init__()
+        self.embed = nn.Embedding(VOCABULARY_SIZE, hidden_size)
+        self.layers = nn.ModuleList([CausalBlock(hidden_size, heads) for _ in range(layers)])
+        self.final_norm = nn.LayerNorm(hidden_size)
+        self.output = nn.Linear(hidden_size, VOCABULARY_SIZE, bias=False)
+
+    def forward(self, tokens: torch.Tensor) -> torch.Tensor:
+        hidden = self.embed(tokens)
+        sequence_length = tokens.shape[1]
+        causal_mask = torch.triu(
+            torch.ones(
+                sequence_length,
+                sequence_length,
+                dtype=torch.bool,
+                device=tokens.device,
+            ),
+            diagonal=1,
+        )
+        for layer in self.layers:
+            hidden = layer(hidden, causal_mask)
+        return self.output(self.final_norm(hidden))
+
+
+def percentile(values: list[float], quantile: float) -> float:
+    if not values:
+        raise ValueError("cannot compute a percentile from no samples")
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * quantile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction
+
+
+def _tokens(
+    rank: int,
+    step: int,
+    *,
+    batch_size: int,
+    sequence_length: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    generator = torch.Generator().manual_seed(1_000_003 * rank + step)
+    values = torch.randint(
+        0,
+        VOCABULARY_SIZE,
+        (batch_size, sequence_length + 1),
+        generator=generator,
+    ).to(device)
+    return values[:, :-1], values[:, 1:]
+
+
+def _train_step(
+    model: nn.Module,
+    optimizer: torch.optim.Optimizer,
+    rank: int,
+    step: int,
+    args: argparse.Namespace,
+    device: torch.device,
+) -> None:
+    tokens, labels = _tokens(
+        rank,
+        step,
+        batch_size=args.batch_size,
+        sequence_length=args.sequence_length,
+        device=device,
+    )
+    optimizer.zero_grad(set_to_none=True)
+    with torch.autocast(
+        device_type=device.type,
+        dtype=torch.bfloat16,
+        enabled=device.type == "cuda",
+    ):
+        logits = model(tokens)
+        loss = nn.functional.cross_entropy(
+            logits.reshape(-1, VOCABULARY_SIZE),
+            labels.reshape(-1),
+        )
+    loss.backward()
+    optimizer.step()
+
+
+def _tree_tensor_bytes(value: object) -> int:
+    if isinstance(value, torch.Tensor):
+        return value.numel() * value.element_size()
+    if isinstance(value, dict):
+        return sum(
+            _tree_tensor_bytes(key) + _tree_tensor_bytes(item) for key, item in value.items()
+        )
+    if isinstance(value, (list, tuple)):
+        return sum(_tree_tensor_bytes(item) for item in value)
+    return 0
+
+
+def _max_rss_bytes() -> int:
+    value = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return value if sys.platform == "darwin" else value * 1024
+
+
+def _git_revision() -> str | None:
+    completed = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip() if completed.returncode == 0 else None
+
+
+def _run(args: argparse.Namespace) -> dict[str, Any]:
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if args.device == "cuda":
+        if not torch.cuda.is_available():
+            raise RuntimeError("--device cuda requires an available CUDA device")
+        torch.cuda.set_device(local_rank)
+        device = torch.device("cuda", local_rank)
+        backend = "cpu:gloo,cuda:nccl"
+    else:
+        device = torch.device("cpu")
+        backend = "gloo"
+
+    dist.init_process_group(backend=backend)
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    torch.manual_seed(args.seed)
+
+    model: nn.Module = TinyCausalLM(
+        hidden_size=args.hidden_size,
+        layers=args.layers,
+        heads=args.heads,
+    ).to(device)
+    model = DistributedDataParallel(
+        model,
+        device_ids=[local_rank] if device.type == "cuda" else None,
+    )
+    optimizer = torch.optim.AdamW(model.parameters(), lr=2e-4)
+
+    enable_checkpoint = args.mode in {"gemini", "combined"}
+    enable_detection = args.mode in {"scout", "combined"}
+    handle = None
+    if enable_checkpoint or enable_detection:
+        handle = enable_resiliency(
+            model,
+            optimizer,
+            interval=args.interval,
+            enable_checkpoint=enable_checkpoint,
+            enable_detection=enable_detection,
+            checkpoint=InMemoryCkptConfig(
+                enable=enable_checkpoint,
+                interval=args.interval,
+                replication_jump=max(1, world_size // 2),
+                replication_chunk_size=args.replication_chunk_size,
+                disk_flush_interval=0,
+                pin_memory=device.type == "cuda" and args.pin_memory,
+            ),
+            replay=ReplayHarnessConfig(
+                check_interval=args.interval,
+                rotate_layers=True,
+                enable_temporal=False,
+                all_to_all_policy=None,
+                scale_factors=[],
+                hang_stall_threshold_s=300.0,
+            ),
+            group=dist.group.WORLD,
+            nccl_group=dist.group.WORLD,
+            device=device,
+        )
+
+    try:
+        for step in range(args.warmup_steps):
+            _train_step(model, optimizer, rank, step, args, device)
+
+        if handle is not None and handle.ckpt_manager is not None:
+            handle.ckpt_manager.maybe_wait()
+        dist.barrier()
+        if device.type == "cuda":
+            torch.cuda.synchronize(device)
+            torch.cuda.reset_peak_memory_stats(device)
+
+        step_times_ms: list[float] = []
+        cuda_events: list[tuple[torch.cuda.Event, torch.cuda.Event]] = []
+        measured_started = time.perf_counter()
+        for offset in range(args.steps):
+            step = args.warmup_steps + offset
+            if device.type == "cuda":
+                started = torch.cuda.Event(enable_timing=True)
+                completed = torch.cuda.Event(enable_timing=True)
+                started.record()
+                _train_step(model, optimizer, rank, step, args, device)
+                completed.record()
+                cuda_events.append((started, completed))
+            else:
+                started_at = time.perf_counter()
+                _train_step(model, optimizer, rank, step, args, device)
+                step_times_ms.append((time.perf_counter() - started_at) * 1000.0)
+
+        if device.type == "cuda":
+            torch.cuda.synchronize(device)
+            step_times_ms = [started.elapsed_time(completed) for started, completed in cuda_events]
+        measured_seconds = time.perf_counter() - measured_started
+        dist.barrier()
+
+        rank_result = {
+            "rank": rank,
+            "duration_seconds": measured_seconds,
+            "step_times_ms": step_times_ms,
+            "peak_host_memory_bytes": _max_rss_bytes(),
+            "peak_gpu_memory_bytes": (
+                torch.cuda.max_memory_allocated(device) if device.type == "cuda" else None
+            ),
+        }
+        rank_results: list[dict[str, Any] | None] = [None] * world_size
+        dist.all_gather_object(rank_results, rank_result)
+
+        if rank != 0:
+            return {}
+        complete_results = [result for result in rank_results if result is not None]
+        all_step_times = [value for result in complete_results for value in result["step_times_ms"]]
+        max_duration = max(result["duration_seconds"] for result in complete_results)
+        tokens = args.steps * args.batch_size * args.sequence_length * world_size
+        return {
+            "schema_version": 1,
+            "commit_sha": os.environ.get("GITHUB_SHA") or _git_revision(),
+            "mode": args.mode,
+            "environment": {
+                "host": platform.node(),
+                "platform": platform.platform(),
+                "python": platform.python_version(),
+                "torch": torch.__version__,
+                "cuda_runtime": torch.version.cuda,
+                "device": args.device,
+                "device_name": torch.cuda.get_device_name(0) if device.type == "cuda" else None,
+            },
+            "topology": {
+                "hosts": 1,
+                "world_size": world_size,
+                "data_parallel": world_size,
+                "tensor_parallel": 1,
+                "pipeline_parallel": 1,
+                "context_parallel": 1,
+                "sequence_parallel": 1,
+                "expert_parallel": 1,
+            },
+            "workload": {
+                "model": "native-pytorch-tiny-causal-lm",
+                "seed": args.seed,
+                "steps": args.steps,
+                "warmup_steps": args.warmup_steps,
+                "batch_size_per_rank": args.batch_size,
+                "sequence_length": args.sequence_length,
+                "hidden_size": args.hidden_size,
+                "layers": args.layers,
+                "heads": args.heads,
+                "checkpoint_bytes_per_rank": _tree_tensor_bytes(model.state_dict())
+                + _tree_tensor_bytes(optimizer.state_dict()),
+            },
+            "protection": {
+                "checkpoint_interval": args.interval if enable_checkpoint else None,
+                "replay_interval": args.interval if enable_detection else None,
+                "pin_memory": args.pin_memory if enable_checkpoint else None,
+                "replication": enable_checkpoint and world_size > 1,
+                "replication_chunk_size": (
+                    args.replication_chunk_size if enable_checkpoint else None
+                ),
+                "qualification_boundary": (
+                    "SCOUT healthy-path overhead only; exact localization requires at least three peers"
+                    if enable_detection and world_size < 3
+                    else None
+                ),
+            },
+            "metrics": {
+                "throughput_tokens_per_second": tokens / max_duration,
+                "step_latency_p50_ms": percentile(all_step_times, 0.50),
+                "step_latency_p95_ms": percentile(all_step_times, 0.95),
+                "peak_host_memory_bytes": max(
+                    result["peak_host_memory_bytes"] for result in complete_results
+                ),
+                "peak_gpu_memory_bytes": (
+                    max(result["peak_gpu_memory_bytes"] for result in complete_results)
+                    if device.type == "cuda"
+                    else None
+                ),
+            },
+            "ranks": complete_results,
+        }
+    finally:
+        if handle is not None:
+            handle.close()
+        dist.barrier()
+        dist.destroy_process_group()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mode", choices=("baseline", "gemini", "scout", "combined"), required=True
+    )
+    parser.add_argument("--device", choices=("cpu", "cuda"), default="cuda")
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--steps", type=int, default=40)
+    parser.add_argument("--warmup-steps", type=int, default=10)
+    parser.add_argument("--interval", type=int, default=5)
+    parser.add_argument("--batch-size", type=int, default=4)
+    parser.add_argument("--sequence-length", type=int, default=128)
+    parser.add_argument("--hidden-size", type=int, default=512)
+    parser.add_argument("--layers", type=int, default=4)
+    parser.add_argument("--heads", type=int, default=8)
+    parser.add_argument("--seed", type=int, default=123)
+    parser.add_argument("--replication-chunk-size", type=int, default=16 * 1024 * 1024)
+    parser.add_argument("--pin-memory", action=argparse.BooleanOptionalAction, default=True)
+    args = parser.parse_args()
+    if min(args.steps, args.interval, args.batch_size, args.sequence_length, args.hidden_size) < 1:
+        parser.error(
+            "steps, interval, batch size, sequence length, and hidden size must be positive"
+        )
+    if args.warmup_steps < 0:
+        parser.error("warmup steps cannot be negative")
+    if args.hidden_size % args.heads:
+        parser.error("hidden size must be divisible by heads")
+
+    result = _run(args)
+    if result:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        print(json.dumps(result, sort_keys=True), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/run_healthy_path.py
+++ b/benchmarks/run_healthy_path.py
@@ -16,7 +16,18 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from benchmarks.healthy_path import replication_jump  # noqa: E402
+from benchmarks.healthy_path import _git_worktree_dirty, replication_jump  # noqa: E402
+
+_RESULT_NAMES = {
+    "baseline.json",
+    "gemini.json",
+    "scout.json",
+    "combined.json",
+    "summary.json",
+    "summary.md",
+    "commands.json",
+    "checksums.txt",
+}
 
 
 def _free_local_port() -> int:
@@ -62,9 +73,10 @@ def summarize_results(
             comparisons.append(comparison)
             if not comparison["passed"]:
                 violations.append(comparison)
+    status = "not_qualified" if not comparisons else ("passed" if not violations else "failed")
     return {
         "schema_version": 1,
-        "status": "passed" if not violations else "failed",
+        "status": status,
         "commit_sha": runs["baseline"].get("commit_sha"),
         "thresholds": thresholds,
         "comparisons": comparisons,
@@ -93,11 +105,17 @@ def _write_markdown(path: Path, summary: dict[str, Any]) -> None:
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
-def _write_checksums(output_dir: Path) -> None:
+def _prepare_output_dir(output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for name in _RESULT_NAMES:
+        (output_dir / name).unlink(missing_ok=True)
+
+
+def _write_checksums(output_dir: Path, generated_names: set[str]) -> None:
     lines = []
-    for path in sorted(item for item in output_dir.iterdir() if item.is_file()):
-        if path.name == "checksums.txt":
-            continue
+    for path in sorted(output_dir / name for name in generated_names):
+        if not path.is_file():
+            raise FileNotFoundError(f"benchmark output is missing: {path}")
         lines.append(f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.name}")
     (output_dir / "checksums.txt").write_text("\n".join(lines) + "\n", encoding="utf-8")
 
@@ -112,7 +130,12 @@ def main() -> int:
     )
     parser.add_argument("--device", choices=("cpu", "cuda"), default="cuda")
     parser.add_argument("--world-size", type=int, default=2)
-    parser.add_argument("--modes", nargs="+", default=["baseline", "gemini", "scout", "combined"])
+    parser.add_argument(
+        "--modes",
+        nargs="+",
+        choices=("baseline", "gemini", "scout", "combined"),
+        default=["baseline", "gemini", "scout", "combined"],
+    )
     parser.add_argument("--steps", type=int, default=40)
     parser.add_argument("--warmup-steps", type=int, default=10)
     parser.add_argument("--interval", type=int, default=5)
@@ -137,7 +160,18 @@ def main() -> int:
     if args.device == "cpu" and {"scout", "combined"}.intersection(args.modes):
         parser.error("SCOUT healthy-path modes require --device cuda")
 
-    args.output_dir.mkdir(parents=True, exist_ok=True)
+    thresholds = json.loads(args.thresholds.read_text())
+    protected_modes = {
+        mode
+        for policy in thresholds["metrics"].values()
+        for mode in policy["maximum_regression_percent"]
+        if mode != "baseline"
+    }
+    if args.enforce and not protected_modes.intersection(args.modes):
+        parser.error("--enforce requires at least one threshold-protected mode")
+
+    worktree_dirty = _git_worktree_dirty()
+    _prepare_output_dir(args.output_dir)
     runs = {}
     commands = []
     for mode in args.modes:
@@ -178,13 +212,15 @@ def main() -> int:
         ]
         commands.append(command)
         environment = os.environ.copy()
+        environment["LM_BENCHMARK_WORKTREE_DIRTY"] = (
+            "unknown" if worktree_dirty is None else ("1" if worktree_dirty else "0")
+        )
         environment["PYTHONPATH"] = os.pathsep.join(
             part for part in (str(ROOT), environment.get("PYTHONPATH")) if part
         )
         subprocess.run(command, cwd=ROOT, env=environment, check=True)
         runs[mode] = json.loads(output.read_text())
 
-    thresholds = json.loads(args.thresholds.read_text())
     summary = summarize_results(runs, thresholds)
     (args.output_dir / "summary.json").write_text(
         json.dumps(summary, indent=2, sort_keys=True) + "\n",
@@ -195,7 +231,9 @@ def main() -> int:
         encoding="utf-8",
     )
     _write_markdown(args.output_dir / "summary.md", summary)
-    _write_checksums(args.output_dir)
+    generated_names = {f"{mode}.json" for mode in args.modes}
+    generated_names.update({"summary.json", "summary.md", "commands.json"})
+    _write_checksums(args.output_dir, generated_names)
     print(json.dumps(summary, sort_keys=True))
     return 1 if args.enforce and summary["status"] != "passed" else 0
 

--- a/benchmarks/run_healthy_path.py
+++ b/benchmarks/run_healthy_path.py
@@ -13,6 +13,10 @@ from pathlib import Path
 from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from benchmarks.healthy_path import replication_jump  # noqa: E402
 
 
 def _free_local_port() -> int:
@@ -125,6 +129,11 @@ def main() -> int:
         parser.error("world size must be positive")
     if "baseline" not in args.modes:
         parser.error("modes must include baseline")
+    if {"gemini", "combined"}.intersection(args.modes):
+        try:
+            replication_jump(args.world_size)
+        except ValueError as error:
+            parser.error(str(error))
     if args.device == "cpu" and {"scout", "combined"}.intersection(args.modes):
         parser.error("SCOUT healthy-path modes require --device cuda")
 

--- a/benchmarks/run_healthy_path.py
+++ b/benchmarks/run_healthy_path.py
@@ -1,0 +1,195 @@
+"""Run isolated healthy-path modes and enforce regression thresholds."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _free_local_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+def regression_percent(baseline: float, current: float, *, direction: str) -> float:
+    if baseline <= 0:
+        raise ValueError("baseline metrics must be positive")
+    if direction == "higher":
+        return (baseline - current) / baseline * 100.0
+    if direction == "lower":
+        return (current - baseline) / baseline * 100.0
+    raise ValueError(f"unsupported metric direction: {direction}")
+
+
+def summarize_results(
+    runs: dict[str, dict[str, Any]], thresholds: dict[str, Any]
+) -> dict[str, Any]:
+    baseline = runs["baseline"]["metrics"]
+    comparisons = []
+    violations = []
+    for metric, policy in thresholds["metrics"].items():
+        for mode, limit in policy["maximum_regression_percent"].items():
+            if mode not in runs:
+                continue
+            regression = regression_percent(
+                float(baseline[metric]),
+                float(runs[mode]["metrics"][metric]),
+                direction=policy["direction"],
+            )
+            comparison = {
+                "metric": metric,
+                "mode": mode,
+                "baseline": baseline[metric],
+                "current": runs[mode]["metrics"][metric],
+                "regression_percent": regression,
+                "maximum_regression_percent": limit,
+                "passed": regression <= limit,
+            }
+            comparisons.append(comparison)
+            if not comparison["passed"]:
+                violations.append(comparison)
+    return {
+        "schema_version": 1,
+        "status": "passed" if not violations else "failed",
+        "commit_sha": runs["baseline"].get("commit_sha"),
+        "thresholds": thresholds,
+        "comparisons": comparisons,
+        "violations": violations,
+        "runs": runs,
+    }
+
+
+def _write_markdown(path: Path, summary: dict[str, Any]) -> None:
+    lines = [
+        "## Healthy-path performance",
+        "",
+        f"- Status: **{summary['status']}**",
+        f"- Commit: `{summary['commit_sha']}`",
+        "",
+        "| Mode | Metric | Regression | Limit | Result |",
+        "|---|---|---:|---:|---|",
+    ]
+    for comparison in summary["comparisons"]:
+        lines.append(
+            f"| `{comparison['mode']}` | `{comparison['metric']}` | "
+            f"{comparison['regression_percent']:.2f}% | "
+            f"{comparison['maximum_regression_percent']:.2f}% | "
+            f"{'passed' if comparison['passed'] else 'failed'} |"
+        )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_checksums(output_dir: Path) -> None:
+    lines = []
+    for path in sorted(item for item in output_dir.iterdir() if item.is_file()):
+        if path.name == "checksums.txt":
+            continue
+        lines.append(f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.name}")
+    (output_dir / "checksums.txt").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument(
+        "--thresholds",
+        type=Path,
+        default=ROOT / "benchmarks" / "thresholds.json",
+    )
+    parser.add_argument("--device", choices=("cpu", "cuda"), default="cuda")
+    parser.add_argument("--world-size", type=int, default=2)
+    parser.add_argument("--modes", nargs="+", default=["baseline", "gemini", "scout", "combined"])
+    parser.add_argument("--steps", type=int, default=40)
+    parser.add_argument("--warmup-steps", type=int, default=10)
+    parser.add_argument("--interval", type=int, default=5)
+    parser.add_argument("--batch-size", type=int, default=4)
+    parser.add_argument("--sequence-length", type=int, default=128)
+    parser.add_argument("--hidden-size", type=int, default=512)
+    parser.add_argument("--layers", type=int, default=4)
+    parser.add_argument("--heads", type=int, default=8)
+    parser.add_argument("--replication-chunk-size", type=int, default=16 * 1024 * 1024)
+    parser.add_argument("--pin-memory", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--enforce", action="store_true")
+    args = parser.parse_args()
+    if args.world_size < 1:
+        parser.error("world size must be positive")
+    if "baseline" not in args.modes:
+        parser.error("modes must include baseline")
+    if args.device == "cpu" and {"scout", "combined"}.intersection(args.modes):
+        parser.error("SCOUT healthy-path modes require --device cuda")
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    runs = {}
+    commands = []
+    for mode in args.modes:
+        output = args.output_dir / f"{mode}.json"
+        command = [
+            sys.executable,
+            "-m",
+            "torch.distributed.run",
+            "--master-addr=127.0.0.1",
+            f"--master-port={_free_local_port()}",
+            f"--nproc-per-node={args.world_size}",
+            "benchmarks/healthy_path.py",
+            "--mode",
+            mode,
+            "--device",
+            args.device,
+            "--output",
+            str(output),
+            "--steps",
+            str(args.steps),
+            "--warmup-steps",
+            str(args.warmup_steps),
+            "--interval",
+            str(args.interval),
+            "--batch-size",
+            str(args.batch_size),
+            "--sequence-length",
+            str(args.sequence_length),
+            "--hidden-size",
+            str(args.hidden_size),
+            "--layers",
+            str(args.layers),
+            "--heads",
+            str(args.heads),
+            "--replication-chunk-size",
+            str(args.replication_chunk_size),
+            "--pin-memory" if args.pin_memory else "--no-pin-memory",
+        ]
+        commands.append(command)
+        environment = os.environ.copy()
+        environment["PYTHONPATH"] = os.pathsep.join(
+            part for part in (str(ROOT), environment.get("PYTHONPATH")) if part
+        )
+        subprocess.run(command, cwd=ROOT, env=environment, check=True)
+        runs[mode] = json.loads(output.read_text())
+
+    thresholds = json.loads(args.thresholds.read_text())
+    summary = summarize_results(runs, thresholds)
+    (args.output_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (args.output_dir / "commands.json").write_text(
+        json.dumps(commands, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    _write_markdown(args.output_dir / "summary.md", summary)
+    _write_checksums(args.output_dir)
+    print(json.dumps(summary, sort_keys=True))
+    return 1 if args.enforce and summary["status"] != "passed" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/thresholds.json
+++ b/benchmarks/thresholds.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "metrics": {
+    "throughput_tokens_per_second": {
+      "direction": "higher",
+      "maximum_regression_percent": {
+        "gemini": 5.0,
+        "scout": 3.0,
+        "combined": 7.5
+      }
+    },
+    "step_latency_p95_ms": {
+      "direction": "lower",
+      "maximum_regression_percent": {
+        "gemini": 10.0,
+        "scout": 7.5,
+        "combined": 15.0
+      }
+    }
+  }
+}

--- a/docs/gemini.md
+++ b/docs/gemini.md
@@ -228,6 +228,8 @@ The following measurements used eight A100-SXM4-80GB GPUs and approximately 1 bi
 These values measure the synchronization-visible portion of asynchronous capture.
 They do not infer overhead from small differences between independent end-to-end step-time runs.
 Hardware, state layout, capture cadence, and available copy or network overlap can change the result.
+The reproducible [healthy-path benchmark](../benchmarks/README.md) records current-package baseline, GEMINI, SCOUT, and combined measurements and applies explicit scheduled-run thresholds.
+The table above remains historical evidence for its stated A100 workload and is not a baseline for different benchmark shapes or hardware.
 
 ## Boundaries
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -11,6 +11,8 @@ The [GPU Qualification workflow](https://github.com/LMResiliency/lm-resiliency/a
 
 This frequent tier exercises single-GPU trajectory-equivalent recovery plus two-rank Gloo/NCCL replay, synchronized RNG, FSDP2 checkpoint recovery, and process-exit cleanup. It does not replace the larger release-qualification campaigns documented below. Self-hosted runner provisioning and isolation requirements are documented in the [test guide](../tests/README.md#automated-gpu-qualification).
 
+The same scheduled job runs the [healthy-path performance suite](../benchmarks/README.md) in isolated baseline, GEMINI-only, SCOUT-only, and combined processes. It publishes workload, environment, topology, throughput, p50/p95 latency, peak memory, per-mode results, and threshold comparisons. Two-peer SCOUT measurements qualify overhead only, not exact fault attribution.
+
 ## Release Baseline
 
 | Check | Result |

--- a/lm_resiliency/detection/oob_service.py
+++ b/lm_resiliency/detection/oob_service.py
@@ -61,6 +61,7 @@ class OOBHangService:
         self._config = config
         self._context = multiprocessing.get_context("spawn")
         self._progress_event = self._context.Event()
+        self._ready_event = self._context.Event()
         self._process: multiprocessing.Process | None = None
         self._report_callback = report_callback
         self._report_queue = self._context.Queue() if report_callback is not None else None
@@ -81,6 +82,7 @@ class OOBHangService:
                 daemon=True,
             )
             self._report_thread.start()
+        self._ready_event.clear()
         self._process = self._context.Process(
             target=_daemon_main,
             args=(
@@ -88,12 +90,28 @@ class OOBHangService:
                 self._peer_ranks,
                 self._config,
                 self._progress_event,
+                self._ready_event,
                 self._report_queue,
             ),
             name=f"scout-oob-rank-{self._global_rank}",
             daemon=True,
         )
         self._process.start()
+
+    def wait_until_ready(self, timeout_s: float | None = None) -> None:
+        """Wait until the child has joined its independent process group."""
+        process = self._process
+        if process is None:
+            raise RuntimeError("SCOUT OOB service has not been started")
+        timeout = self._config.rendezvous_timeout_s if timeout_s is None else timeout_s
+        if not self._ready_event.wait(timeout):
+            if not process.is_alive():
+                raise RuntimeError(
+                    f"SCOUT OOB daemon exited before readiness with code {process.exitcode}"
+                )
+            raise TimeoutError(f"SCOUT OOB daemon was not ready within {timeout:.1f}s")
+        if not process.is_alive():
+            raise RuntimeError(f"SCOUT OOB daemon exited at readiness with code {process.exitcode}")
 
     @property
     def pid(self) -> int | None:
@@ -145,6 +163,7 @@ def _daemon_main(
     peer_ranks: list[int],
     config: OOBHangConfig,
     progress_event,
+    ready_event,
     report_queue,
 ) -> None:
     _set_parent_death_signal()
@@ -180,6 +199,7 @@ def _daemon_main(
             checkpoint_io_confirmation_rounds=config.checkpoint_io_confirmation_rounds,
         )
         _write_daemon_status(config, global_rank, "ready")
+        ready_event.set()
 
         def report(result: HangLocalizationResult) -> None:
             if local_rank != 0:

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,6 +19,7 @@ python -m pytest -q
 Distributed programs document their required `torchrun` command in the module docstring.
 Production-loop integration is exercised directly through `examples/production_loops/` with `--inject-fault`.
 MoE validation is manual because it depends on specific GPU, Triton, Megatron Core, and Transformer Engine environments.
+Reproducible healthy-path performance commands and regression thresholds are documented in [benchmarks](../benchmarks/README.md).
 
 ## Automated GPU Qualification
 

--- a/tests/unit/test_healthy_path_benchmark.py
+++ b/tests/unit/test_healthy_path_benchmark.py
@@ -1,0 +1,64 @@
+import pytest
+
+from benchmarks.healthy_path import percentile
+from benchmarks.run_healthy_path import _write_checksums, regression_percent, summarize_results
+
+
+def test_percentile_interpolates_samples():
+    assert percentile([1.0, 2.0, 3.0, 4.0], 0.50) == 2.5
+    assert percentile([1.0, 2.0, 3.0, 4.0], 0.95) == pytest.approx(3.85)
+
+
+def test_regression_direction():
+    assert regression_percent(100.0, 95.0, direction="higher") == 5.0
+    assert regression_percent(100.0, 105.0, direction="lower") == 5.0
+
+
+def test_summary_reports_threshold_violations():
+    runs = {
+        "baseline": {"commit_sha": "abc", "metrics": {"throughput": 100.0, "p95": 10.0}},
+        "gemini": {"metrics": {"throughput": 96.0, "p95": 10.5}},
+        "scout": {"metrics": {"throughput": 98.0, "p95": 10.2}},
+        "combined": {"metrics": {"throughput": 90.0, "p95": 12.0}},
+    }
+    thresholds = {
+        "metrics": {
+            "throughput": {
+                "direction": "higher",
+                "maximum_regression_percent": {
+                    "gemini": 5.0,
+                    "scout": 3.0,
+                    "combined": 7.5,
+                },
+            },
+            "p95": {
+                "direction": "lower",
+                "maximum_regression_percent": {
+                    "gemini": 10.0,
+                    "scout": 7.5,
+                    "combined": 15.0,
+                },
+            },
+        }
+    }
+
+    summary = summarize_results(runs, thresholds)
+
+    assert summary["status"] == "failed"
+    assert {(item["mode"], item["metric"]) for item in summary["violations"]} == {
+        ("combined", "throughput"),
+        ("combined", "p95"),
+    }
+
+
+def test_checksums_cover_each_result_once(tmp_path):
+    (tmp_path / "baseline.json").write_text("{}\n")
+    (tmp_path / "summary.json").write_text("{}\n")
+
+    _write_checksums(tmp_path)
+    _write_checksums(tmp_path)
+
+    lines = (tmp_path / "checksums.txt").read_text().splitlines()
+    assert len(lines) == 2
+    assert lines[0].endswith("  baseline.json")
+    assert lines[1].endswith("  summary.json")

--- a/tests/unit/test_healthy_path_benchmark.py
+++ b/tests/unit/test_healthy_path_benchmark.py
@@ -2,11 +2,17 @@ import pytest
 
 from benchmarks.healthy_path import (
     _process_peak_rss_bytes,
+    _wait_for_oob_daemon,
     aggregate_step_latencies,
     percentile,
     replication_jump,
 )
-from benchmarks.run_healthy_path import _write_checksums, regression_percent, summarize_results
+from benchmarks.run_healthy_path import (
+    _prepare_output_dir,
+    _write_checksums,
+    regression_percent,
+    summarize_results,
+)
 
 
 def test_percentile_interpolates_samples():
@@ -37,6 +43,23 @@ def test_process_peak_rss_reads_linux_high_water_mark(tmp_path):
     status.write_text("Name:\tscout\nVmHWM:\t2048 kB\n")
 
     assert _process_peak_rss_bytes(123, proc_root=tmp_path) == 2 * 1024 * 1024
+
+
+def test_benchmark_waits_for_oob_daemon_readiness():
+    class Service:
+        ready = False
+
+        def wait_until_ready(self):
+            self.ready = True
+
+    service = Service()
+    handle = type(
+        "Handle", (), {"replay_harness": type("Harness", (), {"_oob_service": service})()}
+    )()
+
+    _wait_for_oob_daemon(handle)
+
+    assert service.ready
 
 
 def test_regression_direction():
@@ -81,14 +104,43 @@ def test_summary_reports_threshold_violations():
     }
 
 
+def test_summary_does_not_qualify_without_protected_comparisons():
+    summary = summarize_results(
+        {"baseline": {"commit_sha": "abc", "metrics": {"throughput": 100.0}}},
+        {
+            "metrics": {
+                "throughput": {
+                    "direction": "higher",
+                    "maximum_regression_percent": {"gemini": 5.0},
+                }
+            }
+        },
+    )
+
+    assert summary["status"] == "not_qualified"
+    assert summary["comparisons"] == []
+
+
 def test_checksums_cover_each_result_once(tmp_path):
     (tmp_path / "baseline.json").write_text("{}\n")
     (tmp_path / "summary.json").write_text("{}\n")
+    (tmp_path / "stale-scout.json").write_text("stale\n")
 
-    _write_checksums(tmp_path)
-    _write_checksums(tmp_path)
+    _write_checksums(tmp_path, {"baseline.json", "summary.json"})
+    _write_checksums(tmp_path, {"baseline.json", "summary.json"})
 
     lines = (tmp_path / "checksums.txt").read_text().splitlines()
     assert len(lines) == 2
     assert lines[0].endswith("  baseline.json")
     assert lines[1].endswith("  summary.json")
+    assert "stale-scout" not in (tmp_path / "checksums.txt").read_text()
+
+
+def test_output_preparation_removes_only_known_benchmark_results(tmp_path):
+    (tmp_path / "scout.json").write_text("stale\n")
+    (tmp_path / "notes.txt").write_text("keep\n")
+
+    _prepare_output_dir(tmp_path)
+
+    assert not (tmp_path / "scout.json").exists()
+    assert (tmp_path / "notes.txt").read_text() == "keep\n"

--- a/tests/unit/test_healthy_path_benchmark.py
+++ b/tests/unit/test_healthy_path_benchmark.py
@@ -1,12 +1,42 @@
 import pytest
 
-from benchmarks.healthy_path import percentile
+from benchmarks.healthy_path import (
+    _process_peak_rss_bytes,
+    aggregate_step_latencies,
+    percentile,
+    replication_jump,
+)
 from benchmarks.run_healthy_path import _write_checksums, regression_percent, summarize_results
 
 
 def test_percentile_interpolates_samples():
     assert percentile([1.0, 2.0, 3.0, 4.0], 0.50) == 2.5
     assert percentile([1.0, 2.0, 3.0, 4.0], 0.95) == pytest.approx(3.85)
+
+
+def test_step_latency_uses_slowest_rank_for_each_offset():
+    results = [
+        {"step_times_ms": [1.0, 20.0, 3.0]},
+        {"step_times_ms": [2.0, 4.0, 30.0]},
+    ]
+
+    assert aggregate_step_latencies(results) == [2.0, 20.0, 30.0]
+
+
+def test_gemini_replication_rejects_odd_multi_rank_topology():
+    assert replication_jump(1) == 1
+    assert replication_jump(2) == 1
+    assert replication_jump(4) == 2
+    with pytest.raises(ValueError, match="even world size"):
+        replication_jump(3)
+
+
+def test_process_peak_rss_reads_linux_high_water_mark(tmp_path):
+    status = tmp_path / "123" / "status"
+    status.parent.mkdir()
+    status.write_text("Name:\tscout\nVmHWM:\t2048 kB\n")
+
+    assert _process_peak_rss_bytes(123, proc_root=tmp_path) == 2 * 1024 * 1024
 
 
 def test_regression_direction():

--- a/tests/unit/test_oob_service.py
+++ b/tests/unit/test_oob_service.py
@@ -1,15 +1,45 @@
 """Unit tests for OOB daemon rendezvous setup."""
 
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
+import pytest
 import torch.distributed as dist
 
 from lm_resiliency.detection.oob_service import (
     OOBHangConfig,
+    OOBHangService,
     _init_daemon_process_group,
     _rendezvous_method,
 )
+
+
+def _unstarted_service() -> OOBHangService:
+    return OOBHangService(global_rank=0, peer_ranks=[0], config=OOBHangConfig())
+
+
+def test_readiness_wait_uses_child_signal():
+    service = _unstarted_service()
+    service._process = Mock(is_alive=Mock(return_value=True), exitcode=None)
+    service._ready_event.set()
+
+    service.wait_until_ready(timeout_s=0.01)
+
+
+def test_readiness_wait_reports_live_child_timeout():
+    service = _unstarted_service()
+    service._process = Mock(is_alive=Mock(return_value=True), exitcode=None)
+
+    with pytest.raises(TimeoutError, match="not ready within"):
+        service.wait_until_ready(timeout_s=0.0)
+
+
+def test_readiness_wait_reports_early_child_exit():
+    service = _unstarted_service()
+    service._process = Mock(is_alive=Mock(return_value=False), exitcode=17)
+
+    with pytest.raises(RuntimeError, match="exited before readiness with code 17"):
+        service.wait_until_ready(timeout_s=0.0)
 
 
 def test_tcp_rendezvous_owns_a_store_instead_of_reusing_torchrun_agent_store():


### PR DESCRIPTION
Closes #23.

## What changed
- adds isolated native-PyTorch baseline, GEMINI-only, SCOUT-only, and combined benchmark modes;
- records revision, environment, topology, workload, protection settings, throughput, p50/p95 latency, peak host/GPU memory, and per-rank data;
- adds explicit throughput/latency regression thresholds, machine-readable summaries, commands, and SHA-256 checksums;
- runs the enforced two-GPU tier in the scheduled/manual GPU qualification workflow;
- labels existing README measurements as historical workload-specific evidence and documents qualification boundaries.

## Validation
- `python -m pytest tests/unit/test_healthy_path_benchmark.py -q` — 4 passed
- sandbox-compatible CPU suite — 602 passed
- Ruff and pre-commit — passed
- CPU baseline/GEMINI harness smoke — passed

The SCOUT/combined path requires CUDA and remains to be exercised by the trusted two-GPU qualification runner. That workflow is scheduled/manual rather than pull-request-triggered so untrusted code does not execute on the self-hosted runner. Existing actionlint warnings for the repository's custom `gpu` and `lm-resiliency` labels are unchanged.