### PR TITLE
[Feature] Publish revision-bound validation evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,45 @@ jobs:
           python -m pip check
 
       - name: Run CPU unit suite
-        run: python -m pytest -q
+        id: cpu_tests
+        run: python -m pytest -q --junitxml="$RUNNER_TEMP/unit-results.xml"
+
+      - name: Create revision-bound CPU evidence
+        if: ${{ always() && matrix.name == 'primary' }}
+        env:
+          TEST_OUTCOME: ${{ steps.cpu_tests.outcome }}
+        run: |
+          python scripts/validation_evidence.py create-pytest \
+            --bundle "$RUNNER_TEMP/cpu-primary-evidence" \
+            --junit "$RUNNER_TEMP/unit-results.xml" \
+            --action-status "$TEST_OUTCOME" \
+            --recorded-command 'python -m pytest -q --junitxml="$RUNNER_TEMP/unit-results.xml"' \
+            --configuration "python=${{ matrix.python }}" \
+            --configuration "numpy=${{ matrix.numpy }}" \
+            --configuration "torch=${{ matrix.torch }}" \
+            --campaign-id cpu-unit-primary \
+            --tier cpu \
+            --repository "$GITHUB_REPOSITORY" \
+            --commit "$GITHUB_SHA" \
+            --ref "$GITHUB_REF" \
+            --artifact-name "cpu-primary-$GITHUB_SHA" \
+            --artifact-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --framework pytorch \
+            --framework gemini \
+            --framework scout \
+            --boundary "CPU tests do not qualify CUDA, NCCL, or multi-process behavior."
+          python scripts/validation_evidence.py verify \
+            --bundle "$RUNNER_TEMP/cpu-primary-evidence" \
+            --expected-commit "$GITHUB_SHA"
+
+      - name: Upload revision-bound CPU evidence
+        if: ${{ always() && matrix.name == 'primary' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cpu-primary-${{ github.sha }}
+          path: ${{ runner.temp }}/cpu-primary-evidence
+          if-no-files-found: error
+          retention-days: 90
 
   package:
     name: Package

--- a/.github/workflows/gpu-qualification.yml
+++ b/.github/workflows/gpu-qualification.yml
@@ -55,8 +55,15 @@ jobs:
           python benchmarks/run_healthy_path.py \
             --device cuda \
             --world-size 2 \
-            --output-dir "$RUNNER_TEMP/gpu-qualification/healthy-path" \
+            --output-dir "$RUNNER_TEMP/healthy-path" \
             --enforce
+
+      - name: Verify revision-bound GPU evidence
+        if: always()
+        run: |
+          python scripts/validation_evidence.py verify \
+            --bundle "$RUNNER_TEMP/gpu-qualification" \
+            --expected-commit "$GITHUB_SHA"
 
       - name: Publish job summary
         if: always()
@@ -64,8 +71,8 @@ jobs:
           if test -f "$RUNNER_TEMP/gpu-qualification/summary.md"; then
             cat "$RUNNER_TEMP/gpu-qualification/summary.md" >> "$GITHUB_STEP_SUMMARY"
           fi
-          if test -f "$RUNNER_TEMP/gpu-qualification/healthy-path/summary.md"; then
-            cat "$RUNNER_TEMP/gpu-qualification/healthy-path/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          if test -f "$RUNNER_TEMP/healthy-path/summary.md"; then
+            cat "$RUNNER_TEMP/healthy-path/summary.md" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Upload qualification evidence
@@ -75,4 +82,13 @@ jobs:
           name: gpu-qualification-${{ github.sha }}
           path: ${{ runner.temp }}/gpu-qualification
           if-no-files-found: error
-          retention-days: 30
+          retention-days: 90
+
+      - name: Upload healthy-path evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: healthy-path-${{ github.sha }}
+          path: ${{ runner.temp }}/healthy-path
+          if-no-files-found: warn
+          retention-days: 90

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Fast checkpoint recovery and fault localization for distributed LLM pre-training
 
-[![16 GPU Feature Tests](https://img.shields.io/badge/16_GPU_Feature_Tests-passing-brightgreen.svg)](docs/validation.md#release-baseline)
+[![Historical 16 GPU Evidence](https://img.shields.io/badge/16_GPU_Evidence-historical_2026--08--13-lightgrey.svg)](docs/validation.md#historical-release-baseline)
 [![GPU Qualification](https://github.com/LMResiliency/lm-resiliency/actions/workflows/gpu-qualification.yml/badge.svg?branch=main)](https://github.com/LMResiliency/lm-resiliency/actions/workflows/gpu-qualification.yml)
 [![pip](https://img.shields.io/pypi/v/lm-resiliency?color=blue)](https://pypi.org/project/lm-resiliency/)
 [![PyTorch 2.10–2.13](https://img.shields.io/badge/PyTorch-2.10--2.13-EE4C2C.svg)](https://pytorch.org/)
@@ -143,7 +143,7 @@ Launcher-specific retry, placement, and replacement policy remains external. See
 | GEMINI checkpoint tiers, recovery, and cadence | [GEMINI guide](docs/gemini.md) |
 | SCOUT coverage, replay, fault reports, and checkpoint certification | [SCOUT guide](docs/scout.md) |
 | MoE regime discovery, qualification, and measured results | [MoE execution regimes](docs/moe_execution_regimes.md) |
-| Complete test evidence and limitations | [Validation report](docs/validation.md) |
+| Revision-bound evidence format, results, and limitations | [Validation report](docs/validation.md) |
 | Planned project direction and priorities | [Roadmap](ROADMAP.md) |
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### Fast checkpoint recovery and fault localization for distributed LLM pre-training
 
 [![Historical 16 GPU Evidence](https://img.shields.io/badge/16_GPU_Evidence-historical_2026--08--13-lightgrey.svg)](docs/validation.md#historical-release-baseline)
-[![GPU Qualification](https://github.com/LMResiliency/lm-resiliency/actions/workflows/gpu-qualification.yml/badge.svg?branch=main)](https://github.com/LMResiliency/lm-resiliency/actions/workflows/gpu-qualification.yml)
+[![Revision-bound GPU Evidence](https://img.shields.io/badge/GPU_Evidence-revision--bound-informational.svg)](https://github.com/LMResiliency/lm-resiliency/actions/workflows/gpu-qualification.yml)
 [![pip](https://img.shields.io/pypi/v/lm-resiliency?color=blue)](https://pypi.org/project/lm-resiliency/)
 [![PyTorch 2.10–2.13](https://img.shields.io/badge/PyTorch-2.10--2.13-EE4C2C.svg)](https://pytorch.org/)
 [![TorchTitan 0.2.2](https://img.shields.io/badge/TorchTitan-0.2.2-EE4C2C.svg)](https://github.com/pytorch/torchtitan)

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -2,18 +2,26 @@
 
 Date: 2026-08-13 UTC.
 
-This report summarizes the release-candidate validation evidence for GEMINI and SCOUT.
+This report summarizes validation evidence for GEMINI and SCOUT.
 Focused integration programs use deterministic training workloads and fault injection to verify checkpoint equivalence, exact fault localization, candidate exclusion, and framework topology handling.
 
 ## Automated Qualification Status
 
-The [GPU Qualification workflow](https://github.com/LMResiliency/lm-resiliency/actions/workflows/gpu-qualification.yml) runs weekly and on trusted maintainer dispatch using a two-GPU self-hosted runner. The workflow badge in the README links to the last run, including its exact revision and completion date. Each run also uploads a machine-readable summary, environment and topology inventory, exact commands, per-command logs, and SHA-256 checksums.
+The [GPU Qualification workflow](https://github.com/LMResiliency/lm-resiliency/actions/workflows/gpu-qualification.yml) runs weekly and on trusted maintainer dispatch using a two-GPU self-hosted runner. Each run uploads a [schema-validated evidence bundle](../validation/README.md) whose manifest records its full commit SHA, package version, completion time, environment and topology inventory, exact commands, per-command logs, qualification boundaries, workflow-artifact location, and SHA-256 payload digests. The primary CPU matrix publishes the same format on every CI run.
+
+A passing result applies only to the commit in its manifest. Download the SHA-named artifact from the linked workflow run and invoke `scripts/validation_evidence.py verify --expected-commit <sha>` before treating it as current. The verifier reports the evidence as stale when `main` has advanced. README therefore labels the manually collected 16-GPU results below as historical instead of presenting an unqualified current passing claim.
 
 This frequent tier exercises single-GPU trajectory-equivalent recovery plus two-rank Gloo/NCCL replay, synchronized RNG, FSDP2 checkpoint recovery, and process-exit cleanup. It does not replace the larger release-qualification campaigns documented below. Self-hosted runner provisioning and isolation requirements are documented in the [test guide](../tests/README.md#automated-gpu-qualification).
 
 The same scheduled job runs the [healthy-path performance suite](../benchmarks/README.md) in isolated baseline, GEMINI-only, SCOUT-only, and combined processes. It publishes workload, environment, topology, throughput, p50/p95 latency, peak memory, per-mode results, and threshold comparisons. Two-peer SCOUT measurements qualify overhead only, not exact fault attribution.
 
-## Release Baseline
+## Historical Release Baseline
+
+The rows in this section were collected on 2026-08-13 before the revision-bound bundle
+format existed. They remain useful historical measurements, but they are not current
+release qualification and are not traceable to sealed manifests. New CPU, single-host
+GPU, multi-host, framework, GEMINI, SCOUT, and MoE campaigns must publish the common
+machine-readable bundle described above.
 
 | Check | Result |
 |---|---|

--- a/scripts/validation_evidence.py
+++ b/scripts/validation_evidence.py
@@ -1,0 +1,589 @@
+"""Create and verify revision-bound validation evidence bundles."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import platform
+import re
+import shutil
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any
+
+import tomllib
+
+_SCHEMA_VERSION = 1
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+_PAYLOAD_NAMES = {"summary.json", "environment.json", "commands.txt"}
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_COMMIT = re.compile(r"^[0-9a-f]{40}$")
+_COMMAND = re.compile(r"^\[([a-z0-9][a-z0-9._-]*)\] (.+)$")
+
+
+def _timestamp() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError) as error:
+        raise ValueError(f"invalid or missing {path}") from error
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _project() -> tuple[str, str]:
+    with (_REPOSITORY_ROOT / "pyproject.toml").open("rb") as handle:
+        project = tomllib.load(handle)["project"]
+    return project["name"], project["version"]
+
+
+def _command_ids(path: Path) -> list[str]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError as error:
+        raise ValueError(f"missing {path}") from error
+    if not lines:
+        raise ValueError("commands.txt must contain at least one command")
+    ids = []
+    for line in lines:
+        match = _COMMAND.fullmatch(line)
+        if match is None:
+            raise ValueError(f"invalid commands.txt line: {line!r}")
+        ids.append(match.group(1))
+    if len(ids) != len(set(ids)):
+        raise ValueError("commands.txt contains duplicate command IDs")
+    return ids
+
+
+def _require_string(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a non-empty string")
+    return value
+
+
+def _validate_summary(summary: Any, campaign_id: str, command_ids: list[str]) -> None:
+    required = {
+        "schema_version",
+        "campaign_id",
+        "status",
+        "started_at",
+        "completed_at",
+        "counts",
+        "metrics",
+        "results",
+        "topology",
+        "seed",
+        "configuration",
+    }
+    if not isinstance(summary, dict) or set(summary) != required:
+        raise ValueError("summary.json has unexpected or missing fields")
+    if summary["schema_version"] != _SCHEMA_VERSION:
+        raise ValueError("summary.json has an unsupported schema version")
+    if summary["campaign_id"] != campaign_id:
+        raise ValueError("summary campaign_id does not match the manifest")
+    if summary["status"] not in {"passed", "failed", "cancelled"}:
+        raise ValueError("summary status is invalid")
+    timestamps = []
+    for field in ("started_at", "completed_at"):
+        timestamp = _require_string(summary[field], f"summary {field}")
+        try:
+            parsed = dt.datetime.fromisoformat(timestamp)
+        except ValueError as error:
+            raise ValueError(f"summary {field} must be an ISO-8601 timestamp") from error
+        if parsed.tzinfo is None:
+            raise ValueError(f"summary {field} must include a timezone")
+        timestamps.append(parsed)
+    if timestamps[1] < timestamps[0]:
+        raise ValueError("summary completed_at precedes started_at")
+    counts = summary["counts"]
+    count_keys = {"total", "passed", "failed", "skipped", "errors"}
+    if (
+        not isinstance(counts, dict)
+        or set(counts) != count_keys
+        or any(type(counts[key]) is not int or counts[key] < 0 for key in count_keys)
+        or counts["total"]
+        != counts["passed"] + counts["failed"] + counts["skipped"] + counts["errors"]
+    ):
+        raise ValueError("summary counts are inconsistent")
+    if not isinstance(summary["metrics"], dict):
+        raise ValueError("summary metrics must be an object")
+    if not isinstance(summary["results"], list):
+        raise ValueError("summary results must be a list")
+    if summary["status"] == "passed" and (
+        counts["passed"] < 1 or counts["failed"] or counts["errors"]
+    ):
+        raise ValueError("a passed summary must contain successful results and no failures")
+    result_ids = []
+    for result in summary["results"]:
+        if not isinstance(result, dict):
+            raise ValueError("summary result entries must be objects")
+        result_ids.append(_require_string(result.get("command_id"), "result command_id"))
+        if result.get("status") not in {"passed", "failed", "skipped", "error"}:
+            raise ValueError("summary result status is invalid")
+    if not set(result_ids).issubset(command_ids):
+        raise ValueError("summary refers to an unknown command ID")
+    topology = summary["topology"]
+    if not isinstance(topology, dict):
+        raise ValueError("summary topology must be an object")
+    for field in ("hosts", "world_size", "gpu_count"):
+        if type(topology.get(field)) is not int or topology[field] < 0:
+            raise ValueError(f"summary topology {field} must be a non-negative integer")
+    if not isinstance(summary["configuration"], dict):
+        raise ValueError("summary configuration must be an object")
+    if summary["seed"] is not None and type(summary["seed"]) is not int:
+        raise ValueError("summary seed must be an integer or null")
+
+
+def _validate_result_logs(bundle: Path, summary: dict[str, Any]) -> None:
+    for result in summary["results"]:
+        log = result.get("log")
+        digest = result.get("log_sha256")
+        if log is None and digest is None:
+            continue
+        if not isinstance(log, str) or not log or _SHA256.fullmatch(str(digest)) is None:
+            raise ValueError("summary result log identity is invalid")
+        path = bundle / log
+        try:
+            path.resolve().relative_to(bundle)
+        except ValueError as error:
+            raise ValueError("summary result log escapes the evidence bundle") from error
+        if not path.is_file() or _sha256(path) != digest:
+            raise ValueError(f"summary result log digest mismatch for {log}")
+
+
+def _validate_environment(environment: Any) -> None:
+    required = {"schema_version", "captured_at", "hardware", "software", "runner"}
+    if not isinstance(environment, dict) or set(environment) != required:
+        raise ValueError("environment.json has unexpected or missing fields")
+    if environment["schema_version"] != _SCHEMA_VERSION:
+        raise ValueError("environment.json has an unsupported schema version")
+    _require_string(environment["captured_at"], "environment captured_at")
+    if not isinstance(environment["hardware"], dict):
+        raise ValueError("environment hardware must be an object")
+    for field in ("hosts", "world_size", "gpu_count"):
+        value = environment["hardware"].get(field)
+        if type(value) is not int or value < 0:
+            raise ValueError(f"environment hardware {field} must be a non-negative integer")
+    if not isinstance(environment["software"], dict):
+        raise ValueError("environment software must be an object")
+    frameworks = environment["software"].get("frameworks")
+    if not isinstance(frameworks, dict) or not frameworks:
+        raise ValueError("environment software frameworks must be a non-empty object")
+    if not isinstance(environment["runner"], dict):
+        raise ValueError("environment runner must be an object")
+
+
+def _payload_files(bundle: Path) -> list[Path]:
+    paths = sorted(
+        path
+        for path in bundle.rglob("*")
+        if path.is_file() and path.name not in {"manifest.json", "checksums.txt"}
+    )
+    if any(path.is_symlink() for path in paths):
+        raise ValueError("evidence payloads must not be symbolic links")
+    return paths
+
+
+def seal_bundle(
+    bundle: Path,
+    *,
+    campaign_id: str,
+    tier: str,
+    repository: str,
+    commit: str,
+    ref: str,
+    artifact_name: str,
+    artifact_url: str,
+    frameworks: list[str],
+    boundaries: list[str],
+) -> dict[str, Any]:
+    """Validate payload records and seal them with an exact identity and digests."""
+    bundle = bundle.resolve()
+    missing = _PAYLOAD_NAMES - {path.name for path in bundle.iterdir() if path.is_file()}
+    if missing:
+        raise ValueError(f"evidence bundle is missing required files: {sorted(missing)}")
+    if _COMMIT.fullmatch(commit) is None:
+        raise ValueError("commit must be a full 40-character lowercase Git SHA")
+    campaign_id = _require_string(campaign_id, "campaign_id")
+    tier = _require_string(tier, "tier")
+    repository = _require_string(repository, "repository")
+    ref = _require_string(ref, "ref")
+    artifact_name = _require_string(artifact_name, "artifact_name")
+    artifact_url = _require_string(artifact_url, "artifact_url")
+    if not frameworks or any(not isinstance(item, str) or not item for item in frameworks):
+        raise ValueError("at least one framework must be recorded")
+    if not boundaries or any(not isinstance(item, str) or not item for item in boundaries):
+        raise ValueError("at least one qualification boundary must be recorded")
+
+    command_ids = _command_ids(bundle / "commands.txt")
+    summary = _read_json(bundle / "summary.json")
+    environment = _read_json(bundle / "environment.json")
+    _validate_summary(summary, campaign_id, command_ids)
+    _validate_environment(environment)
+    for field in ("hosts", "world_size", "gpu_count"):
+        if summary["topology"][field] != environment["hardware"][field]:
+            raise ValueError(f"summary and environment topology {field} differ")
+    _validate_result_logs(bundle, summary)
+    project_name, version = _project()
+    payloads = [
+        {
+            "path": str(path.relative_to(bundle)),
+            "bytes": path.stat().st_size,
+            "sha256": _sha256(path),
+        }
+        for path in _payload_files(bundle)
+    ]
+    manifest = {
+        "schema_version": _SCHEMA_VERSION,
+        "project": {
+            "name": project_name,
+            "version": version,
+            "repository": repository,
+            "commit_sha": commit,
+            "ref": ref,
+        },
+        "campaign": {
+            "id": campaign_id,
+            "tier": tier,
+            "status": summary["status"],
+            "started_at": summary["started_at"],
+            "completed_at": summary["completed_at"],
+            "command_ids": command_ids,
+            "seed": summary["seed"],
+            "configuration": summary["configuration"],
+        },
+        "artifact": {"name": artifact_name, "url": artifact_url},
+        "qualification": {
+            "frameworks": sorted(set(frameworks)),
+            "topology": summary["topology"],
+            "boundaries": boundaries,
+        },
+        "files": payloads,
+    }
+    _write_json(bundle / "manifest.json", manifest)
+    checksum_paths = [bundle / "manifest.json", *_payload_files(bundle)]
+    (bundle / "checksums.txt").write_text(
+        "".join(f"{_sha256(path)}  {path.relative_to(bundle)}\n" for path in checksum_paths),
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def verify_bundle(bundle: Path, *, expected_commit: str | None = None) -> dict[str, Any]:
+    """Reject schema, identity, membership, size, or digest drift in a bundle."""
+    bundle = bundle.resolve()
+    manifest = _read_json(bundle / "manifest.json")
+    required = {"schema_version", "project", "campaign", "artifact", "qualification", "files"}
+    if not isinstance(manifest, dict) or set(manifest) != required:
+        raise ValueError("manifest.json has unexpected or missing fields")
+    if manifest["schema_version"] != _SCHEMA_VERSION:
+        raise ValueError("manifest.json has an unsupported schema version")
+    project = manifest["project"]
+    project_keys = {"name", "version", "repository", "commit_sha", "ref"}
+    if not isinstance(project, dict) or set(project) != project_keys:
+        raise ValueError("manifest project identity is invalid")
+    project_name, version = _project()
+    if project["name"] != project_name or project["version"] != version:
+        raise ValueError("manifest package identity does not match pyproject.toml")
+    if _COMMIT.fullmatch(str(project["commit_sha"])) is None:
+        raise ValueError("manifest commit_sha is not a full lowercase Git SHA")
+    if expected_commit is not None and project["commit_sha"] != expected_commit:
+        raise ValueError(
+            f"validation evidence is stale: covers {project['commit_sha']}, expected {expected_commit}"
+        )
+    for field in ("repository", "ref"):
+        _require_string(project[field], f"manifest project {field}")
+
+    campaign = manifest["campaign"]
+    campaign_keys = {
+        "id",
+        "tier",
+        "status",
+        "started_at",
+        "completed_at",
+        "command_ids",
+        "seed",
+        "configuration",
+    }
+    if not isinstance(campaign, dict) or set(campaign) != campaign_keys:
+        raise ValueError("manifest campaign is invalid")
+    for field in ("id", "tier"):
+        _require_string(campaign[field], f"manifest campaign {field}")
+    command_ids = _command_ids(bundle / "commands.txt")
+    if campaign["command_ids"] != command_ids:
+        raise ValueError("manifest command IDs do not match commands.txt")
+    summary = _read_json(bundle / "summary.json")
+    environment = _read_json(bundle / "environment.json")
+    _validate_summary(summary, campaign["id"], command_ids)
+    _validate_environment(environment)
+    for field in ("hosts", "world_size", "gpu_count"):
+        if summary["topology"][field] != environment["hardware"][field]:
+            raise ValueError(f"summary and environment topology {field} differ")
+    _validate_result_logs(bundle, summary)
+    if campaign["status"] != summary["status"]:
+        raise ValueError("manifest and summary status differ")
+    for field in ("seed", "configuration", "started_at", "completed_at"):
+        if campaign[field] != summary[field]:
+            raise ValueError(f"manifest and summary {field} differ")
+
+    artifact = manifest["artifact"]
+    if not isinstance(artifact, dict) or set(artifact) != {"name", "url"}:
+        raise ValueError("manifest artifact is invalid")
+    _require_string(artifact["name"], "manifest artifact name")
+    _require_string(artifact["url"], "manifest artifact URL")
+    qualification = manifest["qualification"]
+    if not isinstance(qualification, dict) or set(qualification) != {
+        "frameworks",
+        "topology",
+        "boundaries",
+    }:
+        raise ValueError("manifest qualification is invalid")
+    if qualification["topology"] != summary["topology"]:
+        raise ValueError("manifest and summary topology differ")
+    frameworks = qualification["frameworks"]
+    if (
+        not isinstance(frameworks, list)
+        or not frameworks
+        or len(frameworks) != len(set(frameworks))
+        or any(not isinstance(item, str) or not item for item in frameworks)
+    ):
+        raise ValueError("manifest frameworks must be a non-empty list")
+    boundaries = qualification["boundaries"]
+    if (
+        not isinstance(boundaries, list)
+        or not boundaries
+        or any(not isinstance(item, str) or not item for item in boundaries)
+    ):
+        raise ValueError("manifest boundaries must be a non-empty list")
+
+    records = manifest["files"]
+    actual = _payload_files(bundle)
+    if not isinstance(records, list) or len(records) != len(actual):
+        raise ValueError("manifest payload membership does not match the bundle")
+    expected_by_path: dict[str, dict[str, Any]] = {}
+    for record in records:
+        if (
+            not isinstance(record, dict)
+            or set(record) != {"path", "bytes", "sha256"}
+            or not isinstance(record["path"], str)
+            or type(record["bytes"]) is not int
+            or not isinstance(record["sha256"], str)
+            or _SHA256.fullmatch(record["sha256"]) is None
+            or record["path"] in expected_by_path
+        ):
+            raise ValueError("manifest payload record is invalid")
+        expected_by_path[record["path"]] = record
+    if set(expected_by_path) != {str(path.relative_to(bundle)) for path in actual}:
+        raise ValueError("manifest payload membership does not match the bundle")
+    for path in actual:
+        record = expected_by_path[str(path.relative_to(bundle))]
+        if path.stat().st_size != record["bytes"] or _sha256(path) != record["sha256"]:
+            raise ValueError(f"evidence payload digest mismatch for {record['path']}")
+
+    checksum_paths = [bundle / "manifest.json", *actual]
+    expected_checksums = "".join(
+        f"{_sha256(path)}  {path.relative_to(bundle)}\n" for path in checksum_paths
+    )
+    try:
+        checksums = (bundle / "checksums.txt").read_text(encoding="utf-8")
+    except FileNotFoundError as error:
+        raise ValueError("missing checksums.txt") from error
+    if checksums != expected_checksums:
+        raise ValueError("checksums.txt does not match the evidence bundle")
+    return manifest
+
+
+def _framework_versions() -> dict[str, str | None]:
+    try:
+        import torch
+    except ImportError:
+        torch_version = None
+        cuda_version = None
+        nccl_version = None
+    else:
+        torch_version = torch.__version__
+        cuda_version = torch.version.cuda
+        nccl = torch.cuda.nccl.version() if torch.cuda.is_available() else None
+        nccl_version = ".".join(map(str, nccl)) if isinstance(nccl, tuple) else nccl
+    return {"pytorch": torch_version, "cuda": cuda_version, "nccl": nccl_version}
+
+
+def _parse_assignments(values: list[str]) -> dict[str, str]:
+    result = {}
+    for value in values:
+        key, separator, item = value.partition("=")
+        if not separator or not key or not item:
+            raise ValueError(f"configuration must use NAME=VALUE: {value!r}")
+        result[key] = item
+    return result
+
+
+def create_pytest_bundle(
+    bundle: Path,
+    *,
+    junit: Path,
+    action_status: str,
+    command: str,
+    configuration: dict[str, str],
+    seal_options: dict[str, Any],
+) -> dict[str, Any]:
+    """Create a canonical CPU evidence payload from pytest JUnit output."""
+    bundle.mkdir(parents=True, exist_ok=True)
+    result: dict[str, Any]
+    if junit.is_file():
+        destination = bundle / "junit.xml"
+        shutil.copyfile(junit, destination)
+        root = ET.parse(destination).getroot()
+        suites = [root] if root.tag == "testsuite" else list(root)
+        total = sum(int(suite.attrib.get("tests", 0)) for suite in suites)
+        failures = sum(int(suite.attrib.get("failures", 0)) for suite in suites)
+        errors = sum(int(suite.attrib.get("errors", 0)) for suite in suites)
+        skipped = sum(int(suite.attrib.get("skipped", 0)) for suite in suites)
+        passed = total - failures - errors - skipped
+        duration = sum(float(suite.attrib.get("time", 0.0)) for suite in suites)
+        result = {
+            "command_id": "cpu-unit-suite",
+            "status": "passed"
+            if failures == errors == 0 and action_status == "success"
+            else "failed",
+            "duration_seconds": duration,
+            "log": destination.name,
+            "log_sha256": _sha256(destination),
+        }
+    else:
+        total, passed, failures, skipped, errors, duration = 1, 0, 0, 0, 1, 0.0
+        result = {
+            "command_id": "cpu-unit-suite",
+            "status": "error",
+            "duration_seconds": duration,
+            "error": f"pytest did not produce {junit}",
+        }
+    status = "passed" if result["status"] == "passed" else "failed"
+    completed_at = dt.datetime.now(dt.timezone.utc)
+    started_at = completed_at - dt.timedelta(seconds=duration)
+    summary = {
+        "schema_version": _SCHEMA_VERSION,
+        "campaign_id": seal_options["campaign_id"],
+        "status": status,
+        "started_at": started_at.isoformat(),
+        "completed_at": completed_at.isoformat(),
+        "counts": {
+            "total": total,
+            "passed": passed,
+            "failed": failures,
+            "skipped": skipped,
+            "errors": errors,
+        },
+        "metrics": {"duration_seconds": duration},
+        "results": [result],
+        "topology": {"hosts": 1, "world_size": 1, "gpu_count": 0},
+        "seed": None,
+        "configuration": configuration,
+    }
+    environment = {
+        "schema_version": _SCHEMA_VERSION,
+        "captured_at": _timestamp(),
+        "hardware": {
+            "host": platform.node(),
+            "platform": platform.platform(),
+            "hosts": 1,
+            "world_size": 1,
+            "gpu_count": 0,
+            "devices": [],
+        },
+        "software": {
+            "python": platform.python_version(),
+            "frameworks": _framework_versions(),
+        },
+        "runner": {
+            "name": os.environ.get("RUNNER_NAME"),
+            "os": os.environ.get("RUNNER_OS"),
+            "arch": os.environ.get("RUNNER_ARCH"),
+        },
+    }
+    _write_json(bundle / "summary.json", summary)
+    _write_json(bundle / "environment.json", environment)
+    (bundle / "commands.txt").write_text(f"[cpu-unit-suite] {command}\n", encoding="utf-8")
+    return seal_bundle(bundle, **seal_options)
+
+
+def _add_seal_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--bundle", type=Path, required=True)
+    parser.add_argument("--campaign-id", required=True)
+    parser.add_argument("--tier", required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--ref", required=True)
+    parser.add_argument("--artifact-name", required=True)
+    parser.add_argument("--artifact-url", required=True)
+    parser.add_argument("--framework", action="append", dest="frameworks", required=True)
+    parser.add_argument("--boundary", action="append", dest="boundaries", required=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    seal_parser = subparsers.add_parser("seal")
+    _add_seal_arguments(seal_parser)
+    verify_parser = subparsers.add_parser("verify")
+    verify_parser.add_argument("--bundle", type=Path, required=True)
+    verify_parser.add_argument("--expected-commit")
+    pytest_parser = subparsers.add_parser("create-pytest")
+    _add_seal_arguments(pytest_parser)
+    pytest_parser.add_argument("--junit", type=Path, required=True)
+    pytest_parser.add_argument("--action-status", required=True)
+    pytest_parser.add_argument("--recorded-command", required=True)
+    pytest_parser.add_argument("--configuration", action="append", default=[])
+    args = parser.parse_args()
+    try:
+        if args.command == "verify":
+            value = verify_bundle(args.bundle, expected_commit=args.expected_commit)
+        else:
+            seal_options = {
+                "campaign_id": args.campaign_id,
+                "tier": args.tier,
+                "repository": args.repository,
+                "commit": args.commit,
+                "ref": args.ref,
+                "artifact_name": args.artifact_name,
+                "artifact_url": args.artifact_url,
+                "frameworks": args.frameworks,
+                "boundaries": args.boundaries,
+            }
+            if args.command == "seal":
+                value = seal_bundle(args.bundle, **seal_options)
+            else:
+                value = create_pytest_bundle(
+                    args.bundle,
+                    junit=args.junit,
+                    action_status=args.action_status,
+                    command=args.recorded_command,
+                    configuration=_parse_assignments(args.configuration),
+                    seal_options=seal_options,
+                )
+    except (OSError, TypeError, ValueError, ET.ParseError) as error:
+        print(f"validation evidence failed: {error}", file=sys.stderr)
+        return 1
+    print(json.dumps(value, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation_evidence.py
+++ b/scripts/validation_evidence.py
@@ -113,8 +113,9 @@ def _validate_summary(summary: Any, campaign_id: str, command_ids: list[str]) ->
     timestamps = []
     for field in ("started_at", "completed_at"):
         timestamp = _require_string(summary[field], f"summary {field}")
+        normalized_timestamp = timestamp[:-1] + "+00:00" if timestamp.endswith("Z") else timestamp
         try:
-            parsed = dt.datetime.fromisoformat(timestamp)
+            parsed = dt.datetime.fromisoformat(normalized_timestamp)
         except ValueError as error:
             raise ValueError(f"summary {field} must be an ISO-8601 timestamp") from error
         if parsed.tzinfo is None:
@@ -147,8 +148,10 @@ def _validate_summary(summary: Any, campaign_id: str, command_ids: list[str]) ->
         result_ids.append(_require_string(result.get("command_id"), "result command_id"))
         if result.get("status") not in {"passed", "failed", "skipped", "error"}:
             raise ValueError("summary result status is invalid")
-    if not set(result_ids).issubset(command_ids):
-        raise ValueError("summary refers to an unknown command ID")
+    if len(result_ids) != len(set(result_ids)):
+        raise ValueError("summary contains duplicate command results")
+    if set(result_ids) != set(command_ids):
+        raise ValueError("summary results must cover every recorded command exactly once")
     topology = summary["topology"]
     if not isinstance(topology, dict):
         raise ValueError("summary topology must be an object")
@@ -201,11 +204,8 @@ def _validate_environment(environment: Any) -> None:
 
 
 def _payload_files(bundle: Path) -> list[Path]:
-    paths = sorted(
-        path
-        for path in bundle.rglob("*")
-        if path.is_file() and path.name not in {"manifest.json", "checksums.txt"}
-    )
+    generated = {bundle / "manifest.json", bundle / "checksums.txt"}
+    paths = sorted(path for path in bundle.rglob("*") if path.is_file() and path not in generated)
     if any(path.is_symlink() for path in paths):
         raise ValueError("evidence payloads must not be symbolic links")
     return paths

--- a/scripts/validation_evidence.py
+++ b/scripts/validation_evidence.py
@@ -15,8 +15,6 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Any
 
-import tomllib
-
 _SCHEMA_VERSION = 1
 _REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 _PAYLOAD_NAMES = {"summary.json", "environment.json", "commands.txt"}
@@ -49,9 +47,21 @@ def _write_json(path: Path, value: object) -> None:
 
 
 def _project() -> tuple[str, str]:
-    with (_REPOSITORY_ROOT / "pyproject.toml").open("rb") as handle:
-        project = tomllib.load(handle)["project"]
-    return project["name"], project["version"]
+    values = {}
+    in_project = False
+    for line in (_REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("["):
+            in_project = stripped == "[project]"
+            continue
+        if not in_project:
+            continue
+        match = re.fullmatch(r'(name|version)\s*=\s*"([^"]+)"', stripped)
+        if match:
+            values[match.group(1)] = match.group(2)
+    if set(values) != {"name", "version"}:
+        raise ValueError("pyproject.toml must define literal project name and version strings")
+    return values["name"], values["version"]
 
 
 def _command_ids(path: Path) -> list[str]:

--- a/tests/unit/test_gpu_qualification.py
+++ b/tests/unit/test_gpu_qualification.py
@@ -29,9 +29,26 @@ def test_gpu_qualification_writes_failure_evidence_without_required_gpus(tmp_pat
         run_gpu_qualification,
         "_environment",
         lambda: {
-            "cuda_available": False,
-            "device_count": 0,
-            "devices": [],
+            "schema_version": 1,
+            "captured_at": "2026-08-14T00:00:00+00:00",
+            "hardware": {
+                "host": "test",
+                "platform": "test",
+                "hosts": 1,
+                "world_size": 2,
+                "gpu_count": 0,
+                "devices": [],
+                "nvidia_smi": {},
+            },
+            "software": {
+                "python": "3.12",
+                "python_executable": sys.executable,
+                "cuda_available": False,
+                "cuda_runtime": None,
+                "nccl": None,
+                "frameworks": {"lm-resiliency": "0.1.0", "pytorch": "2.13.0"},
+            },
+            "runner": {"name": None, "os": None, "arch": None},
         },
     )
     monkeypatch.setattr(
@@ -50,9 +67,19 @@ def test_gpu_qualification_writes_failure_evidence_without_required_gpus(tmp_pat
     summary = json.loads((artifact_dir / "summary.json").read_text())
     assert summary["schema_version"] == 1
     assert summary["status"] == "failed"
-    assert summary["topology"] == {"hosts": 1, "required_gpus": 2, "visible_gpus": 0}
-    assert summary["error"] == "requires at least 2 CUDA GPUs; found 0"
+    assert summary["topology"] == {"hosts": 1, "world_size": 2, "gpu_count": 0}
+    assert summary["counts"] == {
+        "total": 4,
+        "passed": 0,
+        "failed": 0,
+        "skipped": 4,
+        "errors": 0,
+    }
+    assert {result["reason"] for result in summary["results"]} == {
+        "requires at least 2 CUDA GPUs; found 0"
+    }
     assert (artifact_dir / "environment.json").exists()
     assert (artifact_dir / "commands.txt").exists()
     assert (artifact_dir / "summary.md").exists()
+    assert (artifact_dir / "manifest.json").exists()
     assert (artifact_dir / "checksums.txt").exists()

--- a/tests/unit/test_gpu_qualification.py
+++ b/tests/unit/test_gpu_qualification.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 import sys
 
+import pytest
+
 from tests.validation import run_gpu_qualification
 
 
@@ -62,6 +64,8 @@ def test_gpu_qualification_writes_failure_evidence_without_required_gpus(tmp_pat
             "2",
         ],
     )
+    monkeypatch.setenv("GITHUB_SHA", "a" * 40)
+    monkeypatch.setenv("GITHUB_REF", "refs/heads/test")
 
     assert run_gpu_qualification.main() == 1
     summary = json.loads((artifact_dir / "summary.json").read_text())
@@ -83,3 +87,16 @@ def test_gpu_qualification_writes_failure_evidence_without_required_gpus(tmp_pat
     assert (artifact_dir / "summary.md").exists()
     assert (artifact_dir / "manifest.json").exists()
     assert (artifact_dir / "checksums.txt").exists()
+
+
+def test_git_revision_rejects_tracked_worktree_changes(monkeypatch):
+    class Completed:
+        returncode = 0
+        stdout = " M tracked.py\n"
+
+    monkeypatch.setattr(
+        run_gpu_qualification.subprocess, "run", lambda *args, **kwargs: Completed()
+    )
+
+    with pytest.raises(RuntimeError, match="clean tracked worktree"):
+        run_gpu_qualification._git_revision()

--- a/tests/unit/test_validation_evidence.py
+++ b/tests/unit/test_validation_evidence.py
@@ -9,7 +9,7 @@ import pytest
 
 from scripts import validation_evidence
 
-_COMMIT = "0123456789abcdef0123456789abcdef01234567"
+_COMMIT = "0123456789abcdef" * 2 + "01234567"
 
 
 def _write_payload(bundle: Path) -> None:

--- a/tests/unit/test_validation_evidence.py
+++ b/tests/unit/test_validation_evidence.py
@@ -1,0 +1,169 @@
+"""Tests for revision-bound validation evidence bundles."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import validation_evidence
+
+_COMMIT = "0123456789abcdef0123456789abcdef01234567"
+
+
+def _write_payload(bundle: Path) -> None:
+    bundle.mkdir()
+    summary = {
+        "schema_version": 1,
+        "campaign_id": "test-campaign",
+        "status": "passed",
+        "started_at": "2026-08-14T00:00:00+00:00",
+        "completed_at": "2026-08-14T00:01:00+00:00",
+        "counts": {"total": 1, "passed": 1, "failed": 0, "skipped": 0, "errors": 0},
+        "metrics": {"duration_seconds": 60.0},
+        "results": [{"command_id": "smoke", "status": "passed"}],
+        "topology": {"hosts": 1, "world_size": 1, "gpu_count": 0},
+        "seed": 7,
+        "configuration": {"mode": "test"},
+    }
+    environment = {
+        "schema_version": 1,
+        "captured_at": "2026-08-14T00:00:00+00:00",
+        "hardware": {
+            "host": "test",
+            "hosts": 1,
+            "world_size": 1,
+            "gpu_count": 0,
+            "devices": [],
+        },
+        "software": {
+            "python": "3.12.11",
+            "frameworks": {"pytorch": "2.13.0"},
+        },
+        "runner": {"name": "test"},
+    }
+    (bundle / "summary.json").write_text(json.dumps(summary), encoding="utf-8")
+    (bundle / "environment.json").write_text(json.dumps(environment), encoding="utf-8")
+    (bundle / "commands.txt").write_text("[smoke] python -m pytest -q\n", encoding="utf-8")
+    (bundle / "smoke.log").write_text("passed\n", encoding="utf-8")
+
+
+def _seal(bundle: Path) -> dict:
+    return validation_evidence.seal_bundle(
+        bundle,
+        campaign_id="test-campaign",
+        tier="cpu",
+        repository="LMResiliency/lm-resiliency",
+        commit=_COMMIT,
+        ref="refs/heads/main",
+        artifact_name=f"test-campaign-{_COMMIT}",
+        artifact_url="https://github.com/LMResiliency/lm-resiliency/actions/runs/1",
+        frameworks=["pytorch", "scout"],
+        boundaries=["CPU only."],
+    )
+
+
+def test_seal_and_verify_revision_bound_bundle(tmp_path):
+    bundle = tmp_path / "evidence"
+    _write_payload(bundle)
+
+    manifest = _seal(bundle)
+    verified = validation_evidence.verify_bundle(bundle, expected_commit=_COMMIT)
+
+    assert verified == manifest
+    assert manifest["project"]["version"] == "0.1.0"
+    assert manifest["campaign"]["command_ids"] == ["smoke"]
+    assert manifest["qualification"]["boundaries"] == ["CPU only."]
+    assert {record["path"] for record in manifest["files"]} == {
+        "commands.txt",
+        "environment.json",
+        "smoke.log",
+        "summary.json",
+    }
+
+
+def test_verify_rejects_stale_revision(tmp_path):
+    bundle = tmp_path / "evidence"
+    _write_payload(bundle)
+    _seal(bundle)
+
+    with pytest.raises(ValueError, match="validation evidence is stale"):
+        validation_evidence.verify_bundle(bundle, expected_commit="f" * 40)
+
+
+def test_verify_rejects_payload_tampering(tmp_path):
+    bundle = tmp_path / "evidence"
+    _write_payload(bundle)
+    _seal(bundle)
+    (bundle / "smoke.log").write_text("changed\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="payload digest mismatch"):
+        validation_evidence.verify_bundle(bundle)
+
+
+def test_seal_rejects_unidentified_commands(tmp_path):
+    bundle = tmp_path / "evidence"
+    _write_payload(bundle)
+    summary = json.loads((bundle / "summary.json").read_text(encoding="utf-8"))
+    summary["results"][0]["command_id"] = "unknown"
+    (bundle / "summary.json").write_text(json.dumps(summary), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unknown command ID"):
+        _seal(bundle)
+
+
+def test_create_pytest_bundle_records_counts_environment_and_log(tmp_path):
+    junit = tmp_path / "results.xml"
+    junit.write_text(
+        '<testsuites><testsuite tests="3" failures="0" errors="0" skipped="1" '
+        'time="1.25" /></testsuites>',
+        encoding="utf-8",
+    )
+    bundle = tmp_path / "evidence"
+
+    manifest = validation_evidence.create_pytest_bundle(
+        bundle,
+        junit=junit,
+        action_status="success",
+        command="python -m pytest -q --junitxml=/tmp/results.xml",
+        configuration={"python": "3.12", "torch": "2.13.0"},
+        seal_options={
+            "campaign_id": "cpu-unit-primary",
+            "tier": "cpu",
+            "repository": "LMResiliency/lm-resiliency",
+            "commit": _COMMIT,
+            "ref": "refs/heads/main",
+            "artifact_name": f"cpu-primary-{_COMMIT}",
+            "artifact_url": "https://github.com/LMResiliency/lm-resiliency/actions/runs/1",
+            "frameworks": ["pytorch"],
+            "boundaries": ["CPU only."],
+        },
+    )
+
+    summary = json.loads((bundle / "summary.json").read_text(encoding="utf-8"))
+    assert summary["counts"] == {
+        "total": 3,
+        "passed": 2,
+        "failed": 0,
+        "skipped": 1,
+        "errors": 0,
+    }
+    assert summary["results"][0]["log_sha256"]
+    assert manifest["campaign"]["status"] == "passed"
+    validation_evidence.verify_bundle(bundle, expected_commit=_COMMIT)
+
+
+def test_schema_documents_the_executable_manifest_contract():
+    schema_path = validation_evidence._REPOSITORY_ROOT / "validation/evidence-schema-v1.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+
+    assert schema["properties"]["schema_version"] == {"const": 1}
+    assert set(schema["required"]) == {
+        "schema_version",
+        "project",
+        "campaign",
+        "artifact",
+        "qualification",
+        "files",
+    }

--- a/tests/unit/test_validation_evidence.py
+++ b/tests/unit/test_validation_evidence.py
@@ -102,15 +102,47 @@ def test_verify_rejects_payload_tampering(tmp_path):
         validation_evidence.verify_bundle(bundle)
 
 
-def test_seal_rejects_unidentified_commands(tmp_path):
+def test_seal_requires_exactly_one_result_per_recorded_command(tmp_path):
+    bundle = tmp_path / "evidence"
+    _write_payload(bundle)
+    (bundle / "commands.txt").write_text(
+        "[smoke] python -m pytest -q\n[omitted] python omitted.py\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="cover every recorded command exactly once"):
+        _seal(bundle)
+
+
+def test_verify_covers_nested_manifest_and_checksum_payloads(tmp_path):
+    bundle = tmp_path / "evidence"
+    _write_payload(bundle)
+    nested = bundle / "raw"
+    nested.mkdir()
+    nested_manifest = nested / "manifest.json"
+    nested_manifest.write_text('{"raw": true}\n', encoding="utf-8")
+    (nested / "checksums.txt").write_text("raw campaign checksums\n", encoding="utf-8")
+
+    manifest = _seal(bundle)
+
+    assert "raw/manifest.json" in {record["path"] for record in manifest["files"]}
+    assert "raw/checksums.txt" in {record["path"] for record in manifest["files"]}
+    nested_manifest.write_text('{"raw": false}\n', encoding="utf-8")
+    with pytest.raises(ValueError, match="payload digest mismatch"):
+        validation_evidence.verify_bundle(bundle)
+
+
+def test_seal_accepts_utc_z_timestamps_on_every_supported_python(tmp_path):
     bundle = tmp_path / "evidence"
     _write_payload(bundle)
     summary = json.loads((bundle / "summary.json").read_text(encoding="utf-8"))
-    summary["results"][0]["command_id"] = "unknown"
+    summary["started_at"] = "2026-08-14T00:00:00Z"
+    summary["completed_at"] = "2026-08-14T00:01:00Z"
     (bundle / "summary.json").write_text(json.dumps(summary), encoding="utf-8")
 
-    with pytest.raises(ValueError, match="unknown command ID"):
-        _seal(bundle)
+    _seal(bundle)
+
+    validation_evidence.verify_bundle(bundle, expected_commit=_COMMIT)
 
 
 def test_create_pytest_bundle_records_counts_environment_and_log(tmp_path):

--- a/tests/validation/run_gpu_qualification.py
+++ b/tests/validation/run_gpu_qualification.py
@@ -347,6 +347,15 @@ def main() -> int:
 
 
 def _git_revision() -> str:
+    status = subprocess.run(
+        ["git", "status", "--porcelain", "--untracked-files=no"],
+        cwd=_REPOSITORY_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if status.returncode or status.stdout.strip():
+        raise RuntimeError("manual GPU qualification requires a clean tracked worktree")
     completed = subprocess.run(
         ["git", "rev-parse", "HEAD"],
         cwd=_REPOSITORY_ROOT,

--- a/tests/validation/run_gpu_qualification.py
+++ b/tests/validation/run_gpu_qualification.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import hashlib
+import importlib.metadata
 import json
 import os
 import platform
@@ -65,18 +66,28 @@ def _environment() -> dict[str, Any]:
         )
     nccl_version = torch.cuda.nccl.version() if cuda_available else None
     return {
+        "schema_version": _SCHEMA_VERSION,
         "captured_at": _timestamp(),
-        "host": platform.node(),
-        "platform": platform.platform(),
-        "python": sys.version,
-        "python_executable": sys.executable,
-        "torch": torch.__version__,
-        "cuda_available": cuda_available,
-        "cuda_runtime": torch.version.cuda,
-        "nccl": list(nccl_version) if isinstance(nccl_version, tuple) else nccl_version,
-        "device_count": device_count,
-        "devices": devices,
-        "nvidia_smi": _nvidia_smi(),
+        "hardware": {
+            "host": platform.node(),
+            "platform": platform.platform(),
+            "hosts": 1,
+            "world_size": 2,
+            "gpu_count": device_count,
+            "devices": devices,
+            "nvidia_smi": _nvidia_smi(),
+        },
+        "software": {
+            "python": sys.version,
+            "python_executable": sys.executable,
+            "cuda_available": cuda_available,
+            "cuda_runtime": torch.version.cuda,
+            "nccl": list(nccl_version) if isinstance(nccl_version, tuple) else nccl_version,
+            "frameworks": {
+                "lm-resiliency": importlib.metadata.version("lm-resiliency"),
+                "pytorch": torch.__version__,
+            },
+        },
         "runner": {
             "name": os.environ.get("RUNNER_NAME"),
             "os": os.environ.get("RUNNER_OS"),
@@ -158,7 +169,7 @@ def _run_command(
         returncode = process.wait()
     print("::endgroup::", flush=True)
     return {
-        "name": name,
+        "command_id": name,
         "command": command,
         "started_at": started_at,
         "completed_at": _timestamp(),
@@ -182,35 +193,77 @@ def _write_json(path: Path, value: object) -> None:
     path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
-def _write_summary_markdown(path: Path, summary: dict[str, Any]) -> None:
+def _write_summary_markdown(path: Path, summary: dict[str, Any], commit_sha: str) -> None:
     lines = [
         "## GPU qualification",
         "",
         f"- Status: **{summary['status']}**",
-        f"- Commit: `{summary['commit_sha']}`",
+        f"- Commit: `{commit_sha}`",
         f"- Completed: `{summary['completed_at']}`",
         f"- Topology: `{summary['topology']['hosts']} host / "
-        f"{summary['topology']['visible_gpus']} visible GPUs`",
+        f"{summary['topology']['gpu_count']} visible GPUs`",
         "",
         "| Check | Result | Duration |",
         "|---|---|---:|",
     ]
     for result in summary["results"]:
         lines.append(
-            f"| `{result['name']}` | {result['status']} | {result['duration_seconds']:.3f}s |"
+            f"| `{result['command_id']}` | {result['status']} | "
+            f"{result.get('duration_seconds', 0.0):.3f}s |"
         )
-    if summary.get("error"):
-        lines.extend(["", f"Error: `{summary['error']}`"])
+    reasons = [result.get("reason") for result in summary["results"] if result.get("reason")]
+    if reasons:
+        lines.extend(["", f"Error: `{reasons[0]}`"])
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
-def _write_checksums(artifact_dir: Path) -> None:
-    lines = []
-    for path in sorted(item for item in artifact_dir.rglob("*") if item.is_file()):
-        if path.name == "checksums.txt":
-            continue
-        lines.append(f"{_sha256(path)}  {path.relative_to(artifact_dir)}")
-    (artifact_dir / "checksums.txt").write_text("\n".join(lines) + "\n", encoding="utf-8")
+def _seal_evidence(
+    artifact_dir: Path,
+    summary: dict[str, Any],
+    *,
+    commit_sha: str,
+    ref: str,
+) -> None:
+    repository = os.environ.get("GITHUB_REPOSITORY", "LMResiliency/lm-resiliency")
+    run_id = os.environ.get("GITHUB_RUN_ID")
+    artifact_name = f"gpu-qualification-{commit_sha}"
+    artifact_url = (
+        f"https://github.com/{repository}/actions/runs/{run_id}" if run_id else str(artifact_dir)
+    )
+    command = [
+        sys.executable,
+        str(_REPOSITORY_ROOT / "scripts" / "validation_evidence.py"),
+        "seal",
+        "--bundle",
+        str(artifact_dir),
+        "--campaign-id",
+        "core-gpu-qualification",
+        "--tier",
+        "single-host-gpu",
+        "--repository",
+        repository,
+        "--commit",
+        commit_sha,
+        "--ref",
+        ref,
+        "--artifact-name",
+        artifact_name,
+        "--artifact-url",
+        artifact_url,
+        "--framework",
+        "pytorch",
+        "--framework",
+        "gemini",
+        "--framework",
+        "scout",
+        "--boundary",
+        "One host and two ranks; multi-host transport is not qualified.",
+        "--boundary",
+        "Tiny deterministic workloads qualify recovery and localization, not convergence.",
+    ]
+    completed = subprocess.run(command, cwd=_REPOSITORY_ROOT, check=False)
+    if completed.returncode:
+        raise RuntimeError("failed to seal GPU qualification evidence")
 
 
 def main() -> int:
@@ -228,31 +281,36 @@ def main() -> int:
 
     command_specs = _commands(artifact_dir)
     (artifact_dir / "commands.txt").write_text(
-        "\n".join(shlex.join(command) for _, command in command_specs) + "\n",
+        "\n".join(f"[{name}] {shlex.join(command)}" for name, command in command_specs) + "\n",
         encoding="utf-8",
     )
+    commit_sha = os.environ.get("GITHUB_SHA") or _git_revision()
+    ref = os.environ.get("GITHUB_REF") or _git_ref()
     summary: dict[str, Any] = {
         "schema_version": _SCHEMA_VERSION,
-        "repository": os.environ.get("GITHUB_REPOSITORY"),
-        "commit_sha": os.environ.get("GITHUB_SHA") or _git_revision(),
-        "ref": os.environ.get("GITHUB_REF"),
-        "event": os.environ.get("GITHUB_EVENT_NAME"),
+        "campaign_id": "core-gpu-qualification",
         "started_at": _timestamp(),
         "completed_at": None,
         "status": "running",
         "topology": {
             "hosts": 1,
-            "required_gpus": args.minimum_gpus,
-            "visible_gpus": environment["device_count"],
+            "world_size": 2,
+            "gpu_count": environment["hardware"]["gpu_count"],
         },
+        "seed": None,
+        "configuration": {"minimum_gpus": args.minimum_gpus},
+        "counts": {"total": 0, "passed": 0, "failed": 0, "skipped": 0, "errors": 0},
+        "metrics": {},
         "results": [],
     }
 
-    if not environment["cuda_available"] or environment["device_count"] < args.minimum_gpus:
+    gpu_count = environment["hardware"]["gpu_count"]
+    if not environment["software"]["cuda_available"] or gpu_count < args.minimum_gpus:
         summary["status"] = "failed"
-        summary["error"] = (
-            f"requires at least {args.minimum_gpus} CUDA GPUs; found {environment['device_count']}"
-        )
+        reason = f"requires at least {args.minimum_gpus} CUDA GPUs; found {gpu_count}"
+        summary["results"] = [
+            {"command_id": name, "status": "skipped", "reason": reason} for name, _ in command_specs
+        ]
     else:
         command_environment = os.environ.copy()
         root = str(_REPOSITORY_ROOT)
@@ -270,13 +328,25 @@ def main() -> int:
         )
 
     summary["completed_at"] = _timestamp()
+    summary["counts"] = {
+        "total": len(summary["results"]),
+        "passed": sum(result["status"] == "passed" for result in summary["results"]),
+        "failed": sum(result["status"] == "failed" for result in summary["results"]),
+        "skipped": sum(result["status"] == "skipped" for result in summary["results"]),
+        "errors": sum(result["status"] == "error" for result in summary["results"]),
+    }
+    summary["metrics"] = {
+        "duration_seconds": round(
+            sum(result.get("duration_seconds", 0.0) for result in summary["results"]), 3
+        )
+    }
     _write_json(artifact_dir / "summary.json", summary)
-    _write_summary_markdown(artifact_dir / "summary.md", summary)
-    _write_checksums(artifact_dir)
+    _write_summary_markdown(artifact_dir / "summary.md", summary, commit_sha)
+    _seal_evidence(artifact_dir, summary, commit_sha=commit_sha, ref=ref)
     return 0 if summary["status"] == "passed" else 1
 
 
-def _git_revision() -> str | None:
+def _git_revision() -> str:
     completed = subprocess.run(
         ["git", "rev-parse", "HEAD"],
         cwd=_REPOSITORY_ROOT,
@@ -284,7 +354,21 @@ def _git_revision() -> str | None:
         capture_output=True,
         text=True,
     )
-    return completed.stdout.strip() if completed.returncode == 0 else None
+    revision = completed.stdout.strip()
+    if completed.returncode or not revision:
+        raise RuntimeError("could not determine the repository revision")
+    return revision
+
+
+def _git_ref() -> str:
+    completed = subprocess.run(
+        ["git", "symbolic-ref", "--short", "HEAD"],
+        cwd=_REPOSITORY_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip() if completed.returncode == 0 else "detached"
 
 
 if __name__ == "__main__":

--- a/validation/README.md
+++ b/validation/README.md
@@ -1,0 +1,44 @@
+# Validation Evidence
+
+Every published qualification bundle uses the versioned
+[`evidence-schema-v1.json`](evidence-schema-v1.json) contract:
+
+```text
+<campaign>/
+  manifest.json
+  summary.json
+  environment.json
+  commands.txt
+  checksums.txt
+  <logs and raw results>
+```
+
+`manifest.json` binds the campaign to a full Git commit, package version, ref, tier,
+command IDs, seed and configuration, framework scope, hardware topology, artifact
+location, qualification boundaries, and every payload digest. `summary.json` records
+aggregate counts, metrics, and per-command results. `environment.json` records the
+runner hardware and software versions. `commands.txt` is the exact replayable command
+inventory. `checksums.txt` covers the manifest and every payload file.
+
+The executable schema validator intentionally uses only the Python standard library:
+
+```bash
+python scripts/validation_evidence.py verify \
+  --bundle /path/to/evidence \
+  --expected-commit "$(git rev-parse HEAD)"
+```
+
+The `--expected-commit` check fails with an explicit `validation evidence is stale`
+message whenever a bundle covers another revision. A green result is current only when
+that comparison succeeds. The artifact name includes the same full commit SHA, and its
+manifest links back to the immutable workflow run that produced it.
+
+The primary CPU matrix and trusted single-host GPU workflow currently publish sealed
+bundles. Use `seal` for single-GPU, multi-host, TorchTitan, Megatron Core, DeepSpeed,
+GEMINI, SCOUT, or MoE campaigns by first producing the three payload files. Record each
+framework actually exercised and state topology and coverage limitations as explicit
+`--boundary` values. Large logs may remain in the workflow or release artifact; their
+path, size, and digest must still appear in the bundle manifest.
+
+Do not copy a passing status between revisions. Re-run the campaign and publish a new
+SHA-named bundle instead.

--- a/validation/evidence-schema-v1.json
+++ b/validation/evidence-schema-v1.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/LMResiliency/lm-resiliency/blob/main/validation/evidence-schema-v1.json",
+  "title": "LM Resiliency validation evidence manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "project",
+    "campaign",
+    "artifact",
+    "qualification",
+    "files"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "project": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version", "repository", "commit_sha", "ref"],
+      "properties": {
+        "name": { "const": "lm-resiliency" },
+        "version": { "type": "string", "minLength": 1 },
+        "repository": { "type": "string", "minLength": 1 },
+        "commit_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "ref": { "type": "string", "minLength": 1 }
+      }
+    },
+    "campaign": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "tier",
+        "status",
+        "started_at",
+        "completed_at",
+        "command_ids",
+        "seed",
+        "configuration"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "tier": { "type": "string", "minLength": 1 },
+        "status": { "enum": ["passed", "failed", "cancelled"] },
+        "started_at": { "type": "string", "minLength": 1 },
+        "completed_at": { "type": "string", "minLength": 1 },
+        "command_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[a-z0-9][a-z0-9._-]*$" }
+        },
+        "seed": { "type": ["integer", "null"] },
+        "configuration": { "type": "object" }
+      }
+    },
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "url"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "url": { "type": "string", "minLength": 1 }
+      }
+    },
+    "qualification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["frameworks", "topology", "boundaries"],
+      "properties": {
+        "frameworks": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "topology": {
+          "type": "object",
+          "required": ["hosts", "world_size", "gpu_count"],
+          "properties": {
+            "hosts": { "type": "integer", "minimum": 0 },
+            "world_size": { "type": "integer", "minimum": 0 },
+            "gpu_count": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "boundaries": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "files": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "bytes", "sha256"],
+        "properties": {
+          "path": { "type": "string", "minLength": 1 },
+          "bytes": { "type": "integer", "minimum": 0 },
+          "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #24.

## What changed

- add a versioned machine-readable validation-evidence schema and standard-library sealing/verifying tool
- bind every bundle to the exact Git commit, package version, ref, campaign configuration, topology, frameworks, artifact location, qualification boundaries, and payload digests
- publish and verify SHA-named evidence from the primary CPU matrix and trusted GPU qualification workflow
- distinguish the unsealed 2026-08-13 measurements as historical and document explicit stale-revision verification

## Impact

Consumers can mechanically reproduce commands, validate artifact and log integrity, and reject a passing result once the expected revision advances. The schema supports CPU, GPU, multi-host, framework, GEMINI, SCOUT, and MoE campaign bundles without requiring a new runtime dependency.

## Validation

- `ruff check .`
- `ruff format --check .`
- `pre-commit run --all-files`
- `pytest -q tests/unit/test_validation_evidence.py tests/unit/test_gpu_qualification.py` (8 passed)
- CPU evidence CLI create/verify round trip (6-test JUnit fixture)
- full CPU suite: 735 passed; 40 pre-existing sandbox-only failures because POSIX shared memory is denied in this environment