### PR TITLE
[Feature][Torchrun] Add fail-closed generation reader

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -885,31 +885,32 @@ guard-mutation, and lease-identity chain back to generation zero. Lease
 identities cannot reappear after a different acquisition, and one acquisition
 cannot change coordinator identity, lease duration, or store-stamped guard-key
 lifetime. Every snapshot entry must retain store-stamped mutation sequence `1`,
-while the head mutation sequence must equal `generation + 1`; this rejects
-replacement, recreation, extra rewrites, and rollback. Every generation commit
-must fall within the stamped lease grant and duration. The head must remain in
-its first store-key lifetime, and a stable immediate successor snapshot beyond
-the head is contradictory state for every read API. Replacing a lease in place
-must not overlap the prior lease's stamped expiry, and one fencing token cannot
-identify multiple guard mutations. Fencing revisions are compared only for
-equality; ordering comes from the store-stamped guard mutation sequence. Each
-guard-key lifetime increase requires at least one delete and one create
-mutation, including before the first persisted generation. Because deletion
-advances mutation sequence without advancing value sequence, every entry and
-adjacent transition must also satisfy the corresponding value-sequence upper
-bound. When generations omit intervening renewals of one lease, the mutation
-distance bounds the latest grant time that a valid renewal chain could reach, so
-skipped valid renewals are accepted while resurrection after expiry is rejected.
-A same-key takeover with unobserved intervening mutations is ambiguous and
-rejected. An older generation commit cannot postdate the next guard mutation
-that fences it. Opaque fencing tokens cannot reappear after another guard
-mutation. One lease identity must retain one guard value sequence, so changing A
-to B and back to A cannot be misread as skipped renewals. The durable history of
-the generation-head key is the run initialization marker, so deleting both the
-head and generation zero cannot make an initialized run appear empty. Grant
-times, guard mutation/value sequences, and key-lifetime sequences cannot move
-backward. Missing or contradictory history is corruption, not an empty or
-partially usable assignment.
+lifetime. Every snapshot entry must retain store-stamped mutation, value, and
+lifetime sequence `1`, while the head mutation and value sequences must equal
+`generation + 1`; this rejects replacement, recreation, extra rewrites, and
+rollback. Every generation commit must fall within the stamped lease grant and
+duration. The head must remain in its first store-key lifetime, and a stable
+immediate successor snapshot beyond the head is contradictory state for every
+read API. Replacing a lease in place must not overlap the prior lease's stamped
+expiry, and one fencing token cannot identify multiple guard mutations. Fencing
+revisions are compared only for equality; ordering comes from the store-stamped
+guard mutation sequence. Each guard-key lifetime increase requires at least one
+delete and one create mutation, including before the first persisted generation.
+Because deletion advances mutation sequence without advancing value sequence,
+every entry and adjacent transition must also satisfy the corresponding
+value-sequence upper bound. When generations omit intervening renewals of one
+lease, the mutation distance bounds the latest grant time that a valid renewal
+chain could reach, so skipped valid renewals are accepted while resurrection
+after expiry is rejected. A same-key takeover with unobserved intervening
+mutations is ambiguous and rejected. An older generation commit cannot postdate
+the next guard mutation that fences it. Opaque fencing tokens cannot reappear
+after another guard mutation. One lease identity must retain one guard value
+sequence, so changing A to B and back to A cannot be misread as skipped
+renewals. The durable history of the generation-head key is the run
+initialization marker, so deleting both the head and generation zero cannot make
+an initialized run appear empty. Grant times, guard mutation/value sequences,
+and key-lifetime sequences cannot move backward. Missing or contradictory
+history is corruption, not an empty or partially usable assignment.
 
 Coordinator ownership is stored under a schema-versioned, run-scoped lease key.
 The lease record binds the run, a unique coordinator-process incarnation, a

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -858,24 +858,27 @@ Coordinator state that spans multiple keys uses one guarded store transaction.
 The transaction first checks the coordinator lease revision, then every target
 revision, then one authoritative store-time window. It publishes all target
 values with the same commit timestamp and store-stamped guard key, guard
-revision, guard-value digest, and authoritative guard commit time, or publishes
-none. This is the primitive used to create an immutable generation snapshot and
-advance the generation head without allowing a stale or expired coordinator to
-commit either half alone.
+revision, guard-value digest, ordered guard mutation sequence, guard-key lifetime
+sequence, and authoritative guard commit time, or publishes none. This is the
+primitive used to create an immutable generation snapshot and advance the
+generation head without allowing a stale or expired coordinator to commit
+either half alone.
 
-Persisted generation state uses strict versioned records. A
-`GenerationSnapshotRecord` contains the immutable `RankAssignment`, the previous
-snapshot digest, and the complete coordinator lease identity, duration, and
-fencing token that committed it. Generation zero must not name a predecessor,
-while every later generation must carry a lowercase SHA-256 predecessor digest. A
-`GenerationHeadRecord` contains only the run, generation, and canonical snapshot
-digest. Both records reject missing, unknown, duplicate, or unsupported fields.
+Persisted generation state uses strict versioned records.
+`GenerationSnapshotRecord` schema version 2 contains the immutable
+`RankAssignment`, the previous snapshot digest, and the complete coordinator
+lease identity, duration, and opaque fencing token that committed it. Version 1
+is rejected explicitly rather than being interpreted as the expanded layout.
+Generation zero must not name a predecessor, while every later generation must
+carry a lowercase SHA-256 predecessor digest. A `GenerationHeadRecord` contains
+only the run, generation, and canonical snapshot digest. Both records reject
+missing, unknown, duplicate, or unsupported fields.
 
 The generation-state reader derives snapshot, head, and coordinator-lease keys
 from one run-scoped namespace. It requires the head and snapshot to agree on
 generation, digest, authoritative commit time, and store-stamped guard
 provenance, then verifies the complete predecessor digest, timestamp,
-fencing-token, and lease-identity chain back to generation zero. Lease
+guard-mutation, and lease-identity chain back to generation zero. Lease
 identities cannot reappear after a different acquisition, and one acquisition
 cannot change coordinator identity, lease duration, or store-stamped guard-key
 lifetime. Every snapshot entry must retain store-stamped mutation sequence `1`,
@@ -885,20 +888,26 @@ must fall within the stamped lease grant and duration. The head must remain in
 its first store-key lifetime, and a stable immediate successor snapshot beyond
 the head is contradictory state for every read API. Replacing a lease in place
 must not overlap the prior lease's stamped expiry, and one fencing token cannot
-identify multiple grant times or key lifetimes. Renewing the same lease identity
-must occur before its prior expiry, and grant times or key-lifetime sequences
-cannot move backward. Missing or contradictory history is corruption, not an
-empty or partially usable assignment.
+identify multiple guard mutations. Fencing revisions are compared only for
+equality; ordering comes from the store-stamped guard mutation sequence. Each
+guard-key lifetime increase requires at least one delete and one create
+mutation. When generations omit intervening renewals, the mutation distance
+bounds the latest grant time that a valid renewal chain could reach, so skipped
+valid renewals are accepted while resurrection after expiry is rejected. Grant
+times, guard mutations, and key-lifetime sequences cannot move backward.
+Missing or contradictory history is corruption, not an empty or partially
+usable assignment.
 
 Coordinator ownership is stored under a schema-versioned, run-scoped lease key.
 The lease record binds the run, a unique coordinator-process incarnation, a
 unique lease acquisition, and the lease duration. The control store attaches
 its authoritative commit time to every timed mutation. A held lease expires at
 that commit time plus the persisted duration, so network delay before the CAS
-cannot consume the granted lifetime. The record's control-store revision is the
-fencing token; acquisition, renewal, expiry takeover, release, and reacquisition
-therefore always produce a newer token. Every later authoritative coordinator
-mutation must carry the currently held token and fail closed when it is stale.
+cannot consume the granted lifetime. The record's opaque control-store revision
+is the fencing token; acquisition, renewal, expiry takeover, release, and
+reacquisition therefore produce distinct tokens, while the store's mutation
+sequence supplies ordering. Every later authoritative coordinator mutation must
+carry the currently held token and fail closed when it is stale.
 
 Lease time comes from one authoritative, nondecreasing control-plane clock
 shared by all contenders. A clock that moves backward aborts lease operations.

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -857,24 +857,27 @@ layers rather than weakening this storage primitive.
 Coordinator state that spans multiple keys uses one guarded store transaction.
 The transaction first checks the coordinator lease revision, then every target
 revision, then one authoritative store-time window. It publishes all target
-values with the same commit timestamp or publishes none. This is the primitive
-used to create an immutable generation snapshot and advance the generation head
+values with the same commit timestamp and store-stamped guard key, guard
+revision, and guard-value digest, or publishes none. This is the primitive used
+to create an immutable generation snapshot and advance the generation head
 without allowing a stale or expired coordinator to commit either half alone.
 
 Persisted generation state uses strict versioned records. A
 `GenerationSnapshotRecord` contains the immutable `RankAssignment`, the previous
-snapshot digest, and the coordinator lease identity and fencing token that
-committed it. Generation zero must not name a predecessor, while every later
-generation must carry a lowercase SHA-256 predecessor digest. A
+snapshot digest, and the complete coordinator lease identity, duration, and
+fencing token that committed it. Generation zero must not name a predecessor,
+while every later generation must carry a lowercase SHA-256 predecessor digest. A
 `GenerationHeadRecord` contains only the run, generation, and canonical snapshot
 digest. Both records reject missing, unknown, duplicate, or unsupported fields.
 
 The generation-state reader derives snapshot, head, and coordinator-lease keys
 from one run-scoped namespace. It requires the head and snapshot to agree on
-generation, digest, and authoritative commit time, then verifies the complete
-predecessor digest, timestamp, fencing-token, and lease-identity chain back to
-generation zero. Missing or contradictory history is corruption, not an empty
-or partially usable assignment.
+generation, digest, authoritative commit time, and store-stamped guard
+provenance, then verifies the complete predecessor digest, timestamp,
+fencing-token, and lease-identity chain back to generation zero. Lease
+identities cannot reappear after a different acquisition. Missing or
+contradictory history is corruption, not an empty or partially usable
+assignment.
 
 Coordinator ownership is stored under a schema-versioned, run-scoped lease key.
 The lease record binds the run, a unique coordinator-process incarnation, a

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -878,9 +878,11 @@ provenance, then verifies the complete predecessor digest, timestamp,
 fencing-token, and lease-identity chain back to generation zero. Lease
 identities cannot reappear after a different acquisition, and one acquisition
 cannot change coordinator identity or lease duration. Every snapshot entry must
-retain store-stamped initial-creation provenance, and every generation commit
-must fall within the stamped lease grant and duration. Missing or contradictory
-history is corruption, not an empty or partially usable assignment.
+retain store-stamped mutation sequence `1`, while the head mutation sequence
+must equal `generation + 1`; this rejects replacement, recreation, extra
+rewrites, and rollback. Every generation commit must fall within the stamped
+lease grant and duration. Missing or contradictory history is corruption, not
+an empty or partially usable assignment.
 
 Coordinator ownership is stored under a schema-versioned, run-scoped lease key.
 The lease record binds the run, a unique coordinator-process incarnation, a

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -894,20 +894,22 @@ must not overlap the prior lease's stamped expiry, and one fencing token cannot
 identify multiple guard mutations. Fencing revisions are compared only for
 equality; ordering comes from the store-stamped guard mutation sequence. Each
 guard-key lifetime increase requires at least one delete and one create
-mutation, including before the first persisted generation. When generations
-omit intervening renewals of one lease, the mutation distance bounds the latest
-grant time that a valid renewal chain could reach, so skipped valid renewals are
-accepted while resurrection after expiry is rejected. A same-key takeover with
-unobserved intervening mutations is ambiguous and rejected. An older generation
-commit cannot postdate the next guard mutation that fences it. Opaque fencing
-tokens cannot reappear after another guard mutation. One lease identity must
-retain one guard value sequence, so changing A to B and back to A cannot be
-misread as skipped renewals. The durable history of the generation-head key is
-the run initialization marker, so deleting both the head and generation zero
-cannot make an initialized run appear empty. Grant times, guard mutation/value
-sequences, and key-lifetime sequences cannot move backward. Missing or
-contradictory history is corruption, not an empty or partially usable
-assignment.
+mutation, including before the first persisted generation. Because deletion
+advances mutation sequence without advancing value sequence, every entry and
+adjacent transition must also satisfy the corresponding value-sequence upper
+bound. When generations omit intervening renewals of one lease, the mutation
+distance bounds the latest grant time that a valid renewal chain could reach, so
+skipped valid renewals are accepted while resurrection after expiry is rejected.
+A same-key takeover with unobserved intervening mutations is ambiguous and
+rejected. An older generation commit cannot postdate the next guard mutation
+that fences it. Opaque fencing tokens cannot reappear after another guard
+mutation. One lease identity must retain one guard value sequence, so changing A
+to B and back to A cannot be misread as skipped renewals. The durable history of
+the generation-head key is the run initialization marker, so deleting both the
+head and generation zero cannot make an initialized run appear empty. Grant
+times, guard mutation/value sequences, and key-lifetime sequences cannot move
+backward. Missing or contradictory history is corruption, not an empty or
+partially usable assignment.
 
 Coordinator ownership is stored under a schema-versioned, run-scoped lease key.
 The lease record binds the run, a unique coordinator-process incarnation, a

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -869,6 +869,13 @@ generation must carry a lowercase SHA-256 predecessor digest. A
 `GenerationHeadRecord` contains only the run, generation, and canonical snapshot
 digest. Both records reject missing, unknown, duplicate, or unsupported fields.
 
+The generation-state reader derives snapshot, head, and coordinator-lease keys
+from one run-scoped namespace. It requires the head and snapshot to agree on
+generation, digest, and authoritative commit time, then verifies the complete
+predecessor digest, timestamp, fencing-token, and lease-identity chain back to
+generation zero. Missing or contradictory history is corruption, not an empty
+or partially usable assignment.
+
 Coordinator ownership is stored under a schema-versioned, run-scoped lease key.
 The lease record binds the run, a unique coordinator-process incarnation, a
 unique lease acquisition, and the lease duration. The control store attaches

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -891,12 +891,15 @@ must not overlap the prior lease's stamped expiry, and one fencing token cannot
 identify multiple guard mutations. Fencing revisions are compared only for
 equality; ordering comes from the store-stamped guard mutation sequence. Each
 guard-key lifetime increase requires at least one delete and one create
-mutation. When generations omit intervening renewals, the mutation distance
-bounds the latest grant time that a valid renewal chain could reach, so skipped
-valid renewals are accepted while resurrection after expiry is rejected. Grant
-times, guard mutations, and key-lifetime sequences cannot move backward.
-Missing or contradictory history is corruption, not an empty or partially
-usable assignment.
+mutation, including before the first persisted generation. When generations
+omit intervening renewals of one lease, the mutation distance bounds the latest
+grant time that a valid renewal chain could reach, so skipped valid renewals are
+accepted while resurrection after expiry is rejected. A same-key takeover with
+unobserved intervening mutations is ambiguous and rejected. An older generation
+commit cannot postdate the next guard mutation that fences it. Grant times,
+guard mutations, and key-lifetime sequences cannot move backward. Missing or
+contradictory history is corruption, not an empty or partially usable
+assignment.
 
 Coordinator ownership is stored under a schema-versioned, run-scoped lease key.
 The lease record binds the run, a unique coordinator-process incarnation, a

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -885,8 +885,10 @@ must fall within the stamped lease grant and duration. The head must remain in
 its first store-key lifetime, and a stable immediate successor snapshot beyond
 the head is contradictory state for every read API. Replacing a lease in place
 must not overlap the prior lease's stamped expiry, and one fencing token cannot
-identify multiple grant times or key lifetimes. Missing or contradictory history
-is corruption, not an empty or partially usable assignment.
+identify multiple grant times or key lifetimes. Renewing the same lease identity
+must occur before its prior expiry, and grant times cannot move backward.
+Missing or contradictory history is corruption, not an empty or partially
+usable assignment.
 
 Coordinator ownership is stored under a schema-versioned, run-scoped lease key.
 The lease record binds the run, a unique coordinator-process incarnation, a

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -877,12 +877,12 @@ generation, digest, authoritative commit time, and store-stamped guard
 provenance, then verifies the complete predecessor digest, timestamp,
 fencing-token, and lease-identity chain back to generation zero. Lease
 identities cannot reappear after a different acquisition, and one acquisition
-cannot change coordinator identity or lease duration. Every snapshot entry must
-retain store-stamped mutation sequence `1`, while the head mutation sequence
-must equal `generation + 1`; this rejects replacement, recreation, extra
-rewrites, and rollback. Every generation commit must fall within the stamped
-lease grant and duration. Missing or contradictory history is corruption, not
-an empty or partially usable assignment.
+cannot change coordinator identity, lease duration, or store-stamped guard-key
+lifetime. Every snapshot entry must retain store-stamped mutation sequence `1`,
+while the head mutation sequence must equal `generation + 1`; this rejects
+replacement, recreation, extra rewrites, and rollback. Every generation commit
+must fall within the stamped lease grant and duration. Missing or contradictory
+history is corruption, not an empty or partially usable assignment.
 
 Coordinator ownership is stored under a schema-versioned, run-scoped lease key.
 The lease record binds the run, a unique coordinator-process incarnation, a

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -860,11 +860,12 @@ Coordinator state that spans multiple keys uses one guarded store transaction.
 The transaction first checks the coordinator lease revision, then every target
 revision, then one authoritative store-time window. It publishes all target
 values with the same commit timestamp and store-stamped guard key, guard
-revision, guard-value digest, ordered guard mutation sequence, guard-key lifetime
-sequence, and authoritative guard commit time, or publishes none. This is the
-primitive used to create an immutable generation snapshot and advance the
-generation head without allowing a stale or expired coordinator to commit
-either half alone.
+revision, guard-value digest, ordered guard mutation and value sequences,
+guard-key lifetime sequence, and authoritative guard commit time, or publishes
+none. The value sequence changes whenever the guarded bytes change or the key is
+recreated, but remains stable across same-value renewals. This is the primitive
+used to create an immutable generation snapshot and advance the generation head
+without allowing a stale or expired coordinator to commit either half alone.
 
 Persisted generation state uses strict versioned records.
 `GenerationSnapshotRecord` schema version 2 contains the immutable
@@ -899,10 +900,12 @@ grant time that a valid renewal chain could reach, so skipped valid renewals are
 accepted while resurrection after expiry is rejected. A same-key takeover with
 unobserved intervening mutations is ambiguous and rejected. An older generation
 commit cannot postdate the next guard mutation that fences it. Opaque fencing
-tokens cannot reappear after another guard mutation. The durable history of the
-generation-head key is the run initialization marker, so deleting both the head
-and generation zero cannot make an initialized run appear empty. Grant times,
-guard mutations, and key-lifetime sequences cannot move backward. Missing or
+tokens cannot reappear after another guard mutation. One lease identity must
+retain one guard value sequence, so changing A to B and back to A cannot be
+misread as skipped renewals. The durable history of the generation-head key is
+the run initialization marker, so deleting both the head and generation zero
+cannot make an initialized run appear empty. Grant times, guard mutation/value
+sequences, and key-lifetime sequences cannot move backward. Missing or
 contradictory history is corruption, not an empty or partially usable
 assignment.
 

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -858,9 +858,10 @@ Coordinator state that spans multiple keys uses one guarded store transaction.
 The transaction first checks the coordinator lease revision, then every target
 revision, then one authoritative store-time window. It publishes all target
 values with the same commit timestamp and store-stamped guard key, guard
-revision, and guard-value digest, or publishes none. This is the primitive used
-to create an immutable generation snapshot and advance the generation head
-without allowing a stale or expired coordinator to commit either half alone.
+revision, guard-value digest, and authoritative guard commit time, or publishes
+none. This is the primitive used to create an immutable generation snapshot and
+advance the generation head without allowing a stale or expired coordinator to
+commit either half alone.
 
 Persisted generation state uses strict versioned records. A
 `GenerationSnapshotRecord` contains the immutable `RankAssignment`, the previous
@@ -875,9 +876,11 @@ from one run-scoped namespace. It requires the head and snapshot to agree on
 generation, digest, authoritative commit time, and store-stamped guard
 provenance, then verifies the complete predecessor digest, timestamp,
 fencing-token, and lease-identity chain back to generation zero. Lease
-identities cannot reappear after a different acquisition. Missing or
-contradictory history is corruption, not an empty or partially usable
-assignment.
+identities cannot reappear after a different acquisition, and one acquisition
+cannot change coordinator identity or lease duration. Every snapshot entry must
+retain store-stamped initial-creation provenance, and every generation commit
+must fall within the stamped lease grant and duration. Missing or contradictory
+history is corruption, not an empty or partially usable assignment.
 
 Coordinator ownership is stored under a schema-versioned, run-scoped lease key.
 The lease record binds the run, a unique coordinator-process incarnation, a

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -852,7 +852,9 @@ and deletion require the exact current revision. Revisions never repeat for a
 key, including after deletion and recreation, so a delayed coordinator cannot
 mistake a recreated record for an older value with identical bytes. Higher
 coordinator records add lease fencing and run/schema namespaces in subsequent
-layers rather than weakening this storage primitive.
+layers rather than weakening this storage primitive. The store also retains a
+durable `has_history(key)` bit after deletion, allowing readers to distinguish a
+never-created authoritative key from one that was removed.
 
 Coordinator state that spans multiple keys uses one guarded store transaction.
 The transaction first checks the coordinator lease revision, then every target
@@ -896,7 +898,10 @@ omit intervening renewals of one lease, the mutation distance bounds the latest
 grant time that a valid renewal chain could reach, so skipped valid renewals are
 accepted while resurrection after expiry is rejected. A same-key takeover with
 unobserved intervening mutations is ambiguous and rejected. An older generation
-commit cannot postdate the next guard mutation that fences it. Grant times,
+commit cannot postdate the next guard mutation that fences it. Opaque fencing
+tokens cannot reappear after another guard mutation. The durable history of the
+generation-head key is the run initialization marker, so deleting both the head
+and generation zero cannot make an initialized run appear empty. Grant times,
 guard mutations, and key-lifetime sequences cannot move backward. Missing or
 contradictory history is corruption, not an empty or partially usable
 assignment.

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -883,8 +883,10 @@ while the head mutation sequence must equal `generation + 1`; this rejects
 replacement, recreation, extra rewrites, and rollback. Every generation commit
 must fall within the stamped lease grant and duration. The head must remain in
 its first store-key lifetime, and a stable immediate successor snapshot beyond
-the head is contradictory state. Missing or contradictory history is
-corruption, not an empty or partially usable assignment.
+the head is contradictory state for every read API. Replacing a lease in place
+must not overlap the prior lease's stamped expiry, and one fencing token cannot
+identify multiple grant times or key lifetimes. Missing or contradictory history
+is corruption, not an empty or partially usable assignment.
 
 Coordinator ownership is stored under a schema-versioned, run-scoped lease key.
 The lease record binds the run, a unique coordinator-process incarnation, a

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -881,8 +881,10 @@ cannot change coordinator identity, lease duration, or store-stamped guard-key
 lifetime. Every snapshot entry must retain store-stamped mutation sequence `1`,
 while the head mutation sequence must equal `generation + 1`; this rejects
 replacement, recreation, extra rewrites, and rollback. Every generation commit
-must fall within the stamped lease grant and duration. Missing or contradictory
-history is corruption, not an empty or partially usable assignment.
+must fall within the stamped lease grant and duration. The head must remain in
+its first store-key lifetime, and a stable immediate successor snapshot beyond
+the head is contradictory state. Missing or contradictory history is
+corruption, not an empty or partially usable assignment.
 
 Coordinator ownership is stored under a schema-versioned, run-scoped lease key.
 The lease record binds the run, a unique coordinator-process incarnation, a

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -886,9 +886,9 @@ its first store-key lifetime, and a stable immediate successor snapshot beyond
 the head is contradictory state for every read API. Replacing a lease in place
 must not overlap the prior lease's stamped expiry, and one fencing token cannot
 identify multiple grant times or key lifetimes. Renewing the same lease identity
-must occur before its prior expiry, and grant times cannot move backward.
-Missing or contradictory history is corruption, not an empty or partially
-usable assignment.
+must occur before its prior expiry, and grant times or key-lifetime sequences
+cannot move backward. Missing or contradictory history is corruption, not an
+empty or partially usable assignment.
 
 Coordinator ownership is stored under a schema-versioned, run-scoped lease key.
 The lease record binds the run, a unique coordinator-process incarnation, a

--- a/lm_resiliency/integrations/torchrun/_control_store.py
+++ b/lm_resiliency/integrations/torchrun/_control_store.py
@@ -70,7 +70,7 @@ class ControlStoreEntry:
     value: bytes
     revision: int
     committed_at_unix_ms: int | None = None
