### PR TITLE
[Feature][Torchrun] Add strict restart intent records

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -565,6 +565,15 @@ boundary, prepare eligible checkpoint state, and wait for either a committed
 plan or an explicit abort. The stock torchrun agent still considers the worker
 group healthy during this preparation phase.
 
+The persisted form is an immutable, strict `RestartIntentRecord`. It embeds the
+canonical intent and binds it to the exact committed generation-snapshot digest
+plus the complete coordinator lease identity, duration, and opaque fencing
+token that authorized it. Duplicate or unknown fields, unsupported schema
+versions, malformed nested intents, and noncanonical SHA-256 digests fail
+closed. The record schema does not define a store mutation API; lease-fenced
+intent creation and compare-and-swap semantics are separate control-plane
+components.
+
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be
 absent from the next assignment. Policy may additionally quarantine a removed

--- a/lm_resiliency/integrations/torchrun/_restart_intent_records.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_records.py
@@ -1,0 +1,218 @@
+"""Strict persisted restart-intent records for torchrun resiliency."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import ClassVar
+
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseRecord,
+)
+from lm_resiliency.integrations.torchrun._protocol import (
+    ProtocolValidationError,
+    RestartIntent,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RestartIntentRecord:
+    """One restart intent and the generation and lease that authorized it."""
+
+    SCHEMA_VERSION: ClassVar[int] = 1
+
+    intent: RestartIntent
+    generation_snapshot_digest: str
+    coordinator_id: str
+    lease_id: str
+    coordinator_lease_duration_ms: int
+    coordinator_fencing_token: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.intent, RestartIntent):
+            raise TypeError("RestartIntentRecord.intent must be RestartIntent")
+        _digest(
+            self.generation_snapshot_digest,
+            "RestartIntentRecord.generation_snapshot_digest",
+        )
+        _nonempty_string(
+            self.coordinator_id,
+            "RestartIntentRecord.coordinator_id",
+        )
+        _nonempty_string(self.lease_id, "RestartIntentRecord.lease_id")
+        _positive_integer(
+            self.coordinator_lease_duration_ms,
+            "RestartIntentRecord.coordinator_lease_duration_ms",
+        )
+        _positive_integer(
+            self.coordinator_fencing_token,
+            "RestartIntentRecord.coordinator_fencing_token",
+        )
+
+    @property
+    def digest(self) -> str:
+        return hashlib.sha256(self.to_json()).hexdigest()
+
+    @property
+    def coordinator_lease_digest(self) -> str:
+        record = CoordinatorLeaseRecord(
+            run_id=self.intent.run_id,
+            coordinator_id=self.coordinator_id,
+            lease_id=self.lease_id,
+            lease_duration_ms=self.coordinator_lease_duration_ms,
+        )
+        return hashlib.sha256(record.to_json()).hexdigest()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "intent": self.intent.to_dict(),
+            "generation_snapshot_digest": self.generation_snapshot_digest,
+            "coordinator_id": self.coordinator_id,
+            "lease_id": self.lease_id,
+            "coordinator_lease_duration_ms": self.coordinator_lease_duration_ms,
+            "coordinator_fencing_token": self.coordinator_fencing_token,
+        }
+
+    def to_json(self) -> bytes:
+        return _canonical_json(self.to_dict())
+
+    @classmethod
+    def from_json(cls, encoded: bytes) -> RestartIntentRecord:
+        value = _json_object(encoded, cls.__name__)
+        _fields(
+            value,
+            path=cls.__name__,
+            required={
+                "schema_version",
+                "intent",
+                "generation_snapshot_digest",
+                "coordinator_id",
+                "lease_id",
+                "coordinator_lease_duration_ms",
+                "coordinator_fencing_token",
+            },
+        )
+        _schema_version(
+            value["schema_version"],
+            cls.__name__,
+            expected=cls.SCHEMA_VERSION,
+        )
+        intent_value = value["intent"]
+        if not isinstance(intent_value, Mapping):
+            raise ValueError("RestartIntentRecord.intent must be an object")
+        try:
+            intent = RestartIntent.from_dict(intent_value)
+        except ProtocolValidationError as error:
+            raise ValueError("RestartIntentRecord.intent is invalid") from error
+        return cls(
+            intent=intent,
+            generation_snapshot_digest=_digest(
+                value["generation_snapshot_digest"],
+                "RestartIntentRecord.generation_snapshot_digest",
+            ),
+            coordinator_id=_nonempty_string(
+                value["coordinator_id"],
+                "RestartIntentRecord.coordinator_id",
+            ),
+            lease_id=_nonempty_string(
+                value["lease_id"],
+                "RestartIntentRecord.lease_id",
+            ),
+            coordinator_lease_duration_ms=_positive_integer(
+                value["coordinator_lease_duration_ms"],
+                "RestartIntentRecord.coordinator_lease_duration_ms",
+            ),
+            coordinator_fencing_token=_positive_integer(
+                value["coordinator_fencing_token"],
+                "RestartIntentRecord.coordinator_fencing_token",
+            ),
+        )
+
+
+def _canonical_json(value: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _json_object(encoded: bytes, path: str) -> Mapping[str, object]:
+    if not isinstance(encoded, bytes):
+        raise ValueError(f"{path}: expected encoded bytes")
+    try:
+        value = json.loads(
+            encoded,
+            object_pairs_hook=_reject_duplicate_object_fields,
+        )
+    except _DuplicateRestartIntentField as error:
+        raise ValueError(f"{path}: {error}") from error
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{path}: invalid JSON") from error
+    if not isinstance(value, Mapping) or not all(isinstance(key, str) for key in value):
+        raise ValueError(f"{path}: expected a JSON object")
+    return value
+
+
+def _fields(
+    value: Mapping[str, object],
+    *,
+    path: str,
+    required: set[str],
+) -> None:
+    missing = required - set(value)
+    unknown = set(value) - required
+    if missing:
+        raise ValueError(f"{path}: missing fields {sorted(missing)!r}")
+    if unknown:
+        raise ValueError(f"{path}: unknown fields {sorted(unknown)!r}")
+
+
+def _schema_version(value: object, path: str, *, expected: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value != expected:
+        raise ValueError(f"{path}.schema_version: unsupported value {value!r}")
+    return value
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+def _positive_integer(value: object, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{path} must be a positive integer")
+    return value
+
+
+def _digest(value: object, path: str) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise ValueError(f"{path} must be a lowercase SHA-256 digest")
+    return value
+
+
+class _DuplicateRestartIntentField(ValueError):
+    pass
+
+
+def _reject_duplicate_object_fields(
+    pairs: list[tuple[str, object]],
+) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            raise _DuplicateRestartIntentField(f"duplicate field {key!r}")
+        value[key] = item
+    return value
+
+
+__all__ = ["RestartIntentRecord"]

--- a/lm_resiliency/integrations/torchrun/_restart_intent_records.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_records.py
@@ -103,6 +103,13 @@ class RestartIntentRecord:
         intent_value = value["intent"]
         if not isinstance(intent_value, Mapping):
             raise ValueError("RestartIntentRecord.intent must be an object")
+        nested_schema_version = intent_value.get("schema_version")
+        if (
+            isinstance(nested_schema_version, bool)
+            or not isinstance(nested_schema_version, int)
+            or nested_schema_version != RestartIntent.SCHEMA_VERSION
+        ):
+            raise ValueError("RestartIntentRecord.intent is invalid")
         try:
             intent = RestartIntent.from_dict(intent_value)
         except ProtocolValidationError as error:

--- a/tests/unit/test_torchrun_restart_intent_records.py
+++ b/tests/unit/test_torchrun_restart_intent_records.py
@@ -1,0 +1,206 @@
+"""Contract tests for persisted torchrun restart-intent records."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import replace
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseRecord,
+)
+from lm_resiliency.integrations.torchrun._protocol import RestartIntent
+from lm_resiliency.integrations.torchrun._restart_intent_records import (
+    RestartIntentRecord,
+)
+
+
+def _intent() -> RestartIntent:
+    return RestartIntent(
+        intent_id="intent-a",
+        run_id="training-run",
+        generation=4,
+        incident_ids=("incident-a", "incident-b"),
+        reason_code="attributed_sdc",
+        minimum_recovery_mode="recovery_verified",
+        suspected_node_ids=("node-b",),
+        prepare_deadline_unix_ms=50_000,
+    )
+
+
+def _record() -> RestartIntentRecord:
+    return RestartIntentRecord(
+        intent=_intent(),
+        generation_snapshot_digest="a" * 64,
+        coordinator_id="coordinator-a",
+        lease_id="lease-a",
+        coordinator_lease_duration_ms=30_000,
+        coordinator_fencing_token=7,
+    )
+
+
+def test_restart_intent_record_round_trips_canonical_json():
+    record = _record()
+
+    encoded = record.to_json()
+    decoded = RestartIntentRecord.from_json(encoded)
+
+    assert decoded == record
+    assert encoded == (
+        b'{"coordinator_fencing_token":7,"coordinator_id":"coordinator-a",'
+        b'"coordinator_lease_duration_ms":30000,'
+        b'"generation_snapshot_digest":"'
+        + b"a"
+        * 64
+        + b'","intent":{"generation":4,"incident_ids":["incident-a","incident-b"],'
+        b'"intent_id":"intent-a","minimum_recovery_mode":"recovery_verified",'
+        b'"prepare_deadline_unix_ms":50000,"reason_code":"attributed_sdc",'
+        b'"run_id":"training-run","schema_version":1,'
+        b'"suspected_node_ids":["node-b"]},"lease_id":"lease-a","schema_version":1}'
+    )
+    assert record.digest == hashlib.sha256(encoded).hexdigest()
+    lease_record = CoordinatorLeaseRecord(
+        run_id=record.intent.run_id,
+        coordinator_id=record.coordinator_id,
+        lease_id=record.lease_id,
+        lease_duration_ms=record.coordinator_lease_duration_ms,
+    )
+    assert record.coordinator_lease_digest == hashlib.sha256(lease_record.to_json()).hexdigest()
+
+
+def test_restart_intent_record_is_immutable():
+    record = _record()
+
+    with pytest.raises(AttributeError):
+        record.lease_id = "other"
+    with pytest.raises(AttributeError):
+        record.intent.incident_ids = ()
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("generation_snapshot_digest", "", "generation_snapshot_digest"),
+        ("generation_snapshot_digest", "A" * 64, "generation_snapshot_digest"),
+        ("coordinator_id", "", "coordinator_id"),
+        ("lease_id", "", "lease_id"),
+        ("coordinator_lease_duration_ms", 0, "coordinator_lease_duration_ms"),
+        ("coordinator_lease_duration_ms", True, "coordinator_lease_duration_ms"),
+        ("coordinator_fencing_token", 0, "coordinator_fencing_token"),
+        ("coordinator_fencing_token", True, "coordinator_fencing_token"),
+    ],
+)
+def test_restart_intent_record_validates_constructor_fields(field, value, message):
+    with pytest.raises(ValueError, match=message):
+        replace(_record(), **{field: value})
+
+
+def test_restart_intent_record_requires_restart_intent():
+    with pytest.raises(TypeError, match="RestartIntent"):
+        RestartIntentRecord(
+            intent={},
+            generation_snapshot_digest="a" * 64,
+            coordinator_id="coordinator-a",
+            lease_id="lease-a",
+            coordinator_lease_duration_ms=30_000,
+            coordinator_fencing_token=7,
+        )
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda value: value.pop("intent"),
+            "missing fields",
+        ),
+        (
+            lambda value: value.update({"unknown": True}),
+            "unknown fields",
+        ),
+        (
+            lambda value: value.update({"schema_version": 2}),
+            "unsupported value",
+        ),
+        (
+            lambda value: value.update({"schema_version": True}),
+            "unsupported value",
+        ),
+        (
+            lambda value: value.update({"intent": []}),
+            "intent must be an object",
+        ),
+        (
+            lambda value: value["intent"].update({"generation": -1}),
+            "intent is invalid",
+        ),
+        (
+            lambda value: value["intent"].update({"schema_version": 2}),
+            "intent is invalid",
+        ),
+        (
+            lambda value: value["intent"].update({"unknown": True}),
+            "intent is invalid",
+        ),
+        (
+            lambda value: value.update({"generation_snapshot_digest": "A" * 64}),
+            "generation_snapshot_digest",
+        ),
+        (
+            lambda value: value.update({"coordinator_id": ""}),
+            "coordinator_id",
+        ),
+        (
+            lambda value: value.update({"lease_id": ""}),
+            "lease_id",
+        ),
+        (
+            lambda value: value.update({"coordinator_lease_duration_ms": 0}),
+            "coordinator_lease_duration_ms",
+        ),
+        (
+            lambda value: value.update({"coordinator_fencing_token": 0}),
+            "coordinator_fencing_token",
+        ),
+    ],
+)
+def test_restart_intent_record_rejects_invalid_wire_values(mutate, message):
+    value = json.loads(_record().to_json())
+    mutate(value)
+
+    with pytest.raises(ValueError, match=message):
+        RestartIntentRecord.from_json(
+            json.dumps(value, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        )
+
+
+@pytest.mark.parametrize(
+    "encoded",
+    [
+        b"not-json",
+        b"[]",
+        b'{"schema_version":1,"schema_version":1}',
+        (
+            b'{"coordinator_fencing_token":7,"coordinator_id":"coordinator-a",'
+            b'"coordinator_lease_duration_ms":30000,'
+            b'"generation_snapshot_digest":"'
+            + b"a"
+            * 64
+            + b'","intent":{"generation":4,"generation":5,'
+            b'"incident_ids":["incident-a"],"intent_id":"intent-a",'
+            b'"minimum_recovery_mode":"latest","prepare_deadline_unix_ms":50000,'
+            b'"reason_code":"failure","run_id":"training-run","schema_version":1,'
+            b'"suspected_node_ids":[]},"lease_id":"lease-a","schema_version":1}'
+        ),
+    ],
+)
+def test_restart_intent_record_rejects_malformed_or_duplicate_json(encoded):
+    with pytest.raises(ValueError):
+        RestartIntentRecord.from_json(encoded)
+
+
+def test_restart_intent_record_requires_encoded_bytes():
+    with pytest.raises(ValueError, match="encoded bytes"):
+        RestartIntentRecord.from_json(_record().to_json().decode("utf-8"))

--- a/tests/unit/test_torchrun_restart_intent_records.py
+++ b/tests/unit/test_torchrun_restart_intent_records.py
@@ -141,6 +141,10 @@ def test_restart_intent_record_requires_restart_intent():
             "intent is invalid",
         ),
         (
+            lambda value: value["intent"].update({"schema_version": 1.0}),
+            "intent is invalid",
+        ),
+        (
             lambda value: value["intent"].update({"unknown": True}),
             "intent is invalid",
         ),


### PR DESCRIPTION
## Summary

- add an immutable persisted `RestartIntentRecord` envelope
- bind the canonical intent to the exact generation snapshot digest and coordinator lease provenance
- reject malformed, duplicate, unknown, and unsupported wire fields fail closed
- document that persistence/CAS remains a separate component

## Why

The worker-facing `RestartIntent` does not by itself prove which committed generation or coordinator lease authorized persistence. This records-only slice establishes that strict authority envelope before adding store mutation behavior.

## Compatibility

Internal torchrun integration only. No public import, store mutation, rendezvous registration, or runtime activation is added.

## Validation

- `156 passed` in focused torchrun protocol/record tests
- `1467 passed` in the complete CPU unit suite with CUDA hidden
- Ruff check and format pass
- mypy 1.17.1 passes for the new module and tests
- `git diff --check` passes