### PR TITLE
[Feature][Torchrun] Add guarded transaction revision conditions

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -915,15 +915,20 @@ durable `has_history(key)` bit after deletion, allowing readers to distinguish a
 never-created authoritative key from one that was removed.
 
 Coordinator state that spans multiple keys uses one guarded store transaction.
-The transaction first checks the coordinator lease revision, then every target
-revision, then one authoritative store-time window. It publishes all target
-values with the same commit timestamp and store-stamped guard key, guard
-revision, guard-value digest, ordered guard mutation and value sequences,
-guard-key lifetime sequence, and authoritative guard commit time, or publishes
-none. The value sequence changes whenever the guarded bytes change or the key is
-recreated, but remains stable across same-value renewals. This is the primitive
-used to create an immutable generation snapshot and advance the generation head
-without allowing a stale or expired coordinator to commit either half alone.
+The transaction first checks the coordinator lease revision, then any
+side-effect-free revision conditions, every target revision, and one
+authoritative store-time window under the same lock. Condition keys cannot also
+be the guard or transaction targets. It publishes all target values with the
+same commit timestamp and store-stamped guard key, guard revision, guard-value
+digest, ordered guard mutation and value sequences, guard-key lifetime sequence,
+and authoritative guard commit time, or publishes none. The value sequence
+changes whenever the guarded bytes change or the key is recreated, but remains
+stable across same-value renewals. This is the primitive used to create an
+immutable generation snapshot and advance the generation head without allowing
+a stale or expired coordinator to commit either half alone. Revision conditions
+also let later components prove that the generation head did not advance while
+publishing an intent, without rewriting the head or weakening its immutable
+history checks.
 Create-once transaction targets may additionally require that the key has no
 prior committed history, not merely that it is currently absent. This prevents
 a deleted immutable quarantine or snapshot key from being recreated inside an

--- a/lm_resiliency/integrations/torchrun/_control_store.py
+++ b/lm_resiliency/integrations/torchrun/_control_store.py
@@ -266,8 +266,9 @@ class ControlStore(Protocol):
         expected_guard_revision: int,
         not_before_unix_ms: int,
         deadline_unix_ms: int,
+        conditions: Mapping[str, int | None] | None = None,
     ) -> Mapping[str, ControlStoreEntry]:
-        """Atomically publish writes while a guard revision is live.
+        """Atomically publish writes while a guard and read conditions hold.
 
         Every returned target entry carries store-stamped guard key, revision,
         value digest, ordered mutation and value sequences, key-lifetime
@@ -412,11 +413,20 @@ class InMemoryControlStore:
         expected_guard_revision: int,
         not_before_unix_ms: int,
         deadline_unix_ms: int,
+        conditions: Mapping[str, int | None] | None = None,
     ) -> Mapping[str, ControlStoreEntry]:
         normalized_writes = _control_writes(writes)
+        normalized_conditions = _control_conditions(conditions)
         normalized_guard_key = _control_key(guard_key)
         if normalized_guard_key in normalized_writes:
             raise ValueError("guard_key must not also be a transaction target")
+        if normalized_guard_key in normalized_conditions:
+            raise ValueError("guard_key must not also be a transaction condition")
+        overlapping_keys = sorted(set(normalized_writes) & set(normalized_conditions))
+        if overlapping_keys:
+            raise ValueError(
+                f"transaction conditions must not also be targets: {overlapping_keys!r}"
+            )
         normalized_guard_revision = _required_revision(expected_guard_revision)
         normalized_not_before = _positive_integer(
             not_before_unix_ms,
@@ -432,6 +442,8 @@ class InMemoryControlStore:
             self._require_revision(normalized_guard_key, normalized_guard_revision)
             guard_entry = self._entries[normalized_guard_key]
             guard_value_digest = hashlib.sha256(guard_entry.value).hexdigest()
+            for key, expected_revision in normalized_conditions.items():
+                self._require_revision(key, expected_revision)
             for key, write in normalized_writes.items():
                 self._require_revision(key, write.expected_revision)
                 if write.require_never_created and key in self._last_revisions:
@@ -556,6 +568,25 @@ def _control_writes(value: object) -> dict[str, ControlStoreWrite]:
         if not isinstance(write, ControlStoreWrite):
             raise TypeError("writes values must be ControlStoreWrite")
         result[normalized_key] = write
+    return dict(sorted(result.items()))
+
+
+def _control_conditions(
+    value: object,
+) -> dict[str, int | None]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise TypeError("conditions must be a mapping")
+    result: dict[str, int | None] = {}
+    for key, expected_revision in value.items():
+        normalized_key = _control_key(key)
+        result[normalized_key] = _expected_revision(
+            expected_revision,
+            allow_absent=True,
+        )
+    if len(result) != len(value):
+        raise ValueError("condition keys must be unique")
     return dict(sorted(result.items()))
 
 

--- a/tests/unit/test_torchrun_generation_state.py
+++ b/tests/unit/test_torchrun_generation_state.py
@@ -56,6 +56,7 @@ class TamperedTransactionResultStore(InMemoryControlStore):
         expected_guard_revision: int,
         not_before_unix_ms: int,
         deadline_unix_ms: int,
+        conditions: Mapping[str, int | None] | None = None,
     ) -> Mapping[str, ControlStoreEntry]:
         committed = dict(
             super().compare_set_many_guarded(
@@ -64,6 +65,7 @@ class TamperedTransactionResultStore(InMemoryControlStore):
                 expected_guard_revision=expected_guard_revision,
                 not_before_unix_ms=not_before_unix_ms,
                 deadline_unix_ms=deadline_unix_ms,
+                conditions=conditions,
             )
         )
         head_key = next(key for key in committed if key.endswith("/generation-head"))