-    is_initial_creation: bool = True
+    mutation_sequence: int = 1
     guard_key: str | None = None
     guard_revision: int | None = None
     guard_value_digest: str | None = None
@@ -79,8 +79,11 @@ class ControlStoreEntry:
     def __post_init__(self) -> None:
         object.__setattr__(self, "value", _control_value(self.value))
         object.__setattr__(self, "revision", _required_revision(self.revision))
-        if not isinstance(self.is_initial_creation, bool):
-            raise TypeError("is_initial_creation must be a boolean")
+        object.__setattr__(
+            self,
+            "mutation_sequence",
+            _positive_integer(self.mutation_sequence, "mutation_sequence"),
+        )
         if self.committed_at_unix_ms is not None:
             object.__setattr__(
                 self,
@@ -217,6 +220,7 @@ class InMemoryControlStore:
         self._lock = threading.RLock()
         self._entries: dict[str, ControlStoreEntry] = {}
         self._last_revisions: dict[str, int] = {}
+        self._mutation_sequences: dict[str, int] = {}
         self._clock = clock or _system_unix_ms
         self._last_now_unix_ms = 0
 
@@ -403,13 +407,12 @@ class InMemoryControlStore:
         guard_value_digest: str | None = None,
         guard_committed_at_unix_ms: int | None = None,
     ) -> ControlStoreEntry:
-        is_initial_creation = key not in self._last_revisions
         revision = self._next_revision(key)
         entry = ControlStoreEntry(
             value=value,
             revision=revision,
             committed_at_unix_ms=committed_at_unix_ms,
-            is_initial_creation=is_initial_creation,
+            mutation_sequence=self._mutation_sequences[key],
             guard_key=guard_key,
             guard_revision=guard_revision,
             guard_value_digest=guard_value_digest,
@@ -421,6 +424,7 @@ class InMemoryControlStore:
     def _next_revision(self, key: str) -> int:
         revision = self._last_revisions.get(key, 0) + 1
         self._last_revisions[key] = revision
+        self._mutation_sequences[key] = self._mutation_sequences.get(key, 0) + 1
         return revision
 
     def _store_now_unix_ms(self) -> int:

--- a/lm_resiliency/integrations/torchrun/_control_store.py
+++ b/lm_resiliency/integrations/torchrun/_control_store.py
@@ -71,9 +71,11 @@ class ControlStoreEntry:
     revision: int
     committed_at_unix_ms: int | None = None
     mutation_sequence: int = 1
+    lifetime_sequence: int = 1
     guard_key: str | None = None
     guard_revision: int | None = None
     guard_value_digest: str | None = None
+    guard_lifetime_sequence: int | None = None
     guard_committed_at_unix_ms: int | None = None
 
     def __post_init__(self) -> None:
@@ -83,6 +85,11 @@ class ControlStoreEntry:
             self,
             "mutation_sequence",
             _positive_integer(self.mutation_sequence, "mutation_sequence"),
+        )
+        object.__setattr__(
+            self,
+            "lifetime_sequence",
+            _positive_integer(self.lifetime_sequence, "lifetime_sequence"),
         )
         if self.committed_at_unix_ms is not None:
             object.__setattr__(
@@ -97,6 +104,7 @@ class ControlStoreEntry:
             self.guard_key,
             self.guard_revision,
             self.guard_value_digest,
+            self.guard_lifetime_sequence,
         )
         if any(value is not None for value in guard_values):
             if not all(value is not None for value in guard_values):
@@ -113,6 +121,14 @@ class ControlStoreEntry:
                 _sha256_digest(
                     self.guard_value_digest,
                     "guard_value_digest",
+                ),
+            )
+            object.__setattr__(
+                self,
+                "guard_lifetime_sequence",
+                _positive_integer(
+                    self.guard_lifetime_sequence,
+                    "guard_lifetime_sequence",
                 ),
             )
             if self.guard_committed_at_unix_ms is not None:
@@ -207,8 +223,8 @@ class ControlStore(Protocol):
         """Atomically publish writes while a guard revision is live.
 
         Every returned target entry carries store-stamped guard key, revision,
-        value digest, and authoritative guard commit time from the same
-        linearization point.
+        value digest, key-lifetime sequence, and authoritative guard commit
+        time from the same linearization point.
         """
         ...
 
@@ -221,6 +237,7 @@ class InMemoryControlStore:
         self._entries: dict[str, ControlStoreEntry] = {}
         self._last_revisions: dict[str, int] = {}
         self._mutation_sequences: dict[str, int] = {}
+        self._lifetime_sequences: dict[str, int] = {}
         self._clock = clock or _system_unix_ms
         self._last_now_unix_ms = 0
 
@@ -384,6 +401,7 @@ class InMemoryControlStore:
                     guard_key=normalized_guard_key,
                     guard_revision=normalized_guard_revision,
                     guard_value_digest=guard_value_digest,
+                    guard_lifetime_sequence=guard_entry.lifetime_sequence,
                     guard_committed_at_unix_ms=guard_entry.committed_at_unix_ms,
                 )
                 for key, write in normalized_writes.items()
@@ -405,17 +423,22 @@ class InMemoryControlStore:
         guard_key: str | None = None,
         guard_revision: int | None = None,
         guard_value_digest: str | None = None,
+        guard_lifetime_sequence: int | None = None,
         guard_committed_at_unix_ms: int | None = None,
     ) -> ControlStoreEntry:
+        if key not in self._entries:
+            self._lifetime_sequences[key] = self._lifetime_sequences.get(key, 0) + 1
         revision = self._next_revision(key)
         entry = ControlStoreEntry(
             value=value,
             revision=revision,
             committed_at_unix_ms=committed_at_unix_ms,
             mutation_sequence=self._mutation_sequences[key],
+            lifetime_sequence=self._lifetime_sequences[key],
             guard_key=guard_key,
             guard_revision=guard_revision,
             guard_value_digest=guard_value_digest,
+            guard_lifetime_sequence=guard_lifetime_sequence,
             guard_committed_at_unix_ms=guard_committed_at_unix_ms,
         )
         self._entries[key] = entry

--- a/lm_resiliency/integrations/torchrun/_control_store.py
+++ b/lm_resiliency/integrations/torchrun/_control_store.py
@@ -71,11 +71,13 @@ class ControlStoreEntry:
     revision: int
     committed_at_unix_ms: int | None = None
     mutation_sequence: int = 1
+    value_sequence: int = 1
     lifetime_sequence: int = 1
     guard_key: str | None = None
     guard_revision: int | None = None
     guard_value_digest: str | None = None
     guard_mutation_sequence: int | None = None
+    guard_value_sequence: int | None = None
     guard_lifetime_sequence: int | None = None
     guard_committed_at_unix_ms: int | None = None
 
@@ -86,6 +88,11 @@ class ControlStoreEntry:
             self,
             "mutation_sequence",
             _positive_integer(self.mutation_sequence, "mutation_sequence"),
+        )
+        object.__setattr__(
+            self,
+            "value_sequence",
+            _positive_integer(self.value_sequence, "value_sequence"),
         )
         object.__setattr__(
             self,
@@ -106,6 +113,7 @@ class ControlStoreEntry:
             self.guard_revision,
             self.guard_value_digest,
             self.guard_mutation_sequence,
+            self.guard_value_sequence,
             self.guard_lifetime_sequence,
         )
         if any(value is not None for value in guard_values):
@@ -131,6 +139,14 @@ class ControlStoreEntry:
                 _positive_integer(
                     self.guard_mutation_sequence,
                     "guard_mutation_sequence",
+                ),
+            )
+            object.__setattr__(
+                self,
+                "guard_value_sequence",
+                _positive_integer(
+                    self.guard_value_sequence,
+                    "guard_value_sequence",
                 ),
             )
             object.__setattr__(
@@ -241,8 +257,9 @@ class ControlStore(Protocol):
         """Atomically publish writes while a guard revision is live.
 
         Every returned target entry carries store-stamped guard key, revision,
-        value digest, ordered mutation sequence, key-lifetime sequence, and
-        authoritative guard commit time from the same linearization point.
+        value digest, ordered mutation and value sequences, key-lifetime
+        sequence, and authoritative guard commit time from the same
+        linearization point.
         """
         ...
 
@@ -255,6 +272,7 @@ class InMemoryControlStore:
         self._entries: dict[str, ControlStoreEntry] = {}
         self._last_revisions: dict[str, int] = {}
         self._mutation_sequences: dict[str, int] = {}
+        self._value_sequences: dict[str, int] = {}
         self._lifetime_sequences: dict[str, int] = {}
         self._clock = clock or _system_unix_ms
         self._last_now_unix_ms = 0
@@ -425,6 +443,7 @@ class InMemoryControlStore:
                     guard_revision=normalized_guard_revision,
                     guard_value_digest=guard_value_digest,
                     guard_mutation_sequence=guard_entry.mutation_sequence,
+                    guard_value_sequence=guard_entry.value_sequence,
                     guard_lifetime_sequence=guard_entry.lifetime_sequence,
                     guard_committed_at_unix_ms=guard_entry.committed_at_unix_ms,
                 )
@@ -448,22 +467,29 @@ class InMemoryControlStore:
         guard_revision: int | None = None,
         guard_value_digest: str | None = None,
         guard_mutation_sequence: int | None = None,
+        guard_value_sequence: int | None = None,
         guard_lifetime_sequence: int | None = None,
         guard_committed_at_unix_ms: int | None = None,
     ) -> ControlStoreEntry:
-        if key not in self._entries:
+        current_entry = self._entries.get(key)
+        if current_entry is None:
             self._lifetime_sequences[key] = self._lifetime_sequences.get(key, 0) + 1
+            self._value_sequences[key] = self._value_sequences.get(key, 0) + 1
+        elif current_entry.value != value:
+            self._value_sequences[key] += 1
         revision = self._next_revision(key)
         entry = ControlStoreEntry(
             value=value,
             revision=revision,
             committed_at_unix_ms=committed_at_unix_ms,
             mutation_sequence=self._mutation_sequences[key],
+            value_sequence=self._value_sequences[key],
             lifetime_sequence=self._lifetime_sequences[key],
             guard_key=guard_key,
             guard_revision=guard_revision,
             guard_value_digest=guard_value_digest,
             guard_mutation_sequence=guard_mutation_sequence,
+            guard_value_sequence=guard_value_sequence,
             guard_lifetime_sequence=guard_lifetime_sequence,
             guard_committed_at_unix_ms=guard_committed_at_unix_ms,
         )

--- a/lm_resiliency/integrations/torchrun/_control_store.py
+++ b/lm_resiliency/integrations/torchrun/_control_store.py
@@ -70,13 +70,17 @@ class ControlStoreEntry:
     value: bytes
     revision: int
     committed_at_unix_ms: int | None = None
+    is_initial_creation: bool = True
     guard_key: str | None = None
     guard_revision: int | None = None
     guard_value_digest: str | None = None
+    guard_committed_at_unix_ms: int | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "value", _control_value(self.value))
         object.__setattr__(self, "revision", _required_revision(self.revision))
+        if not isinstance(self.is_initial_creation, bool):
+            raise TypeError("is_initial_creation must be a boolean")
         if self.committed_at_unix_ms is not None:
             object.__setattr__(
                 self,
@@ -108,6 +112,17 @@ class ControlStoreEntry:
                     "guard_value_digest",
                 ),
             )
+            if self.guard_committed_at_unix_ms is not None:
+                object.__setattr__(
+                    self,
+                    "guard_committed_at_unix_ms",
+                    _positive_integer(
+                        self.guard_committed_at_unix_ms,
+                        "guard_committed_at_unix_ms",
+                    ),
+                )
+        elif self.guard_committed_at_unix_ms is not None:
+            raise ValueError("control-store guard grant time requires guard provenance")
 
 
 @dataclass(frozen=True, slots=True)
@@ -189,7 +204,8 @@ class ControlStore(Protocol):
         """Atomically publish writes while a guard revision is live.
 
         Every returned target entry carries store-stamped guard key, revision,
-        and value-digest provenance from the same linearization point.
+        value digest, and authoritative guard commit time from the same
+        linearization point.
         """
         ...
 
@@ -364,6 +380,7 @@ class InMemoryControlStore:
                     guard_key=normalized_guard_key,
                     guard_revision=normalized_guard_revision,
                     guard_value_digest=guard_value_digest,
+                    guard_committed_at_unix_ms=guard_entry.committed_at_unix_ms,
                 )
                 for key, write in normalized_writes.items()
             }
@@ -384,15 +401,19 @@ class InMemoryControlStore:
         guard_key: str | None = None,
         guard_revision: int | None = None,
         guard_value_digest: str | None = None,
+        guard_committed_at_unix_ms: int | None = None,
     ) -> ControlStoreEntry:
+        is_initial_creation = key not in self._last_revisions
         revision = self._next_revision(key)
         entry = ControlStoreEntry(
             value=value,
             revision=revision,
             committed_at_unix_ms=committed_at_unix_ms,
+            is_initial_creation=is_initial_creation,
             guard_key=guard_key,
             guard_revision=guard_revision,
             guard_value_digest=guard_value_digest,
+            guard_committed_at_unix_ms=guard_committed_at_unix_ms,
         )
         self._entries[key] = entry
         return entry

--- a/lm_resiliency/integrations/torchrun/_control_store.py
+++ b/lm_resiliency/integrations/torchrun/_control_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import threading
 import time
 from collections.abc import Callable, Mapping
@@ -69,6 +70,9 @@ class ControlStoreEntry:
     value: bytes
     revision: int
     committed_at_unix_ms: int | None = None
+    guard_key: str | None = None
+    guard_revision: int | None = None
+    guard_value_digest: str | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "value", _control_value(self.value))
@@ -80,6 +84,28 @@ class ControlStoreEntry:
                 _positive_integer(
                     self.committed_at_unix_ms,
                     "committed_at_unix_ms",
+                ),
+            )
+        guard_values = (
+            self.guard_key,
+            self.guard_revision,
+            self.guard_value_digest,
+        )
+        if any(value is not None for value in guard_values):
+            if not all(value is not None for value in guard_values):
+                raise ValueError("control-store guard provenance must be complete")
+            object.__setattr__(self, "guard_key", _control_key(self.guard_key))
+            object.__setattr__(
+                self,
+                "guard_revision",
+                _required_revision(self.guard_revision),
+            )
+            object.__setattr__(
+                self,
+                "guard_value_digest",
+                _sha256_digest(
+                    self.guard_value_digest,
+                    "guard_value_digest",
                 ),
             )
 
@@ -160,7 +186,11 @@ class ControlStore(Protocol):
         not_before_unix_ms: int,
         deadline_unix_ms: int,
     ) -> Mapping[str, ControlStoreEntry]:
-        """Atomically publish writes while a guard revision is live in the time window."""
+        """Atomically publish writes while a guard revision is live.
+
+        Every returned target entry carries store-stamped guard key, revision,
+        and value-digest provenance from the same linearization point.
+        """
         ...
 
 
@@ -309,6 +339,8 @@ class InMemoryControlStore:
             raise ValueError("not_before_unix_ms must be before deadline_unix_ms")
         with self._lock:
             self._require_revision(normalized_guard_key, normalized_guard_revision)
+            guard_entry = self._entries[normalized_guard_key]
+            guard_value_digest = hashlib.sha256(guard_entry.value).hexdigest()
             for key, write in normalized_writes.items():
                 self._require_revision(key, write.expected_revision)
             now_unix_ms = self._store_now_unix_ms()
@@ -329,6 +361,9 @@ class InMemoryControlStore:
                     key,
                     write.value,
                     committed_at_unix_ms=now_unix_ms,
+                    guard_key=normalized_guard_key,
+                    guard_revision=normalized_guard_revision,
+                    guard_value_digest=guard_value_digest,
                 )
                 for key, write in normalized_writes.items()
             }
@@ -346,12 +381,18 @@ class InMemoryControlStore:
         value: bytes,
         *,
         committed_at_unix_ms: int | None = None,
+        guard_key: str | None = None,
+        guard_revision: int | None = None,
+        guard_value_digest: str | None = None,
     ) -> ControlStoreEntry:
         revision = self._next_revision(key)
         entry = ControlStoreEntry(
             value=value,
             revision=revision,
             committed_at_unix_ms=committed_at_unix_ms,
+            guard_key=guard_key,
+            guard_revision=guard_revision,
+            guard_value_digest=guard_value_digest,
         )
         self._entries[key] = entry
         return entry
@@ -379,6 +420,16 @@ def _control_value(value: object) -> bytes:
     if not isinstance(value, bytes):
         raise TypeError("control-store value must be bytes")
     return bytes(value)
+
+
+def _sha256_digest(value: object, path: str) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise ValueError(f"{path} must be a lowercase SHA-256 digest")
+    return value
 
 
 def _control_writes(value: object) -> dict[str, ControlStoreWrite]:

--- a/lm_resiliency/integrations/torchrun/_control_store.py
+++ b/lm_resiliency/integrations/torchrun/_control_store.py
@@ -177,6 +177,14 @@ class ControlStore(Protocol):
         """Return the current value, or ``None`` when the key is absent."""
         ...
 
+    def has_history(self, key: str) -> bool:
+        """Return whether ``key`` has ever held a committed value.
+
+        History remains true after deletion so callers can distinguish a
+        never-created key from a deleted authoritative record.
+        """
+        ...
+
     def compare_set(
         self,
         key: str,
@@ -255,6 +263,11 @@ class InMemoryControlStore:
         normalized_key = _control_key(key)
         with self._lock:
             return self._entries.get(normalized_key)
+
+    def has_history(self, key: str) -> bool:
+        normalized_key = _control_key(key)
+        with self._lock:
+            return normalized_key in self._last_revisions
 
     def compare_set(
         self,

--- a/lm_resiliency/integrations/torchrun/_control_store.py
+++ b/lm_resiliency/integrations/torchrun/_control_store.py
@@ -75,6 +75,7 @@ class ControlStoreEntry:
     guard_key: str | None = None
     guard_revision: int | None = None
     guard_value_digest: str | None = None
+    guard_mutation_sequence: int | None = None
     guard_lifetime_sequence: int | None = None
     guard_committed_at_unix_ms: int | None = None
 
@@ -104,6 +105,7 @@ class ControlStoreEntry:
             self.guard_key,
             self.guard_revision,
             self.guard_value_digest,
+            self.guard_mutation_sequence,
             self.guard_lifetime_sequence,
         )
         if any(value is not None for value in guard_values):
@@ -121,6 +123,14 @@ class ControlStoreEntry:
                 _sha256_digest(
                     self.guard_value_digest,
                     "guard_value_digest",
+                ),
+            )
+            object.__setattr__(
+                self,
+                "guard_mutation_sequence",
+                _positive_integer(
+                    self.guard_mutation_sequence,
+                    "guard_mutation_sequence",
                 ),
             )
             object.__setattr__(
@@ -223,8 +233,8 @@ class ControlStore(Protocol):
         """Atomically publish writes while a guard revision is live.
 
         Every returned target entry carries store-stamped guard key, revision,
-        value digest, key-lifetime sequence, and authoritative guard commit
-        time from the same linearization point.
+        value digest, ordered mutation sequence, key-lifetime sequence, and
+        authoritative guard commit time from the same linearization point.
         """
         ...
 
@@ -401,6 +411,7 @@ class InMemoryControlStore:
                     guard_key=normalized_guard_key,
                     guard_revision=normalized_guard_revision,
                     guard_value_digest=guard_value_digest,
+                    guard_mutation_sequence=guard_entry.mutation_sequence,
                     guard_lifetime_sequence=guard_entry.lifetime_sequence,
                     guard_committed_at_unix_ms=guard_entry.committed_at_unix_ms,
                 )
@@ -423,6 +434,7 @@ class InMemoryControlStore:
         guard_key: str | None = None,
         guard_revision: int | None = None,
         guard_value_digest: str | None = None,
+        guard_mutation_sequence: int | None = None,
         guard_lifetime_sequence: int | None = None,
         guard_committed_at_unix_ms: int | None = None,
     ) -> ControlStoreEntry:
@@ -438,6 +450,7 @@ class InMemoryControlStore:
             guard_key=guard_key,
             guard_revision=guard_revision,
             guard_value_digest=guard_value_digest,
+            guard_mutation_sequence=guard_mutation_sequence,
             guard_lifetime_sequence=guard_lifetime_sequence,
             guard_committed_at_unix_ms=guard_committed_at_unix_ms,
         )

--- a/lm_resiliency/integrations/torchrun/_generation_reader.py
+++ b/lm_resiliency/integrations/torchrun/_generation_reader.py
@@ -305,9 +305,9 @@ class GenerationStateReader:
                 raise GenerationStateCorrupt(
                     "generation snapshot guard lifetime lacks a new value sequence"
                 )
