### PR TITLE
[Feature][Torchrun] Add atomic control store

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -846,6 +846,14 @@ keys must be namespaced separately from worker-group bootstrap keys. Production
 deployments should use a durable external service if the rendezvous endpoint is
 not sufficiently available or persistent.
 
+The internal control-store boundary exposes opaque byte values with per-key
+compare-and-set revisions. Creation requires the key to be absent; replacement
+and deletion require the exact current revision. Revisions never repeat for a
+key, including after deletion and recreation, so a delayed coordinator cannot
+mistake a recreated record for an older value with identical bytes. Higher
+coordinator records add lease fencing and run/schema namespaces in subsequent
+layers rather than weakening this storage primitive.
+
 ### Slot-aware rendezvous
 
 `SlotAwareRendezvousHandler` implements the existing `RendezvousHandler`

--- a/lm_resiliency/integrations/torchrun/_control_store.py
+++ b/lm_resiliency/integrations/torchrun/_control_store.py
@@ -1,0 +1,149 @@
+"""Atomic control-store primitives for the internal torchrun integration."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class ControlStoreError(RuntimeError):
+    """Base error for torchrun control-store operations."""
+
+
+class ControlStoreConflict(ControlStoreError):
+    """Raised when a conditional mutation observes an unexpected revision."""
+
+    def __init__(
+        self,
+        key: str,
+        expected_revision: int | None,
+        actual_revision: int | None,
+    ) -> None:
+        self.key = key
+        self.expected_revision = expected_revision
+        self.actual_revision = actual_revision
+        super().__init__(
+            f"control-store conflict for {key!r}: expected revision "
+            f"{expected_revision!r}, found {actual_revision!r}"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ControlStoreEntry:
+    """One immutable control-store value and its opaque per-key revision."""
+
+    value: bytes
+    revision: int
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "value", _control_value(self.value))
+        object.__setattr__(self, "revision", _required_revision(self.revision))
+
+
+class ControlStore(Protocol):
+    """Strongly consistent per-key compare-and-set storage."""
+
+    def get(self, key: str) -> ControlStoreEntry | None:
+        """Return the current value, or ``None`` when the key is absent."""
+        ...
+
+    def compare_set(
+        self,
+        key: str,
+        *,
+        expected_revision: int | None,
+        value: bytes,
+    ) -> ControlStoreEntry:
+        """Create or replace ``key`` when its revision matches.
+
+        ``expected_revision=None`` means create only when the key is absent.
+        """
+        ...
+
+    def compare_delete(self, key: str, *, expected_revision: int) -> int:
+        """Delete ``key`` when its revision matches and return the tombstone revision."""
+        ...
+
+
+class InMemoryControlStore:
+    """Thread-safe in-memory implementation used by coordinator contract tests."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._entries: dict[str, ControlStoreEntry] = {}
+        self._last_revisions: dict[str, int] = {}
+
+    def get(self, key: str) -> ControlStoreEntry | None:
+        normalized_key = _control_key(key)
+        with self._lock:
+            return self._entries.get(normalized_key)
+
+    def compare_set(
+        self,
+        key: str,
+        *,
+        expected_revision: int | None,
+        value: bytes,
+    ) -> ControlStoreEntry:
+        normalized_key = _control_key(key)
+        normalized_revision = _expected_revision(expected_revision, allow_absent=True)
+        normalized_value = _control_value(value)
+        with self._lock:
+            self._require_revision(normalized_key, normalized_revision)
+            revision = self._next_revision(normalized_key)
+            entry = ControlStoreEntry(value=normalized_value, revision=revision)
+            self._entries[normalized_key] = entry
+            return entry
+
+    def compare_delete(self, key: str, *, expected_revision: int) -> int:
+        normalized_key = _control_key(key)
+        normalized_revision = _required_revision(expected_revision)
+        with self._lock:
+            self._require_revision(normalized_key, normalized_revision)
+            del self._entries[normalized_key]
+            return self._next_revision(normalized_key)
+
+    def _require_revision(self, key: str, expected_revision: int | None) -> None:
+        entry = self._entries.get(key)
+        actual_revision = None if entry is None else entry.revision
+        if actual_revision != expected_revision:
+            raise ControlStoreConflict(key, expected_revision, actual_revision)
+
+    def _next_revision(self, key: str) -> int:
+        revision = self._last_revisions.get(key, 0) + 1
+        self._last_revisions[key] = revision
+        return revision
+
+
+def _control_key(value: object) -> str:
+    if not isinstance(value, str) or not value or value != value.strip() or "\x00" in value:
+        raise ValueError("control-store key must be a non-empty normalized string")
+    return value
+
+
+def _control_value(value: object) -> bytes:
+    if not isinstance(value, bytes):
+        raise TypeError("control-store value must be bytes")
+    return bytes(value)
+
+
+def _expected_revision(value: object, *, allow_absent: bool) -> int | None:
+    if allow_absent and value is None:
+        return None
+    return _required_revision(value)
+
+
+def _required_revision(value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError("expected_revision must be a positive integer")
+    return value
+
+
+__all__ = [
+    "ControlStore",
+    "ControlStoreConflict",
+    "ControlStoreEntry",
+    "ControlStoreError",
+    "InMemoryControlStore",
+]

--- a/tests/unit/test_torchrun_control_store.py
+++ b/tests/unit/test_torchrun_control_store.py
@@ -1,0 +1,174 @@
+"""Contract tests for the internal torchrun control store."""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStoreConflict,
+    ControlStoreEntry,
+    InMemoryControlStore,
+)
+
+
+def test_control_store_create_update_delete_and_recreate():
+    store = InMemoryControlStore()
+
+    created = store.compare_set("run/control", expected_revision=None, value=b"one")
+    updated = store.compare_set(
+        "run/control",
+        expected_revision=created.revision,
+        value=b"two",
+    )
+    tombstone_revision = store.compare_delete(
+        "run/control",
+        expected_revision=updated.revision,
+    )
+    recreated = store.compare_set("run/control", expected_revision=None, value=b"three")
+
+    assert created.value == b"one"
+    assert updated.value == b"two"
+    assert store.get("run/control") == recreated
+    assert created.revision < updated.revision < tombstone_revision < recreated.revision
+
+
+def test_control_store_rejects_stale_update_and_delete():
+    store = InMemoryControlStore()
+    created = store.compare_set("run/control", expected_revision=None, value=b"one")
+    updated = store.compare_set(
+        "run/control",
+        expected_revision=created.revision,
+        value=b"two",
+    )
+
+    with pytest.raises(ControlStoreConflict) as update_error:
+        store.compare_set(
+            "run/control",
+            expected_revision=created.revision,
+            value=b"stale",
+        )
+    with pytest.raises(ControlStoreConflict) as delete_error:
+        store.compare_delete(
+            "run/control",
+            expected_revision=created.revision,
+        )
+
+    assert update_error.value.expected_revision == created.revision
+    assert update_error.value.actual_revision == updated.revision
+    assert delete_error.value.actual_revision == updated.revision
+    assert store.get("run/control") == updated
+
+
+def test_control_store_revision_prevents_delete_recreate_aba():
+    store = InMemoryControlStore()
+    original = store.compare_set("run/control", expected_revision=None, value=b"same")
+    store.compare_delete("run/control", expected_revision=original.revision)
+    recreated = store.compare_set("run/control", expected_revision=None, value=b"same")
+
+    with pytest.raises(ControlStoreConflict) as error:
+        store.compare_set(
+            "run/control",
+            expected_revision=original.revision,
+            value=b"stale",
+        )
+
+    assert error.value.actual_revision == recreated.revision
+    assert recreated.revision != original.revision
+
+
+def test_control_store_allows_only_one_concurrent_creator():
+    store = InMemoryControlStore()
+    workers = 8
+    barrier = threading.Barrier(workers)
+
+    def create(index: int):
+        barrier.wait()
+        try:
+            return store.compare_set(
+                "run/control",
+                expected_revision=None,
+                value=str(index).encode("ascii"),
+            )
+        except ControlStoreConflict:
+            return None
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        results = list(executor.map(create, range(workers)))
+
+    winners = [result for result in results if result is not None]
+    assert len(winners) == 1
+    assert store.get("run/control") == winners[0]
+
+
+def test_control_store_serializes_concurrent_compare_set_updates():
+    store = InMemoryControlStore()
+    initial = store.compare_set("run/counter", expected_revision=None, value=b"0")
+    assert initial.revision == 1
+
+    workers = 8
+    updates_per_worker = 25
+
+    def increment() -> None:
+        for _ in range(updates_per_worker):
+            while True:
+                current = store.get("run/counter")
+                assert current is not None
+                try:
+                    store.compare_set(
+                        "run/counter",
+                        expected_revision=current.revision,
+                        value=str(int(current.value) + 1).encode("ascii"),
+                    )
+                except ControlStoreConflict:
+                    continue
+                break
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        list(executor.map(lambda _: increment(), range(workers)))
+
+    result = store.get("run/counter")
+    assert result is not None
+    assert result.value == str(workers * updates_per_worker).encode("ascii")
+    assert result.revision == 1 + workers * updates_per_worker
+
+
+@pytest.mark.parametrize("key", ["", " run/control", "run/control ", "run/\x00control"])
+def test_control_store_rejects_invalid_keys(key):
+    store = InMemoryControlStore()
+
+    with pytest.raises(ValueError, match="key"):
+        store.get(key)
+
+
+@pytest.mark.parametrize("revision", [False, 0, -1, "1"])
+def test_control_store_rejects_invalid_expected_revisions(revision):
+    store = InMemoryControlStore()
+
+    with pytest.raises(ValueError, match="expected_revision"):
+        store.compare_set("run/control", expected_revision=revision, value=b"value")
+
+
+def test_control_store_rejects_mutable_values():
+    store = InMemoryControlStore()
+
+    with pytest.raises(TypeError, match="bytes"):
+        store.compare_set(
+            "run/control",
+            expected_revision=None,
+            value=bytearray(b"value"),  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize(
+    ("value", "revision", "error"),
+    [
+        (bytearray(b"value"), 1, TypeError),
+        (b"value", 0, ValueError),
+    ],
+)
+def test_control_store_entry_rejects_invalid_backend_values(value, revision, error):
+    with pytest.raises(error):
+        ControlStoreEntry(value=value, revision=revision)


### PR DESCRIPTION
## Summary

- add an internal strongly consistent per-key control-store contract
- add a thread-safe in-memory implementation with revision-guarded create, update, and delete
- preserve monotonically increasing revisions across deletion and recreation to prevent ABA reuse
- document the storage boundary for later coordinator lease and generation records

## Scope

This PR intentionally contains only the storage primitive. Coordinator leases, generation snapshots, placement policy, and checkpoint-plan selection will be separate PRs.

The module remains internal and does not change stable package exports.

## Validation

- `CUDA_VISIBLE_DEVICES='' .venv/bin/python -m pytest -q tests/unit/test_torchrun_control_store.py tests/unit/test_torchrun_protocol.py tests/unit/test_orchestration_api.py` (115 passed)
- `ruff check` and `ruff format --check` for the changed Python files
- `mypy lm_resiliency/integrations/torchrun/_control_store.py`