### PR TITLE
[Feature][Torchrun] Add restart intent head records

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -570,9 +570,13 @@ canonical intent and binds it to the exact committed generation-snapshot digest
 plus the complete coordinator lease identity, duration, and opaque fencing
 token that authorized it. Duplicate or unknown fields, unsupported schema
 versions, malformed nested intents, and noncanonical SHA-256 digests fail
-closed. The record schema does not define a store mutation API; lease-fenced
-intent creation and compare-and-swap semantics are separate control-plane
-components.
+closed. A strict `RestartIntentHeadRecord` identifies the single current intent
+by run, generation, intent ID, and canonical intent-record digest. The head
+payload is immutable; its future store key is compare-and-swap managed so
+opening an intent can atomically create both the create-once intent record and
+the current pointer. The record schemas do not define a store mutation API;
+lease-fenced intent creation and lifecycle transitions are separate
+control-plane components.
 
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be

--- a/lm_resiliency/integrations/torchrun/_restart_intent_records.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_records.py
@@ -139,6 +139,77 @@ class RestartIntentRecord:
         )
 
 
+@dataclass(frozen=True, slots=True)
+class RestartIntentHeadRecord:
+    """Pointer from the current-intent head to one immutable intent record."""
+
+    SCHEMA_VERSION: ClassVar[int] = 1
+
+    run_id: str
+    generation: int
+    intent_id: str
+    intent_digest: str
+
+    def __post_init__(self) -> None:
+        _nonempty_string(self.run_id, "RestartIntentHeadRecord.run_id")
+        _nonnegative_integer(
+            self.generation,
+            "RestartIntentHeadRecord.generation",
+        )
+        _nonempty_string(self.intent_id, "RestartIntentHeadRecord.intent_id")
+        _digest(self.intent_digest, "RestartIntentHeadRecord.intent_digest")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "run_id": self.run_id,
+            "generation": self.generation,
+            "intent_id": self.intent_id,
+            "intent_digest": self.intent_digest,
+        }
+
+    def to_json(self) -> bytes:
+        return _canonical_json(self.to_dict())
+
+    @classmethod
+    def from_json(cls, encoded: bytes) -> RestartIntentHeadRecord:
+        value = _json_object(encoded, cls.__name__)
+        _fields(
+            value,
+            path=cls.__name__,
+            required={
+                "schema_version",
+                "run_id",
+                "generation",
+                "intent_id",
+                "intent_digest",
+            },
+        )
+        _schema_version(
+            value["schema_version"],
+            cls.__name__,
+            expected=cls.SCHEMA_VERSION,
+        )
+        return cls(
+            run_id=_nonempty_string(
+                value["run_id"],
+                "RestartIntentHeadRecord.run_id",
+            ),
+            generation=_nonnegative_integer(
+                value["generation"],
+                "RestartIntentHeadRecord.generation",
+            ),
+            intent_id=_nonempty_string(
+                value["intent_id"],
+                "RestartIntentHeadRecord.intent_id",
+            ),
+            intent_digest=_digest(
+                value["intent_digest"],
+                "RestartIntentHeadRecord.intent_digest",
+            ),
+        )
+
+
 def _canonical_json(value: Mapping[str, object]) -> bytes:
     return json.dumps(
         value,
@@ -197,6 +268,12 @@ def _positive_integer(value: object, path: str) -> int:
     return value
 
 
+def _nonnegative_integer(value: object, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{path} must be a non-negative integer")
+    return value
+
+
 def _digest(value: object, path: str) -> str:
     if (
         not isinstance(value, str)
@@ -222,4 +299,7 @@ def _reject_duplicate_object_fields(
     return value
 
 
-__all__ = ["RestartIntentRecord"]
+__all__ = [
+    "RestartIntentHeadRecord",
+    "RestartIntentRecord",
+]

--- a/tests/unit/test_torchrun_restart_intent_records.py
+++ b/tests/unit/test_torchrun_restart_intent_records.py
@@ -13,6 +13,7 @@ from lm_resiliency.integrations.torchrun._coordinator_lease import (
 )
 from lm_resiliency.integrations.torchrun._protocol import RestartIntent
 from lm_resiliency.integrations.torchrun._restart_intent_records import (
+    RestartIntentHeadRecord,
     RestartIntentRecord,
 )
 
@@ -38,6 +39,16 @@ def _record() -> RestartIntentRecord:
         lease_id="lease-a",
         coordinator_lease_duration_ms=30_000,
         coordinator_fencing_token=7,
+    )
+
+
+def _head() -> RestartIntentHeadRecord:
+    record = _record()
+    return RestartIntentHeadRecord(
+        run_id=record.intent.run_id,
+        generation=record.intent.generation,
+        intent_id=record.intent.intent_id,
+        intent_digest=record.digest,
     )
 
 
@@ -70,6 +81,20 @@ def test_restart_intent_record_round_trips_canonical_json():
     assert record.coordinator_lease_digest == hashlib.sha256(lease_record.to_json()).hexdigest()
 
 
+def test_restart_intent_head_round_trips_canonical_json():
+    head = _head()
+
+    encoded = head.to_json()
+    decoded = RestartIntentHeadRecord.from_json(encoded)
+
+    assert decoded == head
+    assert encoded == (
+        b'{"generation":4,"intent_digest":"'
+        + _record().digest.encode("ascii")
+        + b'","intent_id":"intent-a","run_id":"training-run","schema_version":1}'
+    )
+
+
 def test_restart_intent_record_is_immutable():
     record = _record()
 
@@ -77,6 +102,13 @@ def test_restart_intent_record_is_immutable():
         record.lease_id = "other"
     with pytest.raises(AttributeError):
         record.intent.incident_ids = ()
+
+
+def test_restart_intent_head_is_immutable():
+    head = _head()
+
+    with pytest.raises(AttributeError):
+        head.intent_id = "other"
 
 
 @pytest.mark.parametrize(
@@ -107,6 +139,22 @@ def test_restart_intent_record_requires_restart_intent():
             coordinator_lease_duration_ms=30_000,
             coordinator_fencing_token=7,
         )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("run_id", "", "run_id"),
+        ("generation", -1, "generation"),
+        ("generation", True, "generation"),
+        ("intent_id", "", "intent_id"),
+        ("intent_digest", "", "intent_digest"),
+        ("intent_digest", "A" * 64, "intent_digest"),
+    ],
+)
+def test_restart_intent_head_validates_constructor_fields(field, value, message):
+    with pytest.raises(ValueError, match=message):
+        replace(_head(), **{field: value})
 
 
 @pytest.mark.parametrize(
@@ -181,6 +229,45 @@ def test_restart_intent_record_rejects_invalid_wire_values(mutate, message):
 
 
 @pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda value: value.pop("intent_id"),
+            "missing fields",
+        ),
+        (
+            lambda value: value.update({"unknown": True}),
+            "unknown fields",
+        ),
+        (
+            lambda value: value.update({"schema_version": 2}),
+            "unsupported value",
+        ),
+        (
+            lambda value: value.update({"schema_version": 1.0}),
+            "unsupported value",
+        ),
+        (
+            lambda value: value.update({"generation": -1}),
+            "generation",
+        ),
+        (
+            lambda value: value.update({"intent_digest": "A" * 64}),
+            "intent_digest",
+        ),
+    ],
+)
+def test_restart_intent_head_rejects_invalid_wire_values(mutate, message):
+    value = json.loads(_head().to_json())
+    mutate(value)
+
+    with pytest.raises(ValueError, match=message):
+        RestartIntentHeadRecord.from_json(
+            json.dumps(value, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        )
+
+
+@pytest.mark.parametrize(
     "encoded",
     [
         b"not-json",
@@ -205,6 +292,28 @@ def test_restart_intent_record_rejects_malformed_or_duplicate_json(encoded):
         RestartIntentRecord.from_json(encoded)
 
 
+@pytest.mark.parametrize(
+    "encoded",
+    [
+        b"not-json",
+        b"[]",
+        b'{"schema_version":1,"schema_version":1}',
+        (
+            b'{"generation":4,"intent_digest":"'
+            + b"a" * 64
+            + b'","intent_id":"intent-a","intent_id":"intent-b",'
+            b'"run_id":"training-run","schema_version":1}'
+        ),
+    ],
+)
+def test_restart_intent_head_rejects_malformed_or_duplicate_json(encoded):
+    with pytest.raises(ValueError):
+        RestartIntentHeadRecord.from_json(encoded)
+
+
 def test_restart_intent_record_requires_encoded_bytes():
     with pytest.raises(ValueError, match="encoded bytes"):
         RestartIntentRecord.from_json(_record().to_json().decode("utf-8"))
+
+    with pytest.raises(ValueError, match="encoded bytes"):
+        RestartIntentHeadRecord.from_json(_head().to_json().decode("utf-8"))


### PR DESCRIPTION
## Summary

- add a strict immutable `RestartIntentHeadRecord`
- bind the current-intent pointer to run, generation, intent ID, and canonical intent-record digest
- reject malformed, duplicate, unknown, unsupported, and noncanonical wire values
- document the future atomic head/intent creation contract

## Why

A create-once intent record alone cannot prevent two different intent IDs from opening concurrently for one generation. The future writer needs a strict current-intent pointer that can be created atomically with the immutable intent record.

## Compatibility

Internal records only. No store mutation, reader, abort transition, worker polling, or runtime activation is included.

## Validation

- `153 passed` in focused torchrun record/protocol tests
- `1489 passed` in the complete CPU unit suite with CUDA hidden
- Ruff check and format pass
- mypy 1.17.1 passes for the changed source and tests
- `git diff --check` passes