--- a/tests/unit/test_torchrun_guarded_control_store.py
+++ b/tests/unit/test_torchrun_guarded_control_store.py
@@ -220,6 +220,93 @@ def test_guarded_transaction_rejects_target_conflict_without_partial_writes():
     assert store.get("run/generations/0") is None
 
 
+def test_guarded_transaction_commits_when_revision_conditions_hold():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    guard = _guard(store)
+    head = store.compare_set(
+        "run/generation-head",
+        expected_revision=None,
+        value=b"generation-0",
+    )
+
+    committed = store.compare_set_many_guarded(
+        {
+            "run/restart-intents/intent-a": ControlStoreWrite(
+                expected_revision=None,
+                value=b"intent-a",
+                require_never_created=True,
+            ),
+        },
+        guard_key="run/coordinator-lease",
+        expected_guard_revision=guard.revision,
+        not_before_unix_ms=1_000,
+        deadline_unix_ms=1_100,
+        conditions={"run/generation-head": head.revision},
+    )
+
+    assert store.get("run/generation-head") == head
+    assert committed["run/restart-intents/intent-a"].value == b"intent-a"
+
+
+def test_guarded_transaction_rejects_condition_conflict_without_partial_writes():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    guard = _guard(store)
+    stale_head = store.compare_set(
+        "run/generation-head",
+        expected_revision=None,
+        value=b"generation-0",
+    )
+    current_head = store.compare_set(
+        "run/generation-head",
+        expected_revision=stale_head.revision,
+        value=b"generation-1",
+    )
+
+    with pytest.raises(ControlStoreConflict) as error:
+        store.compare_set_many_guarded(
+            {
+                "run/restart-intents/intent-a": ControlStoreWrite(
+                    expected_revision=None,
+                    value=b"intent-a",
+                ),
+            },
+            guard_key="run/coordinator-lease",
+            expected_guard_revision=guard.revision,
+            not_before_unix_ms=1_000,
+            deadline_unix_ms=1_100,
+            conditions={"run/generation-head": stale_head.revision},
+        )
+
+    assert error.value.key == "run/generation-head"
+    assert error.value.actual_revision == current_head.revision
+    assert store.get("run/restart-intents/intent-a") is None
+
+
+def test_guarded_transaction_can_condition_on_key_absence():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    guard = _guard(store)
+
+    committed = store.compare_set_many_guarded(
+        {
+            "run/restart-intents/intent-a": ControlStoreWrite(
+                expected_revision=None,
+                value=b"intent-a",
+            ),
+        },
+        guard_key="run/coordinator-lease",
+        expected_guard_revision=guard.revision,
+        not_before_unix_ms=1_000,
+        deadline_unix_ms=1_100,
+        conditions={"run/restart-intent-head": None},
+    )
+
+    assert committed["run/restart-intents/intent-a"].value == b"intent-a"
+    assert store.get("run/restart-intent-head") is None
+
+
 def test_guarded_transaction_can_require_target_to_have_no_history():
     store = InMemoryControlStore(clock=ManualClock())
     guard = _guard(store)
@@ -359,6 +446,42 @@ def test_guarded_transaction_rejects_invalid_write_sets():
             expected_guard_revision=guard.revision,
             not_before_unix_ms=1,
             deadline_unix_ms=2,
+        )
+    with pytest.raises(ValueError, match="must not also be a transaction condition"):
+        store.compare_set_many_guarded(
+            _generation_writes(),
+            guard_key="run/coordinator-lease",
+            expected_guard_revision=guard.revision,
+            not_before_unix_ms=1,
+            deadline_unix_ms=2,
+            conditions={"run/coordinator-lease": guard.revision},
+        )
+    with pytest.raises(ValueError, match="must not also be targets"):
+        store.compare_set_many_guarded(
+            _generation_writes(),
+            guard_key="run/coordinator-lease",
+            expected_guard_revision=guard.revision,
+            not_before_unix_ms=1,
+            deadline_unix_ms=2,
+            conditions={"run/generation-head": None},
+        )
+    with pytest.raises(TypeError, match="conditions must be a mapping"):
+        store.compare_set_many_guarded(
+            _generation_writes(),
+            guard_key="run/coordinator-lease",
+            expected_guard_revision=guard.revision,
+            not_before_unix_ms=1,
+            deadline_unix_ms=2,
+            conditions=(),
+        )
+    with pytest.raises(ValueError, match="expected_revision"):
+        store.compare_set_many_guarded(
+            _generation_writes(),
+            guard_key="run/coordinator-lease",
+            expected_guard_revision=guard.revision,
+            not_before_unix_ms=1,
+            deadline_unix_ms=2,
+            conditions={"run/restart-intent-head": False},
         )
 
 


### PR DESCRIPTION
## Summary

- add optional side-effect-free revision conditions to guarded control-store transactions
- validate the lease guard, conditions, targets, and store-time window atomically
- reject condition overlap with the guard or mutation targets
- preserve existing transaction callers and guard provenance

## Why

Restart-intent creation must prove that the generation head did not advance between validation and the lease-fenced write. Rewriting the generation head would violate its mutation invariants, so the store needs an atomic read condition that does not mutate the conditioned key.

## Compatibility

Internal control-store contract only. Existing callers omit `conditions` and retain identical behavior. No restart-intent persistence or runtime activation is included.

## Validation

- `106 passed` in focused store and generation tests
- `1471 passed` in the complete CPU unit suite with CUDA hidden
- Ruff check and format pass
- mypy 1.17.1 passes for the changed source and tests
- `git diff --check` passes