### PR TITLE
[Feature][Torchrun] Add authenticated quarantine transaction writes

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -290,6 +290,15 @@ incident set, policy reason, and any affected resource IDs retained as evidence
 scope. The resource list may be empty when evidence supports only node-level
 exclusion; it does not narrow the effect of the record. A node quarantine is
 permanent for the run and must be create-only under the coordinator lease.
+The quarantine repository does not expose a standalone commit operation. It
+validates plan/intent linkage and trusted resource ownership, then returns
+create-once writes that the coordinator must compose into the same guarded
+transaction as restart-plan publication and generation advancement. Readers
+accept only first-lifetime, first-value records with complete store-stamped
+coordinator-lease provenance; deletion, recreation, malformed identity, or
+unguarded persistence is corruption. Resource evidence passed to the repository
+must already be authorized from validated fault evidence; ownership validation
+prevents that evidence from naming another node's resource.
 
 `node_id` must come from a trusted scheduler, cloud instance identity, or
 deployment inventory. A worker-provided hostname is diagnostic metadata and

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -293,20 +293,16 @@ expanded layout. The resource list may be empty when evidence supports only
 node-level exclusion; it does not narrow the effect of the record. A node
 quarantine is permanent for the run and must be create-only under the
 coordinator lease.
-The quarantine repository does not expose a standalone commit operation. It
-validates plan/intent linkage and trusted resource ownership, then returns
-create-once writes that the coordinator must compose into the same guarded
-transaction as restart-plan publication and generation advancement. Readers
-accept only first-lifetime, first-value records with complete store-stamped
-coordinator-lease provenance; deletion, recreation, malformed identity, or
-unguarded persistence is corruption. Readers reconstruct the persisted lease
-record and require its digest, fencing token, authoritative grant time, and
-lease window to match the store-stamped guard provenance. Guard mutation, value,
-and key-lifetime sequences must also satisfy the same deletion-aware bounds as
-generation state; contradictory provenance is corruption. Resource evidence
-passed to the repository must already be authorized from validated fault
-evidence; ownership validation prevents that evidence from naming another
-node's resource.
+The quarantine write repository does not expose a standalone commit or read
+operation. It authenticates the held coordinator lease, validates plan/intent
+linkage and trusted resource ownership, then returns create-once writes that the
+coordinator must compose into the same guarded transaction as restart-plan
+publication and generation advancement. No quarantine is authoritative until a
+later combined reader verifies the matching persisted plan, successor
+generation, quarantine record, commit timestamp, and guard provenance from that
+transaction. Resource evidence passed to the repository must already be
+authorized from validated fault evidence; ownership validation prevents that
+evidence from naming another node's resource.
 
 `node_id` must come from a trusted scheduler, cloud instance identity, or
 deployment inventory. A worker-provided hostname is diagnostic metadata and

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -283,22 +283,28 @@ framework parallel coordinates stable.
 keys. A quarantine record uses `node_id` and may also contain GPU, NIC, HCA, or
 other resource IDs.
 
-Version 1 persists an immutable whole-node `NodeQuarantineRecord` for every
-excluded node. The record binds the stable run and node identities to the
-committed plan and intent, the failed and effective successor generations, the
-incident set, policy reason, and any affected resource IDs retained as evidence
-scope. The resource list may be empty when evidence supports only node-level
-exclusion; it does not narrow the effect of the record. A node quarantine is
-permanent for the run and must be create-only under the coordinator lease.
+Version 1 behavior persists an immutable whole-node `NodeQuarantineRecord` for
+every excluded node. Record schema version 2 binds the stable run and node
+identities to the committed plan and intent, the failed and effective successor
+generations, the incident set, policy reason, affected resource evidence, and
+the complete coordinator lease identity, duration, and fencing token that
+authorized it. Schema version 1 is rejected rather than interpreted as this
+expanded layout. The resource list may be empty when evidence supports only
+node-level exclusion; it does not narrow the effect of the record. A node
+quarantine is permanent for the run and must be create-only under the
+coordinator lease.
 The quarantine repository does not expose a standalone commit operation. It
 validates plan/intent linkage and trusted resource ownership, then returns
 create-once writes that the coordinator must compose into the same guarded
 transaction as restart-plan publication and generation advancement. Readers
 accept only first-lifetime, first-value records with complete store-stamped
 coordinator-lease provenance; deletion, recreation, malformed identity, or
-unguarded persistence is corruption. Resource evidence passed to the repository
-must already be authorized from validated fault evidence; ownership validation
-prevents that evidence from naming another node's resource.
+unguarded persistence is corruption. Readers reconstruct the persisted lease
+record and require its digest, fencing token, authoritative grant time, and
+lease window to match the store-stamped guard provenance. Resource evidence
+passed to the repository must already be authorized from validated fault
+evidence; ownership validation prevents that evidence from naming another
+node's resource.
 
 `node_id` must come from a trusted scheduler, cloud instance identity, or
 deployment inventory. A worker-provided hostname is diagnostic metadata and

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -301,7 +301,9 @@ accept only first-lifetime, first-value records with complete store-stamped
 coordinator-lease provenance; deletion, recreation, malformed identity, or
 unguarded persistence is corruption. Readers reconstruct the persisted lease
 record and require its digest, fencing token, authoritative grant time, and
-lease window to match the store-stamped guard provenance. Resource evidence
+lease window to match the store-stamped guard provenance. Guard mutation, value,
+and key-lifetime sequences must also satisfy the same deletion-aware bounds as
+generation state; contradictory provenance is corruption. Resource evidence
 passed to the repository must already be authorized from validated fault
 evidence; ownership validation prevents that evidence from naming another
 node's resource.

--- a/lm_resiliency/integrations/torchrun/_quarantine_records.py
+++ b/lm_resiliency/integrations/torchrun/_quarantine_records.py
@@ -13,7 +13,7 @@ from typing import ClassVar
 class NodeQuarantineRecord:
     """One permanent node exclusion authorized by a committed restart plan."""
 
-    SCHEMA_VERSION: ClassVar[int] = 1
+    SCHEMA_VERSION: ClassVar[int] = 2
 
     run_id: str
     node_id: str
@@ -24,6 +24,10 @@ class NodeQuarantineRecord:
     incident_ids: tuple[str, ...]
     reason_code: str
     resource_ids: tuple[str, ...]
+    coordinator_id: str
+    lease_id: str
+    coordinator_lease_duration_ms: int
+    coordinator_fencing_token: int
 
     def __post_init__(self) -> None:
         _nonempty_string(self.run_id, "NodeQuarantineRecord.run_id")
@@ -58,6 +62,22 @@ class NodeQuarantineRecord:
             self.reason_code,
             "NodeQuarantineRecord.reason_code",
         )
+        _nonempty_string(
+            self.coordinator_id,
+            "NodeQuarantineRecord.coordinator_id",
+        )
+        _nonempty_string(
+            self.lease_id,
+            "NodeQuarantineRecord.lease_id",
+        )
+        _positive_integer(
+            self.coordinator_lease_duration_ms,
+            "NodeQuarantineRecord.coordinator_lease_duration_ms",
+        )
+        _positive_integer(
+            self.coordinator_fencing_token,
+            "NodeQuarantineRecord.coordinator_fencing_token",
+        )
 
     @property
     def digest(self) -> str:
@@ -75,6 +95,10 @@ class NodeQuarantineRecord:
             "incident_ids": list(self.incident_ids),
             "reason_code": self.reason_code,
             "resource_ids": list(self.resource_ids),
+            "coordinator_id": self.coordinator_id,
+            "lease_id": self.lease_id,
+            "coordinator_lease_duration_ms": self.coordinator_lease_duration_ms,
+            "coordinator_fencing_token": self.coordinator_fencing_token,
         }
 
     def to_json(self) -> bytes:
@@ -97,6 +121,10 @@ class NodeQuarantineRecord:
                 "incident_ids",
                 "reason_code",
                 "resource_ids",
+                "coordinator_id",
+                "lease_id",
+                "coordinator_lease_duration_ms",
+                "coordinator_fencing_token",
             },
         )
         _schema_version(
@@ -142,6 +170,22 @@ class NodeQuarantineRecord:
                 value["resource_ids"],
                 "NodeQuarantineRecord.resource_ids",
                 require_nonempty=False,
+            ),
+            coordinator_id=_nonempty_string(
+                value["coordinator_id"],
+                "NodeQuarantineRecord.coordinator_id",
+            ),
+            lease_id=_nonempty_string(
+                value["lease_id"],
+                "NodeQuarantineRecord.lease_id",
+            ),
+            coordinator_lease_duration_ms=_positive_integer(
+                value["coordinator_lease_duration_ms"],
+                "NodeQuarantineRecord.coordinator_lease_duration_ms",
+            ),
+            coordinator_fencing_token=_positive_integer(
+                value["coordinator_fencing_token"],
+                "NodeQuarantineRecord.coordinator_fencing_token",
             ),
         )
 

--- a/lm_resiliency/integrations/torchrun/_quarantine_store.py
+++ b/lm_resiliency/integrations/torchrun/_quarantine_store.py
@@ -220,16 +220,43 @@ class NodeQuarantineRepository:
             raise QuarantineStateCorrupt(
                 "persisted node quarantine was not guarded by the run coordinator lease"
             )
