### PR TITLE
[Feature][Torchrun] Add create-once guarded writes

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -902,6 +902,10 @@ none. The value sequence changes whenever the guarded bytes change or the key is
 recreated, but remains stable across same-value renewals. This is the primitive
 used to create an immutable generation snapshot and advance the generation head
 without allowing a stale or expired coordinator to commit either half alone.
+Create-once transaction targets may additionally require that the key has no
+prior committed history, not merely that it is currently absent. This prevents
+a deleted immutable quarantine or snapshot key from being recreated inside an
+otherwise valid atomic commit.
 
 Persisted generation state uses strict versioned records.
 `GenerationSnapshotRecord` schema version 2 contains the immutable

--- a/lm_resiliency/integrations/torchrun/_control_store.py
+++ b/lm_resiliency/integrations/torchrun/_control_store.py
@@ -33,6 +33,14 @@ class ControlStoreConflict(ControlStoreError):
         )
 
 
+class ControlStoreHistoryConflict(ControlStoreError):
+    """Raised when a create-once mutation targets a previously used key."""
+
+    def __init__(self, key: str) -> None:
+        self.key = key
+        super().__init__(f"control-store key {key!r} has prior committed history")
+
+
 class ControlStoreDeadlineExceeded(ControlStoreError):
     """Raised when a conditional mutation reaches its store-side deadline."""
 
@@ -176,6 +184,7 @@ class ControlStoreWrite:
 
     expected_revision: int | None
     value: bytes
+    require_never_created: bool = False
 
     def __post_init__(self) -> None:
         object.__setattr__(
@@ -184,6 +193,10 @@ class ControlStoreWrite:
             _expected_revision(self.expected_revision, allow_absent=True),
         )
         object.__setattr__(self, "value", _control_value(self.value))
+        if not isinstance(self.require_never_created, bool):
+            raise TypeError("require_never_created must be bool")
+        if self.require_never_created and self.expected_revision is not None:
+            raise ValueError("require_never_created is valid only for create-if-absent writes")
 
 
 class ControlStore(Protocol):
@@ -421,6 +434,8 @@ class InMemoryControlStore:
             guard_value_digest = hashlib.sha256(guard_entry.value).hexdigest()
             for key, write in normalized_writes.items():
                 self._require_revision(key, write.expected_revision)
+                if write.require_never_created and key in self._last_revisions:
+                    raise ControlStoreHistoryConflict(key)
             now_unix_ms = self._store_now_unix_ms()
             if now_unix_ms < normalized_not_before:
                 raise ControlStoreTooEarly(
@@ -573,6 +588,7 @@ __all__ = [
     "ControlStoreDeadlineExceeded",
     "ControlStoreEntry",
     "ControlStoreError",
+    "ControlStoreHistoryConflict",
     "ControlStoreTooEarly",
     "ControlStoreWrite",
     "InMemoryControlStore",

--- a/tests/unit/test_torchrun_guarded_control_store.py
+++ b/tests/unit/test_torchrun_guarded_control_store.py
@@ -12,6 +12,7 @@ import pytest
 from lm_resiliency.integrations.torchrun._control_store import (
     ControlStoreConflict,
     ControlStoreDeadlineExceeded,
+    ControlStoreHistoryConflict,
     ControlStoreTooEarly,
     ControlStoreWrite,
     InMemoryControlStore,
@@ -86,7 +87,7 @@ def test_guarded_transaction_commits_all_writes_at_one_store_time():
     assert store.get("run/generation-head") == committed["run/generation-head"]
     assert store.get("run/generations/0") == committed["run/generations/0"]
     with pytest.raises(TypeError):
-        committed["run/other"] = committed["run/generation-head"]  # type: ignore[index]
+        committed["run/other"] = committed["run/generation-head"]
 
 
 def test_guarded_transaction_atomically_updates_head_and_creates_successor():
@@ -219,6 +220,64 @@ def test_guarded_transaction_rejects_target_conflict_without_partial_writes():
     assert store.get("run/generations/0") is None
 
 
+def test_guarded_transaction_can_require_target_to_have_no_history():
+    store = InMemoryControlStore(clock=ManualClock())
+    guard = _guard(store)
+
+    committed = store.compare_set_many_guarded(
+        {
+            "run/quarantine/node-a": ControlStoreWrite(
+                expected_revision=None,
+                value=b"quarantined",
+                require_never_created=True,
+            ),
+        },
+        guard_key="run/coordinator-lease",
+        expected_guard_revision=guard.revision,
+        not_before_unix_ms=1_000,
+        deadline_unix_ms=1_100,
+    )
+
+    assert store.get("run/quarantine/node-a") == committed["run/quarantine/node-a"]
+
+
+def test_guarded_transaction_rejects_deleted_create_once_target_without_partial_writes():
+    store = InMemoryControlStore()
+    guard = _guard(store)
+    quarantine = store.compare_set(
+        "run/quarantine/node-a",
+        expected_revision=None,
+        value=b"old-quarantine",
+    )
+    store.compare_delete(
+        "run/quarantine/node-a",
+        expected_revision=quarantine.revision,
+    )
+
+    with pytest.raises(ControlStoreHistoryConflict) as error:
+        store.compare_set_many_guarded(
+            {
+                "run/generation-head": ControlStoreWrite(
+                    expected_revision=None,
+                    value=b"generation-1",
+                ),
+                "run/quarantine/node-a": ControlStoreWrite(
+                    expected_revision=None,
+                    value=b"new-quarantine",
+                    require_never_created=True,
+                ),
+            },
+            guard_key="run/coordinator-lease",
+            expected_guard_revision=guard.revision,
+            not_before_unix_ms=1,
+            deadline_unix_ms=2,
+        )
+
+    assert error.value.key == "run/quarantine/node-a"
+    assert store.get("run/generation-head") is None
+    assert store.get("run/quarantine/node-a") is None
+
+
 @pytest.mark.parametrize(
     ("now_unix_ms", "error"),
     [
@@ -315,4 +374,19 @@ def test_control_store_write_rejects_invalid_values(expected_revision, value, er
         ControlStoreWrite(
             expected_revision=expected_revision,
             value=value,
+        )
+
+
+def test_control_store_write_restricts_never_created_condition():
+    with pytest.raises(ValueError, match="create-if-absent"):
+        ControlStoreWrite(
+            expected_revision=1,
+            value=b"value",
+            require_never_created=True,
+        )
+    with pytest.raises(TypeError, match="bool"):
+        ControlStoreWrite(
+            expected_revision=None,
+            value=b"value",
+            require_never_created=1,
         )


### PR DESCRIPTION
## Problem

A guarded write with `expected_revision=None` proves that a target is currently absent, but not that it has never existed. Permanent immutable records such as node quarantines must not be recreated after deletion inside an otherwise valid plan transaction.

## Implementation

- add `ControlStoreWrite.require_never_created`
- reject that condition for update writes
- check durable per-key history under the same guarded transaction lock
- raise `ControlStoreHistoryConflict` before publishing any target
- document create-once transaction semantics

This PR changes only the internal control-store primitive. It does not add quarantine persistence or runtime admission behavior.

## Compatibility

The new field defaults to `False`, so existing guarded writes retain their behavior. The module remains internal.

## Validation

- `103 passed` focused store/generation tests
- `1417 passed` complete CPU suite with CUDA hidden
- repository-wide Ruff check and format check
- targeted mypy check
- `git diff --check`
