### PR TITLE
[Feature][Torchrun] Add coordinator lease fencing

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -865,9 +865,12 @@ token and fail closed when it is stale.
 Lease time comes from one authoritative, nondecreasing control-plane clock
 shared by all contenders. A clock that moves backward aborts lease operations.
 Expiry is inclusive: at `expires_at_unix_ms` the old holder may no longer renew,
-and a contender may take over. Retrying acquisition with the same active
-`coordinator_id` is idempotent, so the ID must uniquely identify one live
-process incarnation and must not be reused after process restart.
+and a contender may take over. Renewal uses a deadline-guarded compare-and-set
+whose time predicate is evaluated atomically by that authoritative store; a
+client-side precheck alone cannot resurrect a lease after network delay.
+Retrying acquisition with the same active `coordinator_id` is idempotent, so
+the ID must uniquely identify one live process incarnation and must not be
+reused after process restart.
 
 ### Slot-aware rendezvous
 

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -864,15 +864,21 @@ token and fail closed when it is stale.
 
 Lease time comes from one authoritative, nondecreasing control-plane clock
 shared by all contenders. A clock that moves backward aborts lease operations.
+Every lease mutation atomically requires store time to be no earlier than the
+coordinator's observation, preventing a client-side timestamp from committing
+future-dated ownership after a backward clock step.
 Expiry is inclusive: at `expires_at_unix_ms` the old holder may no longer renew,
 and a contender may take over. Renewal uses a deadline-guarded compare-and-set
 whose time predicate is evaluated atomically by that authoritative store; a
 client-side precheck alone cannot resurrect a lease after network delay.
 Initial acquisition and expired-lease takeover use the same atomic guard
 against the candidate lease's new expiry, so store latency cannot commit and
-return an already-expired ownership record. Retrying acquisition with the same
-active `coordinator_id` is idempotent, so the ID must uniquely identify one live
-process incarnation and must not be reused after process restart.
+return an already-expired ownership record. Takeover uses a single store-time
+sample and is valid only in the half-open interval from the old lease's expiry
+through the candidate lease's expiry. Retrying acquisition with the same active
+`coordinator_id` revalidates the existing record at store time and preserves its
+lease ID, so the coordinator ID must uniquely identify one live process
+incarnation and must not be reused after process restart.
 
 ### Slot-aware rendezvous
 

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -854,6 +854,21 @@ mistake a recreated record for an older value with identical bytes. Higher
 coordinator records add lease fencing and run/schema namespaces in subsequent
 layers rather than weakening this storage primitive.
 
+Coordinator ownership is stored under a schema-versioned, run-scoped lease key.
+The lease record binds the run, a unique coordinator-process incarnation, a
+unique lease acquisition, and its acquisition and expiry times. The record's
+control-store revision is the fencing token; acquisition, renewal, expiry
+takeover, release, and reacquisition therefore always produce a newer token.
+Every later authoritative coordinator mutation must carry the currently held
+token and fail closed when it is stale.
+
+Lease time comes from one authoritative, nondecreasing control-plane clock
+shared by all contenders. A clock that moves backward aborts lease operations.
+Expiry is inclusive: at `expires_at_unix_ms` the old holder may no longer renew,
+and a contender may take over. Retrying acquisition with the same active
+`coordinator_id` is idempotent, so the ID must uniquely identify one live
+process incarnation and must not be reused after process restart.
+
 ### Slot-aware rendezvous
 
 `SlotAwareRendezvousHandler` implements the existing `RendezvousHandler`

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -868,9 +868,11 @@ Expiry is inclusive: at `expires_at_unix_ms` the old holder may no longer renew,
 and a contender may take over. Renewal uses a deadline-guarded compare-and-set
 whose time predicate is evaluated atomically by that authoritative store; a
 client-side precheck alone cannot resurrect a lease after network delay.
-Retrying acquisition with the same active `coordinator_id` is idempotent, so
-the ID must uniquely identify one live process incarnation and must not be
-reused after process restart.
+Initial acquisition and expired-lease takeover use the same atomic guard
+against the candidate lease's new expiry, so store latency cannot commit and
+return an already-expired ownership record. Retrying acquisition with the same
+active `coordinator_id` is idempotent, so the ID must uniquely identify one live
+process incarnation and must not be reused after process restart.
 
 ### Slot-aware rendezvous
 

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -856,29 +856,33 @@ layers rather than weakening this storage primitive.
 
 Coordinator ownership is stored under a schema-versioned, run-scoped lease key.
 The lease record binds the run, a unique coordinator-process incarnation, a
-unique lease acquisition, and its acquisition and expiry times. The record's
-control-store revision is the fencing token; acquisition, renewal, expiry
-takeover, release, and reacquisition therefore always produce a newer token.
-Every later authoritative coordinator mutation must carry the currently held
-token and fail closed when it is stale.
+unique lease acquisition, and the lease duration. The control store attaches
+its authoritative commit time to every timed mutation. A held lease expires at
+that commit time plus the persisted duration, so network delay before the CAS
+cannot consume the granted lifetime. The record's control-store revision is the
+fencing token; acquisition, renewal, expiry takeover, release, and reacquisition
+therefore always produce a newer token. Every later authoritative coordinator
+mutation must carry the currently held token and fail closed when it is stale.
 
 Lease time comes from one authoritative, nondecreasing control-plane clock
 shared by all contenders. A clock that moves backward aborts lease operations.
 Every lease mutation atomically requires store time to be no earlier than the
 coordinator's observation, preventing a client-side timestamp from committing
-future-dated ownership after a backward clock step.
+future-dated ownership after a backward clock step. The client also rejects an
+acquisition or renewal response if the commit-time-derived lease expired while
+the response was in flight.
 Expiry is inclusive: at `expires_at_unix_ms` the old holder may no longer renew,
 and a contender may take over. Renewal uses a deadline-guarded compare-and-set
 whose time predicate is evaluated atomically by that authoritative store; a
 client-side precheck alone cannot resurrect a lease after network delay.
-Initial acquisition and expired-lease takeover use the same atomic guard
-against the candidate lease's new expiry, so store latency cannot commit and
-return an already-expired ownership record. Takeover uses a single store-time
-sample and is valid only in the half-open interval from the old lease's expiry
-through the candidate lease's expiry. Retrying acquisition with the same active
-`coordinator_id` revalidates the existing record at store time and preserves its
-lease ID, so the coordinator ID must uniquely identify one live process
-incarnation and must not be reused after process restart.
+Takeover uses one store-time sample and is permitted only after the old lease's
+derived expiry; the replacement then receives a full duration from that commit
+time. Release uses the same guarded store-time window and cannot delete an
+expired lease or mutate ownership after a clock regression. Retrying acquisition
+with the same active `coordinator_id` revalidates and renews the existing record
+at store time while preserving its lease ID, so the coordinator ID must uniquely
+identify one live process incarnation and must not be reused after process
+restart.
 
 ### Slot-aware rendezvous
 

--- a/lm_resiliency/integrations/torchrun/_control_store.py
+++ b/lm_resiliency/integrations/torchrun/_control_store.py
@@ -88,11 +88,11 @@ class ControlStore(Protocol):
         self,
         key: str,
         *,
-        expected_revision: int,
+        expected_revision: int | None,
         deadline_unix_ms: int,
         value: bytes,
     ) -> ControlStoreEntry:
-        """Replace ``key`` only when its revision matches before the store deadline."""
+        """Create or replace ``key`` when its revision matches before the deadline."""
         ...
 
 
@@ -137,12 +137,12 @@ class InMemoryControlStore:
         self,
         key: str,
         *,
-        expected_revision: int,
+        expected_revision: int | None,
         deadline_unix_ms: int,
         value: bytes,
     ) -> ControlStoreEntry:
         normalized_key = _control_key(key)
-        normalized_revision = _required_revision(expected_revision)
+        normalized_revision = _expected_revision(expected_revision, allow_absent=True)
         normalized_deadline = _positive_integer(
             deadline_unix_ms,
             "deadline_unix_ms",

--- a/lm_resiliency/integrations/torchrun/_control_store.py
+++ b/lm_resiliency/integrations/torchrun/_control_store.py
@@ -67,10 +67,20 @@ class ControlStoreEntry:
 
     value: bytes
     revision: int
+    committed_at_unix_ms: int | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "value", _control_value(self.value))
         object.__setattr__(self, "revision", _required_revision(self.revision))
+        if self.committed_at_unix_ms is not None:
+            object.__setattr__(
+                self,
+                "committed_at_unix_ms",
+                _positive_integer(
+                    self.committed_at_unix_ms,
+                    "committed_at_unix_ms",
+                ),
+            )
 
 
 class ControlStore(Protocol):
@@ -97,27 +107,31 @@ class ControlStore(Protocol):
         """Delete ``key`` when its revision matches and return the tombstone revision."""
         ...
 
-    def compare_set_before(
-        self,
-        key: str,
-        *,
-        expected_revision: int | None,
-        deadline_unix_ms: int,
-        value: bytes,
-    ) -> ControlStoreEntry:
-        """Create or replace ``key`` when its revision matches before the deadline."""
-        ...
-
     def compare_set_in_window(
         self,
         key: str,
         *,
         expected_revision: int | None,
         not_before_unix_ms: int,
-        deadline_unix_ms: int,
+        deadline_unix_ms: int | None,
         value: bytes,
     ) -> ControlStoreEntry:
-        """Create or replace ``key`` within an inclusive-start, exclusive-end window."""
+        """Create or replace ``key`` in a store-time window.
+
+        The start is inclusive. ``deadline_unix_ms=None`` leaves the end
+        unbounded. The returned entry carries the authoritative commit time.
+        """
+        ...
+
+    def compare_delete_in_window(
+        self,
+        key: str,
+        *,
+        expected_revision: int,
+        not_before_unix_ms: int,
+        deadline_unix_ms: int,
+    ) -> int:
+        """Delete ``key`` within an inclusive-start, exclusive-end window."""
         ...
 
 
@@ -158,43 +172,60 @@ class InMemoryControlStore:
             del self._entries[normalized_key]
             return self._next_revision(normalized_key)
 
-    def compare_set_before(
-        self,
-        key: str,
-        *,
-        expected_revision: int | None,
-        deadline_unix_ms: int,
-        value: bytes,
-    ) -> ControlStoreEntry:
-        normalized_key = _control_key(key)
-        normalized_revision = _expected_revision(expected_revision, allow_absent=True)
-        normalized_deadline = _positive_integer(
-            deadline_unix_ms,
-            "deadline_unix_ms",
-        )
-        normalized_value = _control_value(value)
-        with self._lock:
-            self._require_revision(normalized_key, normalized_revision)
-            now_unix_ms = self._store_now_unix_ms()
-            if now_unix_ms >= normalized_deadline:
-                raise ControlStoreDeadlineExceeded(
-                    normalized_key,
-                    normalized_deadline,
-                    now_unix_ms,
-                )
-            return self._set_entry(normalized_key, normalized_value)
-
     def compare_set_in_window(
         self,
         key: str,
         *,
         expected_revision: int | None,
         not_before_unix_ms: int,
-        deadline_unix_ms: int,
+        deadline_unix_ms: int | None,
         value: bytes,
     ) -> ControlStoreEntry:
         normalized_key = _control_key(key)
         normalized_revision = _expected_revision(expected_revision, allow_absent=True)
+        normalized_not_before = _positive_integer(
+            not_before_unix_ms,
+            "not_before_unix_ms",
+        )
+        normalized_deadline = (
+            None
+            if deadline_unix_ms is None
+            else _positive_integer(deadline_unix_ms, "deadline_unix_ms")
+        )
+        if normalized_deadline is not None and normalized_not_before >= normalized_deadline:
+            raise ValueError("not_before_unix_ms must be before deadline_unix_ms")
+        normalized_value = _control_value(value)
+        with self._lock:
+            self._require_revision(normalized_key, normalized_revision)
+            now_unix_ms = self._store_now_unix_ms()
+            if now_unix_ms < normalized_not_before:
+                raise ControlStoreTooEarly(
+                    normalized_key,
+                    normalized_not_before,
+                    now_unix_ms,
+                )
+            if normalized_deadline is not None and now_unix_ms >= normalized_deadline:
+                raise ControlStoreDeadlineExceeded(
+                    normalized_key,
+                    normalized_deadline,
+                    now_unix_ms,
+                )
+            return self._set_entry(
+                normalized_key,
+                normalized_value,
+                committed_at_unix_ms=now_unix_ms,
+            )
+
+    def compare_delete_in_window(
+        self,
+        key: str,
+        *,
+        expected_revision: int,
+        not_before_unix_ms: int,
+        deadline_unix_ms: int,
+    ) -> int:
+        normalized_key = _control_key(key)
+        normalized_revision = _required_revision(expected_revision)
         normalized_not_before = _positive_integer(
             not_before_unix_ms,
             "not_before_unix_ms",
@@ -205,7 +236,6 @@ class InMemoryControlStore:
         )
         if normalized_not_before >= normalized_deadline:
             raise ValueError("not_before_unix_ms must be before deadline_unix_ms")