-        if (
-            entry.guard_revision is None
-            or entry.guard_value_digest is None
-            or entry.guard_mutation_sequence is None
-            or entry.guard_value_sequence is None
-            or entry.guard_lifetime_sequence is None
-            or entry.guard_committed_at_unix_ms is None
+        guard_revision = entry.guard_revision
+        guard_value_digest = entry.guard_value_digest
+        guard_mutation_sequence = entry.guard_mutation_sequence
+        guard_value_sequence = entry.guard_value_sequence
+        guard_lifetime_sequence = entry.guard_lifetime_sequence
+        guard_committed_at_unix_ms = entry.guard_committed_at_unix_ms
+        if any(
+            value is None
+            for value in (
+                guard_revision,
+                guard_value_digest,
+                guard_mutation_sequence,
+                guard_value_sequence,
+                guard_lifetime_sequence,
+                guard_committed_at_unix_ms,
+            )
         ):
             raise QuarantineStateCorrupt(
                 "persisted node quarantine has incomplete guard provenance"
+            )
+        assert guard_mutation_sequence is not None
+        assert guard_value_sequence is not None
+        assert guard_lifetime_sequence is not None
+        assert guard_revision is not None
+        assert guard_value_digest is not None
+        assert guard_committed_at_unix_ms is not None
+        if guard_mutation_sequence < 2 * guard_lifetime_sequence - 1:
+            raise QuarantineStateCorrupt(
+                "node quarantine guard mutation sequence cannot support its lifetime"
+            )
+        if guard_value_sequence < guard_lifetime_sequence:
+            raise QuarantineStateCorrupt(
+                "node quarantine guard value sequence cannot support its lifetime"
+            )
+        if guard_value_sequence > guard_mutation_sequence - guard_lifetime_sequence + 1:
+            raise QuarantineStateCorrupt(
+                "node quarantine guard value sequence includes deletion mutations"
             )
         expected_lease = CoordinatorLeaseRecord(
             run_id=record.run_id,
@@ -237,18 +264,18 @@ class NodeQuarantineRepository:
             lease_id=record.lease_id,
             lease_duration_ms=record.coordinator_lease_duration_ms,
         )
-        if entry.guard_revision != record.coordinator_fencing_token:
+        if guard_revision != record.coordinator_fencing_token:
             raise QuarantineStateCorrupt(
                 "node quarantine fencing token does not match guard provenance"
             )
-        if entry.guard_value_digest != hashlib.sha256(expected_lease.to_json()).hexdigest():
+        if guard_value_digest != hashlib.sha256(expected_lease.to_json()).hexdigest():
             raise QuarantineStateCorrupt(
                 "node quarantine lease identity does not match guard provenance"
             )
         if (
-            entry.committed_at_unix_ms < entry.guard_committed_at_unix_ms
+            entry.committed_at_unix_ms < guard_committed_at_unix_ms
             or entry.committed_at_unix_ms
-            >= entry.guard_committed_at_unix_ms + record.coordinator_lease_duration_ms
+            >= guard_committed_at_unix_ms + record.coordinator_lease_duration_ms
         ):
             raise QuarantineStateCorrupt(
                 "node quarantine committed outside its coordinator lease window"

--- a/lm_resiliency/integrations/torchrun/_quarantine_store.py
+++ b/lm_resiliency/integrations/torchrun/_quarantine_store.py
@@ -1,0 +1,266 @@
+"""Fail-closed quarantine reads and transaction writes for torchrun replacement."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStore,
+    ControlStoreEntry,
+    ControlStoreWrite,
+)
+from lm_resiliency.integrations.torchrun._protocol import RestartIntent, RestartPlan
+from lm_resiliency.integrations.torchrun._quarantine_records import (
+    NodeQuarantineRecord,
+)
+
+_CONTROL_PREFIX = "lm_resiliency/torchrun/v1"
+_MAX_READ_ATTEMPTS = 8
+
+
+class QuarantineStateError(RuntimeError):
+    """Base error for persisted node-quarantine state."""
+
+
+class QuarantineStateCorrupt(QuarantineStateError):
+    """Raised when persisted quarantine state is malformed or contradictory."""
+
+
+@dataclass(frozen=True, slots=True)
+class StoredNodeQuarantine:
+    """One verified permanent node quarantine and its store provenance."""
+
+    record: NodeQuarantineRecord
+    entry: ControlStoreEntry
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.record, NodeQuarantineRecord):
+            raise TypeError("StoredNodeQuarantine.record must be NodeQuarantineRecord")
+        if not isinstance(self.entry, ControlStoreEntry):
+            raise TypeError("StoredNodeQuarantine.entry must be ControlStoreEntry")
+
+
+class NodeQuarantineRepository:
+    """Prepare plan-authorized writes and read permanent node exclusions."""
+
+    def __init__(self, store: ControlStore, *, run_id: str) -> None:
+        self._store = store
+        self._run_id = _nonempty_string(run_id, "run_id")
+        run_digest = hashlib.sha256(self._run_id.encode("utf-8")).hexdigest()
+        self._run_prefix = f"{_CONTROL_PREFIX}/runs/{run_digest}"
+        self._coordinator_lease_key = f"{self._run_prefix}/coordinator-lease"
+
+    @property
+    def coordinator_lease_key(self) -> str:
+        return self._coordinator_lease_key
+
+    def quarantine_key(self, node_id: str) -> str:
+        return node_quarantine_key(self._run_id, node_id)
+
+    def get(self, node_id: str) -> StoredNodeQuarantine | None:
+        normalized_node_id = _nonempty_string(node_id, "node_id")
+        key = self.quarantine_key(normalized_node_id)
+        for _ in range(_MAX_READ_ATTEMPTS):
+            entry = self._store.get(key)
+            if entry is None:
+                if not self._store.has_history(key):
+                    return None
+                if self._store.get(key) is not None:
+                    continue
+                raise QuarantineStateCorrupt(
+                    f"node quarantine for {normalized_node_id!r} was deleted"
+                )
+            stored = self._decode_entry(entry, node_id=normalized_node_id)
+            if self._store.get(key) == entry:
+                return stored
+        raise QuarantineStateError(
+            f"node quarantine for {normalized_node_id!r} changed repeatedly during read"
+        )
+
+    def prepare_plan_writes(
+        self,
+        plan: RestartPlan,
+        intent: RestartIntent,
+        *,
+        authorized_resource_ids_by_node: Mapping[str, Sequence[str]],
+        resource_to_node_id: Mapping[str, str],
+    ) -> Mapping[str, ControlStoreWrite]:
+        """Build create-once writes from coordinator-authorized fault evidence."""
+        self._validate_plan_intent(plan, intent)
+        quarantined_nodes = set(plan.quarantined_node_ids)
+        resources_by_node = _resources_by_node(authorized_resource_ids_by_node)
+        if set(resources_by_node) != quarantined_nodes:
+            raise ValueError(
+                "authorized_resource_ids_by_node keys must exactly match quarantined nodes"
+            )
+        resource_owners = _resource_owners(resource_to_node_id)
+        records: dict[str, NodeQuarantineRecord] = {}
+        for node_id in sorted(quarantined_nodes):
+            resource_ids = resources_by_node[node_id]
+            wrong_owner = sorted(
+                resource_id
+                for resource_id in resource_ids
+                if resource_owners.get(resource_id) != node_id
+            )
+            if wrong_owner:
+                raise ValueError(
+                    f"quarantine resources are not trusted as owned by {node_id!r}: {wrong_owner!r}"
+                )
+            records[node_id] = NodeQuarantineRecord(
+                run_id=plan.run_id,
+                node_id=node_id,
+                plan_id=plan.plan_id,
+                intent_id=plan.intent_id,
+                from_generation=plan.from_generation,
+                effective_generation=plan.to_generation,
+                incident_ids=plan.incident_ids,
+                reason_code=plan.reason_code,
+                resource_ids=resource_ids,
+            )
+        return MappingProxyType(
+            {
+                self.quarantine_key(node_id): ControlStoreWrite(
+                    expected_revision=None,
+                    value=record.to_json(),
+                    require_never_created=True,
+                )
+                for node_id, record in records.items()
+            }
+        )
+
+    def _validate_plan_intent(
+        self,
+        plan: RestartPlan,
+        intent: RestartIntent,
+    ) -> None:
+        if not isinstance(plan, RestartPlan):
+            raise TypeError("plan must be RestartPlan")
+        if not isinstance(intent, RestartIntent):
+            raise TypeError("intent must be RestartIntent")
+        if plan.run_id != self._run_id or intent.run_id != self._run_id:
+            raise ValueError("restart plan and intent must belong to the repository run")
+        if plan.intent_id != intent.intent_id:
+            raise ValueError("restart plan does not reference the supplied intent")
+        if plan.from_generation != intent.generation:
+            raise ValueError("restart plan generation does not match the supplied intent")
+        if plan.incident_ids != intent.incident_ids:
+            raise ValueError("restart plan incidents do not match the supplied intent")
+        if plan.reason_code != intent.reason_code:
+            raise ValueError("restart plan reason does not match the supplied intent")
+        unsupported = sorted(set(plan.quarantined_node_ids) - set(intent.suspected_node_ids))
+        if unsupported:
+            raise ValueError(
+                f"restart plan quarantines nodes outside the intent scope: {unsupported!r}"
+            )
+
+    def _decode_entry(
+        self,
+        entry: ControlStoreEntry,
+        *,
+        node_id: str,
+    ) -> StoredNodeQuarantine:
+        try:
+            record = NodeQuarantineRecord.from_json(entry.value)
+        except (TypeError, ValueError) as error:
+            raise QuarantineStateCorrupt("persisted node quarantine is malformed") from error
+        if record.run_id != self._run_id or record.node_id != node_id:
+            raise QuarantineStateCorrupt("persisted node quarantine belongs to another run or node")
+        if (
+            entry.mutation_sequence != 1
+            or entry.value_sequence != 1
+            or entry.lifetime_sequence != 1
+        ):
+            raise QuarantineStateCorrupt("immutable node quarantine has noninitial store sequences")
+        if entry.committed_at_unix_ms is None:
+            raise QuarantineStateCorrupt(
+                "persisted node quarantine has no authoritative commit time"
+            )
+        if entry.guard_key != self._coordinator_lease_key:
+            raise QuarantineStateCorrupt(
+                "persisted node quarantine was not guarded by the run coordinator lease"
+            )
+        if (
+            entry.guard_revision is None
+            or entry.guard_value_digest is None
+            or entry.guard_mutation_sequence is None
+            or entry.guard_value_sequence is None
+            or entry.guard_lifetime_sequence is None
+            or entry.guard_committed_at_unix_ms is None
+        ):
+            raise QuarantineStateCorrupt(
+                "persisted node quarantine has incomplete guard provenance"
+            )
+        return StoredNodeQuarantine(record=record, entry=entry)
+
+
+def node_quarantine_key(run_id: str, node_id: str) -> str:
+    """Derive one run/node-scoped quarantine key without exposing identities."""
+    normalized_run_id = _nonempty_string(run_id, "run_id")
+    normalized_node_id = _nonempty_string(node_id, "node_id")
+    run_digest = hashlib.sha256(normalized_run_id.encode("utf-8")).hexdigest()
+    node_digest = hashlib.sha256(normalized_node_id.encode("utf-8")).hexdigest()
+    return f"{_CONTROL_PREFIX}/runs/{run_digest}/node-quarantines/{node_digest}"
+
+
+def _resources_by_node(value: object) -> dict[str, tuple[str, ...]]:
+    if not isinstance(value, Mapping):
+        raise TypeError("authorized_resource_ids_by_node must be a mapping")
+    result: dict[str, tuple[str, ...]] = {}
+    for node_id, resource_ids in value.items():
+        normalized_node_id = _nonempty_string(
+            node_id,
+            "authorized_resource_ids_by_node key",
+        )
+        normalized_resource_ids = _strings(
+            resource_ids,
+            f"authorized_resource_ids_by_node[{normalized_node_id!r}]",
+        )
+        result[normalized_node_id] = normalized_resource_ids
+    if len(result) != len(value):
+        raise ValueError("authorized_resource_ids_by_node keys must be unique")
+    return result
+
+
+def _resource_owners(value: object) -> dict[str, str]:
+    if not isinstance(value, Mapping):
+        raise TypeError("resource_to_node_id must be a mapping")
+    result: dict[str, str] = {}
+    for resource_id, node_id in value.items():
+        normalized_resource_id = _nonempty_string(
+            resource_id,
+            "resource_to_node_id key",
+        )
+        result[normalized_resource_id] = _nonempty_string(
+            node_id,
+            f"resource_to_node_id[{normalized_resource_id!r}]",
+        )
+    if len(result) != len(value):
+        raise ValueError("resource_to_node_id keys must be unique")
+    return result
+
+
+def _strings(value: object, path: str) -> tuple[str, ...]:
+    if isinstance(value, (str, bytes, bytearray)) or not isinstance(value, Sequence):
+        raise ValueError(f"{path} must be an array")
+    result = tuple(_nonempty_string(item, f"{path}[{index}]") for index, item in enumerate(value))
+    if len(result) != len(set(result)):
+        raise ValueError(f"{path} values must be unique")
+    return result
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+__all__ = [
+    "NodeQuarantineRepository",
+    "QuarantineStateCorrupt",
+    "QuarantineStateError",
+    "StoredNodeQuarantine",
+    "node_quarantine_key",
+]

--- a/lm_resiliency/integrations/torchrun/_quarantine_store.py
+++ b/lm_resiliency/integrations/torchrun/_quarantine_store.py
@@ -1,15 +1,13 @@
-"""Fail-closed quarantine reads and transaction writes for torchrun replacement."""
+"""Authenticated quarantine writes for torchrun replacement transactions."""
 
 from __future__ import annotations
 
 import hashlib
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
 from types import MappingProxyType
 
 from lm_resiliency.integrations.torchrun._control_store import (
     ControlStore,
-    ControlStoreEntry,
     ControlStoreWrite,
 )
 from lm_resiliency.integrations.torchrun._coordinator_lease import (
@@ -22,37 +20,22 @@ from lm_resiliency.integrations.torchrun._quarantine_records import (
 )
 
 _CONTROL_PREFIX = "lm_resiliency/torchrun/v1"
-_MAX_READ_ATTEMPTS = 8
 
 
-class QuarantineStateError(RuntimeError):
-    """Base error for persisted node-quarantine state."""
+class QuarantineWriteError(RuntimeError):
+    """Base error for preparing node-quarantine transaction writes."""
 
 
-class QuarantineStateCorrupt(QuarantineStateError):
-    """Raised when persisted quarantine state is malformed or contradictory."""
+class QuarantineWriteCorrupt(QuarantineWriteError):
+    """Raised when persisted ownership state is malformed."""
 
 
-class QuarantineLeaseLost(QuarantineStateError):
+class QuarantineLeaseLost(QuarantineWriteError):
     """Raised when quarantine writes use a stale or foreign coordinator lease."""
 
 
-@dataclass(frozen=True, slots=True)
-class StoredNodeQuarantine:
-    """One verified permanent node quarantine and its store provenance."""
-
-    record: NodeQuarantineRecord
-    entry: ControlStoreEntry
-
-    def __post_init__(self) -> None:
-        if not isinstance(self.record, NodeQuarantineRecord):
-            raise TypeError("StoredNodeQuarantine.record must be NodeQuarantineRecord")
-        if not isinstance(self.entry, ControlStoreEntry):
-            raise TypeError("StoredNodeQuarantine.entry must be ControlStoreEntry")
-
-
-class NodeQuarantineRepository:
-    """Prepare plan-authorized writes and read permanent node exclusions."""
+class NodeQuarantineWriteRepository:
+    """Build authenticated create-once writes for a larger plan transaction."""
 
     def __init__(self, store: ControlStore, *, run_id: str) -> None:
         self._store = store
@@ -68,26 +51,6 @@ class NodeQuarantineRepository:
     def quarantine_key(self, node_id: str) -> str:
         return node_quarantine_key(self._run_id, node_id)
 
-    def get(self, node_id: str) -> StoredNodeQuarantine | None:
-        normalized_node_id = _nonempty_string(node_id, "node_id")
-        key = self.quarantine_key(normalized_node_id)
-        for _ in range(_MAX_READ_ATTEMPTS):
-            entry = self._store.get(key)
-            if entry is None:
-                if not self._store.has_history(key):
-                    return None
-                if self._store.get(key) is not None:
-                    continue
-                raise QuarantineStateCorrupt(
-                    f"node quarantine for {normalized_node_id!r} was deleted"
-                )
-            stored = self._decode_entry(entry, node_id=normalized_node_id)
-            if self._store.get(key) == entry:
-                return stored
-        raise QuarantineStateError(
-            f"node quarantine for {normalized_node_id!r} changed repeatedly during read"
-        )
-
     def prepare_plan_writes(
         self,
         plan: RestartPlan,
@@ -97,7 +60,7 @@ class NodeQuarantineRepository:
         authorized_resource_ids_by_node: Mapping[str, Sequence[str]],
         resource_to_node_id: Mapping[str, str],
     ) -> Mapping[str, ControlStoreWrite]:
-        """Build create-once writes from coordinator-authorized fault evidence."""
+        """Build writes for composition with plan and generation publication."""
         self._validate_lease(lease)
         self._validate_plan_intent(plan, intent)
         quarantined_nodes = set(plan.quarantined_node_ids)
@@ -188,99 +151,11 @@ class NodeQuarantineRepository:
         try:
             record = CoordinatorLeaseRecord.from_json(entry.value)
         except (TypeError, ValueError) as error:
-            raise QuarantineStateCorrupt("coordinator lease is malformed") from error
+            raise QuarantineWriteCorrupt("coordinator lease is malformed") from error
         if entry.committed_at_unix_ms is None:
-            raise QuarantineStateCorrupt("coordinator lease has no authoritative grant time")
+            raise QuarantineWriteCorrupt("coordinator lease has no authoritative grant time")
         if record != lease.record or entry.committed_at_unix_ms != lease.granted_at_unix_ms:
             raise QuarantineLeaseLost("coordinator lease handle does not match persisted ownership")
-
-    def _decode_entry(
-        self,
-        entry: ControlStoreEntry,
-        *,
-        node_id: str,
-    ) -> StoredNodeQuarantine:
-        try:
-            record = NodeQuarantineRecord.from_json(entry.value)
-        except (TypeError, ValueError) as error:
-            raise QuarantineStateCorrupt("persisted node quarantine is malformed") from error
-        if record.run_id != self._run_id or record.node_id != node_id:
-            raise QuarantineStateCorrupt("persisted node quarantine belongs to another run or node")
-        if (
-            entry.mutation_sequence != 1
-            or entry.value_sequence != 1
-            or entry.lifetime_sequence != 1
-        ):
-            raise QuarantineStateCorrupt("immutable node quarantine has noninitial store sequences")
-        if entry.committed_at_unix_ms is None:
-            raise QuarantineStateCorrupt(
-                "persisted node quarantine has no authoritative commit time"
-            )
-        if entry.guard_key != self._coordinator_lease_key:
-            raise QuarantineStateCorrupt(
-                "persisted node quarantine was not guarded by the run coordinator lease"
-            )
-        guard_revision = entry.guard_revision
-        guard_value_digest = entry.guard_value_digest
-        guard_mutation_sequence = entry.guard_mutation_sequence
-        guard_value_sequence = entry.guard_value_sequence
-        guard_lifetime_sequence = entry.guard_lifetime_sequence
-        guard_committed_at_unix_ms = entry.guard_committed_at_unix_ms
-        if any(
-            value is None
-            for value in (
-                guard_revision,
-                guard_value_digest,
-                guard_mutation_sequence,
-                guard_value_sequence,
-                guard_lifetime_sequence,
-                guard_committed_at_unix_ms,
-            )
-        ):
-            raise QuarantineStateCorrupt(
-                "persisted node quarantine has incomplete guard provenance"
-            )
-        assert guard_mutation_sequence is not None
-        assert guard_value_sequence is not None
-        assert guard_lifetime_sequence is not None
-        assert guard_revision is not None
-        assert guard_value_digest is not None
-        assert guard_committed_at_unix_ms is not None
-        if guard_mutation_sequence < 2 * guard_lifetime_sequence - 1:
-            raise QuarantineStateCorrupt(
-                "node quarantine guard mutation sequence cannot support its lifetime"
-            )
-        if guard_value_sequence < guard_lifetime_sequence:
-            raise QuarantineStateCorrupt(
-                "node quarantine guard value sequence cannot support its lifetime"
-            )
-        if guard_value_sequence > guard_mutation_sequence - guard_lifetime_sequence + 1:
-            raise QuarantineStateCorrupt(
-                "node quarantine guard value sequence includes deletion mutations"
-            )
-        expected_lease = CoordinatorLeaseRecord(
-            run_id=record.run_id,
-            coordinator_id=record.coordinator_id,
-            lease_id=record.lease_id,
-            lease_duration_ms=record.coordinator_lease_duration_ms,
-        )
-        if guard_revision != record.coordinator_fencing_token:
-            raise QuarantineStateCorrupt(
-                "node quarantine fencing token does not match guard provenance"
-            )
-        if guard_value_digest != hashlib.sha256(expected_lease.to_json()).hexdigest():
-            raise QuarantineStateCorrupt(
-                "node quarantine lease identity does not match guard provenance"
-            )
-        if (
-            entry.committed_at_unix_ms < guard_committed_at_unix_ms
-            or entry.committed_at_unix_ms
-            >= guard_committed_at_unix_ms + record.coordinator_lease_duration_ms
-        ):
-            raise QuarantineStateCorrupt(
-                "node quarantine committed outside its coordinator lease window"
-            )
-        return StoredNodeQuarantine(record=record, entry=entry)
 
 
 def node_quarantine_key(run_id: str, node_id: str) -> str:
@@ -345,10 +220,9 @@ def _nonempty_string(value: object, path: str) -> str:
 
 
 __all__ = [
-    "NodeQuarantineRepository",
+    "NodeQuarantineWriteRepository",
     "QuarantineLeaseLost",
-    "QuarantineStateCorrupt",
-    "QuarantineStateError",
-    "StoredNodeQuarantine",
+    "QuarantineWriteCorrupt",
+    "QuarantineWriteError",
     "node_quarantine_key",
 ]

--- a/lm_resiliency/integrations/torchrun/_quarantine_store.py
+++ b/lm_resiliency/integrations/torchrun/_quarantine_store.py
@@ -12,6 +12,10 @@ from lm_resiliency.integrations.torchrun._control_store import (
     ControlStoreEntry,
     ControlStoreWrite,
 )
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseRecord,
+    HeldCoordinatorLease,
+)
 from lm_resiliency.integrations.torchrun._protocol import RestartIntent, RestartPlan
 from lm_resiliency.integrations.torchrun._quarantine_records import (
     NodeQuarantineRecord,
@@ -27,6 +31,10 @@ class QuarantineStateError(RuntimeError):
 
 class QuarantineStateCorrupt(QuarantineStateError):
     """Raised when persisted quarantine state is malformed or contradictory."""
+
+
+class QuarantineLeaseLost(QuarantineStateError):
+    """Raised when quarantine writes use a stale or foreign coordinator lease."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -84,11 +92,13 @@ class NodeQuarantineRepository:
         self,
         plan: RestartPlan,
         intent: RestartIntent,
+        lease: HeldCoordinatorLease,
         *,
         authorized_resource_ids_by_node: Mapping[str, Sequence[str]],
         resource_to_node_id: Mapping[str, str],
     ) -> Mapping[str, ControlStoreWrite]:
         """Build create-once writes from coordinator-authorized fault evidence."""
+        self._validate_lease(lease)
         self._validate_plan_intent(plan, intent)
         quarantined_nodes = set(plan.quarantined_node_ids)
         resources_by_node = _resources_by_node(authorized_resource_ids_by_node)
@@ -119,6 +129,10 @@ class NodeQuarantineRepository:
                 incident_ids=plan.incident_ids,
                 reason_code=plan.reason_code,
                 resource_ids=resource_ids,
+                coordinator_id=lease.record.coordinator_id,
+                lease_id=lease.record.lease_id,
+                coordinator_lease_duration_ms=lease.record.lease_duration_ms,
+                coordinator_fencing_token=lease.fencing_token,
             )
         return MappingProxyType(
             {
@@ -150,11 +164,35 @@ class NodeQuarantineRepository:
             raise ValueError("restart plan incidents do not match the supplied intent")
         if plan.reason_code != intent.reason_code:
             raise ValueError("restart plan reason does not match the supplied intent")
+        if (
+            intent.minimum_recovery_mode == "recovery_verified"
+            and plan.recovery_mode != "recovery_verified"
+        ):
+            raise ValueError("restart plan recovery mode is weaker than the supplied intent")
         unsupported = sorted(set(plan.quarantined_node_ids) - set(intent.suspected_node_ids))
         if unsupported:
             raise ValueError(
                 f"restart plan quarantines nodes outside the intent scope: {unsupported!r}"
             )
+
+    def _validate_lease(self, lease: HeldCoordinatorLease) -> None:
+        if not isinstance(lease, HeldCoordinatorLease):
+            raise TypeError("lease must be HeldCoordinatorLease")
+        if lease.record.run_id != self._run_id:
+            raise QuarantineLeaseLost("coordinator lease belongs to another run")
+        entry = self._store.get(self._coordinator_lease_key)
+        if entry is None or entry.revision != lease.fencing_token:
+            raise QuarantineLeaseLost(
+                "coordinator lease changed before quarantine write preparation"
+            )
+        try:
+            record = CoordinatorLeaseRecord.from_json(entry.value)
+        except (TypeError, ValueError) as error:
+            raise QuarantineStateCorrupt("coordinator lease is malformed") from error
+        if entry.committed_at_unix_ms is None:
+            raise QuarantineStateCorrupt("coordinator lease has no authoritative grant time")
+        if record != lease.record or entry.committed_at_unix_ms != lease.granted_at_unix_ms:
+            raise QuarantineLeaseLost("coordinator lease handle does not match persisted ownership")
 
     def _decode_entry(
         self,
@@ -192,6 +230,28 @@ class NodeQuarantineRepository:
         ):
             raise QuarantineStateCorrupt(
                 "persisted node quarantine has incomplete guard provenance"
+            )
+        expected_lease = CoordinatorLeaseRecord(
+            run_id=record.run_id,
+            coordinator_id=record.coordinator_id,
+            lease_id=record.lease_id,
+            lease_duration_ms=record.coordinator_lease_duration_ms,
+        )
+        if entry.guard_revision != record.coordinator_fencing_token:
+            raise QuarantineStateCorrupt(
+                "node quarantine fencing token does not match guard provenance"
+            )
+        if entry.guard_value_digest != hashlib.sha256(expected_lease.to_json()).hexdigest():
+            raise QuarantineStateCorrupt(
+                "node quarantine lease identity does not match guard provenance"
+            )
+        if (
+            entry.committed_at_unix_ms < entry.guard_committed_at_unix_ms
+            or entry.committed_at_unix_ms
+            >= entry.guard_committed_at_unix_ms + record.coordinator_lease_duration_ms
+        ):
+            raise QuarantineStateCorrupt(
+                "node quarantine committed outside its coordinator lease window"
             )
         return StoredNodeQuarantine(record=record, entry=entry)
 
@@ -259,6 +319,7 @@ def _nonempty_string(value: object, path: str) -> str:
 
 __all__ = [
     "NodeQuarantineRepository",
+    "QuarantineLeaseLost",
     "QuarantineStateCorrupt",
     "QuarantineStateError",
     "StoredNodeQuarantine",

--- a/tests/unit/test_torchrun_quarantine_records.py
+++ b/tests/unit/test_torchrun_quarantine_records.py
@@ -24,6 +24,10 @@ def _record() -> NodeQuarantineRecord:
         incident_ids=("incident-a", "incident-b"),
         reason_code="attributed_sdc",
         resource_ids=("gpu-b0",),
+        coordinator_id="coordinator-a",
+        lease_id="lease-a",
+        coordinator_lease_duration_ms=30_000,
+        coordinator_fencing_token=7,
     )
 
 
@@ -35,10 +39,13 @@ def test_node_quarantine_record_round_trips_canonical_json():
 
     assert decoded == record
     assert encoded == (
-        b'{"effective_generation":1,"from_generation":0,'
+        b'{"coordinator_fencing_token":7,"coordinator_id":"coordinator-a",'
+        b'"coordinator_lease_duration_ms":30000,"effective_generation":1,'
+        b'"from_generation":0,'
         b'"incident_ids":["incident-a","incident-b"],"intent_id":"intent-a",'
-        b'"node_id":"node-b","plan_id":"plan-a","reason_code":"attributed_sdc",'
-        b'"resource_ids":["gpu-b0"],"run_id":"training-run","schema_version":1}'
+        b'"lease_id":"lease-a","node_id":"node-b","plan_id":"plan-a",'
+        b'"reason_code":"attributed_sdc","resource_ids":["gpu-b0"],'
+        b'"run_id":"training-run","schema_version":2}'
     )
     assert record.digest == hashlib.sha256(encoded).hexdigest()
 
@@ -67,6 +74,10 @@ def test_node_quarantine_record_is_immutable():
         ("incident_ids", ("incident-a", "incident-a"), "unique"),
         ("reason_code", "", "reason_code"),
         ("resource_ids", ("gpu-b0", "gpu-b0"), "unique"),
+        ("coordinator_id", "", "coordinator_id"),
+        ("lease_id", "", "lease_id"),
+        ("coordinator_lease_duration_ms", 0, "coordinator_lease_duration_ms"),
+        ("coordinator_fencing_token", 0, "coordinator_fencing_token"),
     ],
 )
 def test_node_quarantine_record_validates_constructor_fields(field, value, message):
