### PR TITLE
[Feature][Torchrun] Add strict node quarantine records

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -283,6 +283,14 @@ framework parallel coordinates stable.
 keys. A quarantine record uses `node_id` and may also contain GPU, NIC, HCA, or
 other resource IDs.
 
+Version 1 persists an immutable whole-node `NodeQuarantineRecord` for every
+excluded node. The record binds the stable run and node identities to the
+committed plan and intent, the failed and effective successor generations, the
+incident set, policy reason, and any affected resource IDs retained as evidence
+scope. The resource list may be empty when evidence supports only node-level
+exclusion; it does not narrow the effect of the record. A node quarantine is
+permanent for the run and must be create-only under the coordinator lease.
+
 `node_id` must come from a trusted scheduler, cloud instance identity, or
 deployment inventory. A worker-provided hostname is diagnostic metadata and
 must not be allowed to choose its own quarantine identity. If no stable node

--- a/lm_resiliency/integrations/torchrun/_quarantine_records.py
+++ b/lm_resiliency/integrations/torchrun/_quarantine_records.py
@@ -1,0 +1,244 @@
+"""Strict persisted quarantine records for torchrun replacement."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import ClassVar
+
+
+@dataclass(frozen=True, slots=True)
+class NodeQuarantineRecord:
+    """One permanent node exclusion authorized by a committed restart plan."""
+
+    SCHEMA_VERSION: ClassVar[int] = 1
+
+    run_id: str
+    node_id: str
+    plan_id: str
+    intent_id: str
+    from_generation: int
+    effective_generation: int
+    incident_ids: tuple[str, ...]
+    reason_code: str
+    resource_ids: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        _nonempty_string(self.run_id, "NodeQuarantineRecord.run_id")
+        _nonempty_string(self.node_id, "NodeQuarantineRecord.node_id")
+        _nonempty_string(self.plan_id, "NodeQuarantineRecord.plan_id")
+        _nonempty_string(self.intent_id, "NodeQuarantineRecord.intent_id")
+        _nonnegative_integer(
+            self.from_generation,
+            "NodeQuarantineRecord.from_generation",
+        )
+        _positive_integer(
+            self.effective_generation,
+            "NodeQuarantineRecord.effective_generation",
+        )
+        if self.effective_generation != self.from_generation + 1:
+            raise ValueError(
+                "NodeQuarantineRecord.effective_generation must be the successor generation"
+            )
+        incident_ids = _strings(
+            self.incident_ids,
+            "NodeQuarantineRecord.incident_ids",
+            require_nonempty=True,
+        )
+        resource_ids = _strings(
+            self.resource_ids,
+            "NodeQuarantineRecord.resource_ids",
+            require_nonempty=False,
+        )
+        object.__setattr__(self, "incident_ids", incident_ids)
+        object.__setattr__(self, "resource_ids", resource_ids)
+        _nonempty_string(
+            self.reason_code,
+            "NodeQuarantineRecord.reason_code",
+        )
+
+    @property
+    def digest(self) -> str:
+        return hashlib.sha256(self.to_json()).hexdigest()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "run_id": self.run_id,
+            "node_id": self.node_id,
+            "plan_id": self.plan_id,
+            "intent_id": self.intent_id,
+            "from_generation": self.from_generation,
+            "effective_generation": self.effective_generation,
+            "incident_ids": list(self.incident_ids),
+            "reason_code": self.reason_code,
+            "resource_ids": list(self.resource_ids),
+        }
+
+    def to_json(self) -> bytes:
+        return _canonical_json(self.to_dict())
+
+    @classmethod
+    def from_json(cls, encoded: bytes) -> NodeQuarantineRecord:
+        value = _json_object(encoded, cls.__name__)
+        _fields(
+            value,
+            path=cls.__name__,
+            required={
+                "schema_version",
+                "run_id",
+                "node_id",
+                "plan_id",
+                "intent_id",
+                "from_generation",
+                "effective_generation",
+                "incident_ids",
+                "reason_code",
+                "resource_ids",
+            },
+        )
+        _schema_version(
+            value["schema_version"],
+            cls.__name__,
+            expected=cls.SCHEMA_VERSION,
+        )
+        return cls(
+            run_id=_nonempty_string(
+                value["run_id"],
+                "NodeQuarantineRecord.run_id",
+            ),
+            node_id=_nonempty_string(
+                value["node_id"],
+                "NodeQuarantineRecord.node_id",
+            ),
+            plan_id=_nonempty_string(
+                value["plan_id"],
+                "NodeQuarantineRecord.plan_id",
+            ),
+            intent_id=_nonempty_string(
+                value["intent_id"],
+                "NodeQuarantineRecord.intent_id",
+            ),
+            from_generation=_nonnegative_integer(
+                value["from_generation"],
+                "NodeQuarantineRecord.from_generation",
+            ),
+            effective_generation=_positive_integer(
+                value["effective_generation"],
+                "NodeQuarantineRecord.effective_generation",
+            ),
+            incident_ids=_strings(
+                value["incident_ids"],
+                "NodeQuarantineRecord.incident_ids",
+                require_nonempty=True,
+            ),
+            reason_code=_nonempty_string(
+                value["reason_code"],
+                "NodeQuarantineRecord.reason_code",
+            ),
+            resource_ids=_strings(
+                value["resource_ids"],
+                "NodeQuarantineRecord.resource_ids",
+                require_nonempty=False,
+            ),
+        )
+
+
+def _canonical_json(value: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _json_object(encoded: bytes, path: str) -> Mapping[str, object]:
+    if not isinstance(encoded, bytes):
+        raise ValueError(f"{path}: expected encoded bytes")
+    try:
+        value = json.loads(
+            encoded,
+            object_pairs_hook=_reject_duplicate_object_fields,
+        )
+    except _DuplicateQuarantineField as error:
+        raise ValueError(f"{path}: {error}") from error
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{path}: invalid JSON") from error
+    if not isinstance(value, Mapping) or not all(isinstance(key, str) for key in value):
+        raise ValueError(f"{path}: expected a JSON object")
+    return value
+
+
+def _fields(
+    value: Mapping[str, object],
+    *,
+    path: str,
+    required: set[str],
+) -> None:
+    missing = required - set(value)
+    unknown = set(value) - required
+    if missing:
+        raise ValueError(f"{path}: missing fields {sorted(missing)!r}")
+    if unknown:
+        raise ValueError(f"{path}: unknown fields {sorted(unknown)!r}")
+
+
+def _schema_version(value: object, path: str, *, expected: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value != expected:
+        raise ValueError(f"{path}.schema_version: unsupported value {value!r}")
+    return value
+
+
+def _strings(
+    value: object,
+    path: str,
+    *,
+    require_nonempty: bool,
+) -> tuple[str, ...]:
+    if isinstance(value, (str, bytes, bytearray)) or not isinstance(value, Sequence):
+        raise ValueError(f"{path} must be an array")
+    result = tuple(_nonempty_string(item, f"{path}[{index}]") for index, item in enumerate(value))
+    if require_nonempty and not result:
+        raise ValueError(f"{path} must contain at least one value")
+    if len(result) != len(set(result)):
+        raise ValueError(f"{path} values must be unique")
+    return result
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+def _nonnegative_integer(value: object, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{path} must be a non-negative integer")
+    return value
+
+
+def _positive_integer(value: object, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{path} must be a positive integer")
+    return value
+
+
+class _DuplicateQuarantineField(ValueError):
+    pass
+
+
+def _reject_duplicate_object_fields(
+    pairs: list[tuple[str, object]],
+) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            raise _DuplicateQuarantineField(f"duplicate field {key!r}")
+        value[key] = item
+    return value
+
+
+__all__ = ["NodeQuarantineRecord"]

--- a/tests/unit/test_torchrun_quarantine_records.py
+++ b/tests/unit/test_torchrun_quarantine_records.py
@@ -1,0 +1,148 @@
+"""Contract tests for persisted torchrun node quarantine records."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import replace
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._quarantine_records import (
+    NodeQuarantineRecord,
+)
+
+
+def _record() -> NodeQuarantineRecord:
+    return NodeQuarantineRecord(
+        run_id="training-run",
+        node_id="node-b",
+        plan_id="plan-a",
+        intent_id="intent-a",
+        from_generation=0,
+        effective_generation=1,
+        incident_ids=("incident-a", "incident-b"),
+        reason_code="attributed_sdc",
+        resource_ids=("gpu-b0",),
+    )
+
+
+def test_node_quarantine_record_round_trips_canonical_json():
+    record = _record()
+
+    encoded = record.to_json()
+    decoded = NodeQuarantineRecord.from_json(encoded)
+
+    assert decoded == record
+    assert encoded == (
+        b'{"effective_generation":1,"from_generation":0,'
+        b'"incident_ids":["incident-a","incident-b"],"intent_id":"intent-a",'
+        b'"node_id":"node-b","plan_id":"plan-a","reason_code":"attributed_sdc",'
+        b'"resource_ids":["gpu-b0"],"run_id":"training-run","schema_version":1}'
+    )
+    assert record.digest == hashlib.sha256(encoded).hexdigest()
+
+
+def test_node_quarantine_record_is_immutable():
+    record = _record()
+
+    with pytest.raises(AttributeError):
+        record.node_id = "node-c"
+    with pytest.raises(AttributeError):
+        record.incident_ids = ()
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("run_id", "", "run_id"),
+        ("node_id", "", "node_id"),
+        ("plan_id", "", "plan_id"),
+        ("intent_id", "", "intent_id"),
+        ("from_generation", -1, "from_generation"),
+        ("from_generation", True, "from_generation"),
+        ("effective_generation", 0, "effective_generation"),
+        ("effective_generation", 2, "successor generation"),
+        ("incident_ids", (), "at least one"),
+        ("incident_ids", ("incident-a", "incident-a"), "unique"),
+        ("reason_code", "", "reason_code"),
+        ("resource_ids", ("gpu-b0", "gpu-b0"), "unique"),
+    ],
+)
+def test_node_quarantine_record_validates_constructor_fields(field, value, message):
+    with pytest.raises(ValueError, match=message):
+        replace(_record(), **{field: value})
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda value: value.pop("node_id"),
+            "missing fields",
+        ),
+        (
+            lambda value: value.update({"unknown": True}),
+            "unknown fields",
+        ),
+        (
+            lambda value: value.update({"schema_version": 2}),
+            "unsupported value",
+        ),
+        (
+            lambda value: value.update({"schema_version": True}),
+            "unsupported value",
+        ),
+        (
+            lambda value: value.update({"effective_generation": 4}),
+            "successor generation",
+        ),
+        (
+            lambda value: value.update({"incident_ids": []}),
+            "at least one",
+        ),
+        (
+            lambda value: value.update({"resource_ids": "gpu-b0"}),
+            "array",
+        ),
+    ],
+)
+def test_node_quarantine_record_rejects_invalid_wire_values(mutate, message):
+    value = json.loads(_record().to_json())
+    mutate(value)
+
+    with pytest.raises(ValueError, match=message):
+        NodeQuarantineRecord.from_json(
+            json.dumps(value, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        )
+
+
+@pytest.mark.parametrize(
+    "encoded",
+    [
+        b"not-json",
+        b"[]",
+        b'{"schema_version":1,"schema_version":1}',
+        (
+            b'{"effective_generation":1,"from_generation":0,'
+            b'"incident_ids":["incident-a"],"intent_id":"intent-a",'
+            b'"node_id":"node-b","node_id":"node-c","plan_id":"plan-a",'
+            b'"reason_code":"sdc","resource_ids":[],"run_id":"training-run",'
+            b'"schema_version":1}'
+        ),
+    ],
+)
+def test_node_quarantine_record_rejects_malformed_or_duplicate_json(encoded):
+    with pytest.raises(ValueError):
+        NodeQuarantineRecord.from_json(encoded)
+
+
+def test_node_quarantine_record_requires_encoded_bytes():
+    with pytest.raises(ValueError, match="encoded bytes"):
+        NodeQuarantineRecord.from_json(_record().to_json().decode("utf-8"))
+
+
+def test_node_quarantine_record_allows_empty_resource_evidence():
+    record = replace(_record(), resource_ids=())
+
+    assert NodeQuarantineRecord.from_json(record.to_json()) == record


### PR DESCRIPTION
## Problem

Torchrun replacement needs a durable, fail-closed record for every node excluded by a committed restart plan. The design currently names quarantine as authoritative coordinator state but does not define its persisted wire contract.

## Implementation

- add immutable, versioned `NodeQuarantineRecord`
- bind run/node identity, plan and intent IDs, generation transition, incidents, policy reason, and affected resource evidence
- require canonical JSON, strict field/schema validation, unique identifiers, and successor-generation semantics
- document whole-node, permanent, create-only quarantine behavior for version 1

This PR defines records only. It does not add control-store persistence, restart-plan cross-validation, standby eligibility, or rendezvous admission behavior.

## Compatibility

The new module is internal and is not exported from the package root. No existing public API or runtime path changes.

## Validation

- `113 passed` focused quarantine/protocol tests
- `1414 passed` complete CPU suite with CUDA hidden
- repository-wide Ruff check and format check
- targeted mypy check
- `git diff --check`
