### PR TITLE
[Feature][Torchrun] Add guarded control-store transactions

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -854,6 +854,13 @@ mistake a recreated record for an older value with identical bytes. Higher
 coordinator records add lease fencing and run/schema namespaces in subsequent
 layers rather than weakening this storage primitive.
 
+Coordinator state that spans multiple keys uses one guarded store transaction.
+The transaction first checks the coordinator lease revision, then every target
+revision, then one authoritative store-time window. It publishes all target
+values with the same commit timestamp or publishes none. This is the primitive
+used to create an immutable generation snapshot and advance the generation head
+without allowing a stale or expired coordinator to commit either half alone.
+
 Coordinator ownership is stored under a schema-versioned, run-scoped lease key.
 The lease record binds the run, a unique coordinator-process incarnation, a
 unique lease acquisition, and the lease duration. The control store attaches

--- a/lm_resiliency/integrations/torchrun/_control_store.py
+++ b/lm_resiliency/integrations/torchrun/_control_store.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Protocol
 
 
@@ -83,6 +84,22 @@ class ControlStoreEntry:
             )
 
 
+@dataclass(frozen=True, slots=True)
+class ControlStoreWrite:
+    """One expected revision and immutable value in an atomic store transaction."""
+
+    expected_revision: int | None
+    value: bytes
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "expected_revision",
+            _expected_revision(self.expected_revision, allow_absent=True),
+        )
+        object.__setattr__(self, "value", _control_value(self.value))
+
+
 class ControlStore(Protocol):
     """Strongly consistent per-key compare-and-set storage."""
 
@@ -132,6 +149,18 @@ class ControlStore(Protocol):
         deadline_unix_ms: int,
     ) -> int:
         """Delete ``key`` within an inclusive-start, exclusive-end window."""
+        ...
+
+    def compare_set_many_guarded(
+        self,
+        writes: Mapping[str, ControlStoreWrite],
+        *,
+        guard_key: str,
+        expected_guard_revision: int,
+        not_before_unix_ms: int,
+        deadline_unix_ms: int,
+    ) -> Mapping[str, ControlStoreEntry]:
+        """Atomically publish writes while a guard revision is live in the time window."""
         ...
 
 
@@ -254,6 +283,57 @@ class InMemoryControlStore:
             del self._entries[normalized_key]
             return self._next_revision(normalized_key)
 
+    def compare_set_many_guarded(
+        self,
+        writes: Mapping[str, ControlStoreWrite],
+        *,
+        guard_key: str,
+        expected_guard_revision: int,
+        not_before_unix_ms: int,
+        deadline_unix_ms: int,
+    ) -> Mapping[str, ControlStoreEntry]:
+        normalized_writes = _control_writes(writes)
+        normalized_guard_key = _control_key(guard_key)
+        if normalized_guard_key in normalized_writes:
+            raise ValueError("guard_key must not also be a transaction target")
+        normalized_guard_revision = _required_revision(expected_guard_revision)
+        normalized_not_before = _positive_integer(
+            not_before_unix_ms,
+            "not_before_unix_ms",
+        )
+        normalized_deadline = _positive_integer(
+            deadline_unix_ms,
+            "deadline_unix_ms",
+        )
+        if normalized_not_before >= normalized_deadline:
+            raise ValueError("not_before_unix_ms must be before deadline_unix_ms")
+        with self._lock:
+            self._require_revision(normalized_guard_key, normalized_guard_revision)
+            for key, write in normalized_writes.items():
+                self._require_revision(key, write.expected_revision)
+            now_unix_ms = self._store_now_unix_ms()
+            if now_unix_ms < normalized_not_before:
+                raise ControlStoreTooEarly(
+                    normalized_guard_key,
+                    normalized_not_before,
+                    now_unix_ms,
+                )
+            if now_unix_ms >= normalized_deadline:
+                raise ControlStoreDeadlineExceeded(
+                    normalized_guard_key,
+                    normalized_deadline,
+                    now_unix_ms,
+                )
+            committed = {
+                key: self._set_entry(
+                    key,
+                    write.value,
+                    committed_at_unix_ms=now_unix_ms,
+                )
+                for key, write in normalized_writes.items()
+            }
+            return MappingProxyType(committed)
+
     def _require_revision(self, key: str, expected_revision: int | None) -> None:
         entry = self._entries.get(key)
         actual_revision = None if entry is None else entry.revision
@@ -301,6 +381,18 @@ def _control_value(value: object) -> bytes:
     return bytes(value)
 
 