@@ -86,7 +97,7 @@ def test_node_quarantine_record_validates_constructor_fields(field, value, messa
             "unknown fields",
         ),
         (
-            lambda value: value.update({"schema_version": 2}),
+            lambda value: value.update({"schema_version": 1}),
             "unsupported value",
         ),
         (
@@ -122,13 +133,15 @@ def test_node_quarantine_record_rejects_invalid_wire_values(mutate, message):
     [
         b"not-json",
         b"[]",
-        b'{"schema_version":1,"schema_version":1}',
+        b'{"schema_version":2,"schema_version":2}',
         (
-            b'{"effective_generation":1,"from_generation":0,'
+            b'{"coordinator_fencing_token":7,"coordinator_id":"coordinator-a",'
+            b'"coordinator_lease_duration_ms":30000,"effective_generation":1,'
+            b'"from_generation":0,'
             b'"incident_ids":["incident-a"],"intent_id":"intent-a",'
-            b'"node_id":"node-b","node_id":"node-c","plan_id":"plan-a",'
-            b'"reason_code":"sdc","resource_ids":[],"run_id":"training-run",'
-            b'"schema_version":1}'
+            b'"lease_id":"lease-a","node_id":"node-b","node_id":"node-c",'
+            b'"plan_id":"plan-a","reason_code":"sdc","resource_ids":[],'
+            b'"run_id":"training-run","schema_version":2}'
         ),
     ],
 )

