### PR TITLE
[Feature][Torchrun] Add strict generation records

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -861,6 +861,14 @@ values with the same commit timestamp or publishes none. This is the primitive
 used to create an immutable generation snapshot and advance the generation head
 without allowing a stale or expired coordinator to commit either half alone.
 
+Persisted generation state uses strict versioned records. A
+`GenerationSnapshotRecord` contains the immutable `RankAssignment`, the previous
+snapshot digest, and the coordinator lease identity and fencing token that
+committed it. Generation zero must not name a predecessor, while every later
+generation must carry a lowercase SHA-256 predecessor digest. A
+`GenerationHeadRecord` contains only the run, generation, and canonical snapshot
+digest. Both records reject missing, unknown, duplicate, or unsupported fields.
+
 Coordinator ownership is stored under a schema-versioned, run-scoped lease key.
 The lease record binds the run, a unique coordinator-process incarnation, a
 unique lease acquisition, and the lease duration. The control store attaches

--- a/lm_resiliency/integrations/torchrun/_generation_records.py
+++ b/lm_resiliency/integrations/torchrun/_generation_records.py
@@ -1,0 +1,259 @@
+"""Strict persisted records for torchrun resiliency generations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import ClassVar
+
+from lm_resiliency.integrations.torchrun._protocol import (
+    ProtocolValidationError,
+    RankAssignment,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class GenerationSnapshotRecord:
+    """One immutable rank assignment and its coordinator fencing provenance."""
+
+    SCHEMA_VERSION: ClassVar[int] = 1
+
+    assignment: RankAssignment
+    previous_snapshot_digest: str | None
+    coordinator_id: str
+    lease_id: str
+    coordinator_fencing_token: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.assignment, RankAssignment):
+            raise TypeError("GenerationSnapshotRecord.assignment must be RankAssignment")
+        if self.assignment.generation == 0:
+            if self.previous_snapshot_digest is not None:
+                raise ValueError("generation zero must not name a previous snapshot")
+        else:
+            _digest(
+                self.previous_snapshot_digest,
+                "GenerationSnapshotRecord.previous_snapshot_digest",
+            )
+        _nonempty_string(
+            self.coordinator_id,
+            "GenerationSnapshotRecord.coordinator_id",
+        )
+        _nonempty_string(self.lease_id, "GenerationSnapshotRecord.lease_id")
+        _positive_integer(
+            self.coordinator_fencing_token,
+            "GenerationSnapshotRecord.coordinator_fencing_token",
+        )
+
+    @property
+    def digest(self) -> str:
+        return hashlib.sha256(self.to_json()).hexdigest()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "assignment": self.assignment.to_dict(),
+            "previous_snapshot_digest": self.previous_snapshot_digest,
+            "coordinator_id": self.coordinator_id,
+            "lease_id": self.lease_id,
+            "coordinator_fencing_token": self.coordinator_fencing_token,
+        }
+
+    def to_json(self) -> bytes:
+        return _canonical_json(self.to_dict())
+
+    @classmethod
+    def from_json(cls, encoded: bytes) -> GenerationSnapshotRecord:
+        value = _json_object(encoded, cls.__name__)
+        _fields(
+            value,
+            path=cls.__name__,
+            required={
+                "schema_version",
+                "assignment",
+                "previous_snapshot_digest",
+                "coordinator_id",
+                "lease_id",
+                "coordinator_fencing_token",
+            },
+        )
+        _schema_version(value["schema_version"], cls.__name__)
+        assignment_value = value["assignment"]
+        if not isinstance(assignment_value, Mapping):
+            raise ValueError("GenerationSnapshotRecord.assignment must be an object")
+        try:
+            assignment = RankAssignment.from_dict(assignment_value)
+        except ProtocolValidationError as error:
+            raise ValueError("GenerationSnapshotRecord.assignment is invalid") from error
+        previous_digest = value["previous_snapshot_digest"]
+        if previous_digest is not None:
+            previous_digest = _digest(
+                previous_digest,
+                "GenerationSnapshotRecord.previous_snapshot_digest",
+            )
+        return cls(
+            assignment=assignment,
+            previous_snapshot_digest=previous_digest,
+            coordinator_id=_nonempty_string(
+                value["coordinator_id"],
+                "GenerationSnapshotRecord.coordinator_id",
+            ),
+            lease_id=_nonempty_string(
+                value["lease_id"],
+                "GenerationSnapshotRecord.lease_id",
+            ),
+            coordinator_fencing_token=_positive_integer(
+                value["coordinator_fencing_token"],
+                "GenerationSnapshotRecord.coordinator_fencing_token",
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class GenerationHeadRecord:
+    """Pointer from the mutable generation head to an immutable snapshot."""
+
+    SCHEMA_VERSION: ClassVar[int] = 1
+
+    run_id: str
+    generation: int
+    snapshot_digest: str
+
+    def __post_init__(self) -> None:
+        _nonempty_string(self.run_id, "GenerationHeadRecord.run_id")
+        _nonnegative_integer(self.generation, "GenerationHeadRecord.generation")
+        _digest(self.snapshot_digest, "GenerationHeadRecord.snapshot_digest")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "run_id": self.run_id,
+            "generation": self.generation,
+            "snapshot_digest": self.snapshot_digest,
+        }
+
+    def to_json(self) -> bytes:
+        return _canonical_json(self.to_dict())
+
+    @classmethod
+    def from_json(cls, encoded: bytes) -> GenerationHeadRecord:
+        value = _json_object(encoded, cls.__name__)
+        _fields(
+            value,
+            path=cls.__name__,
+            required={
+                "schema_version",
+                "run_id",
+                "generation",
+                "snapshot_digest",
+            },
+        )
+        _schema_version(value["schema_version"], cls.__name__)
+        return cls(
+            run_id=_nonempty_string(value["run_id"], "GenerationHeadRecord.run_id"),
+            generation=_nonnegative_integer(
+                value["generation"],
+                "GenerationHeadRecord.generation",
+            ),
+            snapshot_digest=_digest(
+                value["snapshot_digest"],
+                "GenerationHeadRecord.snapshot_digest",
+            ),
+        )
+
+
+def _canonical_json(value: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _json_object(encoded: bytes, path: str) -> Mapping[str, object]:
+    if not isinstance(encoded, bytes):
+        raise ValueError(f"{path}: expected encoded bytes")
+    try:
+        value = json.loads(
+            encoded,
+            object_pairs_hook=_reject_duplicate_object_fields,
+        )
+    except _DuplicateGenerationField as error:
+        raise ValueError(f"{path}: {error}") from error
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{path}: invalid JSON") from error
+    if not isinstance(value, Mapping) or not all(isinstance(key, str) for key in value):
+        raise ValueError(f"{path}: expected a JSON object")
+    return value
+
+
+def _fields(
+    value: Mapping[str, object],
+    *,
+    path: str,
+    required: set[str],
+) -> None:
+    missing = required - set(value)
+    unknown = set(value) - required
+    if missing:
+        raise ValueError(f"{path}: missing fields {sorted(missing)!r}")
+    if unknown:
+        raise ValueError(f"{path}: unknown fields {sorted(unknown)!r}")
+
+
+def _schema_version(value: object, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value != 1:
+        raise ValueError(f"{path}.schema_version: unsupported value {value!r}")
+    return value
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+def _nonnegative_integer(value: object, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{path} must be a non-negative integer")
+    return value
+
+
+def _positive_integer(value: object, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{path} must be a positive integer")
+    return value
+
+
+def _digest(value: object, path: str) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise ValueError(f"{path} must be a lowercase SHA-256 digest")
+    return value
+
+
+class _DuplicateGenerationField(ValueError):
+    pass
+
+
+def _reject_duplicate_object_fields(
+    pairs: list[tuple[str, object]],
+) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            raise _DuplicateGenerationField(f"duplicate field {key!r}")
+        value[key] = item
+    return value
+
+
+__all__ = [
+    "GenerationHeadRecord",
+    "GenerationSnapshotRecord",
+]

--- a/tests/unit/test_torchrun_generation_records.py
+++ b/tests/unit/test_torchrun_generation_records.py
@@ -1,0 +1,162 @@
+"""Contract tests for persisted torchrun generation records."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._generation_records import (
+    GenerationHeadRecord,
+    GenerationSnapshotRecord,
+)
+from lm_resiliency.integrations.torchrun._protocol import RankAssignment, SlotAssignment
+
+RUN_ID = "training-run"
+
+
+def _assignment(generation: int) -> RankAssignment:
+    return RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=generation,
+        assignments=(
+            SlotAssignment(
+                logical_node_slot=0,
+                node_id="node-a",
+                first_global_rank=0,
+                local_world_size=2,
+            ),
+            SlotAssignment(
+                logical_node_slot=1,
+                node_id="node-b",
+                first_global_rank=2,
+                local_world_size=2,
+            ),
+        ),
+        topology_digest="topology-v1",
+    )
+
+
+def _snapshot(generation: int = 1) -> GenerationSnapshotRecord:
+    return GenerationSnapshotRecord(
+        assignment=_assignment(generation),
+        previous_snapshot_digest=None if generation == 0 else "a" * 64,
+        coordinator_id="coordinator-a",
+        lease_id="lease-a",
+        coordinator_fencing_token=4,
+    )
+
+
+def test_generation_records_round_trip_as_canonical_json():
+    snapshot = _snapshot()
+    head = GenerationHeadRecord(
+        run_id=RUN_ID,
+        generation=1,
+        snapshot_digest=snapshot.digest,
+    )
+
+    assert GenerationSnapshotRecord.from_json(snapshot.to_json()) == snapshot
+    assert GenerationHeadRecord.from_json(head.to_json()) == head
+    assert json.loads(snapshot.to_json()) == snapshot.to_dict()
+    assert json.loads(head.to_json()) == head.to_dict()
+    assert snapshot.digest == hashlib.sha256(snapshot.to_json()).hexdigest()
+    assert snapshot.to_json() == snapshot.to_json()
+
+
+def test_generation_records_reject_duplicate_fields_at_any_depth():
+    duplicate_head_generation = (
+        b'{"schema_version":1,"run_id":"training-run",'
+        b'"generation":0,"generation":1,"snapshot_digest":"' + b"a" * 64 + b'"}'
+    )
+    with pytest.raises(ValueError, match="duplicate field 'generation'"):
+        GenerationHeadRecord.from_json(duplicate_head_generation)
+
+    value = _snapshot().to_dict()
+    assignment = json.dumps(value["assignment"], separators=(",", ":"), sort_keys=True)
+    assignment = assignment.replace(
+        '"generation":1',
+        '"generation":1,"generation":2',
+    )
+    encoded = (
+        '{"assignment":'
+        + assignment
+        + ',"coordinator_fencing_token":4,"coordinator_id":"coordinator-a",'
+        '"lease_id":"lease-a","previous_snapshot_digest":"' + "a" * 64 + '","schema_version":1}'
+    ).encode()
+    with pytest.raises(ValueError, match="duplicate field 'generation'"):
+        GenerationSnapshotRecord.from_json(encoded)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value.pop("lease_id"),
+        lambda value: value.update({"unknown": "field"}),
+        lambda value: value.update({"schema_version": 2}),
+        lambda value: value.update({"schema_version": True}),
+        lambda value: value.update({"assignment": []}),
+    ],
+)
+def test_generation_snapshot_rejects_invalid_wire_shapes(mutation):
+    value = _snapshot().to_dict()
+    mutation(value)
+
+    with pytest.raises(ValueError):
+        GenerationSnapshotRecord.from_json(
+            json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+        )
+
+
+@pytest.mark.parametrize(
+    "encoded",
+    [
+        b"[]",
+        b"null",
+        b"not-json",
+    ],
+)
+def test_generation_records_require_json_objects(encoded):
+    with pytest.raises(ValueError):
+        GenerationHeadRecord.from_json(encoded)
+
+
+def test_generation_snapshot_requires_exact_predecessor_shape():
+    with pytest.raises(ValueError, match="must not name"):
+        GenerationSnapshotRecord(
+            assignment=_assignment(0),
+            previous_snapshot_digest="a" * 64,
+            coordinator_id="coordinator-a",
+            lease_id="lease-a",
+            coordinator_fencing_token=1,
+        )
+
+    with pytest.raises(ValueError, match="SHA-256"):
+        GenerationSnapshotRecord(
+            assignment=_assignment(1),
+            previous_snapshot_digest=None,
+            coordinator_id="coordinator-a",
+            lease_id="lease-a",
+            coordinator_fencing_token=1,
+        )
+
+    with pytest.raises(ValueError, match="SHA-256"):
+        GenerationSnapshotRecord(
+            assignment=_assignment(1),
+            previous_snapshot_digest="A" * 64,
+            coordinator_id="coordinator-a",
+            lease_id="lease-a",
+            coordinator_fencing_token=1,
+        )
+
+
+@pytest.mark.parametrize("fencing_token", [0, -1, True])
+def test_generation_snapshot_requires_positive_integer_fencing_token(fencing_token):
+    with pytest.raises(ValueError, match="positive integer"):
+        GenerationSnapshotRecord(
+            assignment=_assignment(1),
+            previous_snapshot_digest="a" * 64,
+            coordinator_id="coordinator-a",
+            lease_id="lease-a",
+            coordinator_fencing_token=fencing_token,
+        )


### PR DESCRIPTION
## Problem

Torchrun-native resiliency needs durable generation metadata before the coordinator can atomically advance rank assignments. These persisted records must fail closed on malformed or ambiguous JSON because they anchor rank-to-node history and coordinator fencing provenance.

## Implementation

- Add strict internal `GenerationSnapshotRecord` and `GenerationHeadRecord` schemas.
- Canonically encode records and derive snapshot identities with SHA-256.
- Bind snapshots to the immutable `RankAssignment`, predecessor digest, coordinator identity, lease identity, and fencing token.
- Reject missing, unknown, duplicate, unsupported, or type-invalid fields.
- Require generation zero to have no predecessor and later generations to carry a lowercase SHA-256 predecessor digest.

This PR intentionally does not add generation keys, head transitions, node registration, standby policy, or recovery planning.

## Compatibility

The records are internal and do not change public imports or runtime behavior.

## Validation

- `CUDA_VISIBLE_DEVICES='' .venv/bin/python -m pytest -q tests/unit/test_torchrun_generation_records.py tests/unit/test_torchrun_protocol.py` (100 passed)
- Ruff check and format validation on the changed Python files
- mypy on `_generation_records.py`
- `git diff --check`