### PR TITLE
[Feature][Torchrun] Add lease-fenced generation mutations

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -916,10 +916,11 @@ proves the run has no committed or deleted head history. It commits the mutable
 head and one create-only immutable snapshot in the same lease-guarded
 transaction. A successor must name the exact current head, advance by one
 generation, preserve active-node count, local world size, logical rank ranges,
-and topology digest, and link to the predecessor's canonical snapshot digest.
-Concurrent initializers or successor writers therefore produce one committed
-winner; stale leases, stale heads, expired store-time windows, partial target
-conflicts, and unexpected transaction results fail closed.
+topology digest, and the logical slot of every surviving node, and link to the
+predecessor's canonical snapshot digest. Concurrent initializers or successor
+writers therefore produce one committed winner; stale leases, stale heads,
+expired store-time windows, partial target conflicts, and unexpected
+transaction results fail closed.
 
 Coordinator ownership is stored under a schema-versioned, run-scoped lease key.
 The lease record binds the run, a unique coordinator-process incarnation, a

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -884,7 +884,6 @@ provenance, then verifies the complete predecessor digest, timestamp,
 guard-mutation, and lease-identity chain back to generation zero. Lease
 identities cannot reappear after a different acquisition, and one acquisition
 cannot change coordinator identity, lease duration, or store-stamped guard-key
-lifetime. Every snapshot entry must retain store-stamped mutation sequence `1`,
 lifetime. Every snapshot entry must retain store-stamped mutation, value, and
 lifetime sequence `1`, while the head mutation and value sequences must equal
 `generation + 1`; this rejects replacement, recreation, extra rewrites, and
@@ -911,6 +910,16 @@ initialization marker, so deleting both the head and generation zero cannot make
 an initialized run appear empty. Grant times, guard mutation/value sequences,
 and key-lifetime sequences cannot move backward. Missing or contradictory
 history is corruption, not an empty or partially usable assignment.
+
+The generation-state manager initializes generation zero only after the reader
+proves the run has no committed or deleted head history. It commits the mutable
+head and one create-only immutable snapshot in the same lease-guarded
+transaction. A successor must name the exact current head, advance by one
+generation, preserve active-node count, local world size, logical rank ranges,
+and topology digest, and link to the predecessor's canonical snapshot digest.
+Concurrent initializers or successor writers therefore produce one committed
+winner; stale leases, stale heads, expired store-time windows, partial target
+conflicts, and unexpected transaction results fail closed.
 
 Coordinator ownership is stored under a schema-versioned, run-scoped lease key.
 The lease record binds the run, a unique coordinator-process incarnation, a

--- a/lm_resiliency/integrations/torchrun/_generation_state.py
+++ b/lm_resiliency/integrations/torchrun/_generation_state.py
@@ -83,6 +83,12 @@ class GenerationStateManager(GenerationStateReader):
             raise ValueError("successor assignment must preserve logical rank ranges")
         if assignment.topology_digest != previous.topology_digest:
             raise ValueError("successor assignment must preserve topology digest")