-            if guard_value_delta > guard_mutation_delta:
+            if guard_value_delta > guard_mutation_delta - guard_lifetime_delta:
                 raise GenerationStateCorrupt(
-                    "generation snapshot guard values advance faster than mutations"
+                    "generation snapshot guard values include deletion mutations"
                 )
             if (
                 guard_mutation_delta > 0
@@ -462,9 +462,9 @@ class GenerationStateReader:
             raise GenerationStateCorrupt(
                 "generation state guard value sequence cannot support its lifetime"
             )
-        if guard_value_sequence > guard_mutation_sequence:
+        if guard_value_sequence > guard_mutation_sequence - guard_lifetime_sequence + 1:
             raise GenerationStateCorrupt(
-                "generation state guard value sequence exceeds its mutations"
+                "generation state guard value sequence includes deletion mutations"
             )
         guard_committed_at_unix_ms = entry.guard_committed_at_unix_ms
         if guard_committed_at_unix_ms is None:

--- a/lm_resiliency/integrations/torchrun/_generation_reader.py
+++ b/lm_resiliency/integrations/torchrun/_generation_reader.py
@@ -1,0 +1,243 @@
+"""Fail-closed reads of immutable torchrun generation state."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStore,
+    ControlStoreEntry,
+)
+from lm_resiliency.integrations.torchrun._generation_records import (
+    GenerationHeadRecord,
+    GenerationSnapshotRecord,
+)
+
+_CONTROL_PREFIX = "lm_resiliency/torchrun/v1"
+_MAX_READ_ATTEMPTS = 8
+
+
+class GenerationStateError(RuntimeError):
+    """Base error for generation-state operations."""
+
+
+class GenerationStateCorrupt(GenerationStateError):
+    """Raised when persisted generation state is malformed or contradictory."""
+
+
+@dataclass(frozen=True, slots=True)
+class StoredGenerationSnapshot:
+    """One decoded immutable snapshot and its store metadata."""
+
+    record: GenerationSnapshotRecord
+    revision: int
+    committed_at_unix_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class CurrentGeneration:
+    """The generation head and the immutable snapshot it references."""
+
+    snapshot: StoredGenerationSnapshot
+    head_revision: int
+
+
+class GenerationStateReader:
+    """Read and verify one run's immutable generation history."""
+
+    def __init__(
+        self,
+        store: ControlStore,
+        *,
+        run_id: str,
+    ) -> None:
+        self._store = store
+        self._run_id = _nonempty_string(run_id, "run_id")
+        run_digest = hashlib.sha256(self._run_id.encode("utf-8")).hexdigest()
+        self._run_prefix = f"{_CONTROL_PREFIX}/runs/{run_digest}"
+        self._coordinator_lease_key = f"{self._run_prefix}/coordinator-lease"
+        self._head_key = f"{self._run_prefix}/generation-head"
+
+    @property
+    def coordinator_lease_key(self) -> str:
+        return self._coordinator_lease_key
+
+    @property
+    def head_key(self) -> str:
+        return self._head_key
+
+    def snapshot_key(self, generation: int) -> str:
+        normalized_generation = _nonnegative_integer(generation, "generation")
+        return f"{self._run_prefix}/generations/{normalized_generation}"
+
+    def current(self) -> CurrentGeneration | None:
+        result = self._read_current_history()
+        if result is None:
+            return None
+        current, _ = result
+        return current
+
+    def get(self, generation: int) -> StoredGenerationSnapshot | None:
+        normalized_generation = _nonnegative_integer(generation, "generation")
+        snapshot_key = self.snapshot_key(normalized_generation)
+        for _ in range(_MAX_READ_ATTEMPTS):
+            result = self._read_current_history()
+            if result is None:
+                if self._store.get(snapshot_key) is None:
+                    return None
+                if self._store.get(self._head_key) is not None:
+                    continue
+                raise GenerationStateCorrupt("generation snapshot exists without a generation head")
+            current, history = result
+            current_generation = current.snapshot.record.assignment.generation
+            if normalized_generation <= current_generation:
+                return history[normalized_generation]
+            if self._store.get(snapshot_key) is None:
+                return None
+            observed_head = self._store.get(self._head_key)
+            if observed_head is not None and observed_head.revision != current.head_revision:
+                continue
+            if observed_head is None:
+                raise GenerationStateCorrupt("generation head disappeared while reading a snapshot")
+            if observed_head.revision == current.head_revision:
+                raise GenerationStateCorrupt(
+                    "generation snapshot is newer than the generation head"
+                )
+        raise GenerationStateError("generation head changed repeatedly during read")
+
+    def _read_current_history(
+        self,
+    ) -> tuple[CurrentGeneration, dict[int, StoredGenerationSnapshot]] | None:
+        head_entry = self._store.get(self._head_key)
+        if head_entry is None:
+            return None
+        head = self._decode_head(head_entry)
+        snapshot_entry = self._store.get(self.snapshot_key(head.generation))
+        if snapshot_entry is None:
+            raise GenerationStateCorrupt("generation head references a missing snapshot")
+        snapshot = self._decode_snapshot(
+            snapshot_entry,
+            expected_generation=head.generation,
+        )
+        history = self._read_snapshot_history(snapshot)
+        self._validate_head_link(head, head_entry, snapshot)
+        return (
+            CurrentGeneration(
+                snapshot=snapshot,
+                head_revision=head_entry.revision,
+            ),
+            history,
+        )
+
+    def _decode_head(self, entry: ControlStoreEntry) -> GenerationHeadRecord:
+        try:
+            head = GenerationHeadRecord.from_json(entry.value)
+        except (TypeError, ValueError) as error:
+            raise GenerationStateCorrupt("generation head is malformed") from error
+        if head.run_id != self._run_id:
+            raise GenerationStateCorrupt("generation head belongs to another run")
+        if entry.committed_at_unix_ms is None:
+            raise GenerationStateCorrupt("generation head has no authoritative commit time")
+        return head
+
+    def _decode_snapshot(
+        self,
+        entry: ControlStoreEntry,
+        *,
+        expected_generation: int,
+    ) -> StoredGenerationSnapshot:
+        try:
+            record = GenerationSnapshotRecord.from_json(entry.value)
+        except (TypeError, ValueError) as error:
+            raise GenerationStateCorrupt("generation snapshot is malformed") from error
+        assignment = record.assignment
+        if assignment.run_id != self._run_id:
+            raise GenerationStateCorrupt("generation snapshot belongs to another run")
+        if assignment.generation != expected_generation:
+            raise GenerationStateCorrupt("generation snapshot key and payload disagree")
+        if entry.committed_at_unix_ms is None:
+            raise GenerationStateCorrupt("generation snapshot has no authoritative commit time")
+        return StoredGenerationSnapshot(
+            record=record,
+            revision=entry.revision,
+            committed_at_unix_ms=entry.committed_at_unix_ms,
+        )
+
+    def _validate_head_link(
+        self,
+        head: GenerationHeadRecord,
+        head_entry: ControlStoreEntry,
+        snapshot: StoredGenerationSnapshot,
+    ) -> None:
+        if head.snapshot_digest != snapshot.record.digest:
+            raise GenerationStateCorrupt("generation head snapshot digest does not match")
+        if head_entry.committed_at_unix_ms != snapshot.committed_at_unix_ms:
+            raise GenerationStateCorrupt(
+                "generation head and snapshot commit timestamps do not match"
+            )
+
+    def _read_snapshot_history(
+        self,
+        snapshot: StoredGenerationSnapshot,
+    ) -> dict[int, StoredGenerationSnapshot]:
+        successor = snapshot
+        history = {successor.record.assignment.generation: successor}
+        while successor.record.assignment.generation > 0:
+            predecessor_generation = successor.record.assignment.generation - 1
+            predecessor_entry = self._store.get(self.snapshot_key(predecessor_generation))
+            if predecessor_entry is None:
+                raise GenerationStateCorrupt("generation snapshot references a missing predecessor")
+            predecessor = self._decode_snapshot(
+                predecessor_entry,
+                expected_generation=predecessor_generation,
+            )
+            if successor.record.previous_snapshot_digest != predecessor.record.digest:
+                raise GenerationStateCorrupt(
+                    "generation snapshot predecessor digest does not match"
+                )
+            if predecessor.committed_at_unix_ms > successor.committed_at_unix_ms:
+                raise GenerationStateCorrupt("generation snapshot commit timestamps move backward")
+            if (
+                predecessor.record.coordinator_fencing_token
+                > successor.record.coordinator_fencing_token
+            ):
+                raise GenerationStateCorrupt("generation snapshot fencing tokens move backward")
+            if (
+                predecessor.record.coordinator_fencing_token
+                == successor.record.coordinator_fencing_token
+                and (
+                    predecessor.record.coordinator_id != successor.record.coordinator_id
+                    or predecessor.record.lease_id != successor.record.lease_id
+                )
+            ):
+                raise GenerationStateCorrupt("generation snapshots disagree on one lease identity")
+            if (
+                predecessor.record.lease_id == successor.record.lease_id
+                and predecessor.record.coordinator_id != successor.record.coordinator_id
+            ):
+                raise GenerationStateCorrupt("one generation lease changes coordinator identity")
+            history[predecessor_generation] = predecessor
+            successor = predecessor
+        return history
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+def _nonnegative_integer(value: object, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{path} must be a non-negative integer")
+    return value
+
+
+__all__ = [
+    "CurrentGeneration",
+    "GenerationStateCorrupt",
+    "GenerationStateError",
+    "GenerationStateReader",
+    "StoredGenerationSnapshot",
+]

--- a/lm_resiliency/integrations/torchrun/_generation_reader.py
+++ b/lm_resiliency/integrations/torchrun/_generation_reader.py
@@ -253,6 +253,8 @@ class GenerationStateReader:
                 )
             if predecessor.committed_at_unix_ms > successor.committed_at_unix_ms:
                 raise GenerationStateCorrupt("generation snapshot commit timestamps move backward")
+            if predecessor.guard_committed_at_unix_ms > successor.guard_committed_at_unix_ms:
+                raise GenerationStateCorrupt("generation snapshot lease grant times move backward")
             if (
                 predecessor.record.coordinator_fencing_token
                 > successor.record.coordinator_fencing_token
@@ -294,6 +296,19 @@ class GenerationStateReader:
             ):
                 raise GenerationStateCorrupt(
                     "one generation lease crosses a recreated guard lifetime"
+                )
+            if (
+                predecessor.record.lease_id == successor.record.lease_id
+                and predecessor.record.coordinator_fencing_token
+                != successor.record.coordinator_fencing_token
+                and successor.guard_committed_at_unix_ms
+                >= (
+                    predecessor.guard_committed_at_unix_ms
+                    + predecessor.record.coordinator_lease_duration_ms
+                )
+            ):
+                raise GenerationStateCorrupt(
+                    "generation snapshot renews an expired coordinator lease"
                 )
             if (
                 predecessor.record.lease_id != successor.record.lease_id

--- a/lm_resiliency/integrations/torchrun/_generation_reader.py
+++ b/lm_resiliency/integrations/torchrun/_generation_reader.py
@@ -79,21 +79,8 @@ class GenerationStateReader:
             result = self._read_current_history()
             if result is not None:
                 current, _ = result
-                successor_key = self.snapshot_key(current.snapshot.record.assignment.generation + 1)
-                if self._store.get(successor_key) is not None:
-                    observed_head = self._store.get(self._head_key)
-                    if (
-                        observed_head is not None
-                        and observed_head.revision != current.head_revision
-                    ):
-                        continue
-                    if observed_head is None:
-                        raise GenerationStateCorrupt(
-                            "generation head disappeared while checking its successor"
-                        )
-                    raise GenerationStateCorrupt(
-                        "generation snapshot is newer than the generation head"
-                    )
+                if self._head_changed_while_checking_successor(current):
+                    continue
                 return current
             if self._store.get(generation_zero_key) is None:
                 return None
@@ -116,6 +103,8 @@ class GenerationStateReader:
                     continue
                 raise GenerationStateCorrupt("generation snapshot exists without a generation head")
             current, history = result
+            if self._head_changed_while_checking_successor(current):
+                continue
             current_generation = current.snapshot.record.assignment.generation
             if normalized_generation <= current_generation:
                 return history[normalized_generation]
@@ -131,6 +120,20 @@ class GenerationStateReader:
                     "generation snapshot is newer than the generation head"
                 )
         raise GenerationStateError("generation head changed repeatedly during read")
+
+    def _head_changed_while_checking_successor(
+        self,
+        current: CurrentGeneration,
+    ) -> bool:
+        successor_key = self.snapshot_key(current.snapshot.record.assignment.generation + 1)
+        if self._store.get(successor_key) is None:
+            return False
+        observed_head = self._store.get(self._head_key)
+        if observed_head is not None and observed_head.revision != current.head_revision:
+            return True
+        if observed_head is None:
+            raise GenerationStateCorrupt("generation head disappeared while checking its successor")
+        raise GenerationStateCorrupt("generation snapshot is newer than the generation head")
 
     def _read_current_history(
         self,
@@ -265,6 +268,16 @@ class GenerationStateReader:
             ):
                 raise GenerationStateCorrupt("generation snapshots disagree on one lease identity")
             if (
+                predecessor.record.coordinator_fencing_token
+                == successor.record.coordinator_fencing_token
+                and (
+                    predecessor.guard_lifetime_sequence != successor.guard_lifetime_sequence
+                    or predecessor.guard_committed_at_unix_ms
+                    != successor.guard_committed_at_unix_ms
+                )
+            ):
+                raise GenerationStateCorrupt("generation snapshots disagree on one lease grant")
+            if (
                 predecessor.record.lease_id == successor.record.lease_id
                 and predecessor.record.coordinator_id != successor.record.coordinator_id
             ):
@@ -282,6 +295,16 @@ class GenerationStateReader:
                 raise GenerationStateCorrupt(
                     "one generation lease crosses a recreated guard lifetime"
                 )
+            if (
+                predecessor.record.lease_id != successor.record.lease_id
+                and predecessor.guard_lifetime_sequence == successor.guard_lifetime_sequence
+                and successor.guard_committed_at_unix_ms
+                < (
+                    predecessor.guard_committed_at_unix_ms
+                    + predecessor.record.coordinator_lease_duration_ms
+                )
+            ):
+                raise GenerationStateCorrupt("generation snapshot coordinator leases overlap")
             if predecessor.record.lease_id != successor.record.lease_id:
                 if predecessor.record.lease_id in seen_lease_ids:
                     raise GenerationStateCorrupt(

--- a/lm_resiliency/integrations/torchrun/_generation_reader.py
+++ b/lm_resiliency/integrations/torchrun/_generation_reader.py
@@ -255,6 +255,8 @@ class GenerationStateReader:
                 raise GenerationStateCorrupt("generation snapshot commit timestamps move backward")
             if predecessor.guard_committed_at_unix_ms > successor.guard_committed_at_unix_ms:
                 raise GenerationStateCorrupt("generation snapshot lease grant times move backward")
+            if predecessor.guard_lifetime_sequence > successor.guard_lifetime_sequence:
+                raise GenerationStateCorrupt("generation snapshot guard lifetimes move backward")
             if (
                 predecessor.record.coordinator_fencing_token
                 > successor.record.coordinator_fencing_token

--- a/lm_resiliency/integrations/torchrun/_generation_reader.py
+++ b/lm_resiliency/integrations/torchrun/_generation_reader.py
@@ -34,6 +34,7 @@ class StoredGenerationSnapshot:
     revision: int
     committed_at_unix_ms: int
     guard_mutation_sequence: int
+    guard_value_sequence: int
     guard_lifetime_sequence: int
     guard_committed_at_unix_ms: int
 
@@ -203,6 +204,7 @@ class GenerationStateReader:
             raise GenerationStateCorrupt("generation snapshot has no authoritative commit time")
         (
             guard_mutation_sequence,
+            guard_value_sequence,
             guard_lifetime_sequence,
             guard_committed_at_unix_ms,
         ) = self._validate_guard_provenance(entry, record)
@@ -211,6 +213,7 @@ class GenerationStateReader:
             revision=entry.revision,
             committed_at_unix_ms=entry.committed_at_unix_ms,
             guard_mutation_sequence=guard_mutation_sequence,
+            guard_value_sequence=guard_value_sequence,
             guard_lifetime_sequence=guard_lifetime_sequence,
             guard_committed_at_unix_ms=guard_committed_at_unix_ms,
         )
@@ -235,12 +238,17 @@ class GenerationStateReader:
             )
         (
             head_guard_mutation,
+            head_guard_value,
             head_guard_lifetime,
             head_guard_committed_at,
         ) = self._validate_guard_provenance(head_entry, snapshot.record)
         if head_guard_mutation != snapshot.guard_mutation_sequence:
             raise GenerationStateCorrupt(
                 "generation head and snapshot guard mutation sequences do not match"
+            )
+        if head_guard_value != snapshot.guard_value_sequence:
+            raise GenerationStateCorrupt(
+                "generation head and snapshot guard value sequences do not match"
             )
         if head_guard_lifetime != snapshot.guard_lifetime_sequence:
             raise GenerationStateCorrupt(
@@ -280,15 +288,35 @@ class GenerationStateReader:
                 raise GenerationStateCorrupt("generation snapshot guard lifetimes move backward")
             if predecessor.guard_mutation_sequence > successor.guard_mutation_sequence:
                 raise GenerationStateCorrupt("generation snapshot guard mutations move backward")
+            if predecessor.guard_value_sequence > successor.guard_value_sequence:
+                raise GenerationStateCorrupt("generation snapshot guard values move backward")
             guard_mutation_delta = (
                 successor.guard_mutation_sequence - predecessor.guard_mutation_sequence
             )
+            guard_value_delta = successor.guard_value_sequence - predecessor.guard_value_sequence
             guard_lifetime_delta = (
                 successor.guard_lifetime_sequence - predecessor.guard_lifetime_sequence
             )
             if guard_mutation_delta < 2 * guard_lifetime_delta:
                 raise GenerationStateCorrupt(
                     "generation snapshot guard lifetime lacks delete-and-recreate mutations"
+                )
+            if guard_value_delta < guard_lifetime_delta:
+                raise GenerationStateCorrupt(
+                    "generation snapshot guard lifetime lacks a new value sequence"
+                )
+            if guard_value_delta > guard_mutation_delta:
+                raise GenerationStateCorrupt(
+                    "generation snapshot guard values advance faster than mutations"
+                )
+            if (
+                guard_mutation_delta > 0
+                and predecessor.record.coordinator_lease_digest
+                != successor.record.coordinator_lease_digest
+                and guard_value_delta == 0
+            ):
+                raise GenerationStateCorrupt(
+                    "different generation leases share one guard value sequence"
                 )
             if (
                 guard_mutation_delta > 0
@@ -342,6 +370,11 @@ class GenerationStateReader:
                 )
             if (
                 predecessor.record.lease_id == successor.record.lease_id
+                and predecessor.guard_value_sequence != successor.guard_value_sequence
+            ):
+                raise GenerationStateCorrupt("one generation lease value changed between renewals")
+            if (
+                predecessor.record.lease_id == successor.record.lease_id
                 and guard_mutation_delta > 0
                 and successor.guard_committed_at_unix_ms
                 > (
@@ -393,7 +426,7 @@ class GenerationStateReader:
         self,
         entry: ControlStoreEntry,
         snapshot: GenerationSnapshotRecord,
-    ) -> tuple[int, int, int]:
+    ) -> tuple[int, int, int, int]:
         if entry.guard_key != self._coordinator_lease_key:
             raise GenerationStateCorrupt(
                 "generation state has no matching coordinator-lease guard key"
@@ -411,6 +444,11 @@ class GenerationStateReader:
             raise GenerationStateCorrupt(
                 "generation state guard has no authoritative mutation sequence"
             )
+        guard_value_sequence = entry.guard_value_sequence
+        if guard_value_sequence is None:
+            raise GenerationStateCorrupt(
+                "generation state guard has no authoritative value sequence"
+            )
         guard_lifetime_sequence = entry.guard_lifetime_sequence
         if guard_lifetime_sequence is None:
             raise GenerationStateCorrupt(
@@ -419,6 +457,14 @@ class GenerationStateReader:
         if guard_mutation_sequence < 2 * guard_lifetime_sequence - 1:
             raise GenerationStateCorrupt(
                 "generation state guard mutation sequence cannot support its lifetime"
+            )
+        if guard_value_sequence < guard_lifetime_sequence:
+            raise GenerationStateCorrupt(
+                "generation state guard value sequence cannot support its lifetime"
+            )
+        if guard_value_sequence > guard_mutation_sequence:
+            raise GenerationStateCorrupt(
+                "generation state guard value sequence exceeds its mutations"
             )
         guard_committed_at_unix_ms = entry.guard_committed_at_unix_ms
         if guard_committed_at_unix_ms is None:
@@ -437,6 +483,7 @@ class GenerationStateReader:
             )
         return (
             guard_mutation_sequence,
+            guard_value_sequence,
             guard_lifetime_sequence,
             guard_committed_at_unix_ms,
         )

--- a/lm_resiliency/integrations/torchrun/_generation_reader.py
+++ b/lm_resiliency/integrations/torchrun/_generation_reader.py
@@ -33,6 +33,7 @@ class StoredGenerationSnapshot:
     record: GenerationSnapshotRecord
     revision: int
     committed_at_unix_ms: int
+    guard_lifetime_sequence: int
     guard_committed_at_unix_ms: int
 
 
@@ -170,11 +171,14 @@ class GenerationStateReader:
             raise GenerationStateCorrupt("immutable generation snapshot was replaced or recreated")
         if entry.committed_at_unix_ms is None:
             raise GenerationStateCorrupt("generation snapshot has no authoritative commit time")
-        guard_committed_at_unix_ms = self._validate_guard_provenance(entry, record)
+        guard_lifetime_sequence, guard_committed_at_unix_ms = self._validate_guard_provenance(
+            entry, record
+        )
         return StoredGenerationSnapshot(
             record=record,
             revision=entry.revision,
             committed_at_unix_ms=entry.committed_at_unix_ms,
+            guard_lifetime_sequence=guard_lifetime_sequence,
             guard_committed_at_unix_ms=guard_committed_at_unix_ms,
         )
 
@@ -194,10 +198,14 @@ class GenerationStateReader:
             raise GenerationStateCorrupt(
                 "generation head and snapshot commit timestamps do not match"
             )
-        head_guard_committed_at = self._validate_guard_provenance(
+        head_guard_lifetime, head_guard_committed_at = self._validate_guard_provenance(
             head_entry,
             snapshot.record,
         )
+        if head_guard_lifetime != snapshot.guard_lifetime_sequence:
+            raise GenerationStateCorrupt(
+                "generation head and snapshot guard lifetimes do not match"
+            )
         if head_guard_committed_at != snapshot.guard_committed_at_unix_ms:
             raise GenerationStateCorrupt(
                 "generation head and snapshot guard grant times do not match"
@@ -250,6 +258,13 @@ class GenerationStateReader:
                 != successor.record.coordinator_lease_duration_ms
             ):
                 raise GenerationStateCorrupt("one generation lease changes its duration")
+            if (
+                predecessor.record.lease_id == successor.record.lease_id
+                and predecessor.guard_lifetime_sequence != successor.guard_lifetime_sequence
+            ):
+                raise GenerationStateCorrupt(
+                    "one generation lease crosses a recreated guard lifetime"
+                )
             if predecessor.record.lease_id != successor.record.lease_id:
                 if predecessor.record.lease_id in seen_lease_ids:
                     raise GenerationStateCorrupt(
@@ -264,7 +279,7 @@ class GenerationStateReader:
         self,
         entry: ControlStoreEntry,
         snapshot: GenerationSnapshotRecord,
-    ) -> int:
+    ) -> tuple[int, int]:
         if entry.guard_key != self._coordinator_lease_key:
             raise GenerationStateCorrupt(
                 "generation state has no matching coordinator-lease guard key"
@@ -276,6 +291,11 @@ class GenerationStateReader:
         if entry.guard_value_digest != snapshot.coordinator_lease_digest:
             raise GenerationStateCorrupt(
                 "generation state guard digest does not match its lease identity"
+            )
+        guard_lifetime_sequence = entry.guard_lifetime_sequence
+        if guard_lifetime_sequence is None:
+            raise GenerationStateCorrupt(
+                "generation state guard has no authoritative lifetime sequence"
             )
         guard_committed_at_unix_ms = entry.guard_committed_at_unix_ms
         if guard_committed_at_unix_ms is None:
@@ -292,7 +312,7 @@ class GenerationStateReader:
             raise GenerationStateCorrupt(
                 "generation state was committed after its coordinator lease expired"
             )
-        return guard_committed_at_unix_ms
+        return guard_lifetime_sequence, guard_committed_at_unix_ms
 
 
 def _nonempty_string(value: object, path: str) -> str:

--- a/lm_resiliency/integrations/torchrun/_generation_reader.py
+++ b/lm_resiliency/integrations/torchrun/_generation_reader.py
@@ -79,6 +79,21 @@ class GenerationStateReader:
             result = self._read_current_history()
             if result is not None:
                 current, _ = result
+                successor_key = self.snapshot_key(current.snapshot.record.assignment.generation + 1)
+                if self._store.get(successor_key) is not None:
+                    observed_head = self._store.get(self._head_key)
+                    if (
+                        observed_head is not None
+                        and observed_head.revision != current.head_revision
+                    ):
+                        continue
+                    if observed_head is None:
+                        raise GenerationStateCorrupt(
+                            "generation head disappeared while checking its successor"
+                        )
+                    raise GenerationStateCorrupt(
+                        "generation snapshot is newer than the generation head"
+                    )
                 return current
             if self._store.get(generation_zero_key) is None:
                 return None
@@ -190,6 +205,8 @@ class GenerationStateReader:
     ) -> None:
         if head.snapshot_digest != snapshot.record.digest:
             raise GenerationStateCorrupt("generation head snapshot digest does not match")
+        if head_entry.lifetime_sequence != 1:
+            raise GenerationStateCorrupt("generation head was deleted and recreated")
         if head_entry.mutation_sequence != head.generation + 1:
             raise GenerationStateCorrupt(
                 "generation head mutation sequence does not match its generation"

--- a/lm_resiliency/integrations/torchrun/_generation_reader.py
+++ b/lm_resiliency/integrations/torchrun/_generation_reader.py
@@ -279,6 +279,13 @@ class GenerationStateReader:
                     "generation snapshot guard lifetime lacks delete-and-recreate mutations"
                 )
             if (
+                guard_mutation_delta > 0
+                and predecessor.committed_at_unix_ms > successor.guard_committed_at_unix_ms
+            ):
+                raise GenerationStateCorrupt(
+                    "generation snapshot commit postdates a successor guard mutation"
+                )
+            if (
                 guard_mutation_delta == 0
                 and predecessor.record.coordinator_fencing_token
                 != successor.record.coordinator_fencing_token
@@ -336,6 +343,14 @@ class GenerationStateReader:
             if (
                 predecessor.record.lease_id != successor.record.lease_id
                 and predecessor.guard_lifetime_sequence == successor.guard_lifetime_sequence
+                and guard_mutation_delta != 1
+            ):
+                raise GenerationStateCorrupt(
+                    "generation snapshot lease replacement has ambiguous skipped mutations"
+                )
+            if (
+                predecessor.record.lease_id != successor.record.lease_id
+                and predecessor.guard_lifetime_sequence == successor.guard_lifetime_sequence
                 and successor.guard_committed_at_unix_ms
                 < (
                     predecessor.guard_committed_at_unix_ms
@@ -379,6 +394,10 @@ class GenerationStateReader:
         if guard_lifetime_sequence is None:
             raise GenerationStateCorrupt(
                 "generation state guard has no authoritative lifetime sequence"
+            )
+        if guard_mutation_sequence < 2 * guard_lifetime_sequence - 1:
+            raise GenerationStateCorrupt(
+                "generation state guard mutation sequence cannot support its lifetime"
             )
         guard_committed_at_unix_ms = entry.guard_committed_at_unix_ms
         if guard_committed_at_unix_ms is None:

--- a/lm_resiliency/integrations/torchrun/_generation_reader.py
+++ b/lm_resiliency/integrations/torchrun/_generation_reader.py
@@ -72,11 +72,18 @@ class GenerationStateReader:
         return f"{self._run_prefix}/generations/{normalized_generation}"
 
     def current(self) -> CurrentGeneration | None:
-        result = self._read_current_history()
-        if result is None:
-            return None
-        current, _ = result
-        return current
+        generation_zero_key = self.snapshot_key(0)
+        for _ in range(_MAX_READ_ATTEMPTS):
+            result = self._read_current_history()
+            if result is not None:
+                current, _ = result
+                return current
+            if self._store.get(generation_zero_key) is None:
+                return None
+            if self._store.get(self._head_key) is not None:
+                continue
+            raise GenerationStateCorrupt("generation snapshots exist without a generation head")
+        raise GenerationStateError("generation head changed repeatedly during read")
 
     def get(self, generation: int) -> StoredGenerationSnapshot | None:
         normalized_generation = _nonnegative_integer(generation, "generation")
@@ -84,7 +91,9 @@ class GenerationStateReader:
         for _ in range(_MAX_READ_ATTEMPTS):
             result = self._read_current_history()
             if result is None:
-                if self._store.get(snapshot_key) is None:
+                generation_zero = self._store.get(self.snapshot_key(0))
+                requested_snapshot = self._store.get(snapshot_key)
+                if generation_zero is None and requested_snapshot is None:
                     return None
                 if self._store.get(self._head_key) is not None:
                     continue
@@ -158,6 +167,7 @@ class GenerationStateReader:
             raise GenerationStateCorrupt("generation snapshot key and payload disagree")
         if entry.committed_at_unix_ms is None:
             raise GenerationStateCorrupt("generation snapshot has no authoritative commit time")
+        self._validate_guard_provenance(entry, record)
         return StoredGenerationSnapshot(
             record=record,
             revision=entry.revision,
@@ -176,6 +186,7 @@ class GenerationStateReader:
             raise GenerationStateCorrupt(
                 "generation head and snapshot commit timestamps do not match"
             )
+        self._validate_guard_provenance(head_entry, snapshot.record)
 
     def _read_snapshot_history(
         self,
@@ -183,6 +194,7 @@ class GenerationStateReader:
     ) -> dict[int, StoredGenerationSnapshot]:
         successor = snapshot
         history = {successor.record.assignment.generation: successor}
+        seen_lease_ids = {successor.record.lease_id}
         while successor.record.assignment.generation > 0:
             predecessor_generation = successor.record.assignment.generation - 1
             predecessor_entry = self._store.get(self.snapshot_key(predecessor_generation))
@@ -217,9 +229,33 @@ class GenerationStateReader:
                 and predecessor.record.coordinator_id != successor.record.coordinator_id
             ):
                 raise GenerationStateCorrupt("one generation lease changes coordinator identity")
+            if predecessor.record.lease_id != successor.record.lease_id:
+                if predecessor.record.lease_id in seen_lease_ids:
+                    raise GenerationStateCorrupt(
+                        "generation snapshot lease identity reappears after replacement"
+                    )
+                seen_lease_ids.add(predecessor.record.lease_id)
             history[predecessor_generation] = predecessor
             successor = predecessor
         return history
+
+    def _validate_guard_provenance(
+        self,
+        entry: ControlStoreEntry,
+        snapshot: GenerationSnapshotRecord,
+    ) -> None:
+        if entry.guard_key != self._coordinator_lease_key:
+            raise GenerationStateCorrupt(
+                "generation state has no matching coordinator-lease guard key"
+            )
+        if entry.guard_revision != snapshot.coordinator_fencing_token:
+            raise GenerationStateCorrupt(
+                "generation state guard revision does not match its fencing token"
+            )
+        if entry.guard_value_digest != snapshot.coordinator_lease_digest:
+            raise GenerationStateCorrupt(
+                "generation state guard digest does not match its lease identity"
+            )
 
 
 def _nonempty_string(value: object, path: str) -> str:

--- a/lm_resiliency/integrations/torchrun/_generation_reader.py
+++ b/lm_resiliency/integrations/torchrun/_generation_reader.py
@@ -33,6 +33,7 @@ class StoredGenerationSnapshot:
     record: GenerationSnapshotRecord
     revision: int
     committed_at_unix_ms: int
+    guard_mutation_sequence: int
     guard_lifetime_sequence: int
     guard_committed_at_unix_ms: int
 
@@ -189,13 +190,16 @@ class GenerationStateReader:
             raise GenerationStateCorrupt("immutable generation snapshot was replaced or recreated")
         if entry.committed_at_unix_ms is None:
             raise GenerationStateCorrupt("generation snapshot has no authoritative commit time")
-        guard_lifetime_sequence, guard_committed_at_unix_ms = self._validate_guard_provenance(
-            entry, record
-        )
+        (
+            guard_mutation_sequence,
+            guard_lifetime_sequence,
+            guard_committed_at_unix_ms,
+        ) = self._validate_guard_provenance(entry, record)
         return StoredGenerationSnapshot(
             record=record,
             revision=entry.revision,
             committed_at_unix_ms=entry.committed_at_unix_ms,
+            guard_mutation_sequence=guard_mutation_sequence,
             guard_lifetime_sequence=guard_lifetime_sequence,
             guard_committed_at_unix_ms=guard_committed_at_unix_ms,
         )
@@ -218,10 +222,15 @@ class GenerationStateReader:
             raise GenerationStateCorrupt(
                 "generation head and snapshot commit timestamps do not match"
             )
-        head_guard_lifetime, head_guard_committed_at = self._validate_guard_provenance(
-            head_entry,
-            snapshot.record,
-        )
+        (
+            head_guard_mutation,
+            head_guard_lifetime,
+            head_guard_committed_at,
+        ) = self._validate_guard_provenance(head_entry, snapshot.record)
+        if head_guard_mutation != snapshot.guard_mutation_sequence:
+            raise GenerationStateCorrupt(
+                "generation head and snapshot guard mutation sequences do not match"
+            )
         if head_guard_lifetime != snapshot.guard_lifetime_sequence:
             raise GenerationStateCorrupt(
                 "generation head and snapshot guard lifetimes do not match"
@@ -257,33 +266,46 @@ class GenerationStateReader:
                 raise GenerationStateCorrupt("generation snapshot lease grant times move backward")
             if predecessor.guard_lifetime_sequence > successor.guard_lifetime_sequence:
                 raise GenerationStateCorrupt("generation snapshot guard lifetimes move backward")
-            if (
-                predecessor.record.coordinator_fencing_token
-                > successor.record.coordinator_fencing_token
-            ):
-                raise GenerationStateCorrupt("generation snapshot fencing tokens move backward")
-            if (
-                predecessor.record.coordinator_fencing_token
-                == successor.record.coordinator_fencing_token
-                and (
-                    predecessor.record.coordinator_id != successor.record.coordinator_id
-                    or predecessor.record.lease_id != successor.record.lease_id
+            if predecessor.guard_mutation_sequence > successor.guard_mutation_sequence:
+                raise GenerationStateCorrupt("generation snapshot guard mutations move backward")
+            guard_mutation_delta = (
+                successor.guard_mutation_sequence - predecessor.guard_mutation_sequence
+            )
+            guard_lifetime_delta = (
+                successor.guard_lifetime_sequence - predecessor.guard_lifetime_sequence
+            )
+            if guard_mutation_delta < 2 * guard_lifetime_delta:
+                raise GenerationStateCorrupt(
+                    "generation snapshot guard lifetime lacks delete-and-recreate mutations"
                 )
+            if (
+                guard_mutation_delta == 0
+                and predecessor.record.coordinator_fencing_token
+                != successor.record.coordinator_fencing_token
+            ):
+                raise GenerationStateCorrupt(
+                    "one guard mutation identifies multiple fencing tokens"
+                )
+            if (
+                guard_mutation_delta > 0
+                and predecessor.record.coordinator_fencing_token
+                == successor.record.coordinator_fencing_token
+            ):
+                raise GenerationStateCorrupt(
+                    "one fencing token identifies multiple guard mutations"
+                )
+            if guard_mutation_delta == 0 and (
+                predecessor.record.coordinator_id != successor.record.coordinator_id
+                or predecessor.record.lease_id != successor.record.lease_id
             ):
                 raise GenerationStateCorrupt("generation snapshots disagree on one lease identity")
-            if (
-                predecessor.record.coordinator_fencing_token
-                == successor.record.coordinator_fencing_token
-                and (
-                    predecessor.guard_lifetime_sequence != successor.guard_lifetime_sequence
-                    or predecessor.guard_committed_at_unix_ms
-                    != successor.guard_committed_at_unix_ms
-                )
+            if guard_mutation_delta == 0 and (
+                predecessor.guard_lifetime_sequence != successor.guard_lifetime_sequence
+                or predecessor.guard_committed_at_unix_ms != successor.guard_committed_at_unix_ms
             ):
                 raise GenerationStateCorrupt("generation snapshots disagree on one lease grant")
-            if (
-                predecessor.record.lease_id == successor.record.lease_id
-                and predecessor.record.coordinator_id != successor.record.coordinator_id
+            if predecessor.record.lease_id == successor.record.lease_id and (
+                predecessor.record.coordinator_id != successor.record.coordinator_id
             ):
                 raise GenerationStateCorrupt("one generation lease changes coordinator identity")
             if (
@@ -301,12 +323,11 @@ class GenerationStateReader:
                 )
             if (
                 predecessor.record.lease_id == successor.record.lease_id
-                and predecessor.record.coordinator_fencing_token
-                != successor.record.coordinator_fencing_token
+                and guard_mutation_delta > 0
                 and successor.guard_committed_at_unix_ms
-                >= (
+                > (
                     predecessor.guard_committed_at_unix_ms
-                    + predecessor.record.coordinator_lease_duration_ms
+                    + guard_mutation_delta * (predecessor.record.coordinator_lease_duration_ms - 1)
                 )
             ):
                 raise GenerationStateCorrupt(
@@ -336,7 +357,7 @@ class GenerationStateReader:
         self,
         entry: ControlStoreEntry,
         snapshot: GenerationSnapshotRecord,
-    ) -> tuple[int, int]:
+    ) -> tuple[int, int, int]:
         if entry.guard_key != self._coordinator_lease_key:
             raise GenerationStateCorrupt(
                 "generation state has no matching coordinator-lease guard key"
@@ -348,6 +369,11 @@ class GenerationStateReader:
         if entry.guard_value_digest != snapshot.coordinator_lease_digest:
             raise GenerationStateCorrupt(
                 "generation state guard digest does not match its lease identity"
+            )
+        guard_mutation_sequence = entry.guard_mutation_sequence
+        if guard_mutation_sequence is None:
+            raise GenerationStateCorrupt(
+                "generation state guard has no authoritative mutation sequence"
             )
         guard_lifetime_sequence = entry.guard_lifetime_sequence
         if guard_lifetime_sequence is None:
@@ -369,7 +395,11 @@ class GenerationStateReader:
             raise GenerationStateCorrupt(
                 "generation state was committed after its coordinator lease expired"
             )
-        return guard_lifetime_sequence, guard_committed_at_unix_ms
+        return (
+            guard_mutation_sequence,
+            guard_lifetime_sequence,
+            guard_committed_at_unix_ms,
+        )
 
 
 def _nonempty_string(value: object, path: str) -> str:

--- a/lm_resiliency/integrations/torchrun/_generation_reader.py
+++ b/lm_resiliency/integrations/torchrun/_generation_reader.py
@@ -83,10 +83,16 @@ class GenerationStateReader:
                 if self._head_changed_while_checking_successor(current):
                     continue
                 return current
-            if self._store.get(generation_zero_key) is None:
-                return None
-            if self._store.get(self._head_key) is not None:
+            generation_zero = self._store.get(generation_zero_key)
+            observed_head = self._store.get(self._head_key)
+            if observed_head is not None:
                 continue
+            if self._store.has_history(self._head_key):
+                if self._store.get(self._head_key) is not None:
+                    continue
+                raise GenerationStateCorrupt("generation head was deleted after initialization")
+            if generation_zero is None:
+                return None
             raise GenerationStateCorrupt("generation snapshots exist without a generation head")
         raise GenerationStateError("generation head changed repeatedly during read")
 
@@ -98,10 +104,15 @@ class GenerationStateReader:
             if result is None:
                 generation_zero = self._store.get(self.snapshot_key(0))
                 requested_snapshot = self._store.get(snapshot_key)
+                observed_head = self._store.get(self._head_key)
+                if observed_head is not None:
+                    continue
+                if self._store.has_history(self._head_key):
+                    if self._store.get(self._head_key) is not None:
+                        continue
+                    raise GenerationStateCorrupt("generation head was deleted after initialization")
                 if generation_zero is None and requested_snapshot is None:
                     return None
-                if self._store.get(self._head_key) is not None:
-                    continue
                 raise GenerationStateCorrupt("generation snapshot exists without a generation head")
             current, history = result
             if self._head_changed_while_checking_successor(current):
@@ -247,6 +258,7 @@ class GenerationStateReader:
         successor = snapshot
         history = {successor.record.assignment.generation: successor}
         seen_lease_ids = {successor.record.lease_id}
+        seen_fencing_tokens = {successor.record.coordinator_fencing_token}
         while successor.record.assignment.generation > 0:
             predecessor_generation = successor.record.assignment.generation - 1
             predecessor_entry = self._store.get(self.snapshot_key(predecessor_generation))
@@ -364,6 +376,15 @@ class GenerationStateReader:
                         "generation snapshot lease identity reappears after replacement"
                     )
                 seen_lease_ids.add(predecessor.record.lease_id)
+            if (
+                predecessor.record.coordinator_fencing_token
+                != successor.record.coordinator_fencing_token
+            ):
+                if predecessor.record.coordinator_fencing_token in seen_fencing_tokens:
+                    raise GenerationStateCorrupt(
+                        "generation snapshot fencing token reappears after another mutation"
+                    )
+                seen_fencing_tokens.add(predecessor.record.coordinator_fencing_token)
             history[predecessor_generation] = predecessor
             successor = predecessor
         return history

--- a/lm_resiliency/integrations/torchrun/_generation_reader.py
+++ b/lm_resiliency/integrations/torchrun/_generation_reader.py
@@ -33,6 +33,7 @@ class StoredGenerationSnapshot:
     record: GenerationSnapshotRecord
     revision: int
     committed_at_unix_ms: int
+    guard_committed_at_unix_ms: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -165,13 +166,16 @@ class GenerationStateReader:
             raise GenerationStateCorrupt("generation snapshot belongs to another run")
         if assignment.generation != expected_generation:
             raise GenerationStateCorrupt("generation snapshot key and payload disagree")
+        if not entry.is_initial_creation:
+            raise GenerationStateCorrupt("immutable generation snapshot was replaced or recreated")
         if entry.committed_at_unix_ms is None:
             raise GenerationStateCorrupt("generation snapshot has no authoritative commit time")
-        self._validate_guard_provenance(entry, record)
+        guard_committed_at_unix_ms = self._validate_guard_provenance(entry, record)
         return StoredGenerationSnapshot(
             record=record,
             revision=entry.revision,
             committed_at_unix_ms=entry.committed_at_unix_ms,
+            guard_committed_at_unix_ms=guard_committed_at_unix_ms,
         )
 
     def _validate_head_link(
@@ -186,7 +190,14 @@ class GenerationStateReader:
             raise GenerationStateCorrupt(
                 "generation head and snapshot commit timestamps do not match"
             )
-        self._validate_guard_provenance(head_entry, snapshot.record)
+        head_guard_committed_at = self._validate_guard_provenance(
+            head_entry,
+            snapshot.record,
+        )
+        if head_guard_committed_at != snapshot.guard_committed_at_unix_ms:
+            raise GenerationStateCorrupt(
+                "generation head and snapshot guard grant times do not match"
+            )
 
     def _read_snapshot_history(
         self,
@@ -229,6 +240,12 @@ class GenerationStateReader:
                 and predecessor.record.coordinator_id != successor.record.coordinator_id
             ):
                 raise GenerationStateCorrupt("one generation lease changes coordinator identity")
+            if (
+                predecessor.record.lease_id == successor.record.lease_id
+                and predecessor.record.coordinator_lease_duration_ms
+                != successor.record.coordinator_lease_duration_ms
+            ):
+                raise GenerationStateCorrupt("one generation lease changes its duration")
             if predecessor.record.lease_id != successor.record.lease_id:
                 if predecessor.record.lease_id in seen_lease_ids:
                     raise GenerationStateCorrupt(
@@ -243,7 +260,7 @@ class GenerationStateReader:
         self,
         entry: ControlStoreEntry,
         snapshot: GenerationSnapshotRecord,
-    ) -> None:
+    ) -> int:
         if entry.guard_key != self._coordinator_lease_key:
             raise GenerationStateCorrupt(
                 "generation state has no matching coordinator-lease guard key"
@@ -256,6 +273,22 @@ class GenerationStateReader:
             raise GenerationStateCorrupt(
                 "generation state guard digest does not match its lease identity"
             )
+        guard_committed_at_unix_ms = entry.guard_committed_at_unix_ms
+        if guard_committed_at_unix_ms is None:
+            raise GenerationStateCorrupt("generation state guard has no authoritative grant time")
+        committed_at_unix_ms = entry.committed_at_unix_ms
+        if committed_at_unix_ms is None:
+            raise GenerationStateCorrupt("generation state has no authoritative commit time")
+        if committed_at_unix_ms < guard_committed_at_unix_ms:
+            raise GenerationStateCorrupt("generation state predates its coordinator lease grant")
+        if (
+            committed_at_unix_ms
+            >= guard_committed_at_unix_ms + snapshot.coordinator_lease_duration_ms
+        ):
+            raise GenerationStateCorrupt(
+                "generation state was committed after its coordinator lease expired"
+            )
+        return guard_committed_at_unix_ms
 
 
 def _nonempty_string(value: object, path: str) -> str:

--- a/lm_resiliency/integrations/torchrun/_generation_reader.py
+++ b/lm_resiliency/integrations/torchrun/_generation_reader.py
@@ -166,7 +166,7 @@ class GenerationStateReader:
             raise GenerationStateCorrupt("generation snapshot belongs to another run")
         if assignment.generation != expected_generation:
             raise GenerationStateCorrupt("generation snapshot key and payload disagree")
-        if not entry.is_initial_creation:
+        if entry.mutation_sequence != 1:
             raise GenerationStateCorrupt("immutable generation snapshot was replaced or recreated")
         if entry.committed_at_unix_ms is None:
             raise GenerationStateCorrupt("generation snapshot has no authoritative commit time")
@@ -186,6 +186,10 @@ class GenerationStateReader:
     ) -> None:
         if head.snapshot_digest != snapshot.record.digest:
             raise GenerationStateCorrupt("generation head snapshot digest does not match")
+        if head_entry.mutation_sequence != head.generation + 1:
+            raise GenerationStateCorrupt(
+                "generation head mutation sequence does not match its generation"
+            )
         if head_entry.committed_at_unix_ms != snapshot.committed_at_unix_ms:
             raise GenerationStateCorrupt(
                 "generation head and snapshot commit timestamps do not match"

--- a/lm_resiliency/integrations/torchrun/_generation_reader.py
+++ b/lm_resiliency/integrations/torchrun/_generation_reader.py
@@ -198,8 +198,14 @@ class GenerationStateReader:
             raise GenerationStateCorrupt("generation snapshot belongs to another run")
         if assignment.generation != expected_generation:
             raise GenerationStateCorrupt("generation snapshot key and payload disagree")
-        if entry.mutation_sequence != 1:
-            raise GenerationStateCorrupt("immutable generation snapshot was replaced or recreated")
+        if (
+            entry.mutation_sequence != 1
+            or entry.value_sequence != 1
+            or entry.lifetime_sequence != 1
+        ):
+            raise GenerationStateCorrupt(
+                "immutable generation snapshot has noninitial store sequences"
+            )
         if entry.committed_at_unix_ms is None:
             raise GenerationStateCorrupt("generation snapshot has no authoritative commit time")
         (
@@ -231,6 +237,10 @@ class GenerationStateReader:
         if head_entry.mutation_sequence != head.generation + 1:
             raise GenerationStateCorrupt(
                 "generation head mutation sequence does not match its generation"
+            )
+        if head_entry.value_sequence != head.generation + 1:
+            raise GenerationStateCorrupt(
+                "generation head value sequence does not match its generation"
             )
         if head_entry.committed_at_unix_ms != snapshot.committed_at_unix_ms:
             raise GenerationStateCorrupt(

--- a/lm_resiliency/integrations/torchrun/_generation_records.py
+++ b/lm_resiliency/integrations/torchrun/_generation_records.py
@@ -8,6 +8,9 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import ClassVar
 
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseRecord,
+)
 from lm_resiliency.integrations.torchrun._protocol import (
     ProtocolValidationError,
     RankAssignment,
@@ -24,6 +27,7 @@ class GenerationSnapshotRecord:
     previous_snapshot_digest: str | None
     coordinator_id: str
     lease_id: str
+    coordinator_lease_duration_ms: int
     coordinator_fencing_token: int
 
     def __post_init__(self) -> None:
@@ -43,6 +47,10 @@ class GenerationSnapshotRecord:
         )
         _nonempty_string(self.lease_id, "GenerationSnapshotRecord.lease_id")
         _positive_integer(
+            self.coordinator_lease_duration_ms,
+            "GenerationSnapshotRecord.coordinator_lease_duration_ms",
+        )
+        _positive_integer(
             self.coordinator_fencing_token,
             "GenerationSnapshotRecord.coordinator_fencing_token",
         )
@@ -51,6 +59,16 @@ class GenerationSnapshotRecord:
     def digest(self) -> str:
         return hashlib.sha256(self.to_json()).hexdigest()
 
+    @property
+    def coordinator_lease_digest(self) -> str:
+        record = CoordinatorLeaseRecord(
+            run_id=self.assignment.run_id,
+            coordinator_id=self.coordinator_id,
+            lease_id=self.lease_id,
+            lease_duration_ms=self.coordinator_lease_duration_ms,
+        )
+        return hashlib.sha256(record.to_json()).hexdigest()
+
     def to_dict(self) -> dict[str, object]:
         return {
             "schema_version": self.SCHEMA_VERSION,
@@ -58,6 +76,7 @@ class GenerationSnapshotRecord:
             "previous_snapshot_digest": self.previous_snapshot_digest,
             "coordinator_id": self.coordinator_id,
             "lease_id": self.lease_id,
+            "coordinator_lease_duration_ms": self.coordinator_lease_duration_ms,
             "coordinator_fencing_token": self.coordinator_fencing_token,
         }
 
@@ -76,6 +95,7 @@ class GenerationSnapshotRecord:
                 "previous_snapshot_digest",
                 "coordinator_id",
                 "lease_id",
+                "coordinator_lease_duration_ms",
                 "coordinator_fencing_token",
             },
         )
@@ -103,6 +123,10 @@ class GenerationSnapshotRecord:
             lease_id=_nonempty_string(
                 value["lease_id"],
                 "GenerationSnapshotRecord.lease_id",
+            ),
+            coordinator_lease_duration_ms=_positive_integer(
+                value["coordinator_lease_duration_ms"],
+                "GenerationSnapshotRecord.coordinator_lease_duration_ms",
             ),
             coordinator_fencing_token=_positive_integer(
                 value["coordinator_fencing_token"],

--- a/lm_resiliency/integrations/torchrun/_generation_records.py
+++ b/lm_resiliency/integrations/torchrun/_generation_records.py
@@ -21,7 +21,7 @@ from lm_resiliency.integrations.torchrun._protocol import (
 class GenerationSnapshotRecord:
     """One immutable rank assignment and its coordinator fencing provenance."""
 
-    SCHEMA_VERSION: ClassVar[int] = 1
+    SCHEMA_VERSION: ClassVar[int] = 2
 
     assignment: RankAssignment
     previous_snapshot_digest: str | None
@@ -86,6 +86,13 @@ class GenerationSnapshotRecord:
     @classmethod
     def from_json(cls, encoded: bytes) -> GenerationSnapshotRecord:
         value = _json_object(encoded, cls.__name__)
+        if "schema_version" not in value:
+            raise ValueError(f"{cls.__name__}: missing fields ['schema_version']")
+        _schema_version(
+            value["schema_version"],
+            cls.__name__,
+            expected=cls.SCHEMA_VERSION,
+        )
         _fields(
             value,
             path=cls.__name__,
@@ -99,7 +106,6 @@ class GenerationSnapshotRecord:
                 "coordinator_fencing_token",
             },
         )
-        _schema_version(value["schema_version"], cls.__name__)
         assignment_value = value["assignment"]
         if not isinstance(assignment_value, Mapping):
             raise ValueError("GenerationSnapshotRecord.assignment must be an object")
@@ -174,7 +180,11 @@ class GenerationHeadRecord:
                 "snapshot_digest",
             },
         )
-        _schema_version(value["schema_version"], cls.__name__)
+        _schema_version(
+            value["schema_version"],
+            cls.__name__,
+            expected=cls.SCHEMA_VERSION,
+        )
         return cls(
             run_id=_nonempty_string(value["run_id"], "GenerationHeadRecord.run_id"),
             generation=_nonnegative_integer(
@@ -228,8 +238,8 @@ def _fields(
         raise ValueError(f"{path}: unknown fields {sorted(unknown)!r}")
 
 
-def _schema_version(value: object, path: str) -> int:
-    if isinstance(value, bool) or not isinstance(value, int) or value != 1:
+def _schema_version(value: object, path: str, *, expected: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value != expected:
         raise ValueError(f"{path}.schema_version: unsupported value {value!r}")
     return value
 

--- a/tests/unit/test_torchrun_control_store.py
+++ b/tests/unit/test_torchrun_control_store.py
@@ -43,6 +43,9 @@ def test_control_store_create_update_delete_and_recreate():
     assert created.value == b"one"
     assert updated.value == b"two"
     assert store.get("run/control") == recreated
+    assert created.is_initial_creation
+    assert not updated.is_initial_creation
+    assert not recreated.is_initial_creation
     assert created.revision < updated.revision < tombstone_revision < recreated.revision
 
 
@@ -320,4 +323,21 @@ def test_control_store_entry_rejects_invalid_guard_provenance(
             guard_key=guard_key,
             guard_revision=guard_revision,
             guard_value_digest=guard_value_digest,
+        )
+
+    with pytest.raises(ValueError):
+        ControlStoreEntry(
+            value=b"value",
+            revision=1,
+            guard_key="run/lease",
+            guard_revision=1,
+            guard_value_digest="a" * 64,
+            guard_committed_at_unix_ms=0,
+        )
+
+    with pytest.raises(TypeError):
+        ControlStoreEntry(
+            value=b"value",
+            revision=1,
+            is_initial_creation=1,  # type: ignore[arg-type]
         )

--- a/tests/unit/test_torchrun_control_store.py
+++ b/tests/unit/test_torchrun_control_store.py
@@ -297,3 +297,27 @@ def test_control_store_entry_rejects_invalid_backend_values(
             revision=revision,
             committed_at_unix_ms=committed_at_unix_ms,
         )
+
+
+@pytest.mark.parametrize(
+    ("guard_key", "guard_revision", "guard_value_digest"),
+    [
+        ("run/lease", None, None),
+        (None, 1, None),
+        (None, None, "a" * 64),
+        ("run/lease", 1, "invalid"),
+    ],
+)
+def test_control_store_entry_rejects_invalid_guard_provenance(
+    guard_key,
+    guard_revision,
+    guard_value_digest,
+):
+    with pytest.raises(ValueError):
+        ControlStoreEntry(
+            value=b"value",
+            revision=1,
+            guard_key=guard_key,
+            guard_revision=guard_revision,
+            guard_value_digest=guard_value_digest,
+        )

--- a/tests/unit/test_torchrun_control_store.py
+++ b/tests/unit/test_torchrun_control_store.py
@@ -46,6 +46,9 @@ def test_control_store_create_update_delete_and_recreate():
     assert created.mutation_sequence == 1
     assert updated.mutation_sequence == 2
     assert recreated.mutation_sequence == 4
+    assert created.lifetime_sequence == 1
+    assert updated.lifetime_sequence == 1
+    assert recreated.lifetime_sequence == 2
     assert created.revision < updated.revision < tombstone_revision < recreated.revision
 
 
@@ -340,4 +343,20 @@ def test_control_store_entry_rejects_invalid_guard_provenance(
             value=b"value",
             revision=1,
             mutation_sequence=0,
+        )
+
+    with pytest.raises(ValueError):
+        ControlStoreEntry(
+            value=b"value",
+            revision=1,
+            lifetime_sequence=0,
+        )
+
+    with pytest.raises(ValueError):
+        ControlStoreEntry(
+            value=b"value",
+            revision=1,
+            guard_key="run/lease",
+            guard_revision=1,
+            guard_value_digest="a" * 64,
         )

--- a/tests/unit/test_torchrun_control_store.py
+++ b/tests/unit/test_torchrun_control_store.py
@@ -43,9 +43,9 @@ def test_control_store_create_update_delete_and_recreate():
     assert created.value == b"one"
     assert updated.value == b"two"
     assert store.get("run/control") == recreated
-    assert created.is_initial_creation
-    assert not updated.is_initial_creation
-    assert not recreated.is_initial_creation
+    assert created.mutation_sequence == 1
+    assert updated.mutation_sequence == 2
+    assert recreated.mutation_sequence == 4
     assert created.revision < updated.revision < tombstone_revision < recreated.revision
 
 
@@ -335,9 +335,9 @@ def test_control_store_entry_rejects_invalid_guard_provenance(
             guard_committed_at_unix_ms=0,
         )
 
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         ControlStoreEntry(
             value=b"value",
             revision=1,
-            is_initial_creation=1,  # type: ignore[arg-type]
+            mutation_sequence=0,
         )

--- a/tests/unit/test_torchrun_control_store.py
+++ b/tests/unit/test_torchrun_control_store.py
@@ -47,6 +47,9 @@ def test_control_store_create_update_delete_and_recreate():
     assert created.mutation_sequence == 1
     assert updated.mutation_sequence == 2
     assert recreated.mutation_sequence == 4
+    assert created.value_sequence == 1
+    assert updated.value_sequence == 2
+    assert recreated.value_sequence == 3
     assert created.lifetime_sequence == 1
     assert updated.lifetime_sequence == 1
     assert recreated.lifetime_sequence == 2
@@ -62,6 +65,27 @@ def test_control_store_retains_key_history_after_delete():
 
     assert store.get("run/control") is None
     assert store.has_history("run/control")
+
+
+def test_control_store_value_sequence_changes_only_with_value_or_lifetime():
+    store = InMemoryControlStore()
+    created = store.compare_set("run/control", expected_revision=None, value=b"one")
+    repeated = store.compare_set(
+        "run/control",
+        expected_revision=created.revision,
+        value=b"one",
+    )
+    changed = store.compare_set(
+        "run/control",
+        expected_revision=repeated.revision,
+        value=b"two",
+    )
+    store.compare_delete("run/control", expected_revision=changed.revision)
+    recreated = store.compare_set("run/control", expected_revision=None, value=b"two")
+
+    assert created.value_sequence == repeated.value_sequence == 1
+    assert changed.value_sequence == 2
+    assert recreated.value_sequence == 3
 
 
 def test_control_store_rejects_stale_update_and_delete():
@@ -348,6 +372,7 @@ def test_control_store_entry_rejects_invalid_guard_provenance(
             guard_revision=1,
             guard_value_digest="a" * 64,
             guard_mutation_sequence=1,
+            guard_value_sequence=1,
             guard_lifetime_sequence=1,
             guard_committed_at_unix_ms=0,
         )
@@ -357,6 +382,13 @@ def test_control_store_entry_rejects_invalid_guard_provenance(
             value=b"value",
             revision=1,
             mutation_sequence=0,
+        )
+
+    with pytest.raises(ValueError):
+        ControlStoreEntry(
+            value=b"value",
+            revision=1,
+            value_sequence=0,
         )
 
     with pytest.raises(ValueError):
@@ -374,6 +406,19 @@ def test_control_store_entry_rejects_invalid_guard_provenance(
             guard_revision=1,
             guard_value_digest="a" * 64,
             guard_mutation_sequence=0,
+            guard_value_sequence=1,
+            guard_lifetime_sequence=1,
+        )
+
+    with pytest.raises(ValueError):
+        ControlStoreEntry(
+            value=b"value",
+            revision=1,
+            guard_key="run/lease",
+            guard_revision=1,
+            guard_value_digest="a" * 64,
+            guard_mutation_sequence=1,
+            guard_value_sequence=0,
             guard_lifetime_sequence=1,
         )
 

--- a/tests/unit/test_torchrun_control_store.py
+++ b/tests/unit/test_torchrun_control_store.py
@@ -335,6 +335,8 @@ def test_control_store_entry_rejects_invalid_guard_provenance(
             guard_key="run/lease",
             guard_revision=1,
             guard_value_digest="a" * 64,
+            guard_mutation_sequence=1,
+            guard_lifetime_sequence=1,
             guard_committed_at_unix_ms=0,
         )
 
@@ -350,6 +352,17 @@ def test_control_store_entry_rejects_invalid_guard_provenance(
             value=b"value",
             revision=1,
             lifetime_sequence=0,
+        )
+
+    with pytest.raises(ValueError):
+        ControlStoreEntry(
+            value=b"value",
+            revision=1,
+            guard_key="run/lease",
+            guard_revision=1,
+            guard_value_digest="a" * 64,
+            guard_mutation_sequence=0,
+            guard_lifetime_sequence=1,
         )
 
     with pytest.raises(ValueError):

--- a/tests/unit/test_torchrun_control_store.py
+++ b/tests/unit/test_torchrun_control_store.py
@@ -27,6 +27,7 @@ class ManualClock:
 
 def test_control_store_create_update_delete_and_recreate():
     store = InMemoryControlStore()
+    assert not store.has_history("run/control")
 
     created = store.compare_set("run/control", expected_revision=None, value=b"one")
     updated = store.compare_set(
@@ -49,7 +50,18 @@ def test_control_store_create_update_delete_and_recreate():
     assert created.lifetime_sequence == 1
     assert updated.lifetime_sequence == 1
     assert recreated.lifetime_sequence == 2
+    assert store.has_history("run/control")
     assert created.revision < updated.revision < tombstone_revision < recreated.revision
+
+
+def test_control_store_retains_key_history_after_delete():
+    store = InMemoryControlStore()
+    created = store.compare_set("run/control", expected_revision=None, value=b"one")
+
+    store.compare_delete("run/control", expected_revision=created.revision)
+
+    assert store.get("run/control") is None
+    assert store.has_history("run/control")
 
 
 def test_control_store_rejects_stale_update_and_delete():

--- a/tests/unit/test_torchrun_generation_reader.py
+++ b/tests/unit/test_torchrun_generation_reader.py
@@ -1,0 +1,413 @@
+"""Contract tests for fail-closed torchrun generation-state reads."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStoreWrite,
+    InMemoryControlStore,
+)
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseManager,
+    HeldCoordinatorLease,
+)
+from lm_resiliency.integrations.torchrun._generation_reader import (
+    GenerationStateCorrupt,
+    GenerationStateReader,
+)
+from lm_resiliency.integrations.torchrun._generation_records import (
+    GenerationHeadRecord,
+    GenerationSnapshotRecord,
+)
+from lm_resiliency.integrations.torchrun._protocol import RankAssignment, SlotAssignment
+
+RUN_ID = "training-run"
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+    def set(self, now_unix_ms: int) -> None:
+        with self._lock:
+            self.now_unix_ms = now_unix_ms
+
+
+def _assignment(generation: int) -> RankAssignment:
+    return RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=generation,
+        assignments=(
+            SlotAssignment(
+                logical_node_slot=0,
+                node_id="node-a",
+                first_global_rank=0,
+                local_world_size=2,
+            ),
+            SlotAssignment(
+                logical_node_slot=1,
+                node_id="node-b",
+                first_global_rank=2,
+                local_world_size=2,
+            ),
+        ),
+        topology_digest="topology-v1",
+    )
+
+
+def _state():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    lease_manager = CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id="coordinator-a",
+        lease_duration_ms=100,
+        clock=clock,
+    )
+    lease = lease_manager.acquire()
+    reader = GenerationStateReader(store, run_id=RUN_ID)
+    return clock, store, lease, reader
+
+
+def _commit(
+    store: InMemoryControlStore,
+    reader: GenerationStateReader,
+    lease: HeldCoordinatorLease,
+    *,
+    generation: int,
+    previous_snapshot_digest: str | None,
+    expected_head_revision: int | None,
+    coordinator_id: str = "coordinator-a",
+    lease_id: str | None = None,
+    fencing_token: int | None = None,
+):
+    snapshot = GenerationSnapshotRecord(
+        assignment=_assignment(generation),
+        previous_snapshot_digest=previous_snapshot_digest,
+        coordinator_id=coordinator_id,
+        lease_id=lease.record.lease_id if lease_id is None else lease_id,
+        coordinator_fencing_token=(lease.fencing_token if fencing_token is None else fencing_token),
+    )
+    head = GenerationHeadRecord(
+        run_id=RUN_ID,
+        generation=generation,
+        snapshot_digest=snapshot.digest,
+    )
+    return store.compare_set_many_guarded(
+        {
+            reader.head_key: ControlStoreWrite(
+                expected_revision=expected_head_revision,
+                value=head.to_json(),
+            ),
+            reader.snapshot_key(generation): ControlStoreWrite(
+                expected_revision=None,
+                value=snapshot.to_json(),
+            ),
+        },
+        guard_key=reader.coordinator_lease_key,
+        expected_guard_revision=lease.fencing_token,
+        not_before_unix_ms=lease.granted_at_unix_ms,
+        deadline_unix_ms=lease.expires_at_unix_ms,
+    )
+
+
+def test_generation_reader_returns_none_before_initialization():
+    _, _, _, reader = _state()
+
+    assert reader.current() is None
+    assert reader.get(0) is None
+
+
+def test_generation_reader_retries_concurrent_initialization(monkeypatch):
+    _, store, lease, reader = _state()
+    original_get = store.get
+    triggered = False
+
+    def racing_get(key):
+        nonlocal triggered
+        if key == reader.snapshot_key(0) and not triggered:
+            triggered = True
+            _commit(
+                store,
+                reader,
+                lease,
+                generation=0,
+                previous_snapshot_digest=None,
+                expected_head_revision=None,
+            )
+        return original_get(key)
+
+    monkeypatch.setattr(store, "get", racing_get)
+
+    snapshot = reader.get(0)
+
+    assert snapshot is not None
+    assert snapshot.record.assignment.generation == 0
+
+
+def test_generation_reader_reads_current_and_historical_snapshots():
+    clock, store, lease, reader = _state()
+    generation_zero = _commit(
+        store,
+        reader,
+        lease,
+        generation=0,
+        previous_snapshot_digest=None,
+        expected_head_revision=None,
+    )
+    current_zero = reader.current()
+    assert current_zero is not None
+    clock.set(1_010)
+    _commit(
+        store,
+        reader,
+        lease,
+        generation=1,
+        previous_snapshot_digest=current_zero.snapshot.record.digest,
+        expected_head_revision=generation_zero[reader.head_key].revision,
+    )
+
+    current = reader.current()
+
+    assert current is not None
+    assert current.snapshot.record.assignment.generation == 1
+    assert reader.get(0) == current_zero.snapshot
+    assert reader.get(1) == current.snapshot
+
+
+def test_generation_reader_uses_distinct_run_namespaces():
+    _, _, _, reader = _state()
+    other = GenerationStateReader(InMemoryControlStore(), run_id="other-run")
+
+    assert reader.head_key != other.head_key
+    assert reader.coordinator_lease_key != other.coordinator_lease_key
+    assert reader.snapshot_key(0) != other.snapshot_key(0)
+
+
+def test_generation_reader_rejects_snapshots_outside_committed_head():
+    _, store, lease, reader = _state()
+    orphan_zero = GenerationSnapshotRecord(
+        assignment=_assignment(0),
+        previous_snapshot_digest=None,
+        coordinator_id=lease.record.coordinator_id,
+        lease_id=lease.record.lease_id,
+        coordinator_fencing_token=lease.fencing_token,
+    )
+    store.compare_set_in_window(
+        reader.snapshot_key(0),
+        expected_revision=None,
+        not_before_unix_ms=1_000,
+        deadline_unix_ms=None,
+        value=orphan_zero.to_json(),
+    )
+    with pytest.raises(GenerationStateCorrupt, match="without a generation head"):
+        reader.get(0)
+
+    clock, store, lease, reader = _state()
+    committed = _commit(
+        store,
+        reader,
+        lease,
+        generation=0,
+        previous_snapshot_digest=None,
+        expected_head_revision=None,
+    )
+    clock.set(1_010)
+    orphan_one = GenerationSnapshotRecord(
+        assignment=_assignment(1),
+        previous_snapshot_digest=GenerationSnapshotRecord.from_json(
+            committed[reader.snapshot_key(0)].value
+        ).digest,
+        coordinator_id=lease.record.coordinator_id,
+        lease_id=lease.record.lease_id,
+        coordinator_fencing_token=lease.fencing_token,
+    )
+    store.compare_set_in_window(
+        reader.snapshot_key(1),
+        expected_revision=None,
+        not_before_unix_ms=1_010,
+        deadline_unix_ms=None,
+        value=orphan_one.to_json(),
+    )
+    with pytest.raises(GenerationStateCorrupt, match="newer than"):
+        reader.get(1)
+
+
+def test_generation_reader_rejects_missing_or_unstamped_snapshot():
+    _, store, lease, reader = _state()
+    committed = _commit(
+        store,
+        reader,
+        lease,
+        generation=0,
+        previous_snapshot_digest=None,
+        expected_head_revision=None,
+    )
+    snapshot_entry = committed[reader.snapshot_key(0)]
+    store.compare_delete(
+        reader.snapshot_key(0),
+        expected_revision=snapshot_entry.revision,
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="missing snapshot"):
+        reader.current()
+
+    store.compare_set(
+        reader.snapshot_key(0),
+        expected_revision=None,
+        value=snapshot_entry.value,
+    )
+    with pytest.raises(GenerationStateCorrupt, match="commit time"):
+        reader.current()
+
+
+def test_generation_reader_rejects_head_digest_or_timestamp_substitution():
+    clock, store, lease, reader = _state()
+    committed = _commit(
+        store,
+        reader,
+        lease,
+        generation=0,
+        previous_snapshot_digest=None,
+        expected_head_revision=None,
+    )
+    head_entry = committed[reader.head_key]
+    substituted = GenerationHeadRecord(
+        run_id=RUN_ID,
+        generation=0,
+        snapshot_digest="f" * 64,
+    )
+    store.compare_set_in_window(
+        reader.head_key,
+        expected_revision=head_entry.revision,
+        not_before_unix_ms=1_000,
+        deadline_unix_ms=None,
+        value=substituted.to_json(),
+    )
+    with pytest.raises(GenerationStateCorrupt, match="digest"):
+        reader.current()
+
+    current_head = store.get(reader.head_key)
+    assert current_head is not None
+    clock.set(1_010)
+    original = GenerationHeadRecord(
+        run_id=RUN_ID,
+        generation=0,
+        snapshot_digest=GenerationSnapshotRecord.from_json(
+            committed[reader.snapshot_key(0)].value
+        ).digest,
+    )
+    store.compare_set_in_window(
+        reader.head_key,
+        expected_revision=current_head.revision,
+        not_before_unix_ms=1_010,
+        deadline_unix_ms=None,
+        value=original.to_json(),
+    )
+    with pytest.raises(GenerationStateCorrupt, match="timestamps"):
+        reader.current()
+
+
+def test_generation_reader_rejects_missing_or_substituted_predecessor():
+    clock, store, lease, reader = _state()
+    generation_zero = _commit(
+        store,
+        reader,
+        lease,
+        generation=0,
+        previous_snapshot_digest=None,
+        expected_head_revision=None,
+    )
+    snapshot_zero = GenerationSnapshotRecord.from_json(
+        generation_zero[reader.snapshot_key(0)].value
+    )
+    clock.set(1_010)
+    _commit(
+        store,
+        reader,
+        lease,
+        generation=1,
+        previous_snapshot_digest=snapshot_zero.digest,
+        expected_head_revision=generation_zero[reader.head_key].revision,
+    )
+    predecessor_entry = store.get(reader.snapshot_key(0))
+    assert predecessor_entry is not None
+    store.compare_delete(
+        reader.snapshot_key(0),
+        expected_revision=predecessor_entry.revision,
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="missing predecessor"):
+        reader.current()
+
+    substituted = GenerationSnapshotRecord(
+        assignment=_assignment(0),
+        previous_snapshot_digest=None,
+        coordinator_id="coordinator-a",
+        lease_id="substituted-lease",
+        coordinator_fencing_token=lease.fencing_token,
+    )
+    store.compare_set_in_window(
+        reader.snapshot_key(0),
+        expected_revision=None,
+        not_before_unix_ms=1_010,
+        deadline_unix_ms=None,
+        value=substituted.to_json(),
+    )
+    with pytest.raises(GenerationStateCorrupt, match="predecessor digest"):
+        reader.current()
+
+
+@pytest.mark.parametrize(
+    ("first_fencing_token", "first_lease_id", "second_lease_id", "message"),
+    [
+        (5, "lease-a", "lease-b", "fencing tokens"),
+        (4, "lease-a", "lease-b", "lease identity"),
+        (3, "lease-a", "lease-a", "changes coordinator"),
+    ],
+)
+def test_generation_reader_rejects_invalid_lease_provenance(
+    first_fencing_token,
+    first_lease_id,
+    second_lease_id,
+    message,
+):
+    clock, store, lease, reader = _state()
+    generation_zero = _commit(
+        store,
+        reader,
+        lease,
+        generation=0,
+        previous_snapshot_digest=None,
+        expected_head_revision=None,
+        coordinator_id="coordinator-a",
+        lease_id=first_lease_id,
+        fencing_token=first_fencing_token,
+    )
+    snapshot_zero = GenerationSnapshotRecord.from_json(
+        generation_zero[reader.snapshot_key(0)].value
+    )
+    clock.set(1_010)
+    _commit(
+        store,
+        reader,
+        lease,
+        generation=1,
+        previous_snapshot_digest=snapshot_zero.digest,
+        expected_head_revision=generation_zero[reader.head_key].revision,
+        coordinator_id="coordinator-b",
+        lease_id=second_lease_id,
+        fencing_token=4,
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match=message):
+        reader.current()

--- a/tests/unit/test_torchrun_generation_reader.py
+++ b/tests/unit/test_torchrun_generation_reader.py
@@ -154,6 +154,7 @@ def _reader_from_history(
     head_committed_at_offset_ms: int = 0,
     guard_lifetime_sequences: tuple[int, ...] | None = None,
     guard_grant_times_unix_ms: tuple[int, ...] | None = None,
+    snapshot_commit_times_unix_ms: tuple[int, ...] | None = None,
 ) -> GenerationStateReader:
     if guard_lifetime_sequences is None:
         guard_lifetime_sequences = (1,) * len(records)
@@ -176,19 +177,22 @@ def _reader_from_history(
             else:
                 grant_times.append(grant_times[-1] + 1)
         guard_grant_times_unix_ms = tuple(grant_times)
+    if snapshot_commit_times_unix_ms is None:
+        snapshot_commit_times_unix_ms = guard_grant_times_unix_ms
     store = StaticControlStore()
     reader = GenerationStateReader(store, run_id=RUN_ID)
-    for record, guard_lifetime_sequence, guard_grant_time in zip(
+    for record, guard_lifetime_sequence, guard_grant_time, snapshot_commit_time in zip(
         records,
         guard_lifetime_sequences,
         guard_grant_times_unix_ms,
+        snapshot_commit_times_unix_ms,
         strict=True,
     ):
         generation = record.assignment.generation
         store.entries[reader.snapshot_key(generation)] = ControlStoreEntry(
             value=record.to_json(),
             revision=1,
-            committed_at_unix_ms=guard_grant_time,
+            committed_at_unix_ms=snapshot_commit_time,
             guard_key=reader.coordinator_lease_key,
             guard_revision=record.coordinator_fencing_token,
             guard_value_digest=record.coordinator_lease_digest,
@@ -204,7 +208,7 @@ def _reader_from_history(
     store.entries[reader.head_key] = ControlStoreEntry(
         value=head.to_json(),
         revision=len(records),
-        committed_at_unix_ms=(guard_grant_times_unix_ms[-1] + head_committed_at_offset_ms),
+        committed_at_unix_ms=(snapshot_commit_times_unix_ms[-1] + head_committed_at_offset_ms),
         mutation_sequence=len(records),
         guard_key=reader.coordinator_lease_key,
         guard_revision=latest.coordinator_fencing_token,
@@ -753,6 +757,35 @@ def test_generation_reader_rejects_overlapping_in_place_lease_replacement():
     )
 
     with pytest.raises(GenerationStateCorrupt, match="leases overlap"):
+        reader.current()
+
+
+def test_generation_reader_rejects_expired_same_lease_renewal():
+    records = _history(
+        ("coordinator-a", "lease-a", 1),
+        ("coordinator-a", "lease-a", 2),
+    )
+    reader = _reader_from_history(
+        records,
+        guard_grant_times_unix_ms=(1_000, 1_100),
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="renews an expired"):
+        reader.current()
+
+
+def test_generation_reader_rejects_lease_grant_time_rollback():
+    records = _history(
+        ("coordinator-a", "lease-a", 1),
+        ("coordinator-a", "lease-a", 2),
+    )
+    reader = _reader_from_history(
+        records,
+        guard_grant_times_unix_ms=(1_001, 1_000),
+        snapshot_commit_times_unix_ms=(1_001, 1_002),
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="grant times move backward"):
         reader.current()
 
 

--- a/tests/unit/test_torchrun_generation_reader.py
+++ b/tests/unit/test_torchrun_generation_reader.py
@@ -266,6 +266,44 @@ def test_generation_reader_retries_concurrent_initialization(monkeypatch):
     assert reader.get(0) == current.snapshot
 
 
+def test_generation_reader_retries_concurrent_head_advance(monkeypatch):
+    _, store, lease, reader = _state()
+    generation_zero = _commit(
+        store,
+        reader,
+        lease,
+        generation=0,
+        previous_snapshot_digest=None,
+        expected_head_revision=None,
+    )
+    snapshot_zero = GenerationSnapshotRecord.from_json(
+        generation_zero[reader.snapshot_key(0)].value
+    )
+    original_get = store.get
+    triggered = False
+
+    def racing_get(key):
+        nonlocal triggered
+        if key == reader.snapshot_key(1) and not triggered:
+            triggered = True
+            _commit(
+                store,
+                reader,
+                lease,
+                generation=1,
+                previous_snapshot_digest=snapshot_zero.digest,
+                expected_head_revision=generation_zero[reader.head_key].revision,
+            )
+        return original_get(key)
+
+    monkeypatch.setattr(store, "get", racing_get)
+
+    current = reader.current()
+
+    assert current is not None
+    assert current.snapshot.record.assignment.generation == 1
+
+
 def test_generation_reader_reads_current_and_historical_snapshots():
     clock, store, lease, reader = _state()
     generation_zero = _commit(
@@ -354,6 +392,8 @@ def test_generation_reader_rejects_snapshots_outside_committed_head():
         deadline_unix_ms=None,
         value=orphan_one.to_json(),
     )
+    with pytest.raises(GenerationStateCorrupt, match="newer than"):
+        reader.current()
     with pytest.raises(GenerationStateCorrupt, match="newer than"):
         reader.get(1)
 
@@ -591,6 +631,77 @@ def test_generation_reader_rejects_same_timestamp_head_rollback():
     )
 
     with pytest.raises(GenerationStateCorrupt, match="mutation sequence"):
+        reader.current()
+
+
+def test_generation_reader_rejects_recreated_generation_head_lifetime():
+    _, store, lease, reader = _state()
+    generation_zero = _commit(
+        store,
+        reader,
+        lease,
+        generation=0,
+        previous_snapshot_digest=None,
+        expected_head_revision=None,
+    )
+    snapshot_zero = GenerationSnapshotRecord.from_json(
+        generation_zero[reader.snapshot_key(0)].value
+    )
+    snapshot_one = _snapshot(
+        1,
+        previous_snapshot_digest=snapshot_zero.digest,
+        coordinator_id=lease.record.coordinator_id,
+        lease_id=lease.record.lease_id,
+        fencing_token=lease.fencing_token,
+    )
+    store.compare_set_many_guarded(
+        {
+            reader.snapshot_key(1): ControlStoreWrite(
+                expected_revision=None,
+                value=snapshot_one.to_json(),
+            )
+        },
+        guard_key=reader.coordinator_lease_key,
+        expected_guard_revision=lease.fencing_token,
+        not_before_unix_ms=lease.granted_at_unix_ms,
+        deadline_unix_ms=lease.expires_at_unix_ms,
+    )
+    store.compare_delete(
+        reader.head_key,
+        expected_revision=generation_zero[reader.head_key].revision,
+    )
+    snapshot_two = _snapshot(
+        2,
+        previous_snapshot_digest=snapshot_one.digest,
+        coordinator_id=lease.record.coordinator_id,
+        lease_id=lease.record.lease_id,
+        fencing_token=lease.fencing_token,
+    )
+    head_two = GenerationHeadRecord(
+        run_id=RUN_ID,
+        generation=2,
+        snapshot_digest=snapshot_two.digest,
+    )
+    committed = store.compare_set_many_guarded(
+        {
+            reader.head_key: ControlStoreWrite(
+                expected_revision=None,
+                value=head_two.to_json(),
+            ),
+            reader.snapshot_key(2): ControlStoreWrite(
+                expected_revision=None,
+                value=snapshot_two.to_json(),
+            ),
+        },
+        guard_key=reader.coordinator_lease_key,
+        expected_guard_revision=lease.fencing_token,
+        not_before_unix_ms=lease.granted_at_unix_ms,
+        deadline_unix_ms=lease.expires_at_unix_ms,
+    )
+    assert committed[reader.head_key].mutation_sequence == 3
+    assert committed[reader.head_key].lifetime_sequence == 2
+
+    with pytest.raises(GenerationStateCorrupt, match="deleted and recreated"):
         reader.current()
 
 

--- a/tests/unit/test_torchrun_generation_reader.py
+++ b/tests/unit/test_torchrun_generation_reader.py
@@ -156,6 +156,7 @@ def _reader_from_history(
     *,
     head_committed_at_offset_ms: int = 0,
     guard_mutation_sequences: tuple[int, ...] | None = None,
+    guard_value_sequences: tuple[int, ...] | None = None,
     guard_lifetime_sequences: tuple[int, ...] | None = None,
     guard_grant_times_unix_ms: tuple[int, ...] | None = None,
     snapshot_commit_times_unix_ms: tuple[int, ...] | None = None,
@@ -177,6 +178,32 @@ def _reader_from_history(
                 lifetime_delta = successor_lifetime - predecessor_lifetime
                 mutation_sequences.append(mutation_sequences[-1] + max(1, 2 * lifetime_delta))
         guard_mutation_sequences = tuple(mutation_sequences)
+    if guard_value_sequences is None:
+        value_sequences = [1]
+        for (
+            predecessor,
+            successor,
+            predecessor_mutation,
+            successor_mutation,
+            predecessor_lifetime,
+            successor_lifetime,
+        ) in zip(
+            records[:-1],
+            records[1:],
+            guard_mutation_sequences[:-1],
+            guard_mutation_sequences[1:],
+            guard_lifetime_sequences[:-1],
+            guard_lifetime_sequences[1:],
+            strict=True,
+        ):
+            if successor_mutation == predecessor_mutation or (
+                successor.coordinator_lease_digest == predecessor.coordinator_lease_digest
+                and successor_lifetime == predecessor_lifetime
+            ):
+                value_sequences.append(value_sequences[-1])
+            else:
+                value_sequences.append(value_sequences[-1] + 1)
+        guard_value_sequences = tuple(value_sequences)
     if guard_grant_times_unix_ms is None:
         grant_times = [1_000]
         for predecessor, successor, predecessor_lifetime, successor_lifetime in zip(
@@ -203,12 +230,14 @@ def _reader_from_history(
     for (
         record,
         guard_mutation_sequence,
+        guard_value_sequence,
         guard_lifetime_sequence,
         guard_grant_time,
         snapshot_commit_time,
     ) in zip(
         records,
         guard_mutation_sequences,
+        guard_value_sequences,
         guard_lifetime_sequences,
         guard_grant_times_unix_ms,
         snapshot_commit_times_unix_ms,
@@ -223,6 +252,7 @@ def _reader_from_history(
             guard_revision=record.coordinator_fencing_token,
             guard_value_digest=record.coordinator_lease_digest,
             guard_mutation_sequence=guard_mutation_sequence,
+            guard_value_sequence=guard_value_sequence,
             guard_lifetime_sequence=guard_lifetime_sequence,
             guard_committed_at_unix_ms=guard_grant_time,
         )
@@ -241,6 +271,7 @@ def _reader_from_history(
         guard_revision=latest.coordinator_fencing_token,
         guard_value_digest=latest.coordinator_lease_digest,
         guard_mutation_sequence=guard_mutation_sequences[-1],
+        guard_value_sequence=guard_value_sequences[-1],
         guard_lifetime_sequence=guard_lifetime_sequences[-1],
         guard_committed_at_unix_ms=guard_grant_times_unix_ms[-1],
     )
@@ -870,6 +901,22 @@ def test_generation_reader_accepts_skipped_valid_renewals_and_opaque_revisions()
     assert current.snapshot.record == records[-1]
 
 
+def test_generation_reader_rejects_same_lease_restored_after_skipped_mutation():
+    records = _history(
+        ("coordinator-a", "lease-a", 100),
+        ("coordinator-a", "lease-a", 50),
+    )
+    reader = _reader_from_history(
+        records,
+        guard_mutation_sequences=(1, 3),
+        guard_value_sequences=(1, 3),
+        guard_grant_times_unix_ms=(1_000, 1_100),
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="value changed between renewals"):
+        reader.current()
+
+
 def test_generation_reader_rejects_expired_renewal_after_skipped_mutations():
     records = _history(
         ("coordinator-a", "lease-a", 100),
@@ -908,6 +955,7 @@ def test_generation_reader_rejects_guard_lifetime_rollback():
     reader = _reader_from_history(
         records,
         guard_mutation_sequences=(3, 4),
+        guard_value_sequences=(2, 3),
         guard_lifetime_sequences=(2, 1),
     )
 
@@ -954,6 +1002,34 @@ def test_generation_reader_rejects_impossible_initial_guard_lifetime():
     )
 
     with pytest.raises(GenerationStateCorrupt, match="cannot support its lifetime"):
+        reader.current()
+
+
+def test_generation_reader_rejects_initial_value_sequence_beyond_mutations():
+    records = _history(("coordinator-a", "lease-a", 100))
+    reader = _reader_from_history(
+        records,
+        guard_mutation_sequences=(1,),
+        guard_value_sequences=(2,),
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="exceeds its mutations"):
+        reader.current()
+
+
+def test_generation_reader_rejects_different_leases_with_one_value_sequence():
+    records = _history(
+        ("coordinator-a", "lease-a", 100),
+        ("coordinator-b", "lease-b", 50),
+    )
+    reader = _reader_from_history(
+        records,
+        guard_mutation_sequences=(1, 2),
+        guard_value_sequences=(1, 1),
+        guard_grant_times_unix_ms=(1_000, 1_100),
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="share one guard value sequence"):
         reader.current()
 
 

--- a/tests/unit/test_torchrun_generation_reader.py
+++ b/tests/unit/test_torchrun_generation_reader.py
@@ -150,6 +150,8 @@ def _snapshot(
 
 def _reader_from_history(
     records: tuple[GenerationSnapshotRecord, ...],
+    *,
+    head_committed_at_offset_ms: int = 0,
 ) -> GenerationStateReader:
     store = StaticControlStore()
     reader = GenerationStateReader(store, run_id=RUN_ID)
@@ -173,7 +175,8 @@ def _reader_from_history(
     store.entries[reader.head_key] = ControlStoreEntry(
         value=head.to_json(),
         revision=len(records),
-        committed_at_unix_ms=1_000 + latest.assignment.generation,
+        committed_at_unix_ms=(1_000 + latest.assignment.generation + head_committed_at_offset_ms),
+        mutation_sequence=len(records),
         guard_key=reader.coordinator_lease_key,
         guard_revision=latest.coordinator_fencing_token,
         guard_value_digest=latest.coordinator_lease_digest,
@@ -500,7 +503,7 @@ def test_generation_reader_rejects_replaced_snapshot_key():
 
 
 def test_generation_reader_rejects_head_digest_or_timestamp_substitution():
-    clock, store, lease, reader = _state()
+    _, store, lease, reader = _state()
     committed = _commit(
         store,
         reader,
@@ -515,7 +518,7 @@ def test_generation_reader_rejects_head_digest_or_timestamp_substitution():
         generation=0,
         snapshot_digest="f" * 64,
     )
-    updated = store.compare_set_many_guarded(
+    store.compare_set_many_guarded(
         {
             reader.head_key: ControlStoreWrite(
                 expected_revision=head_entry.revision,
@@ -530,27 +533,55 @@ def test_generation_reader_rejects_head_digest_or_timestamp_substitution():
     with pytest.raises(GenerationStateCorrupt, match="digest"):
         reader.current()
 
-    clock.set(1_010)
-    original = GenerationHeadRecord(
+    snapshot_zero = GenerationSnapshotRecord.from_json(committed[reader.snapshot_key(0)].value)
+    timestamp_reader = _reader_from_history(
+        (snapshot_zero,),
+        head_committed_at_offset_ms=1,
+    )
+    with pytest.raises(GenerationStateCorrupt, match="timestamps"):
+        timestamp_reader.current()
+
+
+def test_generation_reader_rejects_same_timestamp_head_rollback():
+    _, store, lease, reader = _state()
+    generation_zero = _commit(
+        store,
+        reader,
+        lease,
+        generation=0,
+        previous_snapshot_digest=None,
+        expected_head_revision=None,
+    )
+    snapshot_zero = GenerationSnapshotRecord.from_json(
+        generation_zero[reader.snapshot_key(0)].value
+    )
+    generation_one = _commit(
+        store,
+        reader,
+        lease,
+        generation=1,
+        previous_snapshot_digest=snapshot_zero.digest,
+        expected_head_revision=generation_zero[reader.head_key].revision,
+    )
+    rollback = GenerationHeadRecord(
         run_id=RUN_ID,
         generation=0,
-        snapshot_digest=GenerationSnapshotRecord.from_json(
-            committed[reader.snapshot_key(0)].value
-        ).digest,
+        snapshot_digest=snapshot_zero.digest,
     )
     store.compare_set_many_guarded(
         {
             reader.head_key: ControlStoreWrite(
-                expected_revision=updated[reader.head_key].revision,
-                value=original.to_json(),
+                expected_revision=generation_one[reader.head_key].revision,
+                value=rollback.to_json(),
             )
         },
         guard_key=reader.coordinator_lease_key,
         expected_guard_revision=lease.fencing_token,
-        not_before_unix_ms=1_010,
+        not_before_unix_ms=lease.granted_at_unix_ms,
         deadline_unix_ms=lease.expires_at_unix_ms,
     )
-    with pytest.raises(GenerationStateCorrupt, match="timestamps"):
+
+    with pytest.raises(GenerationStateCorrupt, match="mutation sequence"):
         reader.current()
 
 

--- a/tests/unit/test_torchrun_generation_reader.py
+++ b/tests/unit/test_torchrun_generation_reader.py
@@ -789,6 +789,20 @@ def test_generation_reader_rejects_lease_grant_time_rollback():
         reader.current()
 
 
+def test_generation_reader_rejects_guard_lifetime_rollback():
+    records = _history(
+        ("coordinator-a", "lease-a", 1),
+        ("coordinator-b", "lease-b", 2),
+    )
+    reader = _reader_from_history(
+        records,
+        guard_lifetime_sequences=(2, 1),
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="guard lifetimes move backward"):
+        reader.current()
+
+
 def test_generation_reader_rejects_one_guard_revision_with_two_grant_times():
     records = _history(
         ("coordinator-a", "lease-a", 1),

--- a/tests/unit/test_torchrun_generation_reader.py
+++ b/tests/unit/test_torchrun_generation_reader.py
@@ -152,12 +152,28 @@ def _reader_from_history(
     records: tuple[GenerationSnapshotRecord, ...],
     *,
     head_committed_at_offset_ms: int = 0,
+    guard_mutation_sequences: tuple[int, ...] | None = None,
     guard_lifetime_sequences: tuple[int, ...] | None = None,
     guard_grant_times_unix_ms: tuple[int, ...] | None = None,
     snapshot_commit_times_unix_ms: tuple[int, ...] | None = None,
 ) -> GenerationStateReader:
     if guard_lifetime_sequences is None:
         guard_lifetime_sequences = (1,) * len(records)
+    if guard_mutation_sequences is None:
+        mutation_sequences = [1]
+        for predecessor, successor, predecessor_lifetime, successor_lifetime in zip(
+            records[:-1],
+            records[1:],
+            guard_lifetime_sequences[:-1],
+            guard_lifetime_sequences[1:],
+            strict=True,
+        ):
+            if successor.coordinator_fencing_token == predecessor.coordinator_fencing_token:
+                mutation_sequences.append(mutation_sequences[-1])
+            else:
+                lifetime_delta = successor_lifetime - predecessor_lifetime
+                mutation_sequences.append(mutation_sequences[-1] + max(1, 2 * lifetime_delta))
+        guard_mutation_sequences = tuple(mutation_sequences)
     if guard_grant_times_unix_ms is None:
         grant_times = [1_000]
         for predecessor, successor, predecessor_lifetime, successor_lifetime in zip(
@@ -181,8 +197,15 @@ def _reader_from_history(
         snapshot_commit_times_unix_ms = guard_grant_times_unix_ms
     store = StaticControlStore()
     reader = GenerationStateReader(store, run_id=RUN_ID)
-    for record, guard_lifetime_sequence, guard_grant_time, snapshot_commit_time in zip(
+    for (
+        record,
+        guard_mutation_sequence,
+        guard_lifetime_sequence,
+        guard_grant_time,
+        snapshot_commit_time,
+    ) in zip(
         records,
+        guard_mutation_sequences,
         guard_lifetime_sequences,
         guard_grant_times_unix_ms,
         snapshot_commit_times_unix_ms,
@@ -196,6 +219,7 @@ def _reader_from_history(
             guard_key=reader.coordinator_lease_key,
             guard_revision=record.coordinator_fencing_token,
             guard_value_digest=record.coordinator_lease_digest,
+            guard_mutation_sequence=guard_mutation_sequence,
             guard_lifetime_sequence=guard_lifetime_sequence,
             guard_committed_at_unix_ms=guard_grant_time,
         )
@@ -213,6 +237,7 @@ def _reader_from_history(
         guard_key=reader.coordinator_lease_key,
         guard_revision=latest.coordinator_fencing_token,
         guard_value_digest=latest.coordinator_lease_digest,
+        guard_mutation_sequence=guard_mutation_sequences[-1],
         guard_lifetime_sequence=guard_lifetime_sequences[-1],
         guard_committed_at_unix_ms=guard_grant_times_unix_ms[-1],
     )
@@ -774,6 +799,38 @@ def test_generation_reader_rejects_expired_same_lease_renewal():
         reader.current()
 
 
+def test_generation_reader_accepts_skipped_valid_renewals_and_opaque_revisions():
+    records = _history(
+        ("coordinator-a", "lease-a", 100),
+        ("coordinator-a", "lease-a", 50),
+    )
+    reader = _reader_from_history(
+        records,
+        guard_mutation_sequences=(1, 3),
+        guard_grant_times_unix_ms=(1_000, 1_100),
+    )
+
+    current = reader.current()
+
+    assert current is not None
+    assert current.snapshot.record == records[-1]
+
+
+def test_generation_reader_rejects_expired_renewal_after_skipped_mutations():
+    records = _history(
+        ("coordinator-a", "lease-a", 100),
+        ("coordinator-a", "lease-a", 50),
+    )
+    reader = _reader_from_history(
+        records,
+        guard_mutation_sequences=(1, 3),
+        guard_grant_times_unix_ms=(1_000, 1_199),
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="renews an expired"):
+        reader.current()
+
+
 def test_generation_reader_rejects_lease_grant_time_rollback():
     records = _history(
         ("coordinator-a", "lease-a", 1),
@@ -800,6 +857,36 @@ def test_generation_reader_rejects_guard_lifetime_rollback():
     )
 
     with pytest.raises(GenerationStateCorrupt, match="guard lifetimes move backward"):
+        reader.current()
+
+
+def test_generation_reader_rejects_guard_mutation_rollback():
+    records = _history(
+        ("coordinator-a", "lease-a", 100),
+        ("coordinator-a", "lease-a", 50),
+    )
+    reader = _reader_from_history(
+        records,
+        guard_mutation_sequences=(2, 1),
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="guard mutations move backward"):
+        reader.current()
+
+
+def test_generation_reader_rejects_guard_recreation_without_two_mutations():
+    records = _history(
+        ("coordinator-a", "lease-a", 100),
+        ("coordinator-b", "lease-b", 50),
+    )
+    reader = _reader_from_history(
+        records,
+        guard_mutation_sequences=(1, 2),
+        guard_lifetime_sequences=(1, 2),
+        guard_grant_times_unix_ms=(1_000, 1_100),
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="delete-and-recreate"):
         reader.current()
 
 
@@ -948,13 +1035,6 @@ def test_generation_reader_anchors_fencing_token_to_store_guard():
 @pytest.mark.parametrize(
     ("history", "message"),
     [
-        (
-            _history(
-                ("coordinator-a", "lease-a", 5),
-                ("coordinator-b", "lease-b", 4),
-            ),
-            "fencing tokens",
-        ),
         (
             _history(
                 ("coordinator-a", "lease-a", 4),

--- a/tests/unit/test_torchrun_generation_reader.py
+++ b/tests/unit/test_torchrun_generation_reader.py
@@ -152,10 +152,17 @@ def _reader_from_history(
     records: tuple[GenerationSnapshotRecord, ...],
     *,
     head_committed_at_offset_ms: int = 0,
+    guard_lifetime_sequences: tuple[int, ...] | None = None,
 ) -> GenerationStateReader:
+    if guard_lifetime_sequences is None:
+        guard_lifetime_sequences = (1,) * len(records)
     store = StaticControlStore()
     reader = GenerationStateReader(store, run_id=RUN_ID)
-    for record in records:
+    for record, guard_lifetime_sequence in zip(
+        records,
+        guard_lifetime_sequences,
+        strict=True,
+    ):
         generation = record.assignment.generation
         store.entries[reader.snapshot_key(generation)] = ControlStoreEntry(
             value=record.to_json(),
@@ -164,6 +171,7 @@ def _reader_from_history(
             guard_key=reader.coordinator_lease_key,
             guard_revision=record.coordinator_fencing_token,
             guard_value_digest=record.coordinator_lease_digest,
+            guard_lifetime_sequence=guard_lifetime_sequence,
             guard_committed_at_unix_ms=1_000 + generation,
         )
     latest = records[-1]
@@ -180,6 +188,7 @@ def _reader_from_history(
         guard_key=reader.coordinator_lease_key,
         guard_revision=latest.coordinator_fencing_token,
         guard_value_digest=latest.coordinator_lease_digest,
+        guard_lifetime_sequence=guard_lifetime_sequences[-1],
         guard_committed_at_unix_ms=1_000 + latest.assignment.generation,
     )
     return reader
@@ -582,6 +591,20 @@ def test_generation_reader_rejects_same_timestamp_head_rollback():
     )
 
     with pytest.raises(GenerationStateCorrupt, match="mutation sequence"):
+        reader.current()
+
+
+def test_generation_reader_rejects_recreated_guard_with_reused_lease_identity():
+    records = _history(
+        ("coordinator-a", "lease-a", 1),
+        ("coordinator-a", "lease-a", 3),
+    )
+    reader = _reader_from_history(
+        records,
+        guard_lifetime_sequences=(1, 2),
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="recreated guard lifetime"):
         reader.current()
 
 

--- a/tests/unit/test_torchrun_generation_reader.py
+++ b/tests/unit/test_torchrun_generation_reader.py
@@ -51,6 +51,9 @@ class StaticControlStore:
     def get(self, key: str) -> ControlStoreEntry | None:
         return self.entries.get(key)
 
+    def has_history(self, key: str) -> bool:
+        return key in self.entries
+
 
 def _assignment(generation: int) -> RankAssignment:
     return RankAssignment.from_assignments(
@@ -448,6 +451,42 @@ def test_generation_reader_rejects_snapshots_outside_committed_head():
         reader.get(0)
     with pytest.raises(GenerationStateCorrupt, match="newer than"):
         reader.get(1)
+
+
+def test_generation_reader_rejects_deleted_head_after_generation_zero_is_gone():
+    _, store, lease, reader = _state()
+    generation_zero = _commit(
+        store,
+        reader,
+        lease,
+        generation=0,
+        previous_snapshot_digest=None,
+        expected_head_revision=None,
+    )
+    snapshot_zero = GenerationSnapshotRecord.from_json(
+        generation_zero[reader.snapshot_key(0)].value
+    )
+    generation_one = _commit(
+        store,
+        reader,
+        lease,
+        generation=1,
+        previous_snapshot_digest=snapshot_zero.digest,
+        expected_head_revision=generation_zero[reader.head_key].revision,
+    )
+    store.compare_delete(
+        reader.head_key,
+        expected_revision=generation_one[reader.head_key].revision,
+    )
+    store.compare_delete(
+        reader.snapshot_key(0),
+        expected_revision=generation_zero[reader.snapshot_key(0)].revision,
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="head was deleted"):
+        reader.current()
+    with pytest.raises(GenerationStateCorrupt, match="head was deleted"):
+        reader.get(0)
 
 
 def test_generation_reader_rejects_missing_or_recreated_snapshot():
@@ -945,6 +984,22 @@ def test_generation_reader_rejects_one_guard_revision_with_two_grant_times():
     )
 
     with pytest.raises(GenerationStateCorrupt, match="one lease grant"):
+        reader.current()
+
+
+def test_generation_reader_rejects_reappearing_fencing_token():
+    records = _history(
+        ("coordinator-a", "lease-a", 100),
+        ("coordinator-a", "lease-a", 50),
+        ("coordinator-a", "lease-a", 100),
+    )
+    reader = _reader_from_history(
+        records,
+        guard_mutation_sequences=(1, 2, 3),
+        guard_grant_times_unix_ms=(1_000, 1_050, 1_100),
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="fencing token reappears"):
         reader.current()
 
 

--- a/tests/unit/test_torchrun_generation_reader.py
+++ b/tests/unit/test_torchrun_generation_reader.py
@@ -785,6 +785,21 @@ def test_generation_reader_rejects_overlapping_in_place_lease_replacement():
         reader.current()
 
 
+def test_generation_reader_rejects_takeover_after_ambiguous_skipped_mutations():
+    records = _history(
+        ("coordinator-a", "lease-a", 100),
+        ("coordinator-b", "lease-b", 50),
+    )
+    reader = _reader_from_history(
+        records,
+        guard_mutation_sequences=(1, 3),
+        guard_grant_times_unix_ms=(1_000, 1_100),
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="ambiguous skipped mutations"):
+        reader.current()
+
+
 def test_generation_reader_rejects_expired_same_lease_renewal():
     records = _history(
         ("coordinator-a", "lease-a", 1),
@@ -853,6 +868,7 @@ def test_generation_reader_rejects_guard_lifetime_rollback():
     )
     reader = _reader_from_history(
         records,
+        guard_mutation_sequences=(3, 4),
         guard_lifetime_sequences=(2, 1),
     )
 
@@ -881,12 +897,40 @@ def test_generation_reader_rejects_guard_recreation_without_two_mutations():
     )
     reader = _reader_from_history(
         records,
-        guard_mutation_sequences=(1, 2),
+        guard_mutation_sequences=(2, 3),
         guard_lifetime_sequences=(1, 2),
         guard_grant_times_unix_ms=(1_000, 1_100),
     )
 
     with pytest.raises(GenerationStateCorrupt, match="delete-and-recreate"):
+        reader.current()
+
+
+def test_generation_reader_rejects_impossible_initial_guard_lifetime():
+    records = _history(("coordinator-a", "lease-a", 100))
+    reader = _reader_from_history(
+        records,
+        guard_mutation_sequences=(1,),
+        guard_lifetime_sequences=(2,),
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="cannot support its lifetime"):
+        reader.current()
+
+
+def test_generation_reader_rejects_commit_after_successor_guard_mutation():
+    records = _history(
+        ("coordinator-a", "lease-a", 100),
+        ("coordinator-a", "lease-a", 50),
+    )
+    reader = _reader_from_history(
+        records,
+        guard_mutation_sequences=(1, 2),
+        guard_grant_times_unix_ms=(1_000, 1_050),
+        snapshot_commit_times_unix_ms=(1_090, 1_091),
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="postdates"):
         reader.current()
 
 

--- a/tests/unit/test_torchrun_generation_reader.py
+++ b/tests/unit/test_torchrun_generation_reader.py
@@ -153,26 +153,47 @@ def _reader_from_history(
     *,
     head_committed_at_offset_ms: int = 0,
     guard_lifetime_sequences: tuple[int, ...] | None = None,
+    guard_grant_times_unix_ms: tuple[int, ...] | None = None,
 ) -> GenerationStateReader:
     if guard_lifetime_sequences is None:
         guard_lifetime_sequences = (1,) * len(records)
+    if guard_grant_times_unix_ms is None:
+        grant_times = [1_000]
+        for predecessor, successor, predecessor_lifetime, successor_lifetime in zip(
+            records[:-1],
+            records[1:],
+            guard_lifetime_sequences[:-1],
+            guard_lifetime_sequences[1:],
+            strict=True,
+        ):
+            if successor.coordinator_fencing_token == predecessor.coordinator_fencing_token:
+                grant_times.append(grant_times[-1])
+            elif (
+                successor.lease_id != predecessor.lease_id
+                and successor_lifetime == predecessor_lifetime
+            ):
+                grant_times.append(grant_times[-1] + predecessor.coordinator_lease_duration_ms)
+            else:
+                grant_times.append(grant_times[-1] + 1)
+        guard_grant_times_unix_ms = tuple(grant_times)
     store = StaticControlStore()
     reader = GenerationStateReader(store, run_id=RUN_ID)
-    for record, guard_lifetime_sequence in zip(
+    for record, guard_lifetime_sequence, guard_grant_time in zip(
         records,
         guard_lifetime_sequences,
+        guard_grant_times_unix_ms,
         strict=True,
     ):
         generation = record.assignment.generation
         store.entries[reader.snapshot_key(generation)] = ControlStoreEntry(
             value=record.to_json(),
             revision=1,
-            committed_at_unix_ms=1_000 + generation,
+            committed_at_unix_ms=guard_grant_time,
             guard_key=reader.coordinator_lease_key,
             guard_revision=record.coordinator_fencing_token,
             guard_value_digest=record.coordinator_lease_digest,
             guard_lifetime_sequence=guard_lifetime_sequence,
-            guard_committed_at_unix_ms=1_000 + generation,
+            guard_committed_at_unix_ms=guard_grant_time,
         )
     latest = records[-1]
     head = GenerationHeadRecord(
@@ -183,13 +204,13 @@ def _reader_from_history(
     store.entries[reader.head_key] = ControlStoreEntry(
         value=head.to_json(),
         revision=len(records),
-        committed_at_unix_ms=(1_000 + latest.assignment.generation + head_committed_at_offset_ms),
+        committed_at_unix_ms=(guard_grant_times_unix_ms[-1] + head_committed_at_offset_ms),
         mutation_sequence=len(records),
         guard_key=reader.coordinator_lease_key,
         guard_revision=latest.coordinator_fencing_token,
         guard_value_digest=latest.coordinator_lease_digest,
         guard_lifetime_sequence=guard_lifetime_sequences[-1],
-        guard_committed_at_unix_ms=1_000 + latest.assignment.generation,
+        guard_committed_at_unix_ms=guard_grant_times_unix_ms[-1],
     )
     return reader
 
@@ -394,6 +415,8 @@ def test_generation_reader_rejects_snapshots_outside_committed_head():
     )
     with pytest.raises(GenerationStateCorrupt, match="newer than"):
         reader.current()
+    with pytest.raises(GenerationStateCorrupt, match="newer than"):
+        reader.get(0)
     with pytest.raises(GenerationStateCorrupt, match="newer than"):
         reader.get(1)
 
@@ -716,6 +739,34 @@ def test_generation_reader_rejects_recreated_guard_with_reused_lease_identity():
     )
 
     with pytest.raises(GenerationStateCorrupt, match="recreated guard lifetime"):
+        reader.current()
+
+
+def test_generation_reader_rejects_overlapping_in_place_lease_replacement():
+    records = _history(
+        ("coordinator-a", "lease-a", 1),
+        ("coordinator-b", "lease-b", 2),
+    )
+    reader = _reader_from_history(
+        records,
+        guard_grant_times_unix_ms=(1_000, 1_050),
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="leases overlap"):
+        reader.current()
+
+
+def test_generation_reader_rejects_one_guard_revision_with_two_grant_times():
+    records = _history(
+        ("coordinator-a", "lease-a", 1),
+        ("coordinator-a", "lease-a", 1),
+    )
+    reader = _reader_from_history(
+        records,
+        guard_grant_times_unix_ms=(1_000, 1_001),
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="one lease grant"):
         reader.current()
 
 

--- a/tests/unit/test_torchrun_generation_reader.py
+++ b/tests/unit/test_torchrun_generation_reader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import threading
 
 import pytest
@@ -13,6 +14,7 @@ from lm_resiliency.integrations.torchrun._control_store import (
 )
 from lm_resiliency.integrations.torchrun._coordinator_lease import (
     CoordinatorLeaseManager,
+    CoordinatorLeaseRecord,
     HeldCoordinatorLease,
 )
 from lm_resiliency.integrations.torchrun._generation_reader import (
@@ -134,13 +136,14 @@ def _snapshot(
     coordinator_id: str,
     lease_id: str,
     fencing_token: int,
+    lease_duration_ms: int = 100,
 ) -> GenerationSnapshotRecord:
     return GenerationSnapshotRecord(
         assignment=_assignment(generation),
         previous_snapshot_digest=previous_snapshot_digest,
         coordinator_id=coordinator_id,
         lease_id=lease_id,
-        coordinator_lease_duration_ms=100,
+        coordinator_lease_duration_ms=lease_duration_ms,
         coordinator_fencing_token=fencing_token,
     )
 
@@ -159,6 +162,7 @@ def _reader_from_history(
             guard_key=reader.coordinator_lease_key,
             guard_revision=record.coordinator_fencing_token,
             guard_value_digest=record.coordinator_lease_digest,
+            guard_committed_at_unix_ms=1_000 + generation,
         )
     latest = records[-1]
     head = GenerationHeadRecord(
@@ -173,6 +177,7 @@ def _reader_from_history(
         guard_key=reader.coordinator_lease_key,
         guard_revision=latest.coordinator_fencing_token,
         guard_value_digest=latest.coordinator_lease_digest,
+        guard_committed_at_unix_ms=1_000 + latest.assignment.generation,
     )
     return reader
 
@@ -192,6 +197,26 @@ def _history(
             )
         )
     return tuple(records)
+
+
+def _duration_change_history() -> tuple[GenerationSnapshotRecord, ...]:
+    generation_zero = _snapshot(
+        0,
+        previous_snapshot_digest=None,
+        coordinator_id="coordinator-a",
+        lease_id="lease-a",
+        fencing_token=1,
+        lease_duration_ms=100,
+    )
+    generation_one = _snapshot(
+        1,
+        previous_snapshot_digest=generation_zero.digest,
+        coordinator_id="coordinator-a",
+        lease_id="lease-a",
+        fencing_token=2,
+        lease_duration_ms=200,
+    )
+    return generation_zero, generation_one
 
 
 def test_generation_reader_returns_none_before_initialization():
@@ -321,7 +346,7 @@ def test_generation_reader_rejects_snapshots_outside_committed_head():
         reader.get(1)
 
 
-def test_generation_reader_rejects_missing_or_unstamped_snapshot():
+def test_generation_reader_rejects_missing_or_recreated_snapshot():
     _, store, lease, reader = _state()
     committed = _commit(
         store,
@@ -345,7 +370,132 @@ def test_generation_reader_rejects_missing_or_unstamped_snapshot():
         expected_revision=None,
         value=snapshot_entry.value,
     )
-    with pytest.raises(GenerationStateCorrupt, match="commit time"):
+    with pytest.raises(GenerationStateCorrupt, match="replaced or recreated"):
+        reader.current()
+
+
+def test_generation_reader_rejects_untimed_or_expired_lease_guards():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    lease_record = CoordinatorLeaseRecord(
+        run_id=RUN_ID,
+        coordinator_id="coordinator-a",
+        lease_id="lease-a",
+        lease_duration_ms=100,
+    )
+    untimed_guard = store.compare_set(
+        "lm_resiliency/torchrun/v1/runs/"
+        + hashlib.sha256(RUN_ID.encode()).hexdigest()
+        + "/coordinator-lease",
+        expected_revision=None,
+        value=lease_record.to_json(),
+    )
+    reader = GenerationStateReader(store, run_id=RUN_ID)
+    snapshot = _snapshot(
+        0,
+        previous_snapshot_digest=None,
+        coordinator_id=lease_record.coordinator_id,
+        lease_id=lease_record.lease_id,
+        fencing_token=untimed_guard.revision,
+    )
+    head = GenerationHeadRecord(
+        run_id=RUN_ID,
+        generation=0,
+        snapshot_digest=snapshot.digest,
+    )
+    store.compare_set_many_guarded(
+        {
+            reader.head_key: ControlStoreWrite(
+                expected_revision=None,
+                value=head.to_json(),
+            ),
+            reader.snapshot_key(0): ControlStoreWrite(
+                expected_revision=None,
+                value=snapshot.to_json(),
+            ),
+        },
+        guard_key=reader.coordinator_lease_key,
+        expected_guard_revision=untimed_guard.revision,
+        not_before_unix_ms=1_000,
+        deadline_unix_ms=1_200,
+    )
+    with pytest.raises(GenerationStateCorrupt, match="grant time"):
+        reader.current()
+
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    reader = GenerationStateReader(store, run_id=RUN_ID)
+    timed_guard = store.compare_set_in_window(
+        reader.coordinator_lease_key,
+        expected_revision=None,
+        not_before_unix_ms=1_000,
+        deadline_unix_ms=None,
+        value=lease_record.to_json(),
+    )
+    clock.set(1_100)
+    expired_snapshot = _snapshot(
+        0,
+        previous_snapshot_digest=None,
+        coordinator_id=lease_record.coordinator_id,
+        lease_id=lease_record.lease_id,
+        fencing_token=timed_guard.revision,
+    )
+    expired_head = GenerationHeadRecord(
+        run_id=RUN_ID,
+        generation=0,
+        snapshot_digest=expired_snapshot.digest,
+    )
+    store.compare_set_many_guarded(
+        {
+            reader.head_key: ControlStoreWrite(
+                expected_revision=None,
+                value=expired_head.to_json(),
+            ),
+            reader.snapshot_key(0): ControlStoreWrite(
+                expected_revision=None,
+                value=expired_snapshot.to_json(),
+            ),
+        },
+        guard_key=reader.coordinator_lease_key,
+        expected_guard_revision=timed_guard.revision,
+        not_before_unix_ms=1_000,
+        deadline_unix_ms=1_200,
+    )
+    with pytest.raises(GenerationStateCorrupt, match="lease expired"):
+        reader.current()
+
+
+def test_generation_reader_rejects_replaced_snapshot_key():
+    clock, store, lease, reader = _state()
+    committed = _commit(
+        store,
+        reader,
+        lease,
+        generation=0,
+        previous_snapshot_digest=None,
+        expected_head_revision=None,
+    )
+    snapshot_entry = committed[reader.snapshot_key(0)]
+    head_entry = committed[reader.head_key]
+    clock.set(1_010)
+    store.compare_set_many_guarded(
+        {
+            reader.head_key: ControlStoreWrite(
+                expected_revision=head_entry.revision,
+                value=head_entry.value,
+            ),
+            reader.snapshot_key(0): ControlStoreWrite(
+                expected_revision=snapshot_entry.revision,
+                value=snapshot_entry.value,
+            ),
+        },
+        guard_key=reader.coordinator_lease_key,
+        expected_guard_revision=lease.fencing_token,
+        not_before_unix_ms=1_010,
+        deadline_unix_ms=lease.expires_at_unix_ms,
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="replaced or recreated"):
         reader.current()
 
 
@@ -555,6 +705,10 @@ def test_generation_reader_anchors_fencing_token_to_store_guard():
                 ("coordinator-b", "lease-a", 4),
             ),
             "changes coordinator",
+        ),
+        (
+            _duration_change_history(),
+            "changes its duration",
         ),
         (
             _history(

--- a/tests/unit/test_torchrun_generation_reader.py
+++ b/tests/unit/test_torchrun_generation_reader.py
@@ -1005,15 +1005,33 @@ def test_generation_reader_rejects_impossible_initial_guard_lifetime():
         reader.current()
 
 
-def test_generation_reader_rejects_initial_value_sequence_beyond_mutations():
+def test_generation_reader_rejects_initial_value_sequence_advanced_by_delete():
     records = _history(("coordinator-a", "lease-a", 100))
     reader = _reader_from_history(
         records,
-        guard_mutation_sequences=(1,),
-        guard_value_sequences=(2,),
+        guard_mutation_sequences=(3,),
+        guard_value_sequences=(3,),
+        guard_lifetime_sequences=(2,),
     )
 
-    with pytest.raises(GenerationStateCorrupt, match="exceeds its mutations"):
+    with pytest.raises(GenerationStateCorrupt, match="includes deletion mutations"):
+        reader.current()
+
+
+def test_generation_reader_rejects_value_delta_advanced_by_delete():
+    records = _history(
+        ("coordinator-a", "lease-a", 100),
+        ("coordinator-b", "lease-b", 50),
+    )
+    reader = _reader_from_history(
+        records,
+        guard_mutation_sequences=(3, 5),
+        guard_value_sequences=(1, 3),
+        guard_lifetime_sequences=(1, 2),
+        guard_grant_times_unix_ms=(1_000, 1_100),
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="include deletion mutations"):
         reader.current()
 
 

--- a/tests/unit/test_torchrun_generation_reader.py
+++ b/tests/unit/test_torchrun_generation_reader.py
@@ -155,11 +155,14 @@ def _reader_from_history(
     records: tuple[GenerationSnapshotRecord, ...],
     *,
     head_committed_at_offset_ms: int = 0,
+    head_value_sequence: int | None = None,
     guard_mutation_sequences: tuple[int, ...] | None = None,
     guard_value_sequences: tuple[int, ...] | None = None,
     guard_lifetime_sequences: tuple[int, ...] | None = None,
     guard_grant_times_unix_ms: tuple[int, ...] | None = None,
     snapshot_commit_times_unix_ms: tuple[int, ...] | None = None,
+    snapshot_value_sequences: tuple[int, ...] | None = None,
+    snapshot_lifetime_sequences: tuple[int, ...] | None = None,
 ) -> GenerationStateReader:
     if guard_lifetime_sequences is None:
         guard_lifetime_sequences = (1,) * len(records)
@@ -225,6 +228,12 @@ def _reader_from_history(
         guard_grant_times_unix_ms = tuple(grant_times)
     if snapshot_commit_times_unix_ms is None:
         snapshot_commit_times_unix_ms = guard_grant_times_unix_ms
+    if snapshot_value_sequences is None:
+        snapshot_value_sequences = (1,) * len(records)
+    if snapshot_lifetime_sequences is None:
+        snapshot_lifetime_sequences = (1,) * len(records)
+    if head_value_sequence is None:
+        head_value_sequence = len(records)
     store = StaticControlStore()
     reader = GenerationStateReader(store, run_id=RUN_ID)
     for (
@@ -234,6 +243,8 @@ def _reader_from_history(
         guard_lifetime_sequence,
         guard_grant_time,
         snapshot_commit_time,
+        snapshot_value_sequence,
+        snapshot_lifetime_sequence,
     ) in zip(
         records,
         guard_mutation_sequences,
@@ -241,6 +252,8 @@ def _reader_from_history(
         guard_lifetime_sequences,
         guard_grant_times_unix_ms,
         snapshot_commit_times_unix_ms,
+        snapshot_value_sequences,
+        snapshot_lifetime_sequences,
         strict=True,
     ):
         generation = record.assignment.generation
@@ -248,6 +261,8 @@ def _reader_from_history(
             value=record.to_json(),
             revision=1,
             committed_at_unix_ms=snapshot_commit_time,
+            value_sequence=snapshot_value_sequence,
+            lifetime_sequence=snapshot_lifetime_sequence,
             guard_key=reader.coordinator_lease_key,
             guard_revision=record.coordinator_fencing_token,
             guard_value_digest=record.coordinator_lease_digest,
@@ -267,6 +282,7 @@ def _reader_from_history(
         revision=len(records),
         committed_at_unix_ms=(snapshot_commit_times_unix_ms[-1] + head_committed_at_offset_ms),
         mutation_sequence=len(records),
+        value_sequence=head_value_sequence,
         guard_key=reader.coordinator_lease_key,
         guard_revision=latest.coordinator_fencing_token,
         guard_value_digest=latest.coordinator_lease_digest,
@@ -544,7 +560,37 @@ def test_generation_reader_rejects_missing_or_recreated_snapshot():
         expected_revision=None,
         value=snapshot_entry.value,
     )
-    with pytest.raises(GenerationStateCorrupt, match="replaced or recreated"):
+    with pytest.raises(GenerationStateCorrupt, match="noninitial store sequences"):
+        reader.current()
+
+
+@pytest.mark.parametrize(
+    ("snapshot_value_sequence", "snapshot_lifetime_sequence"),
+    [(2, 1), (1, 2)],
+)
+def test_generation_reader_rejects_noninitial_snapshot_store_sequences(
+    snapshot_value_sequence,
+    snapshot_lifetime_sequence,
+):
+    records = _history(("coordinator-a", "lease-a", 100))
+    reader = _reader_from_history(
+        records,
+        snapshot_value_sequences=(snapshot_value_sequence,),
+        snapshot_lifetime_sequences=(snapshot_lifetime_sequence,),
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="noninitial store sequences"):
+        reader.current()
+
+
+def test_generation_reader_rejects_head_value_sequence_mismatch():
+    records = _history(
+        ("coordinator-a", "lease-a", 100),
+        ("coordinator-a", "lease-a", 100),
+    )
+    reader = _reader_from_history(records, head_value_sequence=1)
+
+    with pytest.raises(GenerationStateCorrupt, match="head value sequence"):
         reader.current()
 
 
@@ -669,7 +715,7 @@ def test_generation_reader_rejects_replaced_snapshot_key():
         deadline_unix_ms=lease.expires_at_unix_ms,
     )
 
-    with pytest.raises(GenerationStateCorrupt, match="replaced or recreated"):
+    with pytest.raises(GenerationStateCorrupt, match="noninitial store sequences"):
         reader.current()
 
 

--- a/tests/unit/test_torchrun_generation_reader.py
+++ b/tests/unit/test_torchrun_generation_reader.py
@@ -7,6 +7,7 @@ import threading
 import pytest
 
 from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStoreEntry,
     ControlStoreWrite,
     InMemoryControlStore,
 )
@@ -39,6 +40,14 @@ class ManualClock:
     def set(self, now_unix_ms: int) -> None:
         with self._lock:
             self.now_unix_ms = now_unix_ms
+
+
+class StaticControlStore:
+    def __init__(self) -> None:
+        self.entries: dict[str, ControlStoreEntry] = {}
+
+    def get(self, key: str) -> ControlStoreEntry | None:
+        return self.entries.get(key)
 
 
 def _assignment(generation: int) -> RankAssignment:
@@ -86,16 +95,14 @@ def _commit(
     generation: int,
     previous_snapshot_digest: str | None,
     expected_head_revision: int | None,
-    coordinator_id: str = "coordinator-a",
-    lease_id: str | None = None,
-    fencing_token: int | None = None,
 ):
     snapshot = GenerationSnapshotRecord(
         assignment=_assignment(generation),
         previous_snapshot_digest=previous_snapshot_digest,
-        coordinator_id=coordinator_id,
-        lease_id=lease.record.lease_id if lease_id is None else lease_id,
-        coordinator_fencing_token=(lease.fencing_token if fencing_token is None else fencing_token),
+        coordinator_id=lease.record.coordinator_id,
+        lease_id=lease.record.lease_id,
+        coordinator_lease_duration_ms=lease.record.lease_duration_ms,
+        coordinator_fencing_token=lease.fencing_token,
     )
     head = GenerationHeadRecord(
         run_id=RUN_ID,
@@ -118,6 +125,73 @@ def _commit(
         not_before_unix_ms=lease.granted_at_unix_ms,
         deadline_unix_ms=lease.expires_at_unix_ms,
     )
+
+
+def _snapshot(
+    generation: int,
+    *,
+    previous_snapshot_digest: str | None,
+    coordinator_id: str,
+    lease_id: str,
+    fencing_token: int,
+) -> GenerationSnapshotRecord:
+    return GenerationSnapshotRecord(
+        assignment=_assignment(generation),
+        previous_snapshot_digest=previous_snapshot_digest,
+        coordinator_id=coordinator_id,
+        lease_id=lease_id,
+        coordinator_lease_duration_ms=100,
+        coordinator_fencing_token=fencing_token,
+    )
+
+
+def _reader_from_history(
+    records: tuple[GenerationSnapshotRecord, ...],
+) -> GenerationStateReader:
+    store = StaticControlStore()
+    reader = GenerationStateReader(store, run_id=RUN_ID)
+    for record in records:
+        generation = record.assignment.generation
+        store.entries[reader.snapshot_key(generation)] = ControlStoreEntry(
+            value=record.to_json(),
+            revision=1,
+            committed_at_unix_ms=1_000 + generation,
+            guard_key=reader.coordinator_lease_key,
+            guard_revision=record.coordinator_fencing_token,
+            guard_value_digest=record.coordinator_lease_digest,
+        )
+    latest = records[-1]
+    head = GenerationHeadRecord(
+        run_id=RUN_ID,
+        generation=latest.assignment.generation,
+        snapshot_digest=latest.digest,
+    )
+    store.entries[reader.head_key] = ControlStoreEntry(
+        value=head.to_json(),
+        revision=len(records),
+        committed_at_unix_ms=1_000 + latest.assignment.generation,
+        guard_key=reader.coordinator_lease_key,
+        guard_revision=latest.coordinator_fencing_token,
+        guard_value_digest=latest.coordinator_lease_digest,
+    )
+    return reader
+
+
+def _history(
+    *provenance: tuple[str, str, int],
+) -> tuple[GenerationSnapshotRecord, ...]:
+    records: list[GenerationSnapshotRecord] = []
+    for generation, (coordinator_id, lease_id, fencing_token) in enumerate(provenance):
+        records.append(
+            _snapshot(
+                generation,
+                previous_snapshot_digest=None if not records else records[-1].digest,
+                coordinator_id=coordinator_id,
+                lease_id=lease_id,
+                fencing_token=fencing_token,
+            )
+        )
+    return tuple(records)
 
 
 def test_generation_reader_returns_none_before_initialization():
@@ -148,10 +222,11 @@ def test_generation_reader_retries_concurrent_initialization(monkeypatch):
 
     monkeypatch.setattr(store, "get", racing_get)
 
-    snapshot = reader.get(0)
+    current = reader.current()
 
-    assert snapshot is not None
-    assert snapshot.record.assignment.generation == 0
+    assert current is not None
+    assert current.snapshot.record.assignment.generation == 0
+    assert reader.get(0) == current.snapshot
 
 
 def test_generation_reader_reads_current_and_historical_snapshots():
@@ -200,6 +275,7 @@ def test_generation_reader_rejects_snapshots_outside_committed_head():
         previous_snapshot_digest=None,
         coordinator_id=lease.record.coordinator_id,
         lease_id=lease.record.lease_id,
+        coordinator_lease_duration_ms=lease.record.lease_duration_ms,
         coordinator_fencing_token=lease.fencing_token,
     )
     store.compare_set_in_window(
@@ -209,6 +285,8 @@ def test_generation_reader_rejects_snapshots_outside_committed_head():
         deadline_unix_ms=None,
         value=orphan_zero.to_json(),
     )
+    with pytest.raises(GenerationStateCorrupt, match="without a generation head"):
+        reader.current()
     with pytest.raises(GenerationStateCorrupt, match="without a generation head"):
         reader.get(0)
 
@@ -229,6 +307,7 @@ def test_generation_reader_rejects_snapshots_outside_committed_head():
         ).digest,
         coordinator_id=lease.record.coordinator_id,
         lease_id=lease.record.lease_id,
+        coordinator_lease_duration_ms=lease.record.lease_duration_ms,
         coordinator_fencing_token=lease.fencing_token,
     )
     store.compare_set_in_window(
@@ -286,18 +365,21 @@ def test_generation_reader_rejects_head_digest_or_timestamp_substitution():
         generation=0,
         snapshot_digest="f" * 64,
     )
-    store.compare_set_in_window(
-        reader.head_key,
-        expected_revision=head_entry.revision,
+    updated = store.compare_set_many_guarded(
+        {
+            reader.head_key: ControlStoreWrite(
+                expected_revision=head_entry.revision,
+                value=substituted.to_json(),
+            )
+        },
+        guard_key=reader.coordinator_lease_key,
+        expected_guard_revision=lease.fencing_token,
         not_before_unix_ms=1_000,
-        deadline_unix_ms=None,
-        value=substituted.to_json(),
+        deadline_unix_ms=lease.expires_at_unix_ms,
     )
     with pytest.raises(GenerationStateCorrupt, match="digest"):
         reader.current()
 
-    current_head = store.get(reader.head_key)
-    assert current_head is not None
     clock.set(1_010)
     original = GenerationHeadRecord(
         run_id=RUN_ID,
@@ -306,12 +388,17 @@ def test_generation_reader_rejects_head_digest_or_timestamp_substitution():
             committed[reader.snapshot_key(0)].value
         ).digest,
     )
-    store.compare_set_in_window(
-        reader.head_key,
-        expected_revision=current_head.revision,
+    store.compare_set_many_guarded(
+        {
+            reader.head_key: ControlStoreWrite(
+                expected_revision=updated[reader.head_key].revision,
+                value=original.to_json(),
+            )
+        },
+        guard_key=reader.coordinator_lease_key,
+        expected_guard_revision=lease.fencing_token,
         not_before_unix_ms=1_010,
-        deadline_unix_ms=None,
-        value=original.to_json(),
+        deadline_unix_ms=lease.expires_at_unix_ms,
     )
     with pytest.raises(GenerationStateCorrupt, match="timestamps"):
         reader.current()
@@ -349,65 +436,138 @@ def test_generation_reader_rejects_missing_or_substituted_predecessor():
     with pytest.raises(GenerationStateCorrupt, match="missing predecessor"):
         reader.current()
 
-    substituted = GenerationSnapshotRecord(
-        assignment=_assignment(0),
+    original_zero = _snapshot(
+        0,
+        previous_snapshot_digest=None,
+        coordinator_id="coordinator-a",
+        lease_id="lease-a",
+        fencing_token=1,
+    )
+    substituted_zero = _snapshot(
+        0,
         previous_snapshot_digest=None,
         coordinator_id="coordinator-a",
         lease_id="substituted-lease",
-        coordinator_fencing_token=lease.fencing_token,
+        fencing_token=1,
     )
-    store.compare_set_in_window(
-        reader.snapshot_key(0),
-        expected_revision=None,
-        not_before_unix_ms=1_010,
-        deadline_unix_ms=None,
-        value=substituted.to_json(),
+    generation_one = _snapshot(
+        1,
+        previous_snapshot_digest=original_zero.digest,
+        coordinator_id="coordinator-a",
+        lease_id="lease-a",
+        fencing_token=1,
     )
+    substituted_reader = _reader_from_history((substituted_zero, generation_one))
     with pytest.raises(GenerationStateCorrupt, match="predecessor digest"):
+        substituted_reader.current()
+
+
+def test_generation_reader_anchors_snapshot_to_store_guard():
+    _, store, lease, reader = _state()
+    forged = _snapshot(
+        0,
+        previous_snapshot_digest=None,
+        coordinator_id="forged-coordinator",
+        lease_id="forged-lease",
+        fencing_token=lease.fencing_token,
+    )
+    head = GenerationHeadRecord(
+        run_id=RUN_ID,
+        generation=0,
+        snapshot_digest=forged.digest,
+    )
+    store.compare_set_many_guarded(
+        {
+            reader.head_key: ControlStoreWrite(
+                expected_revision=None,
+                value=head.to_json(),
+            ),
+            reader.snapshot_key(0): ControlStoreWrite(
+                expected_revision=None,
+                value=forged.to_json(),
+            ),
+        },
+        guard_key=reader.coordinator_lease_key,
+        expected_guard_revision=lease.fencing_token,
+        not_before_unix_ms=lease.granted_at_unix_ms,
+        deadline_unix_ms=lease.expires_at_unix_ms,
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="guard digest"):
+        reader.current()
+
+
+def test_generation_reader_anchors_fencing_token_to_store_guard():
+    _, store, lease, reader = _state()
+    forged = _snapshot(
+        0,
+        previous_snapshot_digest=None,
+        coordinator_id=lease.record.coordinator_id,
+        lease_id=lease.record.lease_id,
+        fencing_token=lease.fencing_token + 1,
+    )
+    head = GenerationHeadRecord(
+        run_id=RUN_ID,
+        generation=0,
+        snapshot_digest=forged.digest,
+    )
+    store.compare_set_many_guarded(
+        {
+            reader.head_key: ControlStoreWrite(
+                expected_revision=None,
+                value=head.to_json(),
+            ),
+            reader.snapshot_key(0): ControlStoreWrite(
+                expected_revision=None,
+                value=forged.to_json(),
+            ),
+        },
+        guard_key=reader.coordinator_lease_key,
+        expected_guard_revision=lease.fencing_token,
+        not_before_unix_ms=lease.granted_at_unix_ms,
+        deadline_unix_ms=lease.expires_at_unix_ms,
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="guard revision"):
         reader.current()
 
 
 @pytest.mark.parametrize(
-    ("first_fencing_token", "first_lease_id", "second_lease_id", "message"),
+    ("history", "message"),
     [
-        (5, "lease-a", "lease-b", "fencing tokens"),
-        (4, "lease-a", "lease-b", "lease identity"),
-        (3, "lease-a", "lease-a", "changes coordinator"),
+        (
+            _history(
+                ("coordinator-a", "lease-a", 5),
+                ("coordinator-b", "lease-b", 4),
+            ),
+            "fencing tokens",
+        ),
+        (
+            _history(
+                ("coordinator-a", "lease-a", 4),
+                ("coordinator-b", "lease-b", 4),
+            ),
+            "lease identity",
+        ),
+        (
+            _history(
+                ("coordinator-a", "lease-a", 3),
+                ("coordinator-b", "lease-a", 4),
+            ),
+            "changes coordinator",
+        ),
+        (
+            _history(
+                ("coordinator-a", "lease-a", 1),
+                ("coordinator-b", "lease-b", 3),
+                ("coordinator-a", "lease-a", 5),
+            ),
+            "reappears",
+        ),
     ],
 )
-def test_generation_reader_rejects_invalid_lease_provenance(
-    first_fencing_token,
-    first_lease_id,
-    second_lease_id,
-    message,
-):
-    clock, store, lease, reader = _state()
-    generation_zero = _commit(
-        store,
-        reader,
-        lease,
-        generation=0,
-        previous_snapshot_digest=None,
-        expected_head_revision=None,
-        coordinator_id="coordinator-a",
-        lease_id=first_lease_id,
-        fencing_token=first_fencing_token,
-    )
-    snapshot_zero = GenerationSnapshotRecord.from_json(
-        generation_zero[reader.snapshot_key(0)].value
-    )
-    clock.set(1_010)
-    _commit(
-        store,
-        reader,
-        lease,
-        generation=1,
-        previous_snapshot_digest=snapshot_zero.digest,
-        expected_head_revision=generation_zero[reader.head_key].revision,
-        coordinator_id="coordinator-b",
-        lease_id=second_lease_id,
-        fencing_token=4,
-    )
+def test_generation_reader_rejects_invalid_lease_history(history, message):
+    reader = _reader_from_history(history)
 
     with pytest.raises(GenerationStateCorrupt, match=message):
         reader.current()

--- a/tests/unit/test_torchrun_generation_records.py
+++ b/tests/unit/test_torchrun_generation_records.py
@@ -93,7 +93,8 @@ def test_generation_records_reject_duplicate_fields_at_any_depth():
         '{"assignment":'
         + assignment
         + ',"coordinator_fencing_token":4,"coordinator_id":"coordinator-a",'
-        '"lease_id":"lease-a","previous_snapshot_digest":"' + "a" * 64 + '","schema_version":1}'
+        '"coordinator_lease_duration_ms":100,"lease_id":"lease-a",'
+        '"previous_snapshot_digest":"' + "a" * 64 + '","schema_version":2}'
     ).encode()
     with pytest.raises(ValueError, match="duplicate field 'generation'"):
         GenerationSnapshotRecord.from_json(encoded)
@@ -105,7 +106,7 @@ def test_generation_records_reject_duplicate_fields_at_any_depth():
         lambda value: value.pop("lease_id"),
         lambda value: value.pop("coordinator_lease_duration_ms"),
         lambda value: value.update({"unknown": "field"}),
-        lambda value: value.update({"schema_version": 2}),
+        lambda value: value.update({"schema_version": 3}),
         lambda value: value.update({"schema_version": True}),
         lambda value: value.update({"assignment": []}),
     ],
@@ -117,6 +118,17 @@ def test_generation_snapshot_rejects_invalid_wire_shapes(mutation):
     with pytest.raises(ValueError):
         GenerationSnapshotRecord.from_json(
             json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+        )
+
+
+def test_generation_snapshot_rejects_legacy_schema_before_field_shape():
+    legacy = _snapshot().to_dict()
+    legacy["schema_version"] = 1
+    legacy.pop("coordinator_lease_duration_ms")
+
+    with pytest.raises(ValueError, match="schema_version: unsupported value 1"):
+        GenerationSnapshotRecord.from_json(
+            json.dumps(legacy, separators=(",", ":"), sort_keys=True).encode()
         )
 
 

--- a/tests/unit/test_torchrun_generation_records.py
+++ b/tests/unit/test_torchrun_generation_records.py
@@ -7,6 +7,9 @@ import json
 
 import pytest
 
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseRecord,
+)
 from lm_resiliency.integrations.torchrun._generation_records import (
     GenerationHeadRecord,
     GenerationSnapshotRecord,
@@ -44,6 +47,7 @@ def _snapshot(generation: int = 1) -> GenerationSnapshotRecord:
         previous_snapshot_digest=None if generation == 0 else "a" * 64,
         coordinator_id="coordinator-a",
         lease_id="lease-a",
+        coordinator_lease_duration_ms=100,
         coordinator_fencing_token=4,
     )
 
@@ -61,6 +65,13 @@ def test_generation_records_round_trip_as_canonical_json():
     assert json.loads(snapshot.to_json()) == snapshot.to_dict()
     assert json.loads(head.to_json()) == head.to_dict()
     assert snapshot.digest == hashlib.sha256(snapshot.to_json()).hexdigest()
+    lease_record = CoordinatorLeaseRecord(
+        run_id=RUN_ID,
+        coordinator_id=snapshot.coordinator_id,
+        lease_id=snapshot.lease_id,
+        lease_duration_ms=snapshot.coordinator_lease_duration_ms,
+    )
+    assert snapshot.coordinator_lease_digest == hashlib.sha256(lease_record.to_json()).hexdigest()
     assert snapshot.to_json() == snapshot.to_json()
 
 
@@ -92,6 +103,7 @@ def test_generation_records_reject_duplicate_fields_at_any_depth():
     "mutation",
     [
         lambda value: value.pop("lease_id"),
+        lambda value: value.pop("coordinator_lease_duration_ms"),
         lambda value: value.update({"unknown": "field"}),
         lambda value: value.update({"schema_version": 2}),
         lambda value: value.update({"schema_version": True}),
@@ -128,6 +140,7 @@ def test_generation_snapshot_requires_exact_predecessor_shape():
             previous_snapshot_digest="a" * 64,
             coordinator_id="coordinator-a",
             lease_id="lease-a",
+            coordinator_lease_duration_ms=100,
             coordinator_fencing_token=1,
         )
 
@@ -137,6 +150,7 @@ def test_generation_snapshot_requires_exact_predecessor_shape():
             previous_snapshot_digest=None,
             coordinator_id="coordinator-a",
             lease_id="lease-a",
+            coordinator_lease_duration_ms=100,
             coordinator_fencing_token=1,
         )
 
@@ -146,6 +160,7 @@ def test_generation_snapshot_requires_exact_predecessor_shape():
             previous_snapshot_digest="A" * 64,
             coordinator_id="coordinator-a",
             lease_id="lease-a",
+            coordinator_lease_duration_ms=100,
             coordinator_fencing_token=1,
         )
 
@@ -158,5 +173,19 @@ def test_generation_snapshot_requires_positive_integer_fencing_token(fencing_tok
             previous_snapshot_digest="a" * 64,
             coordinator_id="coordinator-a",
             lease_id="lease-a",
+            coordinator_lease_duration_ms=100,
             coordinator_fencing_token=fencing_token,
+        )
+
+
+@pytest.mark.parametrize("lease_duration_ms", [0, -1, True])
+def test_generation_snapshot_requires_positive_lease_duration(lease_duration_ms):
+    with pytest.raises(ValueError, match="positive integer"):
+        GenerationSnapshotRecord(
+            assignment=_assignment(1),
+            previous_snapshot_digest="a" * 64,
+            coordinator_id="coordinator-a",
+            lease_id="lease-a",
+            coordinator_lease_duration_ms=lease_duration_ms,
+            coordinator_fencing_token=1,
         )

--- a/tests/unit/test_torchrun_guarded_control_store.py
+++ b/tests/unit/test_torchrun_guarded_control_store.py
@@ -73,6 +73,9 @@ def test_guarded_transaction_commits_all_writes_at_one_store_time():
     assert {entry.guard_value_digest for entry in committed.values()} == {
         hashlib.sha256(b"lease-a").hexdigest()
     }
+    assert {entry.guard_lifetime_sequence for entry in committed.values()} == {
+        guard.lifetime_sequence
+    }
     assert {entry.guard_committed_at_unix_ms for entry in committed.values()} == {
         guard.committed_at_unix_ms
     }
@@ -116,6 +119,47 @@ def test_guarded_transaction_atomically_updates_head_and_creates_successor():
     assert store.get("run/generation-head") == successor["run/generation-head"]
     assert store.get("run/generations/1") == successor["run/generations/1"]
     assert {entry.committed_at_unix_ms for entry in successor.values()} == {1_001}
+
+
+def test_guarded_transaction_stamps_recreated_guard_lifetime():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    original_guard = _guard(store)
+    initial = store.compare_set_many_guarded(
+        _generation_writes(),
+        guard_key="run/coordinator-lease",
+        expected_guard_revision=original_guard.revision,
+        not_before_unix_ms=1_000,
+        deadline_unix_ms=1_100,
+    )
+    store.compare_delete(
+        "run/coordinator-lease",
+        expected_revision=original_guard.revision,
+    )
+    recreated_guard = _guard(store)
+    clock.now_unix_ms = 1_001
+
+    successor = store.compare_set_many_guarded(
+        {
+            "run/generation-head": ControlStoreWrite(
+                expected_revision=initial["run/generation-head"].revision,
+                value=b"generation-1",
+            ),
+            "run/generations/1": ControlStoreWrite(
+                expected_revision=None,
+                value=b"snapshot-1",
+            ),
+        },
+        guard_key="run/coordinator-lease",
+        expected_guard_revision=recreated_guard.revision,
+        not_before_unix_ms=1_000,
+        deadline_unix_ms=1_100,
+    )
+
+    assert original_guard.lifetime_sequence == 1
+    assert recreated_guard.lifetime_sequence == 2
+    assert initial["run/generation-head"].guard_lifetime_sequence == 1
+    assert successor["run/generation-head"].guard_lifetime_sequence == 2
 
 
 def test_guarded_transaction_rejects_stale_guard_without_partial_writes():

--- a/tests/unit/test_torchrun_guarded_control_store.py
+++ b/tests/unit/test_torchrun_guarded_control_store.py
@@ -76,6 +76,7 @@ def test_guarded_transaction_commits_all_writes_at_one_store_time():
     assert {entry.guard_mutation_sequence for entry in committed.values()} == {
         guard.mutation_sequence
     }
+    assert {entry.guard_value_sequence for entry in committed.values()} == {guard.value_sequence}
     assert {entry.guard_lifetime_sequence for entry in committed.values()} == {
         guard.lifetime_sequence
     }
@@ -162,8 +163,11 @@ def test_guarded_transaction_stamps_recreated_guard_lifetime():
     assert original_guard.lifetime_sequence == 1
     assert recreated_guard.lifetime_sequence == 2
     assert recreated_guard.mutation_sequence == original_guard.mutation_sequence + 2
+    assert recreated_guard.value_sequence == original_guard.value_sequence + 1
     assert initial["run/generation-head"].guard_mutation_sequence == 1
     assert successor["run/generation-head"].guard_mutation_sequence == 3
+    assert initial["run/generation-head"].guard_value_sequence == 1
+    assert successor["run/generation-head"].guard_value_sequence == 2
     assert initial["run/generation-head"].guard_lifetime_sequence == 1
     assert successor["run/generation-head"].guard_lifetime_sequence == 2
 

--- a/tests/unit/test_torchrun_guarded_control_store.py
+++ b/tests/unit/test_torchrun_guarded_control_store.py
@@ -73,6 +73,9 @@ def test_guarded_transaction_commits_all_writes_at_one_store_time():
     assert {entry.guard_value_digest for entry in committed.values()} == {
         hashlib.sha256(b"lease-a").hexdigest()
     }
+    assert {entry.guard_mutation_sequence for entry in committed.values()} == {
+        guard.mutation_sequence
+    }
     assert {entry.guard_lifetime_sequence for entry in committed.values()} == {
         guard.lifetime_sequence
     }
@@ -158,6 +161,9 @@ def test_guarded_transaction_stamps_recreated_guard_lifetime():
 
     assert original_guard.lifetime_sequence == 1
     assert recreated_guard.lifetime_sequence == 2
+    assert recreated_guard.mutation_sequence == original_guard.mutation_sequence + 2
+    assert initial["run/generation-head"].guard_mutation_sequence == 1
+    assert successor["run/generation-head"].guard_mutation_sequence == 3
     assert initial["run/generation-head"].guard_lifetime_sequence == 1
     assert successor["run/generation-head"].guard_lifetime_sequence == 2
 

--- a/tests/unit/test_torchrun_guarded_control_store.py
+++ b/tests/unit/test_torchrun_guarded_control_store.py
@@ -27,9 +27,11 @@ class ManualClock:
 
 
 def _guard(store: InMemoryControlStore):
-    return store.compare_set(
+    return store.compare_set_in_window(
         "run/coordinator-lease",
         expected_revision=None,
+        not_before_unix_ms=1,
+        deadline_unix_ms=None,
         value=b"lease-a",
     )
 
@@ -70,6 +72,9 @@ def test_guarded_transaction_commits_all_writes_at_one_store_time():
     assert {entry.guard_revision for entry in committed.values()} == {guard.revision}
     assert {entry.guard_value_digest for entry in committed.values()} == {
         hashlib.sha256(b"lease-a").hexdigest()
+    }
+    assert {entry.guard_committed_at_unix_ms for entry in committed.values()} == {
+        guard.committed_at_unix_ms
     }
     assert store.get("run/generation-head") == committed["run/generation-head"]
     assert store.get("run/generations/0") == committed["run/generations/0"]

--- a/tests/unit/test_torchrun_guarded_control_store.py
+++ b/tests/unit/test_torchrun_guarded_control_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from types import MappingProxyType
@@ -65,6 +66,11 @@ def test_guarded_transaction_commits_all_writes_at_one_store_time():
     assert isinstance(committed, MappingProxyType)
     assert set(committed) == {"run/generation-head", "run/generations/0"}
     assert {entry.committed_at_unix_ms for entry in committed.values()} == {1_000}
+    assert {entry.guard_key for entry in committed.values()} == {"run/coordinator-lease"}
+    assert {entry.guard_revision for entry in committed.values()} == {guard.revision}
+    assert {entry.guard_value_digest for entry in committed.values()} == {
+        hashlib.sha256(b"lease-a").hexdigest()
+    }
     assert store.get("run/generation-head") == committed["run/generation-head"]
     assert store.get("run/generations/0") == committed["run/generations/0"]
     with pytest.raises(TypeError):


### PR DESCRIPTION
## Problem

Torchrun agents and coordinators need to read the committed rank assignment after restart or failover without accepting orphan snapshots, partially published state, self-reported lease provenance, expired guards, or a broken generation history.

## Implementation

- Add a run-scoped `GenerationStateReader` for the generation head and immutable snapshots.
- Verify head/snapshot generation, digest, authoritative commit timestamp, and store-stamped guard provenance.
- Extend guarded control-store results with guard key, opaque revision, value digest, authoritative guard grant time, ordered guard mutation sequence, and key-lifetime sequence.
- Bind schema-v2 snapshots to the complete coordinator lease identity and duration so the reader can reconstruct and verify the stamped guard digest and lease lifetime; reject the prior schema explicitly.
- Reject commits outside the stamped lease grant/duration, including untimed and expired guards.
- Verify the full predecessor digest, timestamp, opaque fencing-token equality, ordered guard-mutation, lease-grant, guard-lifetime, and lease-identity chain back to generation zero.
- Reject lease identities that reappear after a different acquisition or change coordinator, duration, guard-key lifetime, or grant identity within one acquisition.
- Reject in-place lease replacement before the prior stamped lease expiry, impossible guard recreation, same-identity renewal beyond the mutation-distance lifetime bound, and backward grant, mutation, or lifetime sequences while allowing skipped valid renewals.
- Require immutable snapshots to remain at mutation sequence 1, the head sequence to equal `generation + 1`, and the head key to remain in its first lifetime.
- Apply a stable immediate-successor check to every read API while retrying concurrent atomic head advances.
- Return only snapshots reachable from the committed head; reject stable orphan keys and a missing head with remaining generation-zero state.
- Retry boundedly when a concurrent atomic initialization or head advance is observed.

This PR is read-only at the generation layer. It intentionally does not add generation initialization/successor APIs, node registration, standby policy, or recovery planning.

## Compatibility

These contracts are internal and no generation writer has shipped. Existing unguarded control-store entries remain valid for non-generation uses; generation state requires guarded provenance.

## Validation

- Full CPU suite with CUDA hidden: 1,321 passed
- Focused control-store, lease, generation-record, reader, and protocol suite: 218 passed
- Repository-wide Ruff check and format validation
- mypy on the changed control-store and generation modules
- `git diff --check`