### PR TITLE
[Feature][Torchrun] Add trusted registration observation

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -318,6 +318,16 @@ store-time-guarded mutation. Expiry takeover creates a new registration ID and
 fencing token. Registration keys are independently scoped by hashed run and node
 identity, so agents on different nodes do not contend.
 
+The coordinator does not enumerate arbitrary control-store keys. A registration
+reader receives the trusted scheduler node-ID set explicitly, derives the same
+hashed keys as the agents, and reads only those registrations. After completing
+the reads, it samples the observer clock once and classifies each trusted node
+as live, expired, or missing. This observation is conservative rather than an
+atomic multi-key snapshot: a concurrent renewal may appear expired or missing,
+but a selected registration must be revalidated before admission or plan
+commit. A store-stamped grant time later than the observer clock is a clock
+error, not a live registration.
+
 ## API: lm-resiliency to the coordinator
 
 The current `OrchestrationHooks` callbacks are the starting point. The torchrun

--- a/lm_resiliency/integrations/torchrun/_agent_registration.py
+++ b/lm_resiliency/integrations/torchrun/_agent_registration.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import hashlib
 import threading
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
 
 from lm_resiliency.integrations.torchrun._agent_registration_records import (
     AgentRegistrationRecord,
@@ -45,6 +47,111 @@ class AgentRegistrationClockError(AgentRegistrationError):
     """Raised when client or store time contradicts the registration timeline."""
 
 
+@dataclass(frozen=True, slots=True)
+class AgentRegistrationObservation:
+    """One conservative observation of trusted node registrations."""
+
+    observed_at_unix_ms: int
+    live: Mapping[str, HeldAgentRegistration]
+    expired: Mapping[str, HeldAgentRegistration]
+    missing_node_ids: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        _positive_integer(
+            self.observed_at_unix_ms,
+            "AgentRegistrationObservation.observed_at_unix_ms",
+        )
+        live = _registration_mapping(
+            self.live,
+            "AgentRegistrationObservation.live",
+        )
+        expired = _registration_mapping(
+            self.expired,
+            "AgentRegistrationObservation.expired",
+        )
+        missing = _node_ids(
+            self.missing_node_ids,
+            "AgentRegistrationObservation.missing_node_ids",
+            require_nonempty=False,
+        )
+        overlap = (set(live) & set(expired)) | ((set(live) | set(expired)) & set(missing))
+        if overlap:
+            raise ValueError("AgentRegistrationObservation node classifications must be disjoint")
+        object.__setattr__(self, "live", MappingProxyType(live))
+        object.__setattr__(self, "expired", MappingProxyType(expired))
+        object.__setattr__(self, "missing_node_ids", missing)
+
+
+class AgentRegistrationReader:
+    """Read registrations for an explicit trusted scheduler node set."""
+
+    def __init__(
+        self,
+        store: ControlStore,
+        *,
+        run_id: str,
+        clock: Callable[[], int],
+    ) -> None:
+        self._store = store
+        self._run_id = _nonempty_string(run_id, "run_id")
+        if not callable(clock):
+            raise TypeError("clock must be callable")
+        self._clock = clock
+        self._clock_lock = threading.Lock()
+        self._last_now_unix_ms = 0
+
+    def get(self, node_id: str) -> HeldAgentRegistration | None:
+        normalized_node_id = _nonempty_string(node_id, "node_id")
+        entry = self._store.get(agent_registration_key(self._run_id, normalized_node_id))
+        if entry is None:
+            return None
+        return _decode_registration_entry(
+            entry,
+            run_id=self._run_id,
+            node_id=normalized_node_id,
+        )
+
+    def observe(self, node_ids: Sequence[str]) -> AgentRegistrationObservation:
+        normalized_node_ids = _node_ids(
+            node_ids,
+            "node_ids",
+            require_nonempty=True,
+        )
+        registrations = {
+            node_id: registration
+            for node_id in normalized_node_ids
+            if (registration := self.get(node_id)) is not None
+        }
+        observed_at_unix_ms = self._now_unix_ms()
+        live: dict[str, HeldAgentRegistration] = {}
+        expired: dict[str, HeldAgentRegistration] = {}
+        for node_id, registration in registrations.items():
+            if observed_at_unix_ms < registration.granted_at_unix_ms:
+                raise AgentRegistrationClockError(
+                    "observer clock precedes an authoritative registration commit"
+                )
+            target = live if registration.expires_at_unix_ms > observed_at_unix_ms else expired
+            target[node_id] = registration
+        return AgentRegistrationObservation(
+            observed_at_unix_ms=observed_at_unix_ms,
+            live=live,
+            expired=expired,
+            missing_node_ids=tuple(
+                node_id for node_id in normalized_node_ids if node_id not in registrations
+            ),
+        )
+
+    def _now_unix_ms(self) -> int:
+        with self._clock_lock:
+            now_unix_ms = _positive_integer(self._clock(), "clock")
+            if now_unix_ms < self._last_now_unix_ms:
+                raise AgentRegistrationClockError(
+                    "agent registration observer clock moved backward"
+                )
+            self._last_now_unix_ms = now_unix_ms
+        return now_unix_ms
+
+
 class AgentRegistrationManager:
     """Maintain one run- and node-scoped agent registration."""
 
@@ -69,10 +176,9 @@ class AgentRegistrationManager:
         self._clock = clock
         self._clock_lock = threading.Lock()
         self._last_now_unix_ms = 0
-        run_digest = hashlib.sha256(agent_identity.run_id.encode("utf-8")).hexdigest()
-        node_digest = hashlib.sha256(agent_identity.node_id.encode("utf-8")).hexdigest()
-        self._registration_key = (
-            f"{_CONTROL_PREFIX}/runs/{run_digest}/agent-registrations/{node_digest}"
+        self._registration_key = agent_registration_key(
+            agent_identity.run_id,
+            agent_identity.node_id,
         )
 
     @property
@@ -83,7 +189,11 @@ class AgentRegistrationManager:
         entry = self._store.get(self._registration_key)
         if entry is None:
             return None
-        return self._decode_entry(entry)
+        return _decode_registration_entry(
+            entry,
+            run_id=self._agent_identity.run_id,
+            node_id=self._agent_identity.node_id,
+        )
 
     def register(self) -> HeldAgentRegistration:
         now_unix_ms = self._now_unix_ms()
@@ -123,7 +233,13 @@ class AgentRegistrationManager:
                     ) from error
                 except ControlStoreConflict:
                     continue
-                return self._require_live_response(self._decode_entry(entry))
+                return self._require_live_response(
+                    _decode_registration_entry(
+                        entry,
+                        run_id=self._agent_identity.run_id,
+                        node_id=self._agent_identity.node_id,
+                    )
+                )
             record = AgentRegistrationRecord(
                 agent_identity=self._agent_identity,
                 registration_id=uuid.uuid4().hex,
@@ -151,7 +267,13 @@ class AgentRegistrationManager:
                 ) from error
             except ControlStoreConflict:
                 continue
-            return self._require_live_response(self._decode_entry(entry))
+            return self._require_live_response(
+                _decode_registration_entry(
+                    entry,
+                    run_id=self._agent_identity.run_id,
+                    node_id=self._agent_identity.node_id,
+                )
+            )
         raise AgentRegistrationUnavailable(
             "agent registration changed repeatedly during registration"
         )
@@ -184,7 +306,13 @@ class AgentRegistrationManager:
         except ControlStoreConflict as error:
             raise AgentRegistrationLost("agent registration changed before renewal") from error
         try:
-            return self._require_live_response(self._decode_entry(entry))
+            return self._require_live_response(
+                _decode_registration_entry(
+                    entry,
+                    run_id=self._agent_identity.run_id,
+                    node_id=self._agent_identity.node_id,
+                )
+            )
         except AgentRegistrationUnavailable as error:
             raise AgentRegistrationLost(
                 "renewed agent registration expired before the response arrived"
@@ -216,29 +344,6 @@ class AgentRegistrationManager:
             ) from error
         except ControlStoreConflict as error:
             raise AgentRegistrationLost("agent registration changed before release") from error
-
-    def _decode_entry(self, entry: ControlStoreEntry) -> HeldAgentRegistration:
-        try:
-            record = AgentRegistrationRecord.from_json(entry.value)
-        except (TypeError, ValueError) as error:
-            raise AgentRegistrationCorrupt("persisted agent registration is malformed") from error
-        identity = record.agent_identity
-        if (
-            identity.run_id != self._agent_identity.run_id
-            or identity.node_id != self._agent_identity.node_id
-        ):
-            raise AgentRegistrationCorrupt(
-                "persisted agent registration belongs to another run or node"
-            )
-        if entry.committed_at_unix_ms is None:
-            raise AgentRegistrationCorrupt(
-                "persisted agent registration has no authoritative commit time"
-            )
-        return HeldAgentRegistration(
-            record=record,
-            fencing_token=entry.revision,
-            granted_at_unix_ms=entry.committed_at_unix_ms,
-        )
 
     def _require_live_response(
         self,
@@ -284,11 +389,90 @@ def _positive_integer(value: object, path: str) -> int:
     return value
 
 
+def agent_registration_key(run_id: str, node_id: str) -> str:
+    """Derive one run/node-scoped registration key without exposing identities."""
+    normalized_run_id = _nonempty_string(run_id, "run_id")
+    normalized_node_id = _nonempty_string(node_id, "node_id")
+    run_digest = hashlib.sha256(normalized_run_id.encode("utf-8")).hexdigest()
+    node_digest = hashlib.sha256(normalized_node_id.encode("utf-8")).hexdigest()
+    return f"{_CONTROL_PREFIX}/runs/{run_digest}/agent-registrations/{node_digest}"
+
+
+def _decode_registration_entry(
+    entry: ControlStoreEntry,
+    *,
+    run_id: str,
+    node_id: str,
+) -> HeldAgentRegistration:
+    try:
+        record = AgentRegistrationRecord.from_json(entry.value)
+    except (TypeError, ValueError) as error:
+        raise AgentRegistrationCorrupt("persisted agent registration is malformed") from error
+    identity = record.agent_identity
+    if identity.run_id != run_id or identity.node_id != node_id:
+        raise AgentRegistrationCorrupt(
+            "persisted agent registration belongs to another run or node"
+        )
+    if entry.committed_at_unix_ms is None:
+        raise AgentRegistrationCorrupt(
+            "persisted agent registration has no authoritative commit time"
+        )
+    return HeldAgentRegistration(
+        record=record,
+        fencing_token=entry.revision,
+        granted_at_unix_ms=entry.committed_at_unix_ms,
+    )
+
+
+def _registration_mapping(
+    value: object,
+    path: str,
+) -> dict[str, HeldAgentRegistration]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{path} must be a mapping")
+    result: dict[str, HeldAgentRegistration] = {}
+    for node_id, registration in value.items():
+        normalized_node_id = _nonempty_string(node_id, f"{path}.key")
+        if not isinstance(registration, HeldAgentRegistration):
+            raise TypeError(f"{path}[{node_id!r}] must be HeldAgentRegistration")
+        if registration.record.agent_identity.node_id != normalized_node_id:
+            raise ValueError(f"{path}[{node_id!r}] registration node does not match key")
+        result[normalized_node_id] = registration
+    return result
+
+
+def _node_ids(
+    value: object,
+    path: str,
+    *,
+    require_nonempty: bool,
+) -> tuple[str, ...]:
+    if isinstance(value, (str, bytes, bytearray)) or not isinstance(value, Sequence):
+        raise TypeError(f"{path} must be a sequence")
+    result = tuple(
+        _nonempty_string(node_id, f"{path}[{index}]") for index, node_id in enumerate(value)
+    )
+    if require_nonempty and not result:
+        raise ValueError(f"{path} must contain at least one node ID")
+    if len(result) != len(set(result)):
+        raise ValueError(f"{path} must contain unique node IDs")
+    return result
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
 __all__ = [
     "AgentRegistrationClockError",
     "AgentRegistrationCorrupt",
     "AgentRegistrationError",
     "AgentRegistrationLost",
     "AgentRegistrationManager",
+    "AgentRegistrationObservation",
+    "AgentRegistrationReader",
     "AgentRegistrationUnavailable",
+    "agent_registration_key",
 ]

--- a/tests/unit/test_torchrun_agent_registration_reader.py
+++ b/tests/unit/test_torchrun_agent_registration_reader.py
@@ -1,0 +1,233 @@
+"""Contract tests for trusted torchrun registration observation."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._agent_registration import (
+    AgentRegistrationClockError,
+    AgentRegistrationCorrupt,
+    AgentRegistrationManager,
+    AgentRegistrationObservation,
+    AgentRegistrationReader,
+    agent_registration_key,
+)
+from lm_resiliency.integrations.torchrun._agent_registration_records import (
+    AgentRegistrationRecord,
+    HeldAgentRegistration,
+)
+from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
+from lm_resiliency.integrations.torchrun._protocol import AgentIdentity
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+    def set(self, now_unix_ms: int) -> None:
+        with self._lock:
+            self.now_unix_ms = now_unix_ms
+
+
+def _identity(node_id: str, agent_id: str | None = None) -> AgentIdentity:
+    return AgentIdentity(
+        run_id="training-run",
+        node_id=node_id,
+        agent_id=agent_id or f"agent-{node_id}",
+        hostname=f"host-{node_id}",
+        local_world_size=2,
+        resource_ids=(f"{node_id}-gpu-0", f"{node_id}-gpu-1"),
+        environment_digest="environment-v1",
+    )
+
+
+def _register(
+    store: InMemoryControlStore,
+    clock: ManualClock,
+    node_id: str,
+) -> HeldAgentRegistration:
+    return AgentRegistrationManager(
+        store,
+        agent_identity=_identity(node_id),
+        lease_duration_ms=100,
+        clock=clock,
+    ).register()
+
+
+def test_registration_reader_uses_same_hashed_key_as_manager():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    identity = _identity("node-a")
+    manager = AgentRegistrationManager(
+        store,
+        agent_identity=identity,
+        lease_duration_ms=100,
+        clock=clock,
+    )
+
+    assert manager.registration_key == agent_registration_key(
+        identity.run_id,
+        identity.node_id,
+    )
+    assert "training-run" not in manager.registration_key
+    assert "node-a" not in manager.registration_key
+
+
+def test_registration_reader_gets_only_requested_trusted_node():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    node_a = _register(store, clock, "node-a")
+    _register(store, clock, "node-b")
+    reader = AgentRegistrationReader(
+        store,
+        run_id="training-run",
+        clock=clock,
+    )
+
+    assert reader.get("node-a") == node_a
+    assert reader.get("node-c") is None
+
+
+def test_registration_reader_classifies_live_expired_and_missing_nodes():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    expired = _register(store, clock, "node-a")
+    clock.set(1_050)
+    live = _register(store, clock, "node-b")
+    clock.set(1_100)
+    reader = AgentRegistrationReader(
+        store,
+        run_id="training-run",
+        clock=clock,
+    )
+
+    observation = reader.observe(("node-a", "node-b", "node-c"))
+
+    assert observation.observed_at_unix_ms == 1_100
+    assert dict(observation.live) == {"node-b": live}
+    assert dict(observation.expired) == {"node-a": expired}
+    assert observation.missing_node_ids == ("node-c",)
+    with pytest.raises(TypeError):
+        observation.live["node-c"] = live
+
+
+def test_registration_reader_rejects_future_authoritative_grant():
+    clock = ManualClock(1_100)
+    store = InMemoryControlStore(clock=clock)
+    _register(store, clock, "node-a")
+    clock.set(1_000)
+    reader = AgentRegistrationReader(
+        store,
+        run_id="training-run",
+        clock=clock,
+    )
+
+    with pytest.raises(AgentRegistrationClockError, match="precedes"):
+        reader.observe(("node-a",))
+
+
+def test_registration_reader_clock_cannot_move_backward():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    reader = AgentRegistrationReader(
+        store,
+        run_id="training-run",
+        clock=clock,
+    )
+    reader.observe(("node-a",))
+    clock.set(999)
+
+    with pytest.raises(AgentRegistrationClockError, match="backward"):
+        reader.observe(("node-a",))
+
+
+def test_registration_reader_fails_closed_on_wrong_node_record():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    record = AgentRegistrationRecord(
+        agent_identity=_identity("node-b"),
+        registration_id="registration-b",
+        lease_duration_ms=100,
+    )
+    store.compare_set_in_window(
+        agent_registration_key("training-run", "node-a"),
+        expected_revision=None,
+        not_before_unix_ms=1_000,
+        deadline_unix_ms=None,
+        value=record.to_json(),
+    )
+    reader = AgentRegistrationReader(
+        store,
+        run_id="training-run",
+        clock=clock,
+    )
+
+    with pytest.raises(AgentRegistrationCorrupt, match="another run or node"):
+        reader.get("node-a")
+
+
+@pytest.mark.parametrize(
+    "node_ids",
+    [
+        (),
+        ("node-a", "node-a"),
+        "node-a",
+        ("",),
+    ],
+)
+def test_registration_reader_rejects_invalid_trusted_node_sets(node_ids):
+    reader = AgentRegistrationReader(
+        InMemoryControlStore(),
+        run_id="training-run",
+        clock=ManualClock(),
+    )
+
+    with pytest.raises((TypeError, ValueError)):
+        reader.observe(node_ids)
+
+
+def test_registration_observation_validates_disjoint_classification():
+    registration = HeldAgentRegistration(
+        record=AgentRegistrationRecord(
+            agent_identity=_identity("node-a"),
+            registration_id="registration-a",
+            lease_duration_ms=100,
+        ),
+        fencing_token=1,
+        granted_at_unix_ms=1_000,
+    )
+
+    with pytest.raises(ValueError, match="disjoint"):
+        AgentRegistrationObservation(
+            observed_at_unix_ms=1_050,
+            live={"node-a": registration},
+            expired={},
+            missing_node_ids=("node-a",),
+        )
+
+
+def test_registration_observation_requires_matching_node_key():
+    registration = HeldAgentRegistration(
+        record=AgentRegistrationRecord(
+            agent_identity=_identity("node-a"),
+            registration_id="registration-a",
+            lease_duration_ms=100,
+        ),
+        fencing_token=1,
+        granted_at_unix_ms=1_000,
+    )
+
+    with pytest.raises(ValueError, match="does not match key"):
+        AgentRegistrationObservation(
+            observed_at_unix_ms=1_050,
+            live={"node-b": registration},
+            expired={},
+            missing_node_ids=(),
+        )


### PR DESCRIPTION
## Summary

- add coordinator-side registration reads for an explicit trusted scheduler node set
- share hashed registration-key derivation and strict persisted-entry decoding with the agent manager
- classify trusted nodes as live, expired, or missing at one conservative observer timestamp
- reject duplicate/untrusted node sets, wrong-node persistence, future authoritative grants, and observer clock regression
- document that observations are conservative and require revalidation before admission or plan commit

## Compatibility

This is an internal torchrun read component. It adds no public import, store enumeration, standby selection, quarantine, admission policy, rendezvous registration, CLI flag, or runtime activation.

## Validation

- `57 passed` focused registration reader, lifecycle, and record tests
- `1387 passed` complete CPU suite with CUDA hidden
- Ruff check and format check
- mypy 1.17.1 on the reader, manager, and tests
- `git diff --check`