--- a/tests/unit/test_torchrun_quarantine_store.py
+++ b/tests/unit/test_torchrun_quarantine_store.py
@@ -1,4 +1,4 @@
-"""Contract tests for fail-closed torchrun node-quarantine storage."""
+"""Contract tests for authenticated torchrun node-quarantine writes."""
 
 from __future__ import annotations
 
@@ -7,10 +7,7 @@ from dataclasses import replace
 
 import pytest
 
-from lm_resiliency.integrations.torchrun._control_store import (
-    ControlStoreWrite,
-    InMemoryControlStore,
-)
+from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
 from lm_resiliency.integrations.torchrun._coordinator_lease import (
     CoordinatorLeaseManager,
     HeldCoordinatorLease,
@@ -24,9 +21,9 @@ from lm_resiliency.integrations.torchrun._quarantine_records import (
     NodeQuarantineRecord,
 )
 from lm_resiliency.integrations.torchrun._quarantine_store import (
-    NodeQuarantineRepository,
+    NodeQuarantineWriteRepository,
     QuarantineLeaseLost,
-    QuarantineStateCorrupt,
+    QuarantineWriteCorrupt,
     node_quarantine_key,
 )
 
@@ -41,24 +38,6 @@ class ManualClock:
     def __call__(self) -> int:
         with self._lock:
             return self.now_unix_ms
-
-
-class TamperedQuarantineReadStore(InMemoryControlStore):
-    def __init__(self, clock: ManualClock) -> None:
-        super().__init__(clock=clock)
-        self.guard_override: tuple[int, int, int] | None = None
-
-    def get(self, key: str):
-        entry = super().get(key)
-        if entry is None or "/node-quarantines/" not in key or self.guard_override is None:
-            return entry
-        mutation_sequence, value_sequence, lifetime_sequence = self.guard_override
-        return replace(
-            entry,
-            guard_mutation_sequence=mutation_sequence,
-            guard_value_sequence=value_sequence,
-            guard_lifetime_sequence=lifetime_sequence,
-        )
 
 
 def _intent(
@@ -117,26 +96,18 @@ def _plan(
     )
 
 
-def _repository(
-    store: InMemoryControlStore,
-    *,
-    run_id: str = RUN_ID,
-) -> NodeQuarantineRepository:
-    return NodeQuarantineRepository(store, run_id=run_id)
-
-
 def _state(
     *,
     run_id: str = RUN_ID,
 ) -> tuple[
     ManualClock,
     InMemoryControlStore,
-    NodeQuarantineRepository,
+    NodeQuarantineWriteRepository,
     HeldCoordinatorLease,
 ]:
     clock = ManualClock()
     store = InMemoryControlStore(clock=clock)
-    repository = _repository(store, run_id=run_id)
+    repository = NodeQuarantineWriteRepository(store, run_id=run_id)
     lease = CoordinatorLeaseManager(
         store,
         run_id=run_id,
@@ -148,7 +119,7 @@ def _state(
 
 
 def _writes(
-    repository: NodeQuarantineRepository,
+    repository: NodeQuarantineWriteRepository,
     lease: HeldCoordinatorLease,
     *,
     plan: RestartPlan | None = None,
@@ -163,7 +134,7 @@ def _writes(
     )
 
 
-def test_plan_writes_are_create_once_and_bind_plan_fields():
+def test_plan_writes_are_create_once_and_bind_authority():
     _, _, repository, lease = _state()
 
     writes = _writes(repository, lease)
@@ -215,11 +186,7 @@ def test_plan_writes_allow_no_quarantine():
         (replace(_plan(), incident_ids=("other-incident",)), _intent(), "incidents"),
         (replace(_plan(), reason_code="other-reason"), _intent(), "reason"),
         (_plan(), _intent(suspected_node_ids=("node-a",)), "outside the intent"),
-        (
-            replace(_plan(), recovery_mode="latest"),
-            _intent(),
-            "weaker",
-        ),
+        (replace(_plan(), recovery_mode="latest"), _intent(), "weaker"),
     ],
 )
 def test_plan_writes_reject_mismatched_plan_and_intent(plan, intent, message):
@@ -291,215 +258,23 @@ def test_plan_writes_reject_stale_coordinator_lease():
         _writes(repository, lease)
 
 
-def test_repository_reads_guarded_quarantine():
-    _, store, repository, lease = _state()
-
-    committed = store.compare_set_many_guarded(
-        _writes(repository, lease),
-        guard_key=repository.coordinator_lease_key,
-        expected_guard_revision=lease.fencing_token,
-        not_before_unix_ms=lease.granted_at_unix_ms,
-        deadline_unix_ms=lease.expires_at_unix_ms,
-    )
-    stored = repository.get("node-b")
-
-    assert stored is not None
-    assert stored.record.node_id == "node-b"
-    assert stored.entry == committed[repository.quarantine_key("node-b")]
-
-
-def test_repository_returns_none_only_for_never_created_quarantine():
-    repository = _repository(InMemoryControlStore())
-
-    assert repository.get("node-b") is None
-
-
-def test_repository_rejects_deleted_quarantine():
-    _, store, repository, lease = _state()
-    committed = store.compare_set_many_guarded(
-        _writes(repository, lease),
-        guard_key=repository.coordinator_lease_key,
-        expected_guard_revision=lease.fencing_token,
-        not_before_unix_ms=lease.granted_at_unix_ms,
-        deadline_unix_ms=lease.expires_at_unix_ms,
-    )
-    entry = committed[repository.quarantine_key("node-b")]
-    store.compare_delete(
-        repository.quarantine_key("node-b"),
-        expected_revision=entry.revision,
-    )
-
-    with pytest.raises(QuarantineStateCorrupt, match="deleted"):
-        repository.get("node-b")
-
-
-@pytest.mark.parametrize(
-    ("value", "message"),
-    [
-        (b"{}", "malformed"),
-        (
-            NodeQuarantineRecord(
-                run_id="other-run",
-                node_id="node-b",
-                plan_id="plan-1",
-                intent_id="intent-0",
-                from_generation=0,
-                effective_generation=1,
-                incident_ids=("incident-a",),
-                reason_code="attributed_sdc",
-                resource_ids=(),
-                coordinator_id="coordinator-a",
-                lease_id="lease-a",
-                coordinator_lease_duration_ms=100,
-                coordinator_fencing_token=1,
-            ).to_json(),
-            "another run or node",
-        ),
-    ],
-)
-def test_repository_rejects_malformed_or_foreign_records(value, message):
-    store = InMemoryControlStore()
-    repository = _repository(store)
-    store.compare_set(
-        repository.quarantine_key("node-b"),
-        expected_revision=None,
-        value=value,
-    )
-
-    with pytest.raises(QuarantineStateCorrupt, match=message):
-        repository.get("node-b")
-
-
-def test_repository_requires_guarded_create_provenance():
-    _, store, repository, lease = _state()
-    write = _writes(repository, lease)[repository.quarantine_key("node-b")]
-    store.compare_set(
-        repository.quarantine_key("node-b"),
-        expected_revision=None,
-        value=write.value,
-    )
-
-    with pytest.raises(QuarantineStateCorrupt, match="commit time"):
-        repository.get("node-b")
-
-
-def test_repository_rejects_quarantine_guarded_by_another_key():
+def test_plan_writes_reject_malformed_persisted_lease():
     clock, store, repository, lease = _state()
-    wrong_guard = store.compare_set_in_window(
-        "other/lease",
-        expected_revision=None,
-        not_before_unix_ms=1_000,
-        deadline_unix_ms=None,
-        value=b"lease",
-    )
-    store.compare_set_many_guarded(
-        _writes(repository, lease),
-        guard_key="other/lease",
-        expected_guard_revision=wrong_guard.revision,
-        not_before_unix_ms=1_000,
-        deadline_unix_ms=1_100,
-    )
-
-    with pytest.raises(QuarantineStateCorrupt, match="run coordinator lease"):
-        repository.get("node-b")
-
-
-def test_repository_authenticates_opaque_coordinator_lease_bytes():
-    clock, store, repository, lease = _state()
-    malformed_guard = store.compare_set_in_window(
+    malformed = store.compare_set_in_window(
         repository.coordinator_lease_key,
         expected_revision=lease.fencing_token,
         not_before_unix_ms=clock.now_unix_ms,
         deadline_unix_ms=lease.expires_at_unix_ms,
-        value=b"malformed-lease",
+        value=b"malformed",
     )
-    record = NodeQuarantineRecord(
-        run_id=RUN_ID,
-        node_id="node-b",
-        plan_id="plan-1",
-        intent_id="intent-0",
-        from_generation=0,
-        effective_generation=1,
-        incident_ids=("incident-a",),
-        reason_code="attributed_sdc",
-        resource_ids=("gpu-b0",),
-        coordinator_id=lease.record.coordinator_id,
-        lease_id=lease.record.lease_id,
-        coordinator_lease_duration_ms=lease.record.lease_duration_ms,
-        coordinator_fencing_token=malformed_guard.revision,
-    )
-    store.compare_set_many_guarded(
-        {
-            repository.quarantine_key("node-b"): ControlStoreWrite(
-                expected_revision=None,
-                value=record.to_json(),
-                require_never_created=True,
-            ),
-        },
-        guard_key=repository.coordinator_lease_key,
-        expected_guard_revision=malformed_guard.revision,
-        not_before_unix_ms=clock.now_unix_ms,
-        deadline_unix_ms=lease.expires_at_unix_ms,
+    fabricated = HeldCoordinatorLease(
+        record=lease.record,
+        fencing_token=malformed.revision,
+        granted_at_unix_ms=malformed.committed_at_unix_ms,
     )
 
-    with pytest.raises(QuarantineStateCorrupt, match="lease identity"):
-        repository.get("node-b")
-
-
-@pytest.mark.parametrize(
-    ("guard_override", "message"),
-    [
-        (
-            (1, 1, 2),
-            "mutation sequence cannot support",
-        ),
-        (
-            (3, 1, 2),
-            "value sequence cannot support",
-        ),
-        (
-            (2, 3, 1),
-            "includes deletion",
-        ),
-    ],
-)
-def test_repository_rejects_contradictory_guard_sequences(
-    guard_override,
-    message,
-):
-    clock = ManualClock()
-    store = TamperedQuarantineReadStore(clock)
-    repository = _repository(store)
-    lease = CoordinatorLeaseManager(
-        store,
-        run_id=RUN_ID,
-        coordinator_id="coordinator-a",
-        lease_duration_ms=100,
-        clock=clock,
-    ).acquire()
-    store.compare_set_many_guarded(
-        _writes(repository, lease),
-        guard_key=repository.coordinator_lease_key,
-        expected_guard_revision=lease.fencing_token,
-        not_before_unix_ms=lease.granted_at_unix_ms,
-        deadline_unix_ms=lease.expires_at_unix_ms,
-    )
-    store.guard_override = guard_override
-
-    with pytest.raises(QuarantineStateCorrupt, match=message):
-        repository.get("node-b")
-
-
-def test_repository_rejects_recreated_quarantine():
-    _, store, repository, lease = _state()
-    key = repository.quarantine_key("node-b")
-    write = _writes(repository, lease)[key]
-    original = store.compare_set(key, expected_revision=None, value=write.value)
-    store.compare_delete(key, expected_revision=original.revision)
-    store.compare_set(key, expected_revision=None, value=write.value)
-
-    with pytest.raises(QuarantineStateCorrupt, match="noninitial"):
-        repository.get("node-b")
+    with pytest.raises(QuarantineWriteCorrupt, match="malformed"):
+        _writes(repository, fabricated)
 
 
 def test_quarantine_keys_are_run_and_node_scoped_without_plaintext_identity():

--- a/tests/unit/test_torchrun_quarantine_store.py
+++ b/tests/unit/test_torchrun_quarantine_store.py
@@ -1,0 +1,371 @@
+"""Contract tests for fail-closed torchrun node-quarantine storage."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import replace
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseManager,
+)
+from lm_resiliency.integrations.torchrun._protocol import (
+    RestartIntent,
+    RestartPlan,
+    SlotAssignment,
+)
+from lm_resiliency.integrations.torchrun._quarantine_records import (
+    NodeQuarantineRecord,
+)
+from lm_resiliency.integrations.torchrun._quarantine_store import (
+    NodeQuarantineRepository,
+    QuarantineStateCorrupt,
+    node_quarantine_key,
+)
+
+RUN_ID = "training-run"
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+
+def _intent(
+    *,
+    run_id: str = RUN_ID,
+    suspected_node_ids: tuple[str, ...] = ("node-b",),
+) -> RestartIntent:
+    return RestartIntent(
+        intent_id="intent-0",
+        run_id=run_id,
+        generation=0,
+        incident_ids=("incident-a",),
+        reason_code="attributed_sdc",
+        minimum_recovery_mode="recovery_verified",
+        suspected_node_ids=suspected_node_ids,
+        prepare_deadline_unix_ms=2_000,
+    )
+
+
+def _plan(
+    *,
+    run_id: str = RUN_ID,
+    quarantined_node_ids: tuple[str, ...] = ("node-b",),
+) -> RestartPlan:
+    return RestartPlan(
+        plan_id="plan-1",
+        intent_id="intent-0",
+        run_id=run_id,
+        from_generation=0,
+        to_generation=1,
+        incident_ids=("incident-a",),
+        reason_code="attributed_sdc",
+        recovery_mode="recovery_verified",
+        checkpoint_source="durable",
+        checkpoint_step=10,
+        checkpoint_id="checkpoint-10",
+        checkpoint_manifest_id="manifest-10",
+        slot_assignments=(
+            SlotAssignment(
+                logical_node_slot=0,
+                node_id="node-a",
+                first_global_rank=0,
+                local_world_size=2,
+            ),
+            SlotAssignment(
+                logical_node_slot=1,
+                node_id="node-c",
+                first_global_rank=2,
+                local_world_size=2,
+            ),
+        ),
+        quarantined_node_ids=quarantined_node_ids,
+        expected_world_size=4,
+        topology_digest="topology-v1",
+        restart_deadline_unix_ms=3_000,
+    )
+
+
+def _repository(
+    store: InMemoryControlStore,
+    *,
+    run_id: str = RUN_ID,
+) -> NodeQuarantineRepository:
+    return NodeQuarantineRepository(store, run_id=run_id)
+
+
+def _writes(
+    repository: NodeQuarantineRepository,
+    *,
+    plan: RestartPlan | None = None,
+    intent: RestartIntent | None = None,
+):
+    return repository.prepare_plan_writes(
+        plan or _plan(),
+        intent or _intent(),
+        authorized_resource_ids_by_node={"node-b": ("gpu-b0",)},
+        resource_to_node_id={"gpu-b0": "node-b"},
+    )
+
+
+def test_plan_writes_are_create_once_and_bind_plan_fields():
+    store = InMemoryControlStore()
+    repository = _repository(store)
+
+    writes = _writes(repository)
+
+    assert list(writes) == [repository.quarantine_key("node-b")]
+    write = writes[repository.quarantine_key("node-b")]
+    assert write.expected_revision is None
+    assert write.require_never_created
+    assert NodeQuarantineRecord.from_json(write.value) == NodeQuarantineRecord(
+        run_id=RUN_ID,
+        node_id="node-b",
+        plan_id="plan-1",
+        intent_id="intent-0",
+        from_generation=0,
+        effective_generation=1,
+        incident_ids=("incident-a",),
+        reason_code="attributed_sdc",
+        resource_ids=("gpu-b0",),
+    )
+    with pytest.raises(TypeError):
+        writes["other"] = write
+
+
+def test_plan_writes_allow_no_quarantine():
+    repository = _repository(InMemoryControlStore())
+
+    writes = repository.prepare_plan_writes(
+        _plan(quarantined_node_ids=()),
+        _intent(suspected_node_ids=()),
+        authorized_resource_ids_by_node={},
+        resource_to_node_id={},
+    )
+
+    assert not writes
+
+
+@pytest.mark.parametrize(
+    ("plan", "intent", "message"),
+    [
+        (_plan(run_id="other-run"), _intent(), "repository run"),
+        (_plan(), _intent(run_id="other-run"), "repository run"),
+        (replace(_plan(), intent_id="other-intent"), _intent(), "supplied intent"),
+        (replace(_plan(), from_generation=1, to_generation=2), _intent(), "generation"),
+        (replace(_plan(), incident_ids=("other-incident",)), _intent(), "incidents"),
+        (replace(_plan(), reason_code="other-reason"), _intent(), "reason"),
+        (_plan(), _intent(suspected_node_ids=("node-a",)), "outside the intent"),
+    ],
+)
+def test_plan_writes_reject_mismatched_plan_and_intent(plan, intent, message):
+    repository = _repository(InMemoryControlStore())
+
+    with pytest.raises(ValueError, match=message):
+        _writes(repository, plan=plan, intent=intent)
+
+
+def test_plan_writes_require_exact_quarantined_node_resource_keys():
+    repository = _repository(InMemoryControlStore())
+
+    with pytest.raises(ValueError, match="exactly match"):
+        repository.prepare_plan_writes(
+            _plan(),
+            _intent(),
+            authorized_resource_ids_by_node={},
+            resource_to_node_id={"gpu-b0": "node-b"},
+        )
+
+
+@pytest.mark.parametrize(
+    "resource_to_node_id",
+    [
+        {},
+        {"gpu-b0": "node-a"},
+    ],
+)
+def test_plan_writes_require_trusted_resource_ownership(resource_to_node_id):
+    repository = _repository(InMemoryControlStore())
+
+    with pytest.raises(ValueError, match="trusted as owned"):
+        repository.prepare_plan_writes(
+            _plan(),
+            _intent(),
+            authorized_resource_ids_by_node={"node-b": ("gpu-b0",)},
+            resource_to_node_id=resource_to_node_id,
+        )
+
+
+def test_plan_writes_allow_node_level_evidence_without_resource_ids():
+    repository = _repository(InMemoryControlStore())
+
+    writes = repository.prepare_plan_writes(
+        _plan(),
+        _intent(),
+        authorized_resource_ids_by_node={"node-b": ()},
+        resource_to_node_id={},
+    )
+
+    record = NodeQuarantineRecord.from_json(writes[repository.quarantine_key("node-b")].value)
+    assert record.resource_ids == ()
+
+
+def test_repository_reads_guarded_quarantine():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    repository = _repository(store)
+    lease = CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id="coordinator-a",
+        lease_duration_ms=100,
+        clock=clock,
+    ).acquire()
+
+    committed = store.compare_set_many_guarded(
+        _writes(repository),
+        guard_key=repository.coordinator_lease_key,
+        expected_guard_revision=lease.fencing_token,
+        not_before_unix_ms=lease.granted_at_unix_ms,
+        deadline_unix_ms=lease.expires_at_unix_ms,
+    )
+    stored = repository.get("node-b")
+
+    assert stored is not None
+    assert stored.record.node_id == "node-b"
+    assert stored.entry == committed[repository.quarantine_key("node-b")]
+
+
+def test_repository_returns_none_only_for_never_created_quarantine():
+    repository = _repository(InMemoryControlStore())
+
+    assert repository.get("node-b") is None
+
+
+def test_repository_rejects_deleted_quarantine():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    repository = _repository(store)
+    lease = CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id="coordinator-a",
+        lease_duration_ms=100,
+        clock=clock,
+    ).acquire()
+    committed = store.compare_set_many_guarded(
+        _writes(repository),
+        guard_key=repository.coordinator_lease_key,
+        expected_guard_revision=lease.fencing_token,
+        not_before_unix_ms=lease.granted_at_unix_ms,
+        deadline_unix_ms=lease.expires_at_unix_ms,
+    )
+    entry = committed[repository.quarantine_key("node-b")]
+    store.compare_delete(
+        repository.quarantine_key("node-b"),
+        expected_revision=entry.revision,
+    )
+
+    with pytest.raises(QuarantineStateCorrupt, match="deleted"):
+        repository.get("node-b")
+
+
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        (b"{}", "malformed"),
+        (
+            NodeQuarantineRecord(
+                run_id="other-run",
+                node_id="node-b",
+                plan_id="plan-1",
+                intent_id="intent-0",
+                from_generation=0,
+                effective_generation=1,
+                incident_ids=("incident-a",),
+                reason_code="attributed_sdc",
+                resource_ids=(),
+            ).to_json(),
+            "another run or node",
+        ),
+    ],
+)
+def test_repository_rejects_malformed_or_foreign_records(value, message):
+    store = InMemoryControlStore()
+    repository = _repository(store)
+    store.compare_set(
+        repository.quarantine_key("node-b"),
+        expected_revision=None,
+        value=value,
+    )
+
+    with pytest.raises(QuarantineStateCorrupt, match=message):
+        repository.get("node-b")
+
+
+def test_repository_requires_guarded_create_provenance():
+    store = InMemoryControlStore()
+    repository = _repository(store)
+    write = _writes(repository)[repository.quarantine_key("node-b")]
+    store.compare_set(
+        repository.quarantine_key("node-b"),
+        expected_revision=None,
+        value=write.value,
+    )
+
+    with pytest.raises(QuarantineStateCorrupt, match="commit time"):
+        repository.get("node-b")
+
+
+def test_repository_rejects_quarantine_guarded_by_another_key():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    repository = _repository(store)
+    wrong_guard = store.compare_set_in_window(
+        "other/lease",
+        expected_revision=None,
+        not_before_unix_ms=1_000,
+        deadline_unix_ms=None,
+        value=b"lease",
+    )
+    store.compare_set_many_guarded(
+        _writes(repository),
+        guard_key="other/lease",
+        expected_guard_revision=wrong_guard.revision,
+        not_before_unix_ms=1_000,
+        deadline_unix_ms=1_100,
+    )
+
+    with pytest.raises(QuarantineStateCorrupt, match="run coordinator lease"):
+        repository.get("node-b")
+
+
+def test_repository_rejects_recreated_quarantine():
+    store = InMemoryControlStore()
+    repository = _repository(store)
+    key = repository.quarantine_key("node-b")
+    write = _writes(repository)[key]
+    original = store.compare_set(key, expected_revision=None, value=write.value)
+    store.compare_delete(key, expected_revision=original.revision)
+    store.compare_set(key, expected_revision=None, value=write.value)
+
+    with pytest.raises(QuarantineStateCorrupt, match="noninitial"):
+        repository.get("node-b")
+
+
+def test_quarantine_keys_are_run_and_node_scoped_without_plaintext_identity():
+    first = node_quarantine_key("run-a", "node-a")
+    second = node_quarantine_key("run-a", "node-b")
+    third = node_quarantine_key("run-b", "node-a")
+
+    assert len({first, second, third}) == 3
+    assert "run-a" not in first
+    assert "node-a" not in first

--- a/tests/unit/test_torchrun_quarantine_store.py
+++ b/tests/unit/test_torchrun_quarantine_store.py
@@ -7,9 +7,13 @@ from dataclasses import replace
 
 import pytest
 
-from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStoreWrite,
+    InMemoryControlStore,
+)
 from lm_resiliency.integrations.torchrun._coordinator_lease import (
     CoordinatorLeaseManager,
+    HeldCoordinatorLease,
 )
 from lm_resiliency.integrations.torchrun._protocol import (
     RestartIntent,
@@ -21,6 +25,7 @@ from lm_resiliency.integrations.torchrun._quarantine_records import (
 )
 from lm_resiliency.integrations.torchrun._quarantine_store import (
     NodeQuarantineRepository,
+    QuarantineLeaseLost,
     QuarantineStateCorrupt,
     node_quarantine_key,
 )
@@ -102,8 +107,31 @@ def _repository(
     return NodeQuarantineRepository(store, run_id=run_id)
 
 
+def _state(
+    *,
+    run_id: str = RUN_ID,
+) -> tuple[
+    ManualClock,
+    InMemoryControlStore,
+    NodeQuarantineRepository,
+    HeldCoordinatorLease,
+]:
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    repository = _repository(store, run_id=run_id)
+    lease = CoordinatorLeaseManager(
+        store,
+        run_id=run_id,
+        coordinator_id="coordinator-a",
+        lease_duration_ms=100,
+        clock=clock,
+    ).acquire()
+    return clock, store, repository, lease
+
+
 def _writes(
     repository: NodeQuarantineRepository,
+    lease: HeldCoordinatorLease,
     *,
     plan: RestartPlan | None = None,
     intent: RestartIntent | None = None,
@@ -111,16 +139,16 @@ def _writes(
     return repository.prepare_plan_writes(
         plan or _plan(),
         intent or _intent(),
+        lease,
         authorized_resource_ids_by_node={"node-b": ("gpu-b0",)},
         resource_to_node_id={"gpu-b0": "node-b"},
     )
 
 
 def test_plan_writes_are_create_once_and_bind_plan_fields():
-    store = InMemoryControlStore()
-    repository = _repository(store)
+    _, _, repository, lease = _state()
 
-    writes = _writes(repository)
+    writes = _writes(repository, lease)
 
     assert list(writes) == [repository.quarantine_key("node-b")]
     write = writes[repository.quarantine_key("node-b")]
@@ -136,17 +164,22 @@ def test_plan_writes_are_create_once_and_bind_plan_fields():
         incident_ids=("incident-a",),
         reason_code="attributed_sdc",
         resource_ids=("gpu-b0",),
+        coordinator_id="coordinator-a",
+        lease_id=lease.record.lease_id,
+        coordinator_lease_duration_ms=100,
+        coordinator_fencing_token=lease.fencing_token,
     )
     with pytest.raises(TypeError):
         writes["other"] = write
 
 
 def test_plan_writes_allow_no_quarantine():
-    repository = _repository(InMemoryControlStore())
+    _, _, repository, lease = _state()
 
     writes = repository.prepare_plan_writes(
         _plan(quarantined_node_ids=()),
         _intent(suspected_node_ids=()),
+        lease,
         authorized_resource_ids_by_node={},
         resource_to_node_id={},
     )
@@ -164,22 +197,28 @@ def test_plan_writes_allow_no_quarantine():
         (replace(_plan(), incident_ids=("other-incident",)), _intent(), "incidents"),
         (replace(_plan(), reason_code="other-reason"), _intent(), "reason"),
         (_plan(), _intent(suspected_node_ids=("node-a",)), "outside the intent"),
+        (
+            replace(_plan(), recovery_mode="latest"),
+            _intent(),
+            "weaker",
+        ),
     ],
 )
 def test_plan_writes_reject_mismatched_plan_and_intent(plan, intent, message):
-    repository = _repository(InMemoryControlStore())
+    _, _, repository, lease = _state()
 
     with pytest.raises(ValueError, match=message):
-        _writes(repository, plan=plan, intent=intent)
+        _writes(repository, lease, plan=plan, intent=intent)
 
 
 def test_plan_writes_require_exact_quarantined_node_resource_keys():
-    repository = _repository(InMemoryControlStore())
+    _, _, repository, lease = _state()
 
     with pytest.raises(ValueError, match="exactly match"):
         repository.prepare_plan_writes(
             _plan(),
             _intent(),
+            lease,
             authorized_resource_ids_by_node={},
             resource_to_node_id={"gpu-b0": "node-b"},
         )
@@ -193,23 +232,25 @@ def test_plan_writes_require_exact_quarantined_node_resource_keys():
     ],
 )
 def test_plan_writes_require_trusted_resource_ownership(resource_to_node_id):
-    repository = _repository(InMemoryControlStore())
+    _, _, repository, lease = _state()
 
     with pytest.raises(ValueError, match="trusted as owned"):
         repository.prepare_plan_writes(
             _plan(),
             _intent(),
+            lease,
             authorized_resource_ids_by_node={"node-b": ("gpu-b0",)},
             resource_to_node_id=resource_to_node_id,
         )
 
 
 def test_plan_writes_allow_node_level_evidence_without_resource_ids():
-    repository = _repository(InMemoryControlStore())
+    _, _, repository, lease = _state()
 
     writes = repository.prepare_plan_writes(
         _plan(),
         _intent(),
+        lease,
         authorized_resource_ids_by_node={"node-b": ()},
         resource_to_node_id={},
     )
@@ -218,20 +259,25 @@ def test_plan_writes_allow_node_level_evidence_without_resource_ids():
     assert record.resource_ids == ()
 
 
+def test_plan_writes_reject_stale_coordinator_lease():
+    clock, store, repository, lease = _state()
+    store.compare_set_in_window(
+        repository.coordinator_lease_key,
+        expected_revision=lease.fencing_token,
+        not_before_unix_ms=clock.now_unix_ms,
+        deadline_unix_ms=lease.expires_at_unix_ms,
+        value=lease.record.to_json(),
+    )
+
+    with pytest.raises(QuarantineLeaseLost, match="changed"):
+        _writes(repository, lease)
+
+
 def test_repository_reads_guarded_quarantine():
-    clock = ManualClock()
-    store = InMemoryControlStore(clock=clock)
-    repository = _repository(store)
-    lease = CoordinatorLeaseManager(
-        store,
-        run_id=RUN_ID,
-        coordinator_id="coordinator-a",
-        lease_duration_ms=100,
-        clock=clock,
-    ).acquire()
+    _, store, repository, lease = _state()
 
     committed = store.compare_set_many_guarded(
-        _writes(repository),
+        _writes(repository, lease),
         guard_key=repository.coordinator_lease_key,
         expected_guard_revision=lease.fencing_token,
         not_before_unix_ms=lease.granted_at_unix_ms,
@@ -251,18 +297,9 @@ def test_repository_returns_none_only_for_never_created_quarantine():
 
 
 def test_repository_rejects_deleted_quarantine():
-    clock = ManualClock()
-    store = InMemoryControlStore(clock=clock)
-    repository = _repository(store)
-    lease = CoordinatorLeaseManager(
-        store,
-        run_id=RUN_ID,
-        coordinator_id="coordinator-a",
-        lease_duration_ms=100,
-        clock=clock,
-    ).acquire()
+    _, store, repository, lease = _state()
     committed = store.compare_set_many_guarded(
-        _writes(repository),
+        _writes(repository, lease),
         guard_key=repository.coordinator_lease_key,
         expected_guard_revision=lease.fencing_token,
         not_before_unix_ms=lease.granted_at_unix_ms,
@@ -293,6 +330,10 @@ def test_repository_rejects_deleted_quarantine():
                 incident_ids=("incident-a",),
                 reason_code="attributed_sdc",
                 resource_ids=(),
+                coordinator_id="coordinator-a",
+                lease_id="lease-a",
+                coordinator_lease_duration_ms=100,
+                coordinator_fencing_token=1,
             ).to_json(),
             "another run or node",
         ),
@@ -312,9 +353,8 @@ def test_repository_rejects_malformed_or_foreign_records(value, message):
 
 
 def test_repository_requires_guarded_create_provenance():
-    store = InMemoryControlStore()
-    repository = _repository(store)
-    write = _writes(repository)[repository.quarantine_key("node-b")]
+    _, store, repository, lease = _state()
+    write = _writes(repository, lease)[repository.quarantine_key("node-b")]
     store.compare_set(
         repository.quarantine_key("node-b"),
         expected_revision=None,
@@ -326,9 +366,7 @@ def test_repository_requires_guarded_create_provenance():
 
 
 def test_repository_rejects_quarantine_guarded_by_another_key():
-    clock = ManualClock()
-    store = InMemoryControlStore(clock=clock)
-    repository = _repository(store)
+    clock, store, repository, lease = _state()
     wrong_guard = store.compare_set_in_window(
         "other/lease",
         expected_revision=None,
@@ -337,7 +375,7 @@ def test_repository_rejects_quarantine_guarded_by_another_key():
         value=b"lease",
     )
     store.compare_set_many_guarded(
-        _writes(repository),
+        _writes(repository, lease),
         guard_key="other/lease",
         expected_guard_revision=wrong_guard.revision,
         not_before_unix_ms=1_000,
@@ -348,11 +386,52 @@ def test_repository_rejects_quarantine_guarded_by_another_key():
         repository.get("node-b")
 
 
+def test_repository_authenticates_opaque_coordinator_lease_bytes():
+    clock, store, repository, lease = _state()
+    malformed_guard = store.compare_set_in_window(
+        repository.coordinator_lease_key,
+        expected_revision=lease.fencing_token,
+        not_before_unix_ms=clock.now_unix_ms,
+        deadline_unix_ms=lease.expires_at_unix_ms,
+        value=b"malformed-lease",
+    )
+    record = NodeQuarantineRecord(
+        run_id=RUN_ID,
+        node_id="node-b",
+        plan_id="plan-1",
+        intent_id="intent-0",
+        from_generation=0,
+        effective_generation=1,
+        incident_ids=("incident-a",),
+        reason_code="attributed_sdc",
+        resource_ids=("gpu-b0",),
+        coordinator_id=lease.record.coordinator_id,
+        lease_id=lease.record.lease_id,
+        coordinator_lease_duration_ms=lease.record.lease_duration_ms,
+        coordinator_fencing_token=malformed_guard.revision,
+    )
+    store.compare_set_many_guarded(
+        {
+            repository.quarantine_key("node-b"): ControlStoreWrite(
+                expected_revision=None,
+                value=record.to_json(),
+                require_never_created=True,
+            ),
+        },
+        guard_key=repository.coordinator_lease_key,
+        expected_guard_revision=malformed_guard.revision,
+        not_before_unix_ms=clock.now_unix_ms,
+        deadline_unix_ms=lease.expires_at_unix_ms,
+    )
+
+    with pytest.raises(QuarantineStateCorrupt, match="lease identity"):
+        repository.get("node-b")
+
+
 def test_repository_rejects_recreated_quarantine():
-    store = InMemoryControlStore()
-    repository = _repository(store)
+    _, store, repository, lease = _state()
     key = repository.quarantine_key("node-b")
-    write = _writes(repository)[key]
+    write = _writes(repository, lease)[key]
     original = store.compare_set(key, expected_revision=None, value=write.value)
     store.compare_delete(key, expected_revision=original.revision)
     store.compare_set(key, expected_revision=None, value=write.value)

--- a/tests/unit/test_torchrun_quarantine_store.py
+++ b/tests/unit/test_torchrun_quarantine_store.py
@@ -43,6 +43,24 @@ class ManualClock:
             return self.now_unix_ms
 
 
+class TamperedQuarantineReadStore(InMemoryControlStore):
+    def __init__(self, clock: ManualClock) -> None:
+        super().__init__(clock=clock)
+        self.guard_override: tuple[int, int, int] | None = None
+
+    def get(self, key: str):
+        entry = super().get(key)
+        if entry is None or "/node-quarantines/" not in key or self.guard_override is None:
+            return entry
+        mutation_sequence, value_sequence, lifetime_sequence = self.guard_override
+        return replace(
+            entry,
+            guard_mutation_sequence=mutation_sequence,
+            guard_value_sequence=value_sequence,
+            guard_lifetime_sequence=lifetime_sequence,
+        )
+
+
 def _intent(
     *,
     run_id: str = RUN_ID,
@@ -425,6 +443,50 @@ def test_repository_authenticates_opaque_coordinator_lease_bytes():
     )
 
     with pytest.raises(QuarantineStateCorrupt, match="lease identity"):
+        repository.get("node-b")
+
+
+@pytest.mark.parametrize(
+    ("guard_override", "message"),
+    [
+        (
+            (1, 1, 2),
+            "mutation sequence cannot support",
+        ),
+        (
+            (3, 1, 2),
+            "value sequence cannot support",
+        ),
+        (
+            (2, 3, 1),
+            "includes deletion",
+        ),
+    ],
+)
+def test_repository_rejects_contradictory_guard_sequences(
+    guard_override,
+    message,
+):
+    clock = ManualClock()
+    store = TamperedQuarantineReadStore(clock)
+    repository = _repository(store)
+    lease = CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id="coordinator-a",
+        lease_duration_ms=100,
+        clock=clock,
+    ).acquire()
+    store.compare_set_many_guarded(
+        _writes(repository, lease),
+        guard_key=repository.coordinator_lease_key,
+        expected_guard_revision=lease.fencing_token,
+        not_before_unix_ms=lease.granted_at_unix_ms,
+        deadline_unix_ms=lease.expires_at_unix_ms,
+    )
+    store.guard_override = guard_override
+
+    with pytest.raises(QuarantineStateCorrupt, match=message):
         repository.get("node-b")
 
 


### PR DESCRIPTION
## Problem

Permanent node quarantines must be published atomically with the committed restart plan and successor generation. A standalone commit or reader would create unsafe partial-state windows and could treat an orphan quarantine as authoritative.

## Implementation

- add run/node-scoped hashed quarantine keys
- advance `NodeQuarantineRecord` to schema version 2 with coordinator lease identity, duration, and fencing token
- authenticate the held coordinator lease before preparing writes
- validate restart plan/intent linkage, quarantine scope, and minimum recovery mode
- verify coordinator-authorized resource evidence against trusted node ownership
- emit create-once `ControlStoreWrite` values for composition into a future plan transaction
- intentionally expose no standalone commit or read operation

A later combined reader will be the first code allowed to expose authoritative quarantines, after verifying the matching persisted plan, successor generation, quarantine record, commit timestamp, and guard provenance from one transaction.

## Compatibility

The write repository and records are internal and not exported from the package root. Schema version 1 quarantine records are rejected rather than interpreted as the expanded schema-v2 layout. No existing runtime path or public API changes.

## Validation

- `170 passed` focused quarantine/protocol/store/lease tests
- `1438 passed` complete CPU suite with CUDA hidden
- repository-wide Ruff check and format check
- targeted mypy check
- `git diff --check`