### PR TITLE
[Feature][Torchrun] Add strict agent registration records

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -300,6 +300,15 @@ checkpoint schema, and model configuration needed to interpret rank-local
 state. It is separate from `environment_digest`, which describes whether a node
 is eligible to run the same software and hardware workload.
 
+Each live agent persists a strict, versioned `AgentRegistrationRecord` that
+contains its complete immutable `AgentIdentity`, a unique registration lifetime
+ID, and the registration lease duration. The control-store revision is the
+opaque fencing token, and the store-stamped commit time plus duration determines
+expiry. Registration proves that one agent incarnation is live on a trusted
+node identity; it does not by itself make the node standby-eligible, admit it to
+a generation, or authorize resources absent from the trusted infrastructure
+inventory.
+
 ## API: lm-resiliency to the coordinator
 
 The current `OrchestrationHooks` callbacks are the starting point. The torchrun

--- a/lm_resiliency/integrations/torchrun/_agent_registration_records.py
+++ b/lm_resiliency/integrations/torchrun/_agent_registration_records.py
@@ -1,0 +1,188 @@
+"""Strict persisted records for torchrun agent registration."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import ClassVar
+
+from lm_resiliency.integrations.torchrun._protocol import (
+    AgentIdentity,
+    ProtocolValidationError,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class AgentRegistrationRecord:
+    """One agent identity and its registration-lease lifetime."""
+
+    SCHEMA_VERSION: ClassVar[int] = 1
+
+    agent_identity: AgentIdentity
+    registration_id: str
+    lease_duration_ms: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.agent_identity, AgentIdentity):
+            raise TypeError("AgentRegistrationRecord.agent_identity must be AgentIdentity")
+        _nonempty_string(
+            self.registration_id,
+            "AgentRegistrationRecord.registration_id",
+        )
+        _positive_integer(
+            self.lease_duration_ms,
+            "AgentRegistrationRecord.lease_duration_ms",
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "agent_identity": self.agent_identity.to_dict(),
+            "registration_id": self.registration_id,
+            "lease_duration_ms": self.lease_duration_ms,
+        }
+
+    def to_json(self) -> bytes:
+        return _canonical_json(self.to_dict())
+
+    @classmethod
+    def from_json(cls, encoded: bytes) -> AgentRegistrationRecord:
+        value = _json_object(encoded, cls.__name__)
+        _fields(
+            value,
+            path=cls.__name__,
+            required={
+                "schema_version",
+                "agent_identity",
+                "registration_id",
+                "lease_duration_ms",
+            },
+        )
+        _schema_version(
+            value["schema_version"],
+            cls.__name__,
+            expected=cls.SCHEMA_VERSION,
+        )
+        identity_value = value["agent_identity"]
+        if not isinstance(identity_value, Mapping):
+            raise ValueError("AgentRegistrationRecord.agent_identity must be an object")
+        try:
+            identity = AgentIdentity.from_dict(identity_value)
+        except ProtocolValidationError as error:
+            raise ValueError("AgentRegistrationRecord.agent_identity is invalid") from error
+        return cls(
+            agent_identity=identity,
+            registration_id=_nonempty_string(
+                value["registration_id"],
+                "AgentRegistrationRecord.registration_id",
+            ),
+            lease_duration_ms=_positive_integer(
+                value["lease_duration_ms"],
+                "AgentRegistrationRecord.lease_duration_ms",
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HeldAgentRegistration:
+    """One observed registration and the revision fencing its mutations."""
+
+    record: AgentRegistrationRecord
+    fencing_token: int
+    granted_at_unix_ms: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.record, AgentRegistrationRecord):
+            raise TypeError("HeldAgentRegistration.record must be AgentRegistrationRecord")
+        _positive_integer(
+            self.fencing_token,
+            "HeldAgentRegistration.fencing_token",
+        )
+        _positive_integer(
+            self.granted_at_unix_ms,
+            "HeldAgentRegistration.granted_at_unix_ms",
+        )
+
+    @property
+    def expires_at_unix_ms(self) -> int:
+        return self.granted_at_unix_ms + self.record.lease_duration_ms
+
+
+def _canonical_json(value: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _json_object(encoded: bytes, path: str) -> Mapping[str, object]:
+    if not isinstance(encoded, bytes):
+        raise ValueError(f"{path}: expected encoded bytes")
+    try:
+        value = json.loads(
+            encoded,
+            object_pairs_hook=_reject_duplicate_object_fields,
+        )
+    except _DuplicateRegistrationField as error:
+        raise ValueError(f"{path}: {error}") from error
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{path}: invalid JSON") from error
+    if not isinstance(value, Mapping) or not all(isinstance(key, str) for key in value):
+        raise ValueError(f"{path}: expected a JSON object")
+    return value
+
+
+def _fields(
+    value: Mapping[str, object],
+    *,
+    path: str,
+    required: set[str],
+) -> None:
+    missing = required - set(value)
+    unknown = set(value) - required
+    if missing:
+        raise ValueError(f"{path}: missing fields {sorted(missing)!r}")
+    if unknown:
+        raise ValueError(f"{path}: unknown fields {sorted(unknown)!r}")
+
+
+def _schema_version(value: object, path: str, *, expected: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value != expected:
+        raise ValueError(f"{path}.schema_version: unsupported value {value!r}")
+    return value
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+def _positive_integer(value: object, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{path} must be a positive integer")
+    return value
+
+
+class _DuplicateRegistrationField(ValueError):
+    pass
+
+
+def _reject_duplicate_object_fields(
+    pairs: list[tuple[str, object]],
+) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            raise _DuplicateRegistrationField(f"duplicate field {key!r}")
+        value[key] = item
+    return value
+
+
+__all__ = [
+    "AgentRegistrationRecord",
+    "HeldAgentRegistration",
+]

--- a/tests/unit/test_torchrun_agent_registration_records.py
+++ b/tests/unit/test_torchrun_agent_registration_records.py
@@ -1,0 +1,210 @@
+"""Contract tests for persisted torchrun agent registration records."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._agent_registration_records import (
+    AgentRegistrationRecord,
+    HeldAgentRegistration,
+)
+from lm_resiliency.integrations.torchrun._protocol import AgentIdentity
+
+
+def _identity() -> AgentIdentity:
+    return AgentIdentity(
+        run_id="training-run",
+        node_id="node-a",
+        agent_id="agent-a",
+        hostname="host-a",
+        local_world_size=2,
+        resource_ids=("gpu-a0", "gpu-a1", "hca-a"),
+        environment_digest="environment-v1",
+    )
+
+
+def _record() -> AgentRegistrationRecord:
+    return AgentRegistrationRecord(
+        agent_identity=_identity(),
+        registration_id="registration-a",
+        lease_duration_ms=30_000,
+    )
+
+
+def test_agent_registration_record_round_trips_strict_json():
+    record = _record()
+
+    encoded = record.to_json()
+    decoded = AgentRegistrationRecord.from_json(encoded)
+
+    assert decoded == record
+    assert encoded == (
+        b'{"agent_identity":{"agent_id":"agent-a",'
+        b'"environment_digest":"environment-v1","hostname":"host-a",'
+        b'"local_world_size":2,"node_id":"node-a",'
+        b'"resource_ids":["gpu-a0","gpu-a1","hca-a"],'
+        b'"run_id":"training-run","schema_version":1},'
+        b'"lease_duration_ms":30000,"registration_id":"registration-a",'
+        b'"schema_version":1}'
+    )
+
+
+def test_agent_registration_record_is_immutable():
+    record = _record()
+
+    with pytest.raises(AttributeError):
+        record.registration_id = "other"
+    with pytest.raises(AttributeError):
+        record.agent_identity.resource_ids = ()
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda value: value.pop("agent_identity"),
+            "missing fields",
+        ),
+        (
+            lambda value: value.update({"unknown": True}),
+            "unknown fields",
+        ),
+        (
+            lambda value: value.update({"schema_version": 2}),
+            "unsupported value",
+        ),
+        (
+            lambda value: value.update({"schema_version": True}),
+            "unsupported value",
+        ),
+        (
+            lambda value: value.update({"agent_identity": []}),
+            "agent_identity must be an object",
+        ),
+        (
+            lambda value: value["agent_identity"].update({"run_id": ""}),
+            "agent_identity is invalid",
+        ),
+        (
+            lambda value: value.update({"registration_id": ""}),
+            "registration_id",
+        ),
+        (
+            lambda value: value.update({"lease_duration_ms": 0}),
+            "lease_duration_ms",
+        ),
+        (
+            lambda value: value.update({"lease_duration_ms": True}),
+            "lease_duration_ms",
+        ),
+    ],
+)
+def test_agent_registration_record_rejects_invalid_wire_values(mutate, message):
+    value = json.loads(_record().to_json())
+    mutate(value)
+
+    with pytest.raises(ValueError, match=message):
+        AgentRegistrationRecord.from_json(
+            json.dumps(value, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        )
+
+
+@pytest.mark.parametrize(
+    "encoded",
+    [
+        b"not-json",
+        b"[]",
+        b'{"schema_version":1,"schema_version":1}',
+        (
+            b'{"agent_identity":{"schema_version":1,"run_id":"training-run",'
+            b'"run_id":"other-run","node_id":"node-a","agent_id":"agent-a",'
+            b'"hostname":"host-a","local_world_size":2,"resource_ids":[],'
+            b'"environment_digest":"environment-v1"},"registration_id":"registration-a",'
+            b'"lease_duration_ms":30000,"schema_version":1}'
+        ),
+    ],
+)
+def test_agent_registration_record_rejects_malformed_or_duplicate_json(encoded):
+    with pytest.raises(ValueError):
+        AgentRegistrationRecord.from_json(encoded)
+
+
+def test_agent_registration_record_requires_encoded_bytes():
+    with pytest.raises(ValueError, match="encoded bytes"):
+        AgentRegistrationRecord.from_json(_record().to_json().decode("utf-8"))
+
+
+def test_agent_registration_record_requires_agent_identity():
+    with pytest.raises(TypeError, match="AgentIdentity"):
+        AgentRegistrationRecord(
+            agent_identity={},
+            registration_id="registration-a",
+            lease_duration_ms=30_000,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("registration_id", ""),
+        ("lease_duration_ms", 0),
+        ("lease_duration_ms", -1),
+        ("lease_duration_ms", True),
+    ],
+)
+def test_agent_registration_record_validates_constructor_fields(field, value):
+    with pytest.raises(ValueError):
+        replace(_record(), **{field: value})
+
+
+def test_held_agent_registration_derives_expiry():
+    held = HeldAgentRegistration(
+        record=_record(),
+        fencing_token=7,
+        granted_at_unix_ms=1_000,
+    )
+
+    assert held.expires_at_unix_ms == 31_000
+
+
+def test_held_agent_registration_is_immutable():
+    held = HeldAgentRegistration(
+        record=_record(),
+        fencing_token=7,
+        granted_at_unix_ms=1_000,
+    )
+
+    with pytest.raises(AttributeError):
+        held.fencing_token = 8
+
+
+def test_held_agent_registration_requires_registration_record():
+    with pytest.raises(TypeError, match="AgentRegistrationRecord"):
+        HeldAgentRegistration(
+            record={},
+            fencing_token=7,
+            granted_at_unix_ms=1_000,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("fencing_token", 0),
+        ("fencing_token", True),
+        ("granted_at_unix_ms", 0),
+        ("granted_at_unix_ms", True),
+    ],
+)
+def test_held_agent_registration_validates_positive_metadata(field, value):
+    held = HeldAgentRegistration(
+        record=_record(),
+        fencing_token=7,
+        granted_at_unix_ms=1_000,
+    )
+
+    with pytest.raises(ValueError):
+        replace(held, **{field: value})


### PR DESCRIPTION
## Summary

- add strict canonical `AgentRegistrationRecord` persistence for immutable `AgentIdentity`, registration lifetime ID, and lease duration
- add immutable `HeldAgentRegistration` metadata with fencing token and authoritative expiry derivation
- reject missing, unknown, duplicate, malformed, and unsupported wire fields, including nested identity duplicates
- document that registration proves liveness but does not grant standby eligibility or admission

## Compatibility

This is an internal torchrun record contract. It adds no public import, registry operations, rendezvous registration, CLI flag, or runtime activation.

## Validation

- `114 passed` focused registration and torchrun protocol tests
- `1358 passed` complete CPU suite with CUDA hidden
- Ruff check and format check
- mypy 1.17.1 on the new records and tests
- `git diff --check`