+        previous_slots = {node_id: slot for slot, node_id in previous.slot_to_node_id.items()}
+        if any(
+            node_id in previous_slots and previous_slots[node_id] != slot
+            for slot, node_id in assignment.slot_to_node_id.items()
+        ):
+            raise ValueError("successor assignment must preserve surviving node slots")
         snapshot_record = self._snapshot_record(
             lease,
             assignment,

--- a/lm_resiliency/integrations/torchrun/_generation_state.py
+++ b/lm_resiliency/integrations/torchrun/_generation_state.py
@@ -1,0 +1,224 @@
+"""Lease-fenced mutation of immutable torchrun generation state."""
+
+from __future__ import annotations
+
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStoreClockError,
+    ControlStoreConflict,
+    ControlStoreDeadlineExceeded,
+    ControlStoreTooEarly,
+    ControlStoreWrite,
+)
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseRecord,
+    HeldCoordinatorLease,
+)
+from lm_resiliency.integrations.torchrun._generation_reader import (
+    CurrentGeneration,
+    GenerationStateCorrupt,
+    GenerationStateError,
+    GenerationStateReader,
+)
+from lm_resiliency.integrations.torchrun._generation_records import (
+    GenerationHeadRecord,
+    GenerationSnapshotRecord,
+)
+from lm_resiliency.integrations.torchrun._protocol import RankAssignment
+
+
+class GenerationStateConflict(GenerationStateError):
+    """Raised when initialization or successor commit observes newer state."""
+
+
+class GenerationStateLeaseLost(GenerationStateError):
+    """Raised when the coordinator lease is stale or expired."""
+
+
+class GenerationStateClockError(GenerationStateError):
+    """Raised when authoritative store time contradicts the lease timeline."""
+
+
+class GenerationStateManager(GenerationStateReader):
+    """Commit immutable generation snapshots under a coordinator lease."""
+
+    def initialize(
+        self,
+        lease: HeldCoordinatorLease,
+        assignment: RankAssignment,
+    ) -> CurrentGeneration:
+        self._validate_lease(lease)
+        self._validate_assignment(assignment)
+        if assignment.generation != 0:
+            raise ValueError("initial generation assignment must use generation zero")
+        if self.current() is not None:
+            raise GenerationStateConflict("generation state is already initialized")
+        snapshot_record = self._snapshot_record(
+            lease,
+            assignment,
+            previous_snapshot_digest=None,
+        )
+        return self._commit(
+            lease=lease,
+            snapshot_record=snapshot_record,
+            expected_head_revision=None,
+        )
+
+    def commit_successor(
+        self,
+        lease: HeldCoordinatorLease,
+        current: CurrentGeneration,
+        assignment: RankAssignment,
+    ) -> CurrentGeneration:
+        self._validate_lease(lease)
+        self._validate_current(current)
+        self._validate_assignment(assignment)
+        previous = current.snapshot.record.assignment
+        if assignment.generation != previous.generation + 1:
+            raise ValueError("successor assignment must advance generation by exactly one")
+        if assignment.active_nodes != previous.active_nodes:
+            raise ValueError("successor assignment must preserve active node count")
+        if assignment.local_world_size != previous.local_world_size:
+            raise ValueError("successor assignment must preserve local world size")
+        if assignment.slot_to_rank_range != previous.slot_to_rank_range:
+            raise ValueError("successor assignment must preserve logical rank ranges")
+        if assignment.topology_digest != previous.topology_digest:
+            raise ValueError("successor assignment must preserve topology digest")
+        snapshot_record = self._snapshot_record(
+            lease,
+            assignment,
+            previous_snapshot_digest=current.snapshot.record.digest,
+        )
+        return self._commit(
+            lease=lease,
+            snapshot_record=snapshot_record,
+            expected_head_revision=current.head_revision,
+        )
+
+    def _commit(
+        self,
+        *,
+        lease: HeldCoordinatorLease,
+        snapshot_record: GenerationSnapshotRecord,
+        expected_head_revision: int | None,
+    ) -> CurrentGeneration:
+        head_record = GenerationHeadRecord(
+            run_id=self._run_id,
+            generation=snapshot_record.assignment.generation,
+            snapshot_digest=snapshot_record.digest,
+        )
+        snapshot_key = self.snapshot_key(snapshot_record.assignment.generation)
+        try:
+            committed = self._store.compare_set_many_guarded(
+                {
+                    self._head_key: ControlStoreWrite(
+                        expected_revision=expected_head_revision,
+                        value=head_record.to_json(),
+                    ),
+                    snapshot_key: ControlStoreWrite(
+                        expected_revision=None,
+                        value=snapshot_record.to_json(),
+                    ),
+                },
+                guard_key=self._coordinator_lease_key,
+                expected_guard_revision=lease.fencing_token,
+                not_before_unix_ms=lease.granted_at_unix_ms,
+                deadline_unix_ms=lease.expires_at_unix_ms,
+            )
+        except ControlStoreConflict as error:
+            if error.key == self._coordinator_lease_key:
+                raise GenerationStateLeaseLost(
+                    "coordinator lease changed before generation commit"
+                ) from error
+            raise GenerationStateConflict(
+                f"generation state changed at {error.key!r} before commit"
+            ) from error
+        except ControlStoreDeadlineExceeded as error:
+            raise GenerationStateLeaseLost(
+                "coordinator lease expired before generation commit"
+            ) from error
+        except (ControlStoreTooEarly, ControlStoreClockError) as error:
+            raise GenerationStateClockError(
+                "control-store time contradicts the coordinator lease"
+            ) from error
+        expected_keys = {self._head_key, snapshot_key}
+        if set(committed) != expected_keys:
+            raise GenerationStateCorrupt(
+                "generation transaction returned an unexpected committed key set"
+            )
+        head_entry = committed[self._head_key]
+        committed_head = self._decode_head(head_entry)
+        if committed_head != head_record:
+            raise GenerationStateCorrupt(
+                "generation transaction returned an unexpected head record"
+            )
+        snapshot = self._decode_snapshot(
+            committed[snapshot_key],
+            expected_generation=snapshot_record.assignment.generation,
+        )
+        if snapshot.record != snapshot_record:
+            raise GenerationStateCorrupt(
+                "generation transaction returned an unexpected snapshot record"
+            )
+        self._validate_head_link(committed_head, head_entry, snapshot)
+        return CurrentGeneration(
+            snapshot=snapshot,
+            head_revision=head_entry.revision,
+        )
+
+    def _snapshot_record(
+        self,
+        lease: HeldCoordinatorLease,
+        assignment: RankAssignment,
+        *,
+        previous_snapshot_digest: str | None,
+    ) -> GenerationSnapshotRecord:
+        return GenerationSnapshotRecord(
+            assignment=assignment,
+            previous_snapshot_digest=previous_snapshot_digest,
+            coordinator_id=lease.record.coordinator_id,
+            lease_id=lease.record.lease_id,
+            coordinator_lease_duration_ms=lease.record.lease_duration_ms,
+            coordinator_fencing_token=lease.fencing_token,
+        )
+
+    def _validate_lease(self, lease: HeldCoordinatorLease) -> None:
+        if not isinstance(lease, HeldCoordinatorLease):
+            raise TypeError("lease must be HeldCoordinatorLease")
+        if lease.record.run_id != self._run_id:
+            raise ValueError("coordinator lease belongs to another run")
+        entry = self._store.get(self._coordinator_lease_key)
+        if entry is None or entry.revision != lease.fencing_token:
+            raise GenerationStateLeaseLost("coordinator lease changed before generation validation")
+        try:
+            record = CoordinatorLeaseRecord.from_json(entry.value)
+        except (TypeError, ValueError) as error:
+            raise GenerationStateCorrupt("coordinator lease is malformed") from error
+        if entry.committed_at_unix_ms is None:
+            raise GenerationStateCorrupt("coordinator lease has no authoritative grant time")
+        if record != lease.record or entry.committed_at_unix_ms != lease.granted_at_unix_ms:
+            raise GenerationStateLeaseLost(
+                "coordinator lease handle does not match persisted ownership"
+            )
+
+    def _validate_assignment(self, assignment: RankAssignment) -> None:
+        if not isinstance(assignment, RankAssignment):
+            raise TypeError("assignment must be RankAssignment")
+        if assignment.run_id != self._run_id:
+            raise ValueError("rank assignment belongs to another run")
+
+    def _validate_current(self, current: CurrentGeneration) -> None:
+        if not isinstance(current, CurrentGeneration):
+            raise TypeError("current must be CurrentGeneration")
+        observed = self.current()
+        if observed != current:
+            raise GenerationStateConflict(
+                "current generation does not match the committed generation head"
+            )
+
+
+__all__ = [
+    "GenerationStateClockError",
+    "GenerationStateConflict",
+    "GenerationStateLeaseLost",
+    "GenerationStateManager",
+]