-        normalized_value = _control_value(value)
         with self._lock:
             self._require_revision(normalized_key, normalized_revision)
             now_unix_ms = self._store_now_unix_ms()
@@ -221,7 +251,8 @@ class InMemoryControlStore:
                     normalized_deadline,
                     now_unix_ms,
                 )
-            return self._set_entry(normalized_key, normalized_value)
+            del self._entries[normalized_key]
+            return self._next_revision(normalized_key)
 
     def _require_revision(self, key: str, expected_revision: int | None) -> None:
         entry = self._entries.get(key)
@@ -229,9 +260,19 @@ class InMemoryControlStore:
         if actual_revision != expected_revision:
             raise ControlStoreConflict(key, expected_revision, actual_revision)
 
-    def _set_entry(self, key: str, value: bytes) -> ControlStoreEntry:
+    def _set_entry(
+        self,
+        key: str,
+        value: bytes,
+        *,
+        committed_at_unix_ms: int | None = None,
+    ) -> ControlStoreEntry:
         revision = self._next_revision(key)
-        entry = ControlStoreEntry(value=value, revision=revision)
+        entry = ControlStoreEntry(
+            value=value,
+            revision=revision,
+            committed_at_unix_ms=committed_at_unix_ms,
+        )
         self._entries[key] = entry
         return entry
 
@@ -289,6 +330,6 @@ __all__ = [
     "ControlStoreDeadlineExceeded",
     "ControlStoreEntry",
     "ControlStoreError",
-    "InMemoryControlStore",
     "ControlStoreTooEarly",
+    "InMemoryControlStore",
 ]

--- a/lm_resiliency/integrations/torchrun/_control_store.py
+++ b/lm_resiliency/integrations/torchrun/_control_store.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import threading
+import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -27,6 +29,23 @@ class ControlStoreConflict(ControlStoreError):
             f"control-store conflict for {key!r}: expected revision "
             f"{expected_revision!r}, found {actual_revision!r}"
         )
+
+
+class ControlStoreDeadlineExceeded(ControlStoreError):
+    """Raised when a conditional mutation reaches its store-side deadline."""
+
+    def __init__(self, key: str, deadline_unix_ms: int, observed_unix_ms: int) -> None:
+        self.key = key
+        self.deadline_unix_ms = deadline_unix_ms
+        self.observed_unix_ms = observed_unix_ms
+        super().__init__(
+            f"control-store deadline for {key!r} elapsed at {observed_unix_ms}; "
+            f"deadline was {deadline_unix_ms}"
+        )
+
+
+class ControlStoreClockError(ControlStoreError):
+    """Raised when the authoritative store clock moves backward."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -65,14 +84,27 @@ class ControlStore(Protocol):
         """Delete ``key`` when its revision matches and return the tombstone revision."""
         ...
 
+    def compare_set_before(
+        self,
+        key: str,
+        *,
+        expected_revision: int,
+        deadline_unix_ms: int,
+        value: bytes,
+    ) -> ControlStoreEntry:
+        """Replace ``key`` only when its revision matches before the store deadline."""
+        ...
+
 
 class InMemoryControlStore:
     """Thread-safe in-memory implementation used by coordinator contract tests."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, clock: Callable[[], int] | None = None) -> None:
         self._lock = threading.RLock()
         self._entries: dict[str, ControlStoreEntry] = {}
         self._last_revisions: dict[str, int] = {}
+        self._clock = clock or _system_unix_ms
+        self._last_now_unix_ms = 0
 
     def get(self, key: str) -> ControlStoreEntry | None:
         normalized_key = _control_key(key)
@@ -91,10 +123,7 @@ class InMemoryControlStore:
         normalized_value = _control_value(value)
         with self._lock:
             self._require_revision(normalized_key, normalized_revision)
-            revision = self._next_revision(normalized_key)
-            entry = ControlStoreEntry(value=normalized_value, revision=revision)
-            self._entries[normalized_key] = entry
-            return entry
+            return self._set_entry(normalized_key, normalized_value)
 
     def compare_delete(self, key: str, *, expected_revision: int) -> int:
         normalized_key = _control_key(key)
@@ -104,16 +133,55 @@ class InMemoryControlStore:
             del self._entries[normalized_key]
             return self._next_revision(normalized_key)
 
+    def compare_set_before(
+        self,
+        key: str,
+        *,
+        expected_revision: int,
+        deadline_unix_ms: int,
+        value: bytes,
+    ) -> ControlStoreEntry:
+        normalized_key = _control_key(key)
+        normalized_revision = _required_revision(expected_revision)
+        normalized_deadline = _positive_integer(
+            deadline_unix_ms,
+            "deadline_unix_ms",
+        )
+        normalized_value = _control_value(value)
+        with self._lock:
+            self._require_revision(normalized_key, normalized_revision)
+            now_unix_ms = self._store_now_unix_ms()
+            if now_unix_ms >= normalized_deadline:
+                raise ControlStoreDeadlineExceeded(
+                    normalized_key,
+                    normalized_deadline,
+                    now_unix_ms,
+                )
+            return self._set_entry(normalized_key, normalized_value)
+
     def _require_revision(self, key: str, expected_revision: int | None) -> None:
         entry = self._entries.get(key)
         actual_revision = None if entry is None else entry.revision
         if actual_revision != expected_revision:
             raise ControlStoreConflict(key, expected_revision, actual_revision)
 
+    def _set_entry(self, key: str, value: bytes) -> ControlStoreEntry:
+        revision = self._next_revision(key)
+        entry = ControlStoreEntry(value=value, revision=revision)
+        self._entries[key] = entry
+        return entry
+
     def _next_revision(self, key: str) -> int:
         revision = self._last_revisions.get(key, 0) + 1
         self._last_revisions[key] = revision
         return revision
+
+    def _store_now_unix_ms(self) -> int:
+        now_unix_ms = _positive_integer(self._clock(), "control-store clock")
+        if now_unix_ms < self._last_now_unix_ms:
+            raise ControlStoreClockError("authoritative control-store clock moved backward")
+        self._last_now_unix_ms = now_unix_ms
+        return now_unix_ms
 
 
 def _control_key(value: object) -> str:
@@ -140,9 +208,21 @@ def _required_revision(value: object) -> int:
     return value
 
 
+def _positive_integer(value: object, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{path} must be a positive integer")
+    return value
+
+
+def _system_unix_ms() -> int:
+    return time.time_ns() // 1_000_000
+
+
 __all__ = [
     "ControlStore",
+    "ControlStoreClockError",
     "ControlStoreConflict",
+    "ControlStoreDeadlineExceeded",
     "ControlStoreEntry",
     "ControlStoreError",
     "InMemoryControlStore",

--- a/lm_resiliency/integrations/torchrun/_control_store.py
+++ b/lm_resiliency/integrations/torchrun/_control_store.py
@@ -44,6 +44,19 @@ class ControlStoreDeadlineExceeded(ControlStoreError):
         )
 
 
+class ControlStoreTooEarly(ControlStoreError):
+    """Raised when a conditional mutation precedes its store-side start time."""
+
+    def __init__(self, key: str, not_before_unix_ms: int, observed_unix_ms: int) -> None:
+        self.key = key
+        self.not_before_unix_ms = not_before_unix_ms
+        self.observed_unix_ms = observed_unix_ms
+        super().__init__(
+            f"control-store time for {key!r} was {observed_unix_ms}; "
+            f"mutation is not valid before {not_before_unix_ms}"
+        )
+
+
 class ControlStoreClockError(ControlStoreError):
     """Raised when the authoritative store clock moves backward."""
 
@@ -93,6 +106,18 @@ class ControlStore(Protocol):
         value: bytes,
     ) -> ControlStoreEntry:
         """Create or replace ``key`` when its revision matches before the deadline."""
+        ...
+
+    def compare_set_in_window(
+        self,
+        key: str,
+        *,
+        expected_revision: int | None,
+        not_before_unix_ms: int,
+        deadline_unix_ms: int,
+        value: bytes,
+    ) -> ControlStoreEntry:
+        """Create or replace ``key`` within an inclusive-start, exclusive-end window."""
         ...
 
 
@@ -151,6 +176,45 @@ class InMemoryControlStore:
         with self._lock:
             self._require_revision(normalized_key, normalized_revision)
             now_unix_ms = self._store_now_unix_ms()
+            if now_unix_ms >= normalized_deadline:
+                raise ControlStoreDeadlineExceeded(
+                    normalized_key,
+                    normalized_deadline,
+                    now_unix_ms,
+                )
+            return self._set_entry(normalized_key, normalized_value)
+
+    def compare_set_in_window(
+        self,
+        key: str,
+        *,
+        expected_revision: int | None,
+        not_before_unix_ms: int,
+        deadline_unix_ms: int,
+        value: bytes,
+    ) -> ControlStoreEntry:
+        normalized_key = _control_key(key)
+        normalized_revision = _expected_revision(expected_revision, allow_absent=True)
+        normalized_not_before = _positive_integer(
+            not_before_unix_ms,
+            "not_before_unix_ms",
+        )
+        normalized_deadline = _positive_integer(
+            deadline_unix_ms,
+            "deadline_unix_ms",
+        )
+        if normalized_not_before >= normalized_deadline:
+            raise ValueError("not_before_unix_ms must be before deadline_unix_ms")
+        normalized_value = _control_value(value)
+        with self._lock:
+            self._require_revision(normalized_key, normalized_revision)
+            now_unix_ms = self._store_now_unix_ms()
+            if now_unix_ms < normalized_not_before:
+                raise ControlStoreTooEarly(
+                    normalized_key,
+                    normalized_not_before,
+                    now_unix_ms,
+                )
             if now_unix_ms >= normalized_deadline:
                 raise ControlStoreDeadlineExceeded(
                     normalized_key,
@@ -226,4 +290,5 @@ __all__ = [
     "ControlStoreEntry",
     "ControlStoreError",
     "InMemoryControlStore",
+    "ControlStoreTooEarly",
 ]

--- a/lm_resiliency/integrations/torchrun/_coordinator_lease.py
+++ b/lm_resiliency/integrations/torchrun/_coordinator_lease.py
@@ -229,11 +229,20 @@ class CoordinatorLeaseManager:
                 expires_at_unix_ms=now_unix_ms + self._lease_duration_ms,
             )
             try:
-                entry = self._store.compare_set(
+                entry = self._store.compare_set_before(
                     self._lease_key,
                     expected_revision=expected_revision,
+                    deadline_unix_ms=record.expires_at_unix_ms,
                     value=record.to_json(),
                 )
+            except ControlStoreDeadlineExceeded as error:
+                raise CoordinatorLeaseUnavailable(
+                    "candidate coordinator lease expired at the control store before acquisition"
+                ) from error
+            except ControlStoreClockError as error:
+                raise CoordinatorLeaseClockError(
+                    "authoritative control-store clock moved backward"
+                ) from error
             except ControlStoreConflict:
                 continue
             return HeldCoordinatorLease(

--- a/lm_resiliency/integrations/torchrun/_coordinator_lease.py
+++ b/lm_resiliency/integrations/torchrun/_coordinator_lease.py
@@ -1,0 +1,325 @@
+"""Coordinator lease and fencing records for torchrun resiliency."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+import uuid
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, replace
+from typing import ClassVar
+
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStore,
+    ControlStoreConflict,
+    ControlStoreEntry,
+)
+
+_CONTROL_PREFIX = "lm_resiliency/torchrun/v1"
+_MAX_CAS_ATTEMPTS = 16
+
+
+class CoordinatorLeaseError(RuntimeError):
+    """Base error for coordinator lease operations."""
+
+
+class CoordinatorLeaseUnavailable(CoordinatorLeaseError):
+    """Raised when another coordinator owns the active lease."""
+
+
+class CoordinatorLeaseLost(CoordinatorLeaseError):
+    """Raised when a held lease expired or its fencing token became stale."""
+
+
+class CoordinatorLeaseCorrupt(CoordinatorLeaseError):
+    """Raised when the persisted lease record is malformed or contradictory."""
+
+
+class CoordinatorLeaseClockError(CoordinatorLeaseError):
+    """Raised when the authoritative lease clock moves backward."""
+
+
+@dataclass(frozen=True, slots=True)
+class CoordinatorLeaseRecord:
+    """Persisted ownership record; the store revision is its fencing token."""
+
+    SCHEMA_VERSION: ClassVar[int] = 1
+
+    run_id: str
+    coordinator_id: str
+    lease_id: str
+    acquired_at_unix_ms: int
+    expires_at_unix_ms: int
+
+    def __post_init__(self) -> None:
+        _nonempty_string(self.run_id, "CoordinatorLeaseRecord.run_id")
+        _nonempty_string(
+            self.coordinator_id,
+            "CoordinatorLeaseRecord.coordinator_id",
+        )
+        _nonempty_string(self.lease_id, "CoordinatorLeaseRecord.lease_id")
+        _positive_integer(
+            self.acquired_at_unix_ms,
+            "CoordinatorLeaseRecord.acquired_at_unix_ms",
+        )
+        _positive_integer(
+            self.expires_at_unix_ms,
+            "CoordinatorLeaseRecord.expires_at_unix_ms",
+        )
+        if self.expires_at_unix_ms <= self.acquired_at_unix_ms:
+            raise ValueError("CoordinatorLeaseRecord.expires_at_unix_ms must be after acquisition")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "run_id": self.run_id,
+            "coordinator_id": self.coordinator_id,
+            "lease_id": self.lease_id,
+            "acquired_at_unix_ms": self.acquired_at_unix_ms,
+            "expires_at_unix_ms": self.expires_at_unix_ms,
+        }
+
+    def to_json(self) -> bytes:
+        return json.dumps(
+            self.to_dict(),
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+
+    @classmethod
+    def from_json(cls, encoded: bytes) -> CoordinatorLeaseRecord:
+        if not isinstance(encoded, bytes):
+            raise ValueError("CoordinatorLeaseRecord: expected encoded bytes")
+        try:
+            value = json.loads(encoded)
+        except (TypeError, ValueError) as error:
+            raise ValueError("CoordinatorLeaseRecord: invalid JSON") from error
+        if not isinstance(value, Mapping) or not all(isinstance(key, str) for key in value):
+            raise ValueError("CoordinatorLeaseRecord: expected a JSON object")
+        expected = {
+            "schema_version",
+            "run_id",
+            "coordinator_id",
+            "lease_id",
+            "acquired_at_unix_ms",
+            "expires_at_unix_ms",
+        }
+        missing = expected - set(value)
+        unknown = set(value) - expected
+        if missing:
+            raise ValueError(f"CoordinatorLeaseRecord: missing fields {sorted(missing)!r}")
+        if unknown:
+            raise ValueError(f"CoordinatorLeaseRecord: unknown fields {sorted(unknown)!r}")
+        if (
+            isinstance(value["schema_version"], bool)
+            or not isinstance(value["schema_version"], int)
+            or value["schema_version"] != cls.SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "CoordinatorLeaseRecord.schema_version: unsupported value "
+                f"{value['schema_version']!r}"
+            )
+        return cls(
+            run_id=_nonempty_string(
+                value["run_id"],
+                "CoordinatorLeaseRecord.run_id",
+            ),
+            coordinator_id=_nonempty_string(
+                value["coordinator_id"],
+                "CoordinatorLeaseRecord.coordinator_id",
+            ),
+            lease_id=_nonempty_string(
+                value["lease_id"],
+                "CoordinatorLeaseRecord.lease_id",
+            ),
+            acquired_at_unix_ms=_positive_integer(
+                value["acquired_at_unix_ms"],
+                "CoordinatorLeaseRecord.acquired_at_unix_ms",
+            ),
+            expires_at_unix_ms=_positive_integer(
+                value["expires_at_unix_ms"],
+                "CoordinatorLeaseRecord.expires_at_unix_ms",
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HeldCoordinatorLease:
+    """One observed lease and the revision that fences its mutations."""
+
+    record: CoordinatorLeaseRecord
+    fencing_token: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.record, CoordinatorLeaseRecord):
+            raise TypeError("HeldCoordinatorLease.record must be CoordinatorLeaseRecord")
+        _positive_integer(
+            self.fencing_token,
+            "HeldCoordinatorLease.fencing_token",
+        )
+
+
+class CoordinatorLeaseManager:
+    """Acquire and maintain one run-scoped coordinator lease."""
+
+    def __init__(
+        self,
+        store: ControlStore,
+        *,
+        run_id: str,
+        coordinator_id: str,
+        lease_duration_ms: int,
+        clock: Callable[[], int],
+    ) -> None:
+        self._store = store
+        self._run_id = _nonempty_string(run_id, "run_id")
+        self._coordinator_id = _nonempty_string(
+            coordinator_id,
+            "coordinator_id",
+        )
+        self._lease_duration_ms = _positive_integer(
+            lease_duration_ms,
+            "lease_duration_ms",
+        )
+        if not callable(clock):
+            raise TypeError("clock must be callable")
+        self._clock = clock
+        self._clock_lock = threading.Lock()
+        self._last_now_unix_ms = 0
+        run_digest = hashlib.sha256(self._run_id.encode("utf-8")).hexdigest()
+        self._lease_key = f"{_CONTROL_PREFIX}/runs/{run_digest}/coordinator-lease"
+
+    @property
+    def lease_key(self) -> str:
+        return self._lease_key
+
+    def current(self) -> HeldCoordinatorLease | None:
+        entry = self._store.get(self._lease_key)
+        if entry is None:
+            return None
+        return self._decode_entry(entry)
+
+    def acquire(self) -> HeldCoordinatorLease:
+        now_unix_ms = self._now_unix_ms()
+        for _ in range(_MAX_CAS_ATTEMPTS):
+            current = self.current()
+            if current is not None and current.record.expires_at_unix_ms > now_unix_ms:
+                if current.record.coordinator_id == self._coordinator_id:
+                    return current
+                raise CoordinatorLeaseUnavailable(
+                    "coordinator lease is held by "
+                    f"{current.record.coordinator_id!r} until "
+                    f"{current.record.expires_at_unix_ms}"
+                )
+            expected_revision = None if current is None else current.fencing_token
+            record = CoordinatorLeaseRecord(
+                run_id=self._run_id,
+                coordinator_id=self._coordinator_id,
+                lease_id=uuid.uuid4().hex,
+                acquired_at_unix_ms=now_unix_ms,
+                expires_at_unix_ms=now_unix_ms + self._lease_duration_ms,
+            )
+            try:
+                entry = self._store.compare_set(
+                    self._lease_key,
+                    expected_revision=expected_revision,
+                    value=record.to_json(),
+                )
+            except ControlStoreConflict:
+                continue
+            return HeldCoordinatorLease(
+                record=record,
+                fencing_token=entry.revision,
+            )
+        raise CoordinatorLeaseUnavailable("coordinator lease changed repeatedly during acquisition")
+
+    def renew(self, lease: HeldCoordinatorLease) -> HeldCoordinatorLease:
+        self._validate_owned_handle(lease)
+        now_unix_ms = self._now_unix_ms()
+        if lease.record.expires_at_unix_ms <= now_unix_ms:
+            raise CoordinatorLeaseLost("coordinator lease expired before renewal")
+        requested_expiry = max(
+            lease.record.expires_at_unix_ms,
+            now_unix_ms + self._lease_duration_ms,
+        )
+        record = replace(
+            lease.record,
+            expires_at_unix_ms=requested_expiry,
+        )
+        try:
+            entry = self._store.compare_set(
+                self._lease_key,
+                expected_revision=lease.fencing_token,
+                value=record.to_json(),
+            )
+        except ControlStoreConflict as error:
+            raise CoordinatorLeaseLost("coordinator lease changed before renewal") from error
+        return HeldCoordinatorLease(
+            record=record,
+            fencing_token=entry.revision,
+        )
+
+    def release(self, lease: HeldCoordinatorLease) -> int:
+        self._validate_owned_handle(lease)
+        try:
+            return self._store.compare_delete(
+                self._lease_key,
+                expected_revision=lease.fencing_token,
+            )
+        except ControlStoreConflict as error:
+            raise CoordinatorLeaseLost("coordinator lease changed before release") from error
+
+    def _decode_entry(self, entry: ControlStoreEntry) -> HeldCoordinatorLease:
+        try:
+            record = CoordinatorLeaseRecord.from_json(entry.value)
+        except (TypeError, ValueError) as error:
+            raise CoordinatorLeaseCorrupt("persisted coordinator lease is malformed") from error
+        if record.run_id != self._run_id:
+            raise CoordinatorLeaseCorrupt("persisted coordinator lease belongs to another run")
+        return HeldCoordinatorLease(
+            record=record,
+            fencing_token=entry.revision,
+        )
+
+    def _validate_owned_handle(self, lease: HeldCoordinatorLease) -> None:
+        if not isinstance(lease, HeldCoordinatorLease):
+            raise TypeError("lease must be HeldCoordinatorLease")
+        if (
+            lease.record.run_id != self._run_id
+            or lease.record.coordinator_id != self._coordinator_id
+        ):
+            raise CoordinatorLeaseLost("coordinator lease handle belongs to another manager")
+
+    def _now_unix_ms(self) -> int:
+        with self._clock_lock:
+            now_unix_ms = _positive_integer(self._clock(), "clock")
+            if now_unix_ms < self._last_now_unix_ms:
+                raise CoordinatorLeaseClockError("coordinator lease clock moved backward")
+            self._last_now_unix_ms = now_unix_ms
+        return now_unix_ms
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+def _positive_integer(value: object, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{path} must be a positive integer")
+    return value
+
+
+__all__ = [
+    "CoordinatorLeaseClockError",
+    "CoordinatorLeaseCorrupt",
+    "CoordinatorLeaseError",
+    "CoordinatorLeaseLost",
+    "CoordinatorLeaseManager",
+    "CoordinatorLeaseRecord",
+    "CoordinatorLeaseUnavailable",
+    "HeldCoordinatorLease",
+]

--- a/lm_resiliency/integrations/torchrun/_coordinator_lease.py
+++ b/lm_resiliency/integrations/torchrun/_coordinator_lease.py
@@ -7,7 +7,7 @@ import json
 import threading
 import uuid
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import ClassVar
 
 from lm_resiliency.integrations.torchrun._control_store import (
@@ -52,8 +52,7 @@ class CoordinatorLeaseRecord:
     run_id: str
     coordinator_id: str
     lease_id: str
-    acquired_at_unix_ms: int
-    expires_at_unix_ms: int
+    lease_duration_ms: int
 
     def __post_init__(self) -> None:
         _nonempty_string(self.run_id, "CoordinatorLeaseRecord.run_id")
@@ -63,15 +62,9 @@ class CoordinatorLeaseRecord:
         )
         _nonempty_string(self.lease_id, "CoordinatorLeaseRecord.lease_id")
         _positive_integer(
-            self.acquired_at_unix_ms,
-            "CoordinatorLeaseRecord.acquired_at_unix_ms",
+            self.lease_duration_ms,
+            "CoordinatorLeaseRecord.lease_duration_ms",
         )
-        _positive_integer(
-            self.expires_at_unix_ms,
-            "CoordinatorLeaseRecord.expires_at_unix_ms",
-        )
-        if self.expires_at_unix_ms <= self.acquired_at_unix_ms:
-            raise ValueError("CoordinatorLeaseRecord.expires_at_unix_ms must be after acquisition")
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -79,8 +72,7 @@ class CoordinatorLeaseRecord:
             "run_id": self.run_id,
             "coordinator_id": self.coordinator_id,
             "lease_id": self.lease_id,
-            "acquired_at_unix_ms": self.acquired_at_unix_ms,
-            "expires_at_unix_ms": self.expires_at_unix_ms,
+            "lease_duration_ms": self.lease_duration_ms,
         }
 
     def to_json(self) -> bytes:
@@ -111,8 +103,7 @@ class CoordinatorLeaseRecord:
             "run_id",
             "coordinator_id",
             "lease_id",
-            "acquired_at_unix_ms",
-            "expires_at_unix_ms",
+            "lease_duration_ms",
         }
         missing = expected - set(value)
         unknown = set(value) - expected
@@ -142,13 +133,9 @@ class CoordinatorLeaseRecord:
                 value["lease_id"],
                 "CoordinatorLeaseRecord.lease_id",
             ),
-            acquired_at_unix_ms=_positive_integer(
-                value["acquired_at_unix_ms"],
-                "CoordinatorLeaseRecord.acquired_at_unix_ms",
-            ),
-            expires_at_unix_ms=_positive_integer(
-                value["expires_at_unix_ms"],
-                "CoordinatorLeaseRecord.expires_at_unix_ms",
+            lease_duration_ms=_positive_integer(
+                value["lease_duration_ms"],
+                "CoordinatorLeaseRecord.lease_duration_ms",
             ),
         )
 
@@ -159,6 +146,7 @@ class HeldCoordinatorLease:
 
     record: CoordinatorLeaseRecord
     fencing_token: int
+    granted_at_unix_ms: int
 
     def __post_init__(self) -> None:
         if not isinstance(self.record, CoordinatorLeaseRecord):
@@ -167,6 +155,14 @@ class HeldCoordinatorLease:
             self.fencing_token,
             "HeldCoordinatorLease.fencing_token",
         )
+        _positive_integer(
+            self.granted_at_unix_ms,
+            "HeldCoordinatorLease.granted_at_unix_ms",
+        )
+
+    @property
+    def expires_at_unix_ms(self) -> int:
+        return self.granted_at_unix_ms + self.record.lease_duration_ms
 
 
 class CoordinatorLeaseManager:
@@ -213,14 +209,14 @@ class CoordinatorLeaseManager:
         now_unix_ms = self._now_unix_ms()
         for _ in range(_MAX_CAS_ATTEMPTS):
             current = self.current()
-            if current is not None and current.record.expires_at_unix_ms > now_unix_ms:
+            if current is not None and current.expires_at_unix_ms > now_unix_ms:
                 if current.record.coordinator_id == self._coordinator_id:
                     try:
                         entry = self._store.compare_set_in_window(
                             self._lease_key,
                             expected_revision=current.fencing_token,
                             not_before_unix_ms=now_unix_ms,
-                            deadline_unix_ms=current.record.expires_at_unix_ms,
+                            deadline_unix_ms=current.expires_at_unix_ms,
                             value=current.record.to_json(),
                         )
                     except ControlStoreDeadlineExceeded as error:
@@ -238,46 +234,29 @@ class CoordinatorLeaseManager:
                         ) from error
                     except ControlStoreConflict:
                         continue
-                    return HeldCoordinatorLease(
-                        record=current.record,
-                        fencing_token=entry.revision,
-                    )
+                    return self._require_live_response(self._decode_entry(entry))
                 raise CoordinatorLeaseUnavailable(
                     "coordinator lease is held by "
                     f"{current.record.coordinator_id!r} until "
-                    f"{current.record.expires_at_unix_ms}"
+                    f"{current.expires_at_unix_ms}"
                 )
             record = CoordinatorLeaseRecord(
                 run_id=self._run_id,
                 coordinator_id=self._coordinator_id,
                 lease_id=uuid.uuid4().hex,
-                acquired_at_unix_ms=now_unix_ms,
-                expires_at_unix_ms=now_unix_ms + self._lease_duration_ms,
+                lease_duration_ms=self._lease_duration_ms,
             )
             try:
-                if current is None:
-                    entry = self._store.compare_set_in_window(
-                        self._lease_key,
-                        expected_revision=None,
-                        not_before_unix_ms=record.acquired_at_unix_ms,
-                        deadline_unix_ms=record.expires_at_unix_ms,
-                        value=record.to_json(),
-                    )
-                else:
-                    entry = self._store.compare_set_in_window(
-                        self._lease_key,
-                        expected_revision=current.fencing_token,
-                        not_before_unix_ms=max(
-                            current.record.expires_at_unix_ms,
-                            record.acquired_at_unix_ms,
-                        ),
-                        deadline_unix_ms=record.expires_at_unix_ms,
-                        value=record.to_json(),
-                    )
-            except ControlStoreDeadlineExceeded as error:
-                raise CoordinatorLeaseUnavailable(
-                    "candidate coordinator lease expired at the control store before acquisition"
-                ) from error
+                entry = self._store.compare_set_in_window(
+                    self._lease_key,
+                    expected_revision=None if current is None else current.fencing_token,
+                    not_before_unix_ms=max(
+                        now_unix_ms,
+                        0 if current is None else current.expires_at_unix_ms,
+                    ),
+                    deadline_unix_ms=None,
+                    value=record.to_json(),
+                )
             except ControlStoreTooEarly as error:
                 raise CoordinatorLeaseClockError(
                     "control-store time precedes the coordinator acquisition observation "
@@ -289,32 +268,21 @@ class CoordinatorLeaseManager:
                 ) from error
             except ControlStoreConflict:
                 continue
-            return HeldCoordinatorLease(
-                record=record,
-                fencing_token=entry.revision,
-            )
+            return self._require_live_response(self._decode_entry(entry))
         raise CoordinatorLeaseUnavailable("coordinator lease changed repeatedly during acquisition")
 
     def renew(self, lease: HeldCoordinatorLease) -> HeldCoordinatorLease:
         self._validate_owned_handle(lease)
         now_unix_ms = self._now_unix_ms()
-        if lease.record.expires_at_unix_ms <= now_unix_ms:
+        if lease.expires_at_unix_ms <= now_unix_ms:
             raise CoordinatorLeaseLost("coordinator lease expired before renewal")
-        requested_expiry = max(
-            lease.record.expires_at_unix_ms,
-            now_unix_ms + self._lease_duration_ms,
-        )
-        record = replace(
-            lease.record,
-            expires_at_unix_ms=requested_expiry,
-        )
         try:
             entry = self._store.compare_set_in_window(
                 self._lease_key,
                 expected_revision=lease.fencing_token,
                 not_before_unix_ms=now_unix_ms,
-                deadline_unix_ms=lease.record.expires_at_unix_ms,
-                value=record.to_json(),
+                deadline_unix_ms=lease.expires_at_unix_ms,
+                value=lease.record.to_json(),
             )
         except ControlStoreDeadlineExceeded as error:
             raise CoordinatorLeaseLost(
@@ -330,18 +298,37 @@ class CoordinatorLeaseManager:
             ) from error
         except ControlStoreConflict as error:
             raise CoordinatorLeaseLost("coordinator lease changed before renewal") from error
-        return HeldCoordinatorLease(
-            record=record,
-            fencing_token=entry.revision,
-        )
+        try:
+            return self._require_live_response(self._decode_entry(entry))
+        except CoordinatorLeaseUnavailable as error:
+            raise CoordinatorLeaseLost(
+                "renewed coordinator lease expired before the response arrived"
+            ) from error
 
     def release(self, lease: HeldCoordinatorLease) -> int:
         self._validate_owned_handle(lease)
+        now_unix_ms = self._now_unix_ms()
+        if lease.expires_at_unix_ms <= now_unix_ms:
+            raise CoordinatorLeaseLost("coordinator lease expired before release")
         try:
-            return self._store.compare_delete(
+            return self._store.compare_delete_in_window(
                 self._lease_key,
                 expected_revision=lease.fencing_token,
+                not_before_unix_ms=now_unix_ms,
+                deadline_unix_ms=lease.expires_at_unix_ms,
             )
+        except ControlStoreDeadlineExceeded as error:
+            raise CoordinatorLeaseLost(
+                "coordinator lease expired at the control store before release"
+            ) from error
+        except ControlStoreTooEarly as error:
+            raise CoordinatorLeaseClockError(
+                "control-store time precedes the coordinator release observation"
+            ) from error
+        except ControlStoreClockError as error:
+            raise CoordinatorLeaseClockError(
+                "authoritative control-store clock moved backward"
+            ) from error
         except ControlStoreConflict as error:
             raise CoordinatorLeaseLost("coordinator lease changed before release") from error
 
@@ -352,10 +339,27 @@ class CoordinatorLeaseManager:
             raise CoordinatorLeaseCorrupt("persisted coordinator lease is malformed") from error
         if record.run_id != self._run_id:
             raise CoordinatorLeaseCorrupt("persisted coordinator lease belongs to another run")
+        if entry.committed_at_unix_ms is None:
+            raise CoordinatorLeaseCorrupt(
+                "persisted coordinator lease has no authoritative commit time"
+            )
         return HeldCoordinatorLease(
             record=record,
             fencing_token=entry.revision,
+            granted_at_unix_ms=entry.committed_at_unix_ms,
         )
+
+    def _require_live_response(self, lease: HeldCoordinatorLease) -> HeldCoordinatorLease:
+        now_unix_ms = self._now_unix_ms()
+        if now_unix_ms < lease.granted_at_unix_ms:
+            raise CoordinatorLeaseClockError(
+                "coordinator clock precedes the authoritative lease commit time"
+            )
+        if lease.expires_at_unix_ms <= now_unix_ms:
+            raise CoordinatorLeaseUnavailable(
+                "coordinator lease expired before the store response arrived"
+            )
+        return lease
 
     def _validate_owned_handle(self, lease: HeldCoordinatorLease) -> None:
         if not isinstance(lease, HeldCoordinatorLease):

--- a/lm_resiliency/integrations/torchrun/_coordinator_lease.py
+++ b/lm_resiliency/integrations/torchrun/_coordinator_lease.py
@@ -16,6 +16,7 @@ from lm_resiliency.integrations.torchrun._control_store import (
     ControlStoreConflict,
     ControlStoreDeadlineExceeded,
     ControlStoreEntry,
+    ControlStoreTooEarly,
 )
 
 _CONTROL_PREFIX = "lm_resiliency/torchrun/v1"
@@ -214,13 +215,38 @@ class CoordinatorLeaseManager:
             current = self.current()
             if current is not None and current.record.expires_at_unix_ms > now_unix_ms:
                 if current.record.coordinator_id == self._coordinator_id:
-                    return current
+                    try:
+                        entry = self._store.compare_set_in_window(
+                            self._lease_key,
+                            expected_revision=current.fencing_token,
+                            not_before_unix_ms=now_unix_ms,
+                            deadline_unix_ms=current.record.expires_at_unix_ms,
+                            value=current.record.to_json(),
+                        )
+                    except ControlStoreDeadlineExceeded as error:
+                        raise CoordinatorLeaseUnavailable(
+                            "existing coordinator lease expired at the control store "
+                            "during acquisition"
+                        ) from error
+                    except ControlStoreTooEarly as error:
+                        raise CoordinatorLeaseClockError(
+                            "control-store time precedes the coordinator acquisition observation"
+                        ) from error
+                    except ControlStoreClockError as error:
+                        raise CoordinatorLeaseClockError(
+                            "authoritative control-store clock moved backward"
+                        ) from error
+                    except ControlStoreConflict:
+                        continue
+                    return HeldCoordinatorLease(
+                        record=current.record,
+                        fencing_token=entry.revision,
+                    )
                 raise CoordinatorLeaseUnavailable(
                     "coordinator lease is held by "
                     f"{current.record.coordinator_id!r} until "
                     f"{current.record.expires_at_unix_ms}"
                 )
-            expected_revision = None if current is None else current.fencing_token
             record = CoordinatorLeaseRecord(
                 run_id=self._run_id,
                 coordinator_id=self._coordinator_id,
@@ -229,15 +255,33 @@ class CoordinatorLeaseManager:
                 expires_at_unix_ms=now_unix_ms + self._lease_duration_ms,
             )
             try:
-                entry = self._store.compare_set_before(
-                    self._lease_key,
-                    expected_revision=expected_revision,
-                    deadline_unix_ms=record.expires_at_unix_ms,
-                    value=record.to_json(),
-                )
+                if current is None:
+                    entry = self._store.compare_set_in_window(
+                        self._lease_key,
+                        expected_revision=None,
+                        not_before_unix_ms=record.acquired_at_unix_ms,
+                        deadline_unix_ms=record.expires_at_unix_ms,
+                        value=record.to_json(),
+                    )
+                else:
+                    entry = self._store.compare_set_in_window(
+                        self._lease_key,
+                        expected_revision=current.fencing_token,
+                        not_before_unix_ms=max(
+                            current.record.expires_at_unix_ms,
+                            record.acquired_at_unix_ms,
+                        ),
+                        deadline_unix_ms=record.expires_at_unix_ms,
+                        value=record.to_json(),
+                    )
             except ControlStoreDeadlineExceeded as error:
                 raise CoordinatorLeaseUnavailable(
                     "candidate coordinator lease expired at the control store before acquisition"
+                ) from error
+            except ControlStoreTooEarly as error:
+                raise CoordinatorLeaseClockError(
+                    "control-store time precedes the coordinator acquisition observation "
+                    "or existing lease expiry"
                 ) from error
             except ControlStoreClockError as error:
                 raise CoordinatorLeaseClockError(
@@ -265,15 +309,20 @@ class CoordinatorLeaseManager:
             expires_at_unix_ms=requested_expiry,
         )
         try:
-            entry = self._store.compare_set_before(
+            entry = self._store.compare_set_in_window(
                 self._lease_key,
                 expected_revision=lease.fencing_token,
+                not_before_unix_ms=now_unix_ms,
                 deadline_unix_ms=lease.record.expires_at_unix_ms,
                 value=record.to_json(),
             )
         except ControlStoreDeadlineExceeded as error:
             raise CoordinatorLeaseLost(
                 "coordinator lease expired at the control store before renewal"
+            ) from error
+        except ControlStoreTooEarly as error:
+            raise CoordinatorLeaseClockError(
+                "control-store time precedes the coordinator renewal observation"
             ) from error
         except ControlStoreClockError as error:
             raise CoordinatorLeaseClockError(

--- a/lm_resiliency/integrations/torchrun/_coordinator_lease.py
+++ b/lm_resiliency/integrations/torchrun/_coordinator_lease.py
@@ -12,7 +12,9 @@ from typing import ClassVar
 
 from lm_resiliency.integrations.torchrun._control_store import (
     ControlStore,
+    ControlStoreClockError,
     ControlStoreConflict,
+    ControlStoreDeadlineExceeded,
     ControlStoreEntry,
 )
 
@@ -93,7 +95,12 @@ class CoordinatorLeaseRecord:
         if not isinstance(encoded, bytes):
             raise ValueError("CoordinatorLeaseRecord: expected encoded bytes")
         try:
-            value = json.loads(encoded)
+            value = json.loads(
+                encoded,
+                object_pairs_hook=_reject_duplicate_object_fields,
+            )
+        except _DuplicateLeaseField as error:
+            raise ValueError(f"CoordinatorLeaseRecord: {error}") from error
         except (TypeError, ValueError) as error:
             raise ValueError("CoordinatorLeaseRecord: invalid JSON") from error
         if not isinstance(value, Mapping) or not all(isinstance(key, str) for key in value):
@@ -249,11 +256,20 @@ class CoordinatorLeaseManager:
             expires_at_unix_ms=requested_expiry,
         )
         try:
-            entry = self._store.compare_set(
+            entry = self._store.compare_set_before(
                 self._lease_key,
                 expected_revision=lease.fencing_token,
+                deadline_unix_ms=lease.record.expires_at_unix_ms,
                 value=record.to_json(),
             )
+        except ControlStoreDeadlineExceeded as error:
+            raise CoordinatorLeaseLost(
+                "coordinator lease expired at the control store before renewal"
+            ) from error
+        except ControlStoreClockError as error:
+            raise CoordinatorLeaseClockError(
+                "authoritative control-store clock moved backward"
+            ) from error
         except ControlStoreConflict as error:
             raise CoordinatorLeaseLost("coordinator lease changed before renewal") from error
         return HeldCoordinatorLease(
@@ -310,6 +326,21 @@ def _nonempty_string(value: object, path: str) -> str:
 def _positive_integer(value: object, path: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value < 1:
         raise ValueError(f"{path} must be a positive integer")
+    return value
+
+
+class _DuplicateLeaseField(ValueError):
+    pass
+
+
+def _reject_duplicate_object_fields(
+    pairs: list[tuple[str, object]],
+) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            raise _DuplicateLeaseField(f"duplicate field {key!r}")
+        value[key] = item
     return value
 
 

--- a/tests/unit/test_torchrun_control_store.py
+++ b/tests/unit/test_torchrun_control_store.py
@@ -12,6 +12,7 @@ from lm_resiliency.integrations.torchrun._control_store import (
     ControlStoreConflict,
     ControlStoreDeadlineExceeded,
     ControlStoreEntry,
+    ControlStoreTooEarly,
     InMemoryControlStore,
 )
 
@@ -235,6 +236,50 @@ def test_control_store_deadline_guard_rejects_backward_clock():
             expected_revision=updated.revision,
             deadline_unix_ms=200,
             value=b"stale-clock",
+        )
+
+    assert store.get("run/control") == updated
+
+
+def test_control_store_time_window_uses_one_authoritative_sample():
+    clock = ManualClock(100)
+    store = InMemoryControlStore(clock=clock)
+    created = store.compare_set_in_window(
+        "run/control",
+        expected_revision=None,
+        not_before_unix_ms=100,
+        deadline_unix_ms=103,
+        value=b"one",
+    )
+
+    with pytest.raises(ControlStoreTooEarly) as early_error:
+        store.compare_set_in_window(
+            "run/control",
+            expected_revision=created.revision,
+            not_before_unix_ms=101,
+            deadline_unix_ms=103,
+            value=b"early",
+        )
+    assert early_error.value.observed_unix_ms == 100
+    assert store.get("run/control") == created
+
+    clock.now_unix_ms = 101
+    updated = store.compare_set_in_window(
+        "run/control",
+        expected_revision=created.revision,
+        not_before_unix_ms=101,
+        deadline_unix_ms=103,
+        value=b"two",
+    )
+    clock.now_unix_ms = 103
+
+    with pytest.raises(ControlStoreDeadlineExceeded):
+        store.compare_set_in_window(
+            "run/control",
+            expected_revision=updated.revision,
+            not_before_unix_ms=101,
+            deadline_unix_ms=103,
+            value=b"expired",
         )
 
     assert store.get("run/control") == updated

--- a/tests/unit/test_torchrun_control_store.py
+++ b/tests/unit/test_torchrun_control_store.py
@@ -173,74 +173,6 @@ def test_control_store_rejects_mutable_values():
         )
 
 
-def test_control_store_deadline_guard_is_checked_atomically():
-    clock = ManualClock(100)
-    store = InMemoryControlStore(clock=clock)
-    created = store.compare_set_before(
-        "run/control",
-        expected_revision=None,
-        deadline_unix_ms=101,
-        value=b"one",
-    )
-
-    updated = store.compare_set_before(
-        "run/control",
-        expected_revision=created.revision,
-        deadline_unix_ms=101,
-        value=b"two",
-    )
-    clock.now_unix_ms = 101
-
-    with pytest.raises(ControlStoreDeadlineExceeded) as error:
-        store.compare_set_before(
-            "run/control",
-            expected_revision=updated.revision,
-            deadline_unix_ms=101,
-            value=b"expired",
-        )
-
-    assert error.value.observed_unix_ms == 101
-    assert store.get("run/control") == updated
-
-
-def test_control_store_deadline_guard_rejects_expired_create():
-    clock = ManualClock(100)
-    store = InMemoryControlStore(clock=clock)
-
-    with pytest.raises(ControlStoreDeadlineExceeded):
-        store.compare_set_before(
-            "run/control",
-            expected_revision=None,
-            deadline_unix_ms=100,
-            value=b"expired",
-        )
-
-    assert store.get("run/control") is None
-
-
-def test_control_store_deadline_guard_rejects_backward_clock():
-    clock = ManualClock(100)
-    store = InMemoryControlStore(clock=clock)
-    created = store.compare_set("run/control", expected_revision=None, value=b"one")
-    updated = store.compare_set_before(
-        "run/control",
-        expected_revision=created.revision,
-        deadline_unix_ms=200,
-        value=b"two",
-    )
-    clock.now_unix_ms = 99
-
-    with pytest.raises(ControlStoreClockError, match="backward"):
-        store.compare_set_before(
-            "run/control",
-            expected_revision=updated.revision,
-            deadline_unix_ms=200,
-            value=b"stale-clock",
-        )
-
-    assert store.get("run/control") == updated
-
-
 def test_control_store_time_window_uses_one_authoritative_sample():
     clock = ManualClock(100)
     store = InMemoryControlStore(clock=clock)
@@ -248,9 +180,10 @@ def test_control_store_time_window_uses_one_authoritative_sample():
         "run/control",
         expected_revision=None,
         not_before_unix_ms=100,
-        deadline_unix_ms=103,
+        deadline_unix_ms=None,
         value=b"one",
     )
+    assert created.committed_at_unix_ms == 100
 
     with pytest.raises(ControlStoreTooEarly) as early_error:
         store.compare_set_in_window(
@@ -271,6 +204,7 @@ def test_control_store_time_window_uses_one_authoritative_sample():
         deadline_unix_ms=103,
         value=b"two",
     )
+    assert updated.committed_at_unix_ms == 101
     clock.now_unix_ms = 103
 
     with pytest.raises(ControlStoreDeadlineExceeded):
@@ -285,13 +219,81 @@ def test_control_store_time_window_uses_one_authoritative_sample():
     assert store.get("run/control") == updated
 
 
+def test_control_store_time_window_rejects_backward_clock():
+    clock = ManualClock(100)
+    store = InMemoryControlStore(clock=clock)
+    created = store.compare_set_in_window(
+        "run/control",
+        expected_revision=None,
+        not_before_unix_ms=100,
+        deadline_unix_ms=None,
+        value=b"one",
+    )
+    clock.now_unix_ms = 99
+
+    with pytest.raises(ControlStoreClockError, match="backward"):
+        store.compare_set_in_window(
+            "run/control",
+            expected_revision=created.revision,
+            not_before_unix_ms=99,
+            deadline_unix_ms=None,
+            value=b"stale-clock",
+        )
+
+    assert store.get("run/control") == created
+
+
+def test_control_store_guarded_delete_uses_same_time_window():
+    clock = ManualClock(100)
+    store = InMemoryControlStore(clock=clock)
+    created = store.compare_set("run/control", expected_revision=None, value=b"one")
+
+    with pytest.raises(ControlStoreTooEarly):
+        store.compare_delete_in_window(
+            "run/control",
+            expected_revision=created.revision,
+            not_before_unix_ms=101,
+            deadline_unix_ms=103,
+        )
+    clock.now_unix_ms = 102
+    tombstone_revision = store.compare_delete_in_window(
+        "run/control",
+        expected_revision=created.revision,
+        not_before_unix_ms=101,
+        deadline_unix_ms=103,
+    )
+
+    recreated = store.compare_set("run/control", expected_revision=None, value=b"two")
+    clock.now_unix_ms = 103
+    with pytest.raises(ControlStoreDeadlineExceeded):
+        store.compare_delete_in_window(
+            "run/control",
+            expected_revision=recreated.revision,
+            not_before_unix_ms=101,
+            deadline_unix_ms=103,
+        )
+
+    assert tombstone_revision > created.revision
+    assert store.get("run/control") == recreated
+
+
 @pytest.mark.parametrize(
-    ("value", "revision", "error"),
+    ("value", "revision", "committed_at_unix_ms", "error"),
     [
-        (bytearray(b"value"), 1, TypeError),
-        (b"value", 0, ValueError),
+        (bytearray(b"value"), 1, None, TypeError),
+        (b"value", 0, None, ValueError),
+        (b"value", 1, 0, ValueError),
     ],
 )
-def test_control_store_entry_rejects_invalid_backend_values(value, revision, error):
+def test_control_store_entry_rejects_invalid_backend_values(
+    value,
+    revision,
+    committed_at_unix_ms,
+    error,
+):
     with pytest.raises(error):
-        ControlStoreEntry(value=value, revision=revision)
+        ControlStoreEntry(
+            value=value,
+            revision=revision,
+            committed_at_unix_ms=committed_at_unix_ms,
+        )

--- a/tests/unit/test_torchrun_control_store.py
+++ b/tests/unit/test_torchrun_control_store.py
@@ -8,10 +8,20 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 
 from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStoreClockError,
     ControlStoreConflict,
+    ControlStoreDeadlineExceeded,
     ControlStoreEntry,
     InMemoryControlStore,
 )
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int) -> None:
+        self.now_unix_ms = now_unix_ms
+
+    def __call__(self) -> int:
+        return self.now_unix_ms
 
 
 def test_control_store_create_update_delete_and_recreate():
@@ -160,6 +170,54 @@ def test_control_store_rejects_mutable_values():
             expected_revision=None,
             value=bytearray(b"value"),  # type: ignore[arg-type]
         )
+
+
+def test_control_store_deadline_guard_is_checked_atomically():
+    clock = ManualClock(100)
+    store = InMemoryControlStore(clock=clock)
+    created = store.compare_set("run/control", expected_revision=None, value=b"one")
+
+    updated = store.compare_set_before(
+        "run/control",
+        expected_revision=created.revision,
+        deadline_unix_ms=101,
+        value=b"two",
+    )
+    clock.now_unix_ms = 101
+
+    with pytest.raises(ControlStoreDeadlineExceeded) as error:
+        store.compare_set_before(
+            "run/control",
+            expected_revision=updated.revision,
+            deadline_unix_ms=101,
+            value=b"expired",
+        )
+
+    assert error.value.observed_unix_ms == 101
+    assert store.get("run/control") == updated
+
+
+def test_control_store_deadline_guard_rejects_backward_clock():
+    clock = ManualClock(100)
+    store = InMemoryControlStore(clock=clock)
+    created = store.compare_set("run/control", expected_revision=None, value=b"one")
+    updated = store.compare_set_before(
+        "run/control",
+        expected_revision=created.revision,
+        deadline_unix_ms=200,
+        value=b"two",
+    )
+    clock.now_unix_ms = 99
+
+    with pytest.raises(ControlStoreClockError, match="backward"):
+        store.compare_set_before(
+            "run/control",
+            expected_revision=updated.revision,
+            deadline_unix_ms=200,
+            value=b"stale-clock",
+        )
+
+    assert store.get("run/control") == updated
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_torchrun_control_store.py
+++ b/tests/unit/test_torchrun_control_store.py
@@ -175,7 +175,12 @@ def test_control_store_rejects_mutable_values():
 def test_control_store_deadline_guard_is_checked_atomically():
     clock = ManualClock(100)
     store = InMemoryControlStore(clock=clock)
-    created = store.compare_set("run/control", expected_revision=None, value=b"one")
+    created = store.compare_set_before(
+        "run/control",
+        expected_revision=None,
+        deadline_unix_ms=101,
+        value=b"one",
+    )
 
     updated = store.compare_set_before(
         "run/control",
@@ -195,6 +200,21 @@ def test_control_store_deadline_guard_is_checked_atomically():
 
     assert error.value.observed_unix_ms == 101
     assert store.get("run/control") == updated
+
+
+def test_control_store_deadline_guard_rejects_expired_create():
+    clock = ManualClock(100)
+    store = InMemoryControlStore(clock=clock)
+
+    with pytest.raises(ControlStoreDeadlineExceeded):
+        store.compare_set_before(
+            "run/control",
+            expected_revision=None,
+            deadline_unix_ms=100,
+            value=b"expired",
+        )
+
+    assert store.get("run/control") is None
 
 
 def test_control_store_deadline_guard_rejects_backward_clock():

--- a/tests/unit/test_torchrun_coordinator_lease.py
+++ b/tests/unit/test_torchrun_coordinator_lease.py
@@ -38,6 +38,28 @@ class ManualClock:
             self.now_unix_ms += duration_ms
 
 
+class ExpireDuringRenewalStore(InMemoryControlStore):
+    def __init__(self, clock: ManualClock) -> None:
+        super().__init__(clock=clock)
+        self._manual_clock = clock
+
+    def compare_set_before(
+        self,
+        key: str,
+        *,
+        expected_revision: int,
+        deadline_unix_ms: int,
+        value: bytes,
+    ):
+        self._manual_clock.set(deadline_unix_ms)
+        return super().compare_set_before(
+            key,
+            expected_revision=expected_revision,
+            deadline_unix_ms=deadline_unix_ms,
+            value=value,
+        )
+
+
 def _manager(
     store: InMemoryControlStore,
     clock: ManualClock,
@@ -77,10 +99,18 @@ def test_coordinator_lease_record_round_trips_strict_json():
         with pytest.raises(ValueError, match="unsupported"):
             CoordinatorLeaseRecord.from_json(json.dumps(value).encode("utf-8"))
 
+    duplicate_run = (
+        b'{"schema_version":1,"run_id":"run-a","run_id":"run-b",'
+        b'"coordinator_id":"coordinator-a","lease_id":"lease-a",'
+        b'"acquired_at_unix_ms":1000,"expires_at_unix_ms":1100}'
+    )
+    with pytest.raises(ValueError, match="duplicate field 'run_id'"):
+        CoordinatorLeaseRecord.from_json(duplicate_run)
+
 
 def test_coordinator_lease_acquire_is_exclusive_and_idempotent():
-    store = InMemoryControlStore()
     clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
     first = _manager(store, clock, "coordinator-a")
     second = _manager(store, clock, "coordinator-b")
 
@@ -95,8 +125,8 @@ def test_coordinator_lease_acquire_is_exclusive_and_idempotent():
 
 
 def test_coordinator_lease_renewal_advances_fencing_token():
-    store = InMemoryControlStore()
     clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
     manager = _manager(store, clock, "coordinator-a")
     original = manager.acquire()
 
@@ -114,8 +144,8 @@ def test_coordinator_lease_renewal_advances_fencing_token():
 
 
 def test_early_renewal_still_checks_and_advances_fencing_token():
-    store = InMemoryControlStore()
     clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
     manager = _manager(store, clock, "coordinator-a")
     original = manager.acquire()
 
@@ -129,9 +159,22 @@ def test_early_renewal_still_checks_and_advances_fencing_token():
         manager.renew(renewed)
 
 
-def test_expired_lease_takeover_fences_old_coordinator():
-    store = InMemoryControlStore()
+def test_renewal_cannot_commit_after_store_observes_expiry():
     clock = ManualClock()
+    store = ExpireDuringRenewalStore(clock)
+    manager = _manager(store, clock, "coordinator-a")
+    lease = manager.acquire()
+    clock.set(1_050)
+
+    with pytest.raises(CoordinatorLeaseLost, match="expired at the control store"):
+        manager.renew(lease)
+
+    assert manager.current() == lease
+
+
+def test_expired_lease_takeover_fences_old_coordinator():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
     first = _manager(store, clock, "coordinator-a")
     second = _manager(store, clock, "coordinator-b")
     stale = first.acquire()
@@ -149,8 +192,8 @@ def test_expired_lease_takeover_fences_old_coordinator():
 
 
 def test_release_and_reacquire_never_reuses_fencing_token():
-    store = InMemoryControlStore()
     clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
     manager = _manager(store, clock, "coordinator-a")
     original = manager.acquire()
 
@@ -162,8 +205,8 @@ def test_release_and_reacquire_never_reuses_fencing_token():
 
 
 def test_concurrent_coordinator_acquisition_has_one_winner():
-    store = InMemoryControlStore()
     clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
     workers = 8
     barrier = threading.Barrier(workers)
     managers = [_manager(store, clock, f"coordinator-{index}") for index in range(workers)]
@@ -184,8 +227,8 @@ def test_concurrent_coordinator_acquisition_has_one_winner():
 
 
 def test_coordinator_lease_fails_closed_on_corrupt_record():
-    store = InMemoryControlStore()
     clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
     manager = _manager(store, clock, "coordinator-a")
     store.compare_set(
         manager.lease_key,
@@ -200,8 +243,8 @@ def test_coordinator_lease_fails_closed_on_corrupt_record():
 
 
 def test_coordinator_lease_clock_cannot_move_backward():
-    store = InMemoryControlStore()
     clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
     manager = _manager(store, clock, "coordinator-a")
     lease = manager.acquire()
 
@@ -211,8 +254,8 @@ def test_coordinator_lease_clock_cannot_move_backward():
 
 
 def test_coordinator_lease_rejects_handle_from_another_manager():
-    store = InMemoryControlStore()
     clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
     first = _manager(store, clock, "coordinator-a")
     second = _manager(store, clock, "coordinator-b")
     lease = first.acquire()
@@ -224,8 +267,8 @@ def test_coordinator_lease_rejects_handle_from_another_manager():
 
 
 def test_distinct_runs_use_distinct_lease_keys():
-    store = InMemoryControlStore()
     clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
     first = _manager(store, clock, "coordinator-a", run_id="run-a")
     second = _manager(store, clock, "coordinator-b", run_id="run-b")
 

--- a/tests/unit/test_torchrun_coordinator_lease.py
+++ b/tests/unit/test_torchrun_coordinator_lease.py
@@ -1,0 +1,251 @@
+"""Contract tests for the internal torchrun coordinator lease."""
+
+from __future__ import annotations
+
+import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseClockError,
+    CoordinatorLeaseCorrupt,
+    CoordinatorLeaseLost,
+    CoordinatorLeaseManager,
+    CoordinatorLeaseRecord,
+    CoordinatorLeaseUnavailable,
+)
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+    def set(self, now_unix_ms: int) -> None:
+        with self._lock:
+            self.now_unix_ms = now_unix_ms
+
+    def advance(self, duration_ms: int) -> None:
+        with self._lock:
+            self.now_unix_ms += duration_ms
+
+
+def _manager(
+    store: InMemoryControlStore,
+    clock: ManualClock,
+    coordinator_id: str,
+    *,
+    run_id: str = "training-run",
+) -> CoordinatorLeaseManager:
+    return CoordinatorLeaseManager(
+        store,
+        run_id=run_id,
+        coordinator_id=coordinator_id,
+        lease_duration_ms=100,
+        clock=clock,
+    )
+
+
+def test_coordinator_lease_record_round_trips_strict_json():
+    record = CoordinatorLeaseRecord(
+        run_id="training-run",
+        coordinator_id="coordinator-a",
+        lease_id="lease-a",
+        acquired_at_unix_ms=1_000,
+        expires_at_unix_ms=1_100,
+    )
+
+    assert CoordinatorLeaseRecord.from_json(record.to_json()) == record
+    assert json.loads(record.to_json()) == record.to_dict()
+
+    value = record.to_dict()
+    value["unknown"] = True
+    with pytest.raises(ValueError, match="unknown fields"):
+        CoordinatorLeaseRecord.from_json(json.dumps(value).encode("utf-8"))
+
+    for invalid_schema in (2, 1.0, True):
+        value = record.to_dict()
+        value["schema_version"] = invalid_schema
+        with pytest.raises(ValueError, match="unsupported"):
+            CoordinatorLeaseRecord.from_json(json.dumps(value).encode("utf-8"))
+
+
+def test_coordinator_lease_acquire_is_exclusive_and_idempotent():
+    store = InMemoryControlStore()
+    clock = ManualClock()
+    first = _manager(store, clock, "coordinator-a")
+    second = _manager(store, clock, "coordinator-b")
+
+    lease = first.acquire()
+
+    assert first.acquire() == lease
+    assert first.current() == lease
+    assert lease.record.coordinator_id == "coordinator-a"
+    assert lease.record.expires_at_unix_ms == 1_100
+    with pytest.raises(CoordinatorLeaseUnavailable, match="coordinator-a"):
+        second.acquire()
+
+
+def test_coordinator_lease_renewal_advances_fencing_token():
+    store = InMemoryControlStore()
+    clock = ManualClock()
+    manager = _manager(store, clock, "coordinator-a")
+    original = manager.acquire()
+
+    clock.advance(50)
+    renewed = manager.renew(original)
+
+    assert renewed.record.lease_id == original.record.lease_id
+    assert renewed.record.acquired_at_unix_ms == original.record.acquired_at_unix_ms
+    assert renewed.record.expires_at_unix_ms == 1_150
+    assert renewed.fencing_token > original.fencing_token
+    assert manager.current() == renewed
+
+    with pytest.raises(CoordinatorLeaseLost, match="changed before release"):
+        manager.release(original)
+
+
+def test_early_renewal_still_checks_and_advances_fencing_token():
+    store = InMemoryControlStore()
+    clock = ManualClock()
+    manager = _manager(store, clock, "coordinator-a")
+    original = manager.acquire()
+
+    renewed = manager.renew(original)
+
+    assert renewed.record == original.record
+    assert renewed.fencing_token > original.fencing_token
+
+    manager.release(renewed)
+    with pytest.raises(CoordinatorLeaseLost, match="changed before renewal"):
+        manager.renew(renewed)
+
+
+def test_expired_lease_takeover_fences_old_coordinator():
+    store = InMemoryControlStore()
+    clock = ManualClock()
+    first = _manager(store, clock, "coordinator-a")
+    second = _manager(store, clock, "coordinator-b")
+    stale = first.acquire()
+
+    clock.set(stale.record.expires_at_unix_ms)
+    replacement = second.acquire()
+
+    assert replacement.record.coordinator_id == "coordinator-b"
+    assert replacement.record.lease_id != stale.record.lease_id
+    assert replacement.fencing_token > stale.fencing_token
+    with pytest.raises(CoordinatorLeaseLost, match="expired"):
+        first.renew(stale)
+    with pytest.raises(CoordinatorLeaseLost, match="changed before release"):
+        first.release(stale)
+
+
+def test_release_and_reacquire_never_reuses_fencing_token():
+    store = InMemoryControlStore()
+    clock = ManualClock()
+    manager = _manager(store, clock, "coordinator-a")
+    original = manager.acquire()
+
+    tombstone_revision = manager.release(original)
+    replacement = manager.acquire()
+
+    assert original.fencing_token < tombstone_revision < replacement.fencing_token
+    assert replacement.record.lease_id != original.record.lease_id
+
+
+def test_concurrent_coordinator_acquisition_has_one_winner():
+    store = InMemoryControlStore()
+    clock = ManualClock()
+    workers = 8
+    barrier = threading.Barrier(workers)
+    managers = [_manager(store, clock, f"coordinator-{index}") for index in range(workers)]
+
+    def acquire(manager: CoordinatorLeaseManager):
+        barrier.wait()
+        try:
+            return manager.acquire()
+        except CoordinatorLeaseUnavailable:
+            return None
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        results = list(executor.map(acquire, managers))
+
+    winners = [result for result in results if result is not None]
+    assert len(winners) == 1
+    assert managers[0].current() == winners[0]
+
+
+def test_coordinator_lease_fails_closed_on_corrupt_record():
+    store = InMemoryControlStore()
+    clock = ManualClock()
+    manager = _manager(store, clock, "coordinator-a")
+    store.compare_set(
+        manager.lease_key,
+        expected_revision=None,
+        value=b"{}",
+    )
+
+    with pytest.raises(CoordinatorLeaseCorrupt, match="malformed"):
+        manager.current()
+    with pytest.raises(CoordinatorLeaseCorrupt, match="malformed"):
+        manager.acquire()
+
+
+def test_coordinator_lease_clock_cannot_move_backward():
+    store = InMemoryControlStore()
+    clock = ManualClock()
+    manager = _manager(store, clock, "coordinator-a")
+    lease = manager.acquire()
+
+    clock.set(999)
+    with pytest.raises(CoordinatorLeaseClockError, match="backward"):
+        manager.renew(lease)
+
+
+def test_coordinator_lease_rejects_handle_from_another_manager():
+    store = InMemoryControlStore()
+    clock = ManualClock()
+    first = _manager(store, clock, "coordinator-a")
+    second = _manager(store, clock, "coordinator-b")
+    lease = first.acquire()
+
+    with pytest.raises(CoordinatorLeaseLost, match="another manager"):
+        second.renew(lease)
+    with pytest.raises(CoordinatorLeaseLost, match="another manager"):
+        second.release(lease)
+
+
+def test_distinct_runs_use_distinct_lease_keys():
+    store = InMemoryControlStore()
+    clock = ManualClock()
+    first = _manager(store, clock, "coordinator-a", run_id="run-a")
+    second = _manager(store, clock, "coordinator-b", run_id="run-b")
+
+    assert first.lease_key != second.lease_key
+    assert first.acquire().fencing_token == 1
+    assert second.acquire().fencing_token == 1
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        CoordinatorLeaseRecord(
+            run_id="training-run",
+            coordinator_id="coordinator-a",
+            lease_id="lease-a",
+            acquired_at_unix_ms=1_000,
+            expires_at_unix_ms=1_100,
+        ),
+    ],
+)
+def test_coordinator_lease_record_rejects_invalid_expiry(record):
+    with pytest.raises(ValueError, match="after acquisition"):
+        replace(record, expires_at_unix_ms=record.acquired_at_unix_ms)

--- a/tests/unit/test_torchrun_coordinator_lease.py
+++ b/tests/unit/test_torchrun_coordinator_lease.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import threading
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import replace
 
 import pytest
 
@@ -44,34 +43,17 @@ class ExpireDuringMutationStore(InMemoryControlStore):
         self._manual_clock = clock
         self.expire_next_mutation = False
 
-    def compare_set_before(
-        self,
-        key: str,
-        *,
-        expected_revision: int | None,
-        deadline_unix_ms: int,
-        value: bytes,
-    ):
-        if self.expire_next_mutation:
-            self._manual_clock.set(deadline_unix_ms)
-            self.expire_next_mutation = False
-        return super().compare_set_before(
-            key,
-            expected_revision=expected_revision,
-            deadline_unix_ms=deadline_unix_ms,
-            value=value,
-        )
-
     def compare_set_in_window(
         self,
         key: str,
         *,
         expected_revision: int | None,
         not_before_unix_ms: int,
-        deadline_unix_ms: int,
+        deadline_unix_ms: int | None,
         value: bytes,
     ):
         if self.expire_next_mutation:
+            assert deadline_unix_ms is not None
             self._manual_clock.set(deadline_unix_ms)
             self.expire_next_mutation = False
         return super().compare_set_in_window(
@@ -81,6 +63,84 @@ class ExpireDuringMutationStore(InMemoryControlStore):
             deadline_unix_ms=deadline_unix_ms,
             value=value,
         )
+
+    def compare_delete_in_window(
+        self,
+        key: str,
+        *,
+        expected_revision: int,
+        not_before_unix_ms: int,
+        deadline_unix_ms: int,
+    ):
+        if self.expire_next_mutation:
+            self._manual_clock.set(deadline_unix_ms)
+            self.expire_next_mutation = False
+        return super().compare_delete_in_window(
+            key,
+            expected_revision=expected_revision,
+            not_before_unix_ms=not_before_unix_ms,
+            deadline_unix_ms=deadline_unix_ms,
+        )
+
+
+class DelayResponseStore(InMemoryControlStore):
+    def __init__(self, clock: ManualClock) -> None:
+        super().__init__(clock=clock)
+        self._manual_clock = clock
+        self.delay_next_response_ms = 0
+
+    def compare_set_in_window(
+        self,
+        key: str,
+        *,
+        expected_revision: int | None,
+        not_before_unix_ms: int,
+        deadline_unix_ms: int | None,
+        value: bytes,
+    ):
+        entry = super().compare_set_in_window(
+            key,
+            expected_revision=expected_revision,
+            not_before_unix_ms=not_before_unix_ms,
+            deadline_unix_ms=deadline_unix_ms,
+            value=value,
+        )
+        if self.delay_next_response_ms:
+            self._manual_clock.advance(self.delay_next_response_ms)
+            self.delay_next_response_ms = 0
+        return entry
+
+
+class RegressResponseClockStore(InMemoryControlStore):
+    def __init__(self, clock: ManualClock) -> None:
+        super().__init__(clock=clock)
+        self._manual_clock = clock
+        self.commit_next_at: int | None = None
+        self.respond_next_at: int | None = None
+
+    def compare_set_in_window(
+        self,
+        key: str,
+        *,
+        expected_revision: int | None,
+        not_before_unix_ms: int,
+        deadline_unix_ms: int | None,
+        value: bytes,
+    ):
+        if self.commit_next_at is not None:
+            self._manual_clock.set(self.commit_next_at)
+            self.commit_next_at = None
+        entry = super().compare_set_in_window(
+            key,
+            expected_revision=expected_revision,
+            not_before_unix_ms=not_before_unix_ms,
+            deadline_unix_ms=deadline_unix_ms,
+            value=value,
+        )
+        if self.respond_next_at is not None:
+            self._manual_clock.set(self.respond_next_at)
+            self.respond_next_at = None
+        return entry
 
 
 class RegressDuringMutationStore(InMemoryControlStore):
@@ -95,7 +155,7 @@ class RegressDuringMutationStore(InMemoryControlStore):
         *,
         expected_revision: int | None,
         not_before_unix_ms: int,
-        deadline_unix_ms: int,
+        deadline_unix_ms: int | None,
         value: bytes,
     ):
         if self.regress_next_mutation_to is not None:
@@ -107,6 +167,24 @@ class RegressDuringMutationStore(InMemoryControlStore):
             not_before_unix_ms=not_before_unix_ms,
             deadline_unix_ms=deadline_unix_ms,
             value=value,
+        )
+
+    def compare_delete_in_window(
+        self,
+        key: str,
+        *,
+        expected_revision: int,
+        not_before_unix_ms: int,
+        deadline_unix_ms: int,
+    ):
+        if self.regress_next_mutation_to is not None:
+            self._manual_clock.set(self.regress_next_mutation_to)
+            self.regress_next_mutation_to = None
+        return super().compare_delete_in_window(
+            key,
+            expected_revision=expected_revision,
+            not_before_unix_ms=not_before_unix_ms,
+            deadline_unix_ms=deadline_unix_ms,
         )
 
 
@@ -131,8 +209,7 @@ def test_coordinator_lease_record_round_trips_strict_json():
         run_id="training-run",
         coordinator_id="coordinator-a",
         lease_id="lease-a",
-        acquired_at_unix_ms=1_000,
-        expires_at_unix_ms=1_100,
+        lease_duration_ms=100,
     )
 
     assert CoordinatorLeaseRecord.from_json(record.to_json()) == record
@@ -152,7 +229,7 @@ def test_coordinator_lease_record_round_trips_strict_json():
     duplicate_run = (
         b'{"schema_version":1,"run_id":"run-a","run_id":"run-b",'
         b'"coordinator_id":"coordinator-a","lease_id":"lease-a",'
-        b'"acquired_at_unix_ms":1000,"expires_at_unix_ms":1100}'
+        b'"lease_duration_ms":100}'
     )
     with pytest.raises(ValueError, match="duplicate field 'run_id'"):
         CoordinatorLeaseRecord.from_json(duplicate_run)
@@ -172,7 +249,8 @@ def test_coordinator_lease_acquire_is_exclusive_and_idempotent():
     assert retry.fencing_token > lease.fencing_token
     assert first.current() == retry
     assert lease.record.coordinator_id == "coordinator-a"
-    assert lease.record.expires_at_unix_ms == 1_100
+    assert lease.granted_at_unix_ms == 1_000
+    assert lease.expires_at_unix_ms == 1_100
     with pytest.raises(CoordinatorLeaseUnavailable, match="coordinator-a"):
         second.acquire()
 
@@ -187,8 +265,8 @@ def test_coordinator_lease_renewal_advances_fencing_token():
     renewed = manager.renew(original)
 
     assert renewed.record.lease_id == original.record.lease_id
-    assert renewed.record.acquired_at_unix_ms == original.record.acquired_at_unix_ms
-    assert renewed.record.expires_at_unix_ms == 1_150
+    assert renewed.granted_at_unix_ms == 1_050
+    assert renewed.expires_at_unix_ms == 1_150
     assert renewed.fencing_token > original.fencing_token
     assert manager.current() == renewed
 
@@ -226,31 +304,34 @@ def test_renewal_cannot_commit_after_store_observes_expiry():
     assert manager.current() == lease
 
 
-def test_initial_acquisition_cannot_commit_an_expired_candidate():
+def test_initial_acquisition_rejects_response_after_committed_lease_expiry():
     clock = ManualClock()
-    store = ExpireDuringMutationStore(clock)
+    store = DelayResponseStore(clock)
     manager = _manager(store, clock, "coordinator-a")
-    store.expire_next_mutation = True
+    store.delay_next_response_ms = 100
 
-    with pytest.raises(CoordinatorLeaseUnavailable, match="expired at the control store"):
+    with pytest.raises(CoordinatorLeaseUnavailable, match="response arrived"):
         manager.acquire()
 
-    assert manager.current() is None
+    expired = manager.current()
+    assert expired is not None
+    assert expired.expires_at_unix_ms == 1_100
 
 
-def test_takeover_cannot_commit_an_expired_candidate():
+def test_renewal_rejects_response_after_committed_lease_expiry():
     clock = ManualClock()
-    store = ExpireDuringMutationStore(clock)
-    first = _manager(store, clock, "coordinator-a")
-    second = _manager(store, clock, "coordinator-b")
-    stale = first.acquire()
-    clock.set(stale.record.expires_at_unix_ms)
-    store.expire_next_mutation = True
+    store = DelayResponseStore(clock)
+    manager = _manager(store, clock, "coordinator-a")
+    lease = manager.acquire()
+    clock.set(1_050)
+    store.delay_next_response_ms = 100
 
-    with pytest.raises(CoordinatorLeaseUnavailable, match="expired at the control store"):
-        second.acquire()
+    with pytest.raises(CoordinatorLeaseLost, match="response arrived"):
+        manager.renew(lease)
 
-    assert second.current() == stale
+    expired = manager.current()
+    assert expired is not None
+    assert expired.expires_at_unix_ms == 1_150
 
 
 def test_takeover_requires_old_lease_expiry_at_store_time():
@@ -280,6 +361,21 @@ def test_initial_acquisition_rejects_store_clock_regression():
     assert manager.current() is None
 
 
+def test_initial_acquisition_rejects_response_clock_before_commit():
+    clock = ManualClock(900)
+    store = RegressResponseClockStore(clock)
+    manager = _manager(store, clock, "coordinator-a")
+    store.commit_next_at = 1_000
+    store.respond_next_at = 950
+
+    with pytest.raises(CoordinatorLeaseClockError, match="commit time"):
+        manager.acquire()
+
+    committed = manager.current()
+    assert committed is not None
+    assert committed.granted_at_unix_ms == 1_000
+
+
 def test_renewal_rejects_store_clock_regression():
     clock = ManualClock()
     store = RegressDuringMutationStore(clock)
@@ -301,7 +397,7 @@ def test_expired_lease_takeover_fences_old_coordinator():
     second = _manager(store, clock, "coordinator-b")
     stale = first.acquire()
 
-    clock.set(stale.record.expires_at_unix_ms)
+    clock.set(stale.expires_at_unix_ms)
     replacement = second.acquire()
 
     assert replacement.record.coordinator_id == "coordinator-b"
@@ -309,7 +405,7 @@ def test_expired_lease_takeover_fences_old_coordinator():
     assert replacement.fencing_token > stale.fencing_token
     with pytest.raises(CoordinatorLeaseLost, match="expired"):
         first.renew(stale)
-    with pytest.raises(CoordinatorLeaseLost, match="changed before release"):
+    with pytest.raises(CoordinatorLeaseLost, match="expired before release"):
         first.release(stale)
 
 
@@ -375,6 +471,34 @@ def test_coordinator_lease_clock_cannot_move_backward():
         manager.renew(lease)
 
 
+def test_release_rejects_store_clock_regression():
+    clock = ManualClock()
+    store = RegressDuringMutationStore(clock)
+    manager = _manager(store, clock, "coordinator-a")
+    lease = manager.acquire()
+    clock.set(1_050)
+    store.regress_next_mutation_to = 1_025
+
+    with pytest.raises(CoordinatorLeaseClockError, match="precedes"):
+        manager.release(lease)
+
+    assert manager.current() == lease
+
+
+def test_release_cannot_commit_after_store_observes_expiry():
+    clock = ManualClock()
+    store = ExpireDuringMutationStore(clock)
+    manager = _manager(store, clock, "coordinator-a")
+    lease = manager.acquire()
+    clock.set(1_050)
+    store.expire_next_mutation = True
+
+    with pytest.raises(CoordinatorLeaseLost, match="expired at the control store"):
+        manager.release(lease)
+
+    assert manager.current() == lease
+
+
 def test_coordinator_lease_rejects_handle_from_another_manager():
     clock = ManualClock()
     store = InMemoryControlStore(clock=clock)
@@ -399,18 +523,31 @@ def test_distinct_runs_use_distinct_lease_keys():
     assert second.acquire().fencing_token == 1
 
 
-@pytest.mark.parametrize(
-    "record",
-    [
+def test_coordinator_lease_record_rejects_invalid_duration():
+    with pytest.raises(ValueError, match="lease_duration_ms"):
         CoordinatorLeaseRecord(
             run_id="training-run",
             coordinator_id="coordinator-a",
             lease_id="lease-a",
-            acquired_at_unix_ms=1_000,
-            expires_at_unix_ms=1_100,
-        ),
-    ],
-)
-def test_coordinator_lease_record_rejects_invalid_expiry(record):
-    with pytest.raises(ValueError, match="after acquisition"):
-        replace(record, expires_at_unix_ms=record.acquired_at_unix_ms)
+            lease_duration_ms=0,
+        )
+
+
+def test_coordinator_lease_requires_authoritative_commit_time():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    manager = _manager(store, clock, "coordinator-a")
+    record = CoordinatorLeaseRecord(
+        run_id="training-run",
+        coordinator_id="coordinator-a",
+        lease_id="lease-a",
+        lease_duration_ms=100,
+    )
+    store.compare_set(
+        manager.lease_key,
+        expected_revision=None,
+        value=record.to_json(),
+    )
+
+    with pytest.raises(CoordinatorLeaseCorrupt, match="commit time"):
+        manager.current()

--- a/tests/unit/test_torchrun_coordinator_lease.py
+++ b/tests/unit/test_torchrun_coordinator_lease.py
@@ -38,20 +38,23 @@ class ManualClock:
             self.now_unix_ms += duration_ms
 
 
-class ExpireDuringRenewalStore(InMemoryControlStore):
+class ExpireDuringMutationStore(InMemoryControlStore):
     def __init__(self, clock: ManualClock) -> None:
         super().__init__(clock=clock)
         self._manual_clock = clock
+        self.expire_next_mutation = False
 
     def compare_set_before(
         self,
         key: str,
         *,
-        expected_revision: int,
+        expected_revision: int | None,
         deadline_unix_ms: int,
         value: bytes,
     ):
-        self._manual_clock.set(deadline_unix_ms)
+        if self.expire_next_mutation:
+            self._manual_clock.set(deadline_unix_ms)
+            self.expire_next_mutation = False
         return super().compare_set_before(
             key,
             expected_revision=expected_revision,
@@ -161,15 +164,43 @@ def test_early_renewal_still_checks_and_advances_fencing_token():
 
 def test_renewal_cannot_commit_after_store_observes_expiry():
     clock = ManualClock()
-    store = ExpireDuringRenewalStore(clock)
+    store = ExpireDuringMutationStore(clock)
     manager = _manager(store, clock, "coordinator-a")
     lease = manager.acquire()
     clock.set(1_050)
+    store.expire_next_mutation = True
 
     with pytest.raises(CoordinatorLeaseLost, match="expired at the control store"):
         manager.renew(lease)
 
     assert manager.current() == lease
+
+
+def test_initial_acquisition_cannot_commit_an_expired_candidate():
+    clock = ManualClock()
+    store = ExpireDuringMutationStore(clock)
+    manager = _manager(store, clock, "coordinator-a")
+    store.expire_next_mutation = True
+
+    with pytest.raises(CoordinatorLeaseUnavailable, match="expired at the control store"):
+        manager.acquire()
+
+    assert manager.current() is None
+
+
+def test_takeover_cannot_commit_an_expired_candidate():
+    clock = ManualClock()
+    store = ExpireDuringMutationStore(clock)
+    first = _manager(store, clock, "coordinator-a")
+    second = _manager(store, clock, "coordinator-b")
+    stale = first.acquire()
+    clock.set(stale.record.expires_at_unix_ms)
+    store.expire_next_mutation = True
+
+    with pytest.raises(CoordinatorLeaseUnavailable, match="expired at the control store"):
+        second.acquire()
+
+    assert second.current() == stale
 
 
 def test_expired_lease_takeover_fences_old_coordinator():

--- a/tests/unit/test_torchrun_coordinator_lease.py
+++ b/tests/unit/test_torchrun_coordinator_lease.py
@@ -62,6 +62,53 @@ class ExpireDuringMutationStore(InMemoryControlStore):
             value=value,
         )
 
+    def compare_set_in_window(
+        self,
+        key: str,
+        *,
+        expected_revision: int | None,
+        not_before_unix_ms: int,
+        deadline_unix_ms: int,
+        value: bytes,
+    ):
+        if self.expire_next_mutation:
+            self._manual_clock.set(deadline_unix_ms)
+            self.expire_next_mutation = False
+        return super().compare_set_in_window(
+            key,
+            expected_revision=expected_revision,
+            not_before_unix_ms=not_before_unix_ms,
+            deadline_unix_ms=deadline_unix_ms,
+            value=value,
+        )
+
+
+class RegressDuringMutationStore(InMemoryControlStore):
+    def __init__(self, clock: ManualClock) -> None:
+        super().__init__(clock=clock)
+        self._manual_clock = clock
+        self.regress_next_mutation_to: int | None = None
+
+    def compare_set_in_window(
+        self,
+        key: str,
+        *,
+        expected_revision: int | None,
+        not_before_unix_ms: int,
+        deadline_unix_ms: int,
+        value: bytes,
+    ):
+        if self.regress_next_mutation_to is not None:
+            self._manual_clock.set(self.regress_next_mutation_to)
+            self.regress_next_mutation_to = None
+        return super().compare_set_in_window(
+            key,
+            expected_revision=expected_revision,
+            not_before_unix_ms=not_before_unix_ms,
+            deadline_unix_ms=deadline_unix_ms,
+            value=value,
+        )
+
 
 def _manager(
     store: InMemoryControlStore,
@@ -119,8 +166,11 @@ def test_coordinator_lease_acquire_is_exclusive_and_idempotent():
 
     lease = first.acquire()
 
-    assert first.acquire() == lease
-    assert first.current() == lease
+    retry = first.acquire()
+
+    assert retry.record == lease.record
+    assert retry.fencing_token > lease.fencing_token
+    assert first.current() == retry
     assert lease.record.coordinator_id == "coordinator-a"
     assert lease.record.expires_at_unix_ms == 1_100
     with pytest.raises(CoordinatorLeaseUnavailable, match="coordinator-a"):
@@ -201,6 +251,47 @@ def test_takeover_cannot_commit_an_expired_candidate():
         second.acquire()
 
     assert second.current() == stale
+
+
+def test_takeover_requires_old_lease_expiry_at_store_time():
+    clock = ManualClock()
+    store = RegressDuringMutationStore(clock)
+    first = _manager(store, clock, "coordinator-a")
+    second = _manager(store, clock, "coordinator-b")
+    stale = first.acquire()
+    clock.set(1_200)
+    store.regress_next_mutation_to = 1_050
+
+    with pytest.raises(CoordinatorLeaseClockError, match="precedes"):
+        second.acquire()
+
+    assert second.current() == stale
+
+
+def test_initial_acquisition_rejects_store_clock_regression():
+    clock = ManualClock(1_200)
+    store = RegressDuringMutationStore(clock)
+    manager = _manager(store, clock, "coordinator-a")
+    store.regress_next_mutation_to = 1_050
+
+    with pytest.raises(CoordinatorLeaseClockError, match="precedes"):
+        manager.acquire()
+
+    assert manager.current() is None
+
+
+def test_renewal_rejects_store_clock_regression():
+    clock = ManualClock()
+    store = RegressDuringMutationStore(clock)
+    manager = _manager(store, clock, "coordinator-a")
+    lease = manager.acquire()
+    clock.set(1_050)
+    store.regress_next_mutation_to = 1_025
+
+    with pytest.raises(CoordinatorLeaseClockError, match="precedes"):
+        manager.renew(lease)
+
+    assert manager.current() == lease
 
 
 def test_expired_lease_takeover_fences_old_coordinator():


### PR DESCRIPTION
## Summary

- add strict persisted coordinator lease records
- use the control-store revision as a monotonic fencing token
- support exclusive acquisition, idempotent retry, revision-guarded renewal and release, and expiry takeover
- derive lease expiry from the authoritative control-store commit timen- enforce acquisition, renewal, takeover, and release time windows atomically at the control store/
- fail closed on stale handles, corrupt records, and backward-moving lease time
- namespace lease keys by schema version and hashed run identity

## Scope

This PR contains only coordinator ownership and fencing. Generation snapshots, slot state, restart intents, and restart-plan commits remain separate follow-up PRs.

The module remains internal and does not change stable package exports.

## Validation

- `CUDA_VISIBLE_DEVICES='' .venv/bin/python -m pytest -q tests/unit/test_torchrun_control_store.py tests/unit/test_torchrun_coordinator_lease.py tests/unit/test_torchrun_protocol.py tests/unit/test_orchestration_api.py` (141 passed)
- `ruff check` and `ruff format --check` for the changed Python files
- `mypy lm_resiliency/integrations/torchrun/_control_store.py lm_resiliency/integrations/torchrun/_coordinator_lease.py`