+def _control_writes(value: object) -> dict[str, ControlStoreWrite]:
+    if not isinstance(value, Mapping) or not value:
+        raise ValueError("writes must be a non-empty mapping")
+    result: dict[str, ControlStoreWrite] = {}
+    for key, write in value.items():
+        normalized_key = _control_key(key)
+        if not isinstance(write, ControlStoreWrite):
+            raise TypeError("writes values must be ControlStoreWrite")
+        result[normalized_key] = write
+    return dict(sorted(result.items()))
+
+
 def _expected_revision(value: object, *, allow_absent: bool) -> int | None:
     if allow_absent and value is None:
         return None
@@ -331,5 +423,6 @@ __all__ = [
     "ControlStoreEntry",
     "ControlStoreError",
     "ControlStoreTooEarly",
+    "ControlStoreWrite",
     "InMemoryControlStore",
 ]

--- a/tests/unit/test_torchrun_guarded_control_store.py
+++ b/tests/unit/test_torchrun_guarded_control_store.py
@@ -1,0 +1,253 @@
+"""Atomic guarded-transaction tests for the internal torchrun control store."""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from types import MappingProxyType
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStoreConflict,
+    ControlStoreDeadlineExceeded,
+    ControlStoreTooEarly,
+    ControlStoreWrite,
+    InMemoryControlStore,
+)
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self.now_unix_ms = now_unix_ms
+
+    def __call__(self) -> int:
+        return self.now_unix_ms
+
+
+def _guard(store: InMemoryControlStore):
+    return store.compare_set(
+        "run/coordinator-lease",
+        expected_revision=None,
+        value=b"lease-a",
+    )
+
+
+def _generation_writes(
+    *,
+    head_revision: int | None = None,
+) -> dict[str, ControlStoreWrite]:
+    return {
+        "run/generation-head": ControlStoreWrite(
+            expected_revision=head_revision,
+            value=b"generation-0",
+        ),
+        "run/generations/0": ControlStoreWrite(
+            expected_revision=None,
+            value=b"snapshot-0",
+        ),
+    }
+
+
+def test_guarded_transaction_commits_all_writes_at_one_store_time():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    guard = _guard(store)
+
+    committed = store.compare_set_many_guarded(
+        _generation_writes(),
+        guard_key="run/coordinator-lease",
+        expected_guard_revision=guard.revision,
+        not_before_unix_ms=1_000,
+        deadline_unix_ms=1_100,
+    )
+
+    assert isinstance(committed, MappingProxyType)
+    assert set(committed) == {"run/generation-head", "run/generations/0"}
+    assert {entry.committed_at_unix_ms for entry in committed.values()} == {1_000}
+    assert store.get("run/generation-head") == committed["run/generation-head"]
+    assert store.get("run/generations/0") == committed["run/generations/0"]
+    with pytest.raises(TypeError):
+        committed["run/other"] = committed["run/generation-head"]  # type: ignore[index]
+
+
+def test_guarded_transaction_atomically_updates_head_and_creates_successor():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    guard = _guard(store)
+    initial = store.compare_set_many_guarded(
+        _generation_writes(),
+        guard_key="run/coordinator-lease",
+        expected_guard_revision=guard.revision,
+        not_before_unix_ms=1_000,
+        deadline_unix_ms=1_100,
+    )
+    clock.now_unix_ms = 1_001
+
+    successor = store.compare_set_many_guarded(
+        {
+            "run/generation-head": ControlStoreWrite(
+                expected_revision=initial["run/generation-head"].revision,
+                value=b"generation-1",
+            ),
+            "run/generations/1": ControlStoreWrite(
+                expected_revision=None,
+                value=b"snapshot-1",
+            ),
+        },
+        guard_key="run/coordinator-lease",
+        expected_guard_revision=guard.revision,
+        not_before_unix_ms=1_001,
+        deadline_unix_ms=1_100,
+    )
+
+    assert store.get("run/generations/0") == initial["run/generations/0"]
+    assert store.get("run/generation-head") == successor["run/generation-head"]
+    assert store.get("run/generations/1") == successor["run/generations/1"]
+    assert {entry.committed_at_unix_ms for entry in successor.values()} == {1_001}
+
+
+def test_guarded_transaction_rejects_stale_guard_without_partial_writes():
+    store = InMemoryControlStore()
+    stale_guard = _guard(store)
+    current_guard = store.compare_set(
+        "run/coordinator-lease",
+        expected_revision=stale_guard.revision,
+        value=b"lease-b",
+    )
+
+    with pytest.raises(ControlStoreConflict) as error:
+        store.compare_set_many_guarded(
+            _generation_writes(),
+            guard_key="run/coordinator-lease",
+            expected_guard_revision=stale_guard.revision,
+            not_before_unix_ms=1,
+            deadline_unix_ms=2,
+        )
+
+    assert error.value.key == "run/coordinator-lease"
+    assert error.value.actual_revision == current_guard.revision
+    assert store.get("run/generation-head") is None
+    assert store.get("run/generations/0") is None
+
+
+def test_guarded_transaction_rejects_target_conflict_without_partial_writes():
+    store = InMemoryControlStore()
+    guard = _guard(store)
+    current_head = store.compare_set(
+        "run/generation-head",
+        expected_revision=None,
+        value=b"generation-0",
+    )
+
+    with pytest.raises(ControlStoreConflict) as error:
+        store.compare_set_many_guarded(
+            _generation_writes(),
+            guard_key="run/coordinator-lease",
+            expected_guard_revision=guard.revision,
+            not_before_unix_ms=1,
+            deadline_unix_ms=2,
+        )
+
+    assert error.value.key == "run/generation-head"
+    assert store.get("run/generation-head") == current_head
+    assert store.get("run/generations/0") is None
+
+
+@pytest.mark.parametrize(
+    ("now_unix_ms", "error"),
+    [
+        (999, ControlStoreTooEarly),
+        (1_100, ControlStoreDeadlineExceeded),
+    ],
+)
+def test_guarded_transaction_enforces_store_time_without_partial_writes(
+    now_unix_ms,
+    error,
+):
+    clock = ManualClock(now_unix_ms)
+    store = InMemoryControlStore(clock=clock)
+    guard = _guard(store)
+
+    with pytest.raises(error):
+        store.compare_set_many_guarded(
+            _generation_writes(),
+            guard_key="run/coordinator-lease",
+            expected_guard_revision=guard.revision,
+            not_before_unix_ms=1_000,
+            deadline_unix_ms=1_100,
+        )
+
+    assert store.get("run/generation-head") is None
+    assert store.get("run/generations/0") is None
+
+
+def test_guarded_transaction_allows_only_one_concurrent_commit():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    guard = _guard(store)
+    workers = 8
+    barrier = threading.Barrier(workers)
+
+    def commit():
+        barrier.wait()
+        try:
+            return store.compare_set_many_guarded(
+                _generation_writes(),
+                guard_key="run/coordinator-lease",
+                expected_guard_revision=guard.revision,
+                not_before_unix_ms=1_000,
+                deadline_unix_ms=1_100,
+            )
+        except ControlStoreConflict:
+            return None
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        results = list(executor.map(lambda _: commit(), range(workers)))
+
+    winners = [result for result in results if result is not None]
+    assert len(winners) == 1
+    assert store.get("run/generation-head") == winners[0]["run/generation-head"]
+    assert store.get("run/generations/0") == winners[0]["run/generations/0"]
+
+
+def test_guarded_transaction_rejects_invalid_write_sets():
+    store = InMemoryControlStore()
+    guard = _guard(store)
+
+    with pytest.raises(ValueError, match="non-empty"):
+        store.compare_set_many_guarded(
+            {},
+            guard_key="run/coordinator-lease",
+            expected_guard_revision=guard.revision,
+            not_before_unix_ms=1,
+            deadline_unix_ms=2,
+        )
+    with pytest.raises(ValueError, match="must not also"):
+        store.compare_set_many_guarded(
+            {
+                "run/coordinator-lease": ControlStoreWrite(
+                    expected_revision=guard.revision,
+                    value=b"replacement",
+                )
+            },
+            guard_key="run/coordinator-lease",
+            expected_guard_revision=guard.revision,
+            not_before_unix_ms=1,
+            deadline_unix_ms=2,
+        )
+
+
+@pytest.mark.parametrize(
+    ("expected_revision", "value", "error"),
+    [
+        (False, b"value", ValueError),
+        (None, bytearray(b"value"), TypeError),
+    ],
+)
+def test_control_store_write_rejects_invalid_values(expected_revision, value, error):
+    with pytest.raises(error):
+        ControlStoreWrite(
+            expected_revision=expected_revision,
+            value=value,
+        )


### PR DESCRIPTION
## Summary

- add an immutable `ControlStoreWrite` descriptor for conditional writes
- atomically validate the coordinator guard revision, every target revision, and one store-time window
- publish all target values with one authoritative commit timestamp or publish none
- support the generation-head update plus immutable-snapshot creation pattern without adding generation schemas yet

## Scope

This PR contains only the guarded multi-key storage transaction required by coordinator state. Generation records, node registration, standby eligibility, quarantine, restart intents, and recovery planning remain separate follow-up PRs.

The API remains internal and does not change stable package exports.

## Validation

- `CUDA_VISIBLE_DEVICES='' .venv/bin/python -m pytest -q tests/unit/test_torchrun_control_store.py tests/unit/test_torchrun_guarded_control_store.py tests/unit/test_torchrun_coordinator_lease.py tests/unit/test_torchrun_protocol.py tests/unit/test_orchestration_api.py` (151 passed)
- `ruff check` and `ruff format --check` for the changed Python files
- `mypy lm_resiliency/integrations/torchrun/_control_store.py`
- `git diff --check`