--- a/tests/unit/test_torchrun_generation_state.py
+++ b/tests/unit/test_torchrun_generation_state.py
@@ -411,6 +411,10 @@ def test_generation_state_rejects_fabricated_current_generation():
             _assignment(1, topology_digest="topology-v2"),
             "topology digest",
         ),
+        (
+            _assignment(1, node_ids=("node-b", "node-a")),
+            "surviving node slots",
+        ),
     ],
 )
 def test_generation_state_rejects_incompatible_successors(assignment, message):

--- a/tests/unit/test_torchrun_generation_state.py
+++ b/tests/unit/test_torchrun_generation_state.py
@@ -1,0 +1,467 @@
+"""Contract tests for lease-fenced torchrun generation state."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Mapping
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStoreEntry,
+    ControlStoreWrite,
+    InMemoryControlStore,
+)
+from lm_resiliency.integrations.torchrun._coordinator_lease import CoordinatorLeaseManager
+from lm_resiliency.integrations.torchrun._generation_reader import GenerationStateCorrupt
+from lm_resiliency.integrations.torchrun._generation_records import GenerationHeadRecord
+from lm_resiliency.integrations.torchrun._generation_state import (
+    GenerationStateClockError,
+    GenerationStateConflict,
+    GenerationStateLeaseLost,
+    GenerationStateManager,
+)
+from lm_resiliency.integrations.torchrun._protocol import RankAssignment, SlotAssignment
+
+RUN_ID = "training-run"
+TOPOLOGY_DIGEST = "topology-v1"
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+    def set(self, now_unix_ms: int) -> None:
+        with self._lock:
+            self.now_unix_ms = now_unix_ms
+
+
+class TamperedTransactionResultStore(InMemoryControlStore):
+    def __init__(self, *, clock: ManualClock, tamper: str) -> None:
+        super().__init__(clock=clock)
+        self._tamper = tamper
+
+    def compare_set_many_guarded(
+        self,
+        writes: Mapping[str, ControlStoreWrite],
+        *,
+        guard_key: str,
+        expected_guard_revision: int,
+        not_before_unix_ms: int,
+        deadline_unix_ms: int,
+    ) -> Mapping[str, ControlStoreEntry]:
+        committed = dict(
+            super().compare_set_many_guarded(
+                writes,
+                guard_key=guard_key,
+                expected_guard_revision=expected_guard_revision,
+                not_before_unix_ms=not_before_unix_ms,
+                deadline_unix_ms=deadline_unix_ms,
+            )
+        )
+        head_key = next(key for key in committed if key.endswith("/generation-head"))
+        if self._tamper == "missing_snapshot":
+            return {head_key: committed[head_key]}
+        committed[head_key] = replace(
+            committed[head_key],
+            value=GenerationHeadRecord(
+                run_id=RUN_ID,
+                generation=0,
+                snapshot_digest="0" * 64,
+            ).to_json(),
+        )
+        return committed
+
+
+def _assignment(
+    generation: int,
+    *,
+    node_ids: tuple[str, ...] = ("node-a", "node-b"),
+    topology_digest: str = TOPOLOGY_DIGEST,
+    local_world_size: int = 2,
+) -> RankAssignment:
+    return RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=generation,
+        assignments=tuple(
+            SlotAssignment(
+                logical_node_slot=slot,
+                node_id=node_id,
+                first_global_rank=slot * local_world_size,
+                local_world_size=local_world_size,
+            )
+            for slot, node_id in enumerate(node_ids)
+        ),
+        topology_digest=topology_digest,
+    )
+
+
+def _managers():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    lease_manager = CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id="coordinator-a",
+        lease_duration_ms=100,
+        clock=clock,
+    )
+    generation_manager = GenerationStateManager(
+        store,
+        run_id=RUN_ID,
+    )
+    return clock, store, lease_manager, generation_manager
+
+
+def test_generation_state_initializes_and_reads_immutable_snapshot():
+    _, store, lease_manager, manager = _managers()
+    lease = lease_manager.acquire()
+
+    current = manager.initialize(lease, _assignment(0))
+
+    assert current.snapshot.record.assignment == _assignment(0)
+    assert current.snapshot.record.previous_snapshot_digest is None
+    assert current.snapshot.record.coordinator_fencing_token == lease.fencing_token
+    assert current.snapshot.committed_at_unix_ms == lease.granted_at_unix_ms
+    assert manager.current() == current
+    assert manager.get(0) == current.snapshot
+    assert store.get(manager.snapshot_key(1)) is None
+
+
+def test_generation_state_rejects_duplicate_initialization_without_overwrite():
+    _, _, lease_manager, manager = _managers()
+    lease = lease_manager.acquire()
+    current = manager.initialize(lease, _assignment(0))
+
+    with pytest.raises(GenerationStateConflict, match="already initialized"):
+        manager.initialize(
+            lease,
+            _assignment(0, node_ids=("node-x", "node-y")),
+        )
+
+    assert manager.current() == current
+
+
+def test_generation_state_rejects_reinitialization_after_head_deletion():
+    _, store, lease_manager, manager = _managers()
+    lease = lease_manager.acquire()
+    current = manager.initialize(lease, _assignment(0))
+    store.compare_delete(
+        manager.head_key,
+        expected_revision=current.head_revision,
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="deleted after initialization"):
+        manager.initialize(lease, _assignment(0))
+
+    assert store.get(manager.head_key) is None
+    assert store.get(manager.snapshot_key(0)) is not None
+
+
+def test_generation_state_commits_successor_and_preserves_history():
+    clock, _, lease_manager, manager = _managers()
+    lease = lease_manager.acquire()
+    generation_zero = manager.initialize(lease, _assignment(0))
+    clock.set(1_010)
+
+    generation_one = manager.commit_successor(
+        lease,
+        generation_zero,
+        _assignment(1, node_ids=("node-a", "node-spare")),
+    )
+
+    assert generation_one.snapshot.record.assignment.generation == 1
+    assert (
+        generation_one.snapshot.record.previous_snapshot_digest
+        == generation_zero.snapshot.record.digest
+    )
+    assert generation_one.head_revision > generation_zero.head_revision
+    assert manager.current() == generation_one
+    assert manager.get(0) == generation_zero.snapshot
+    assert manager.get(1) == generation_one.snapshot
+
+
+def test_generation_state_commits_successor_after_lease_renewal():
+    clock, _, lease_manager, manager = _managers()
+    lease = lease_manager.acquire()
+    generation_zero = manager.initialize(lease, _assignment(0))
+    clock.set(1_010)
+    renewed = lease_manager.renew(lease)
+    clock.set(1_020)
+
+    generation_one = manager.commit_successor(
+        renewed,
+        generation_zero,
+        _assignment(1, node_ids=("node-a", "node-spare")),
+    )
+
+    assert generation_one.snapshot.record.lease_id == lease.record.lease_id
+    assert generation_one.snapshot.record.coordinator_fencing_token == renewed.fencing_token
+    assert manager.current() == generation_one
+
+
+def test_generation_state_commits_successor_after_expired_lease_takeover():
+    clock, store, lease_manager, manager = _managers()
+    lease = lease_manager.acquire()
+    generation_zero = manager.initialize(lease, _assignment(0))
+    clock.set(lease.expires_at_unix_ms)
+    takeover_manager = CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id="coordinator-b",
+        lease_duration_ms=100,
+        clock=clock,
+    )
+    takeover = takeover_manager.acquire()
+
+    generation_one = manager.commit_successor(
+        takeover,
+        generation_zero,
+        _assignment(1, node_ids=("node-a", "node-spare")),
+    )
+
+    assert generation_one.snapshot.record.coordinator_id == "coordinator-b"
+    assert generation_one.snapshot.record.lease_id == takeover.record.lease_id
+    assert manager.current() == generation_one
+
+
+def test_generation_state_rejects_stale_or_expired_lease():
+    clock, store, lease_manager, manager = _managers()
+    stale = lease_manager.acquire()
+    current_lease = lease_manager.renew(stale)
+
+    with pytest.raises(GenerationStateLeaseLost, match="changed"):
+        manager.initialize(stale, _assignment(0))
+    assert store.get(manager.head_key) is None
+    assert store.get(manager.snapshot_key(0)) is None
+
+    clock.set(current_lease.expires_at_unix_ms)
+    with pytest.raises(GenerationStateLeaseLost, match="expired"):
+        manager.initialize(current_lease, _assignment(0))
+    assert store.get(manager.head_key) is None
+    assert store.get(manager.snapshot_key(0)) is None
+
+
+def test_generation_state_rejects_backward_store_clock_without_writes():
+    clock, store, lease_manager, manager = _managers()
+    lease = lease_manager.acquire()
+    clock.set(lease.granted_at_unix_ms - 1)
+
+    with pytest.raises(GenerationStateClockError, match="contradicts"):
+        manager.initialize(lease, _assignment(0))
+
+    assert store.get(manager.head_key) is None
+    assert store.get(manager.snapshot_key(0)) is None
+
+
+@pytest.mark.parametrize(
+    ("tamper", "message"),
+    [
+        ("missing_snapshot", "unexpected committed key set"),
+        ("substituted_head", "unexpected head record"),
+    ],
+)
+def test_generation_state_rejects_tampered_transaction_results(tamper, message):
+    clock = ManualClock()
+    store = TamperedTransactionResultStore(clock=clock, tamper=tamper)
+    lease_manager = CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id="coordinator-a",
+        lease_duration_ms=100,
+        clock=clock,
+    )
+    manager = GenerationStateManager(store, run_id=RUN_ID)
+    lease = lease_manager.acquire()
+
+    with pytest.raises(GenerationStateCorrupt, match=message):
+        manager.initialize(lease, _assignment(0))
+
+
+def test_generation_state_rejects_fabricated_lease_identity():
+    _, store, lease_manager, manager = _managers()
+    lease = lease_manager.acquire()
+    fabricated = replace(
+        lease,
+        record=replace(lease.record, lease_id="forged-lease"),
+    )
+
+    with pytest.raises(GenerationStateLeaseLost, match="persisted ownership"):
+        manager.initialize(fabricated, _assignment(0))
+
+    assert store.get(manager.head_key) is None
+    assert store.get(manager.snapshot_key(0)) is None
+
+
+def test_generation_state_allows_only_one_concurrent_initializer():
+    _, _, lease_manager, manager = _managers()
+    lease = lease_manager.acquire()
+    workers = 8
+    barrier = threading.Barrier(workers)
+
+    def initialize():
+        barrier.wait()
+        try:
+            return manager.initialize(lease, _assignment(0))
+        except GenerationStateConflict:
+            return None
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        results = list(executor.map(lambda _: initialize(), range(workers)))
+
+    winners = [result for result in results if result is not None]
+    assert len(winners) == 1
+    assert manager.current() == winners[0]
+
+
+def test_generation_state_allows_only_one_concurrent_successor():
+    clock, _, lease_manager, manager = _managers()
+    lease = lease_manager.acquire()
+    current = manager.initialize(lease, _assignment(0))
+    clock.set(1_010)
+    workers = 8
+    barrier = threading.Barrier(workers)
+
+    def commit_successor(index: int):
+        barrier.wait()
+        try:
+            return manager.commit_successor(
+                lease,
+                current,
+                _assignment(
+                    1,
+                    node_ids=("node-a", f"node-spare-{index}"),
+                ),
+            )
+        except GenerationStateConflict:
+            return None
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        results = list(executor.map(commit_successor, range(workers)))
+
+    winners = [result for result in results if result is not None]
+    assert len(winners) == 1
+    assert manager.current() == winners[0]
+
+
+def test_generation_state_rejects_stale_successor_without_overwrite():
+    clock, _, lease_manager, manager = _managers()
+    lease = lease_manager.acquire()
+    generation_zero = manager.initialize(lease, _assignment(0))
+    clock.set(1_010)
+    generation_one = manager.commit_successor(
+        lease,
+        generation_zero,
+        _assignment(1, node_ids=("node-a", "node-spare")),
+    )
+
+    with pytest.raises(GenerationStateConflict):
+        manager.commit_successor(
+            lease,
+            generation_zero,
+            _assignment(1, node_ids=("node-replacement", "node-b")),
+        )
+
+    assert manager.current() == generation_one
+    assert manager.get(1) == generation_one.snapshot
+
+
+def test_generation_state_rejects_fabricated_current_generation():
+    _, _, lease_manager, manager = _managers()
+    lease = lease_manager.acquire()
+    current = manager.initialize(lease, _assignment(0))
+    fabricated = replace(
+        current,
+        snapshot=replace(
+            current.snapshot,
+            record=replace(
+                current.snapshot.record,
+                assignment=_assignment(0, node_ids=("node-x", "node-y")),
+            ),
+        ),
+    )
+
+    with pytest.raises(GenerationStateConflict, match="committed generation head"):
+        manager.commit_successor(lease, fabricated, _assignment(1))
+
+    assert manager.current() == current
+    assert manager.get(1) is None
+
+
+@pytest.mark.parametrize(
+    ("assignment", "message"),
+    [
+        (_assignment(2), "exactly one"),
+        (
+            _assignment(1, node_ids=("node-a",)),
+            "active node count",
+        ),
+        (
+            _assignment(1, local_world_size=1),
+            "local world size",
+        ),
+        (
+            _assignment(1, topology_digest="topology-v2"),
+            "topology digest",
+        ),
+    ],
+)
+def test_generation_state_rejects_incompatible_successors(assignment, message):
+    _, _, lease_manager, manager = _managers()
+    lease = lease_manager.acquire()
+    current = manager.initialize(lease, _assignment(0))
+
+    with pytest.raises(ValueError, match=message):
+        manager.commit_successor(lease, current, assignment)
+
+
+def test_generation_state_rejects_wrong_run_assignment_and_lease():
+    _, store, lease_manager, manager = _managers()
+    lease = lease_manager.acquire()
+    wrong_assignment = replace(_assignment(0), run_id="other-run")
+
+    with pytest.raises(ValueError, match="another run"):
+        manager.initialize(lease, wrong_assignment)
+
+    other_lease_manager = CoordinatorLeaseManager(
+        store,
+        run_id="other-run",
+        coordinator_id="coordinator-b",
+        lease_duration_ms=100,
+        clock=ManualClock(),
+    )
+    other_lease = other_lease_manager.acquire()
+    with pytest.raises(ValueError, match="another run"):
+        manager.initialize(other_lease, _assignment(0))
+
+
+def test_generation_state_rejects_orphan_successor_without_advancing_head():
+    clock, store, lease_manager, manager = _managers()
+    lease = lease_manager.acquire()
+    current = manager.initialize(lease, _assignment(0))
+    clock.set(1_010)
+    orphan = replace(
+        current.snapshot.record,
+        assignment=_assignment(1),
+        previous_snapshot_digest=current.snapshot.record.digest,
+    )
+    store.compare_set_in_window(
+        manager.snapshot_key(1),
+        expected_revision=None,
+        not_before_unix_ms=1_010,
+        deadline_unix_ms=None,
+        value=orphan.to_json(),
+    )
+
+    with pytest.raises(GenerationStateCorrupt, match="newer than"):
+        manager.commit_successor(lease, current, _assignment(1))
+
+    with pytest.raises(GenerationStateCorrupt, match="newer than"):
+        manager.current()


### PR DESCRIPTION
## Summary

- add an internal generation-state manager that initializes generation zero and commits exactly one successor
- atomically publish the mutable head and create-only immutable snapshot under the live coordinator lease
- preserve logical slots for every node that survives into the successor generation
- reject stale leases, stale heads, incompatible topology, duplicate writers, corrupt state, and substituted transaction results
- document the mutation contract and fix a duplicated sentence in the reader design text

## Compatibility

This is an internal torchrun component. It adds no public import, rendezvous registration, CLI flag, or runtime activation.

## Validation

- `141 passed` focused control-store, lease, generation-record, reader, and writer tests
- `1330 passed` complete CPU suite with CUDA hidden
- Ruff check and format check
- mypy 1.17.1 on the new writer and tests
- `git diff --check`