### PR TITLE
[Feature][Torchrun] Add restart intent closed head records

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -585,8 +585,14 @@ latest closure by run, positive closure index, generation, intent ID, and
 closure-record digest. The head is the only mutable lifecycle pointer; later
 readers require its store mutation and value sequences to equal the closure
 index so replaying an older A record after B cannot appear to roll lifecycle
-state back. Atomic current-intent closure and lifecycle-head advancement are
-separate control-plane components.
+state back. A strict `RestartIntentClosedHeadRecord` is the durable closed value
+for the current-intent key. It binds the closure index, generation, and intent
+identity to the canonical lifecycle-head digest. A future closure transaction
+atomically replaces the open current-intent head with this marker while
+advancing the lifecycle head and creating the immutable closure record. The
+next intent replaces the marker instead of relying on deletion, so a restarted
+reader can prove closure from persisted state. Atomic opening and closure
+transactions are separate control-plane components.
 
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be

--- a/lm_resiliency/integrations/torchrun/_restart_intent_records.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_records.py
@@ -360,6 +360,10 @@ class RestartIntentLifecycleHeadRecord:
             "RestartIntentLifecycleHeadRecord.lifecycle_digest",
         )
 
+    @property
+    def digest(self) -> str:
+        return hashlib.sha256(self.to_json()).hexdigest()
+
     def to_dict(self) -> dict[str, object]:
         return {
             "schema_version": self.SCHEMA_VERSION,
@@ -413,6 +417,97 @@ class RestartIntentLifecycleHeadRecord:
             lifecycle_digest=_digest(
                 value["lifecycle_digest"],
                 "RestartIntentLifecycleHeadRecord.lifecycle_digest",
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RestartIntentClosedHeadRecord:
+    """Persistent marker that the current restart intent was closed."""
+
+    SCHEMA_VERSION: ClassVar[int] = 1
+
+    run_id: str
+    closure_index: int
+    generation: int
+    intent_id: str
+    lifecycle_head_digest: str
+
+    def __post_init__(self) -> None:
+        _nonempty_string(
+            self.run_id,
+            "RestartIntentClosedHeadRecord.run_id",
+        )
+        _positive_integer(
+            self.closure_index,
+            "RestartIntentClosedHeadRecord.closure_index",
+        )
+        _nonnegative_integer(
+            self.generation,
+            "RestartIntentClosedHeadRecord.generation",
+        )
+        _nonempty_string(
+            self.intent_id,
+            "RestartIntentClosedHeadRecord.intent_id",
+        )
+        _digest(
+            self.lifecycle_head_digest,
+            "RestartIntentClosedHeadRecord.lifecycle_head_digest",
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "run_id": self.run_id,
+            "closure_index": self.closure_index,
+            "generation": self.generation,
+            "intent_id": self.intent_id,
+            "lifecycle_head_digest": self.lifecycle_head_digest,
+        }
+
+    def to_json(self) -> bytes:
+        return _canonical_json(self.to_dict())
+
+    @classmethod
+    def from_json(cls, encoded: bytes) -> RestartIntentClosedHeadRecord:
+        value = _json_object(encoded, cls.__name__)
+        _fields(
+            value,
+            path=cls.__name__,
+            required={
+                "schema_version",
+                "run_id",
+                "closure_index",
+                "generation",
+                "intent_id",
+                "lifecycle_head_digest",
+            },
+        )
+        _schema_version(
+            value["schema_version"],
+            cls.__name__,
+            expected=cls.SCHEMA_VERSION,
+        )
+        return cls(
+            run_id=_nonempty_string(
+                value["run_id"],
+                "RestartIntentClosedHeadRecord.run_id",
+            ),
+            closure_index=_positive_integer(
+                value["closure_index"],
+                "RestartIntentClosedHeadRecord.closure_index",
+            ),
+            generation=_nonnegative_integer(
+                value["generation"],
+                "RestartIntentClosedHeadRecord.generation",
+            ),
+            intent_id=_nonempty_string(
+                value["intent_id"],
+                "RestartIntentClosedHeadRecord.intent_id",
+            ),
+            lifecycle_head_digest=_digest(
+                value["lifecycle_head_digest"],
+                "RestartIntentClosedHeadRecord.lifecycle_head_digest",
             ),
         )
 
@@ -507,6 +602,7 @@ def _reject_duplicate_object_fields(
 
 
 __all__ = [
+    "RestartIntentClosedHeadRecord",
     "RestartIntentHeadRecord",
     "RestartIntentLifecycleHeadRecord",
     "RestartIntentLifecycleRecord",

--- a/tests/unit/test_torchrun_restart_intent_records.py
+++ b/tests/unit/test_torchrun_restart_intent_records.py
@@ -13,6 +13,7 @@ from lm_resiliency.integrations.torchrun._coordinator_lease import (
 )
 from lm_resiliency.integrations.torchrun._protocol import RestartIntent
 from lm_resiliency.integrations.torchrun._restart_intent_records import (
+    RestartIntentClosedHeadRecord,
     RestartIntentHeadRecord,
     RestartIntentLifecycleHeadRecord,
     RestartIntentLifecycleRecord,
@@ -72,6 +73,17 @@ def _lifecycle_head() -> RestartIntentLifecycleHeadRecord:
         generation=lifecycle.closed_intent.generation,
         intent_id=lifecycle.closed_intent.intent_id,
         lifecycle_digest=lifecycle.digest,
+    )
+
+
+def _closed_head() -> RestartIntentClosedHeadRecord:
+    lifecycle_head = _lifecycle_head()
+    return RestartIntentClosedHeadRecord(
+        run_id=lifecycle_head.run_id,
+        closure_index=lifecycle_head.closure_index,
+        generation=lifecycle_head.generation,
+        intent_id=lifecycle_head.intent_id,
+        lifecycle_head_digest=lifecycle_head.digest,
     )
 
 
@@ -156,6 +168,22 @@ def test_restart_intent_lifecycle_head_round_trips_canonical_json():
         + _lifecycle().digest.encode("ascii")
         + b'","run_id":"training-run","schema_version":1}'
     )
+    assert head.digest == hashlib.sha256(encoded).hexdigest()
+
+
+def test_restart_intent_closed_head_round_trips_canonical_json():
+    head = _closed_head()
+
+    encoded = head.to_json()
+    decoded = RestartIntentClosedHeadRecord.from_json(encoded)
+
+    assert decoded == head
+    assert encoded == (
+        b'{"closure_index":3,"generation":4,"intent_id":"intent-a",'
+        b'"lifecycle_head_digest":"'
+        + _lifecycle_head().digest.encode("ascii")
+        + b'","run_id":"training-run","schema_version":1}'
+    )
 
 
 def test_restart_intent_record_is_immutable():
@@ -183,6 +211,13 @@ def test_restart_intent_lifecycle_is_immutable():
 
 def test_restart_intent_lifecycle_head_is_immutable():
     head = _lifecycle_head()
+
+    with pytest.raises(AttributeError):
+        head.closure_index = 4
+
+
+def test_restart_intent_closed_head_is_immutable():
+    head = _closed_head()
 
     with pytest.raises(AttributeError):
         head.closure_index = 4
@@ -231,6 +266,28 @@ def test_restart_intent_lifecycle_head_validates_constructor_fields(
 ):
     with pytest.raises(ValueError, match=message):
         replace(_lifecycle_head(), **{field: value})
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("run_id", "", "run_id"),
+        ("closure_index", 0, "closure_index"),
+        ("closure_index", True, "closure_index"),
+        ("generation", -1, "generation"),
+        ("generation", True, "generation"),
+        ("intent_id", "", "intent_id"),
+        ("lifecycle_head_digest", "", "lifecycle_head_digest"),
+        ("lifecycle_head_digest", "A" * 64, "lifecycle_head_digest"),
+    ],
+)
+def test_restart_intent_closed_head_validates_constructor_fields(
+    field,
+    value,
+    message,
+):
+    with pytest.raises(ValueError, match=message):
+        replace(_closed_head(), **{field: value})
 
 
 @pytest.mark.parametrize(
@@ -475,6 +532,52 @@ def test_restart_intent_lifecycle_head_rejects_invalid_wire_values(
 
 
 @pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda value: value.pop("closure_index"),
+            "missing fields",
+        ),
+        (
+            lambda value: value.update({"unknown": True}),
+            "unknown fields",
+        ),
+        (
+            lambda value: value.update({"schema_version": 2}),
+            "unsupported value",
+        ),
+        (
+            lambda value: value.update({"schema_version": 1.0}),
+            "unsupported value",
+        ),
+        (
+            lambda value: value.update({"closure_index": 0}),
+            "closure_index",
+        ),
+        (
+            lambda value: value.update({"generation": -1}),
+            "generation",
+        ),
+        (
+            lambda value: value.update({"lifecycle_head_digest": "A" * 64}),
+            "lifecycle_head_digest",
+        ),
+    ],
+)
+def test_restart_intent_closed_head_rejects_invalid_wire_values(
+    mutate,
+    message,
+):
+    value = json.loads(_closed_head().to_json())
+    mutate(value)
+
+    with pytest.raises(ValueError, match=message):
+        RestartIntentClosedHeadRecord.from_json(
+            json.dumps(value, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        )
+
+
+@pytest.mark.parametrize(
     "encoded",
     [
         b"not-json",
@@ -539,6 +642,27 @@ def test_restart_intent_lifecycle_head_rejects_malformed_or_duplicate_json(
         RestartIntentLifecycleHeadRecord.from_json(encoded)
 
 
+@pytest.mark.parametrize(
+    "encoded",
+    [
+        b"not-json",
+        b"[]",
+        b'{"schema_version":1,"schema_version":1}',
+        (
+            b'{"closure_index":3,"generation":4,"intent_id":"intent-a",'
+            b'"intent_id":"intent-b","lifecycle_head_digest":"'
+            + b"a" * 64
+            + b'","run_id":"training-run","schema_version":1}'
+        ),
+    ],
+)
+def test_restart_intent_closed_head_rejects_malformed_or_duplicate_json(
+    encoded,
+):
+    with pytest.raises(ValueError):
+        RestartIntentClosedHeadRecord.from_json(encoded)
+
+
 def test_restart_intent_lifecycle_rejects_duplicate_nested_fields():
     encoded = (
         _lifecycle()
@@ -565,3 +689,6 @@ def test_restart_intent_record_requires_encoded_bytes():
 
     with pytest.raises(ValueError, match="encoded bytes"):
         RestartIntentLifecycleHeadRecord.from_json(_lifecycle_head().to_json().decode("utf-8"))
+
+    with pytest.raises(ValueError, match="encoded bytes"):
+        RestartIntentClosedHeadRecord.from_json(_closed_head().to_json().decode("utf-8"))


### PR DESCRIPTION
## Problem

Restart-intent lifecycle closure needs durable evidence that the current-intent pointer was closed in the same transaction as lifecycle advancement. Deleting the pointer would require a separate generic tombstone API for readers after coordinator restart.

## Implementation

- add strict immutable `RestartIntentClosedHeadRecord`
- bind the closure index, generation, intent identity, and canonical lifecycle-head digest
- add a canonical digest to `RestartIntentLifecycleHeadRecord`
- document persistent closed markers as the current-intent lifecycle model

This PR adds records only. It does not add store mutation, intent opening, lifecycle closure, or runtime activation.

## Compatibility

The records are internal and newly introduced. Public APIs and optional dependency behavior are unchanged.

## Validation

- 190 focused torchrun protocol/record tests
- 1,557 full CPU tests with CUDA hidden
- repository-wide Ruff check and format check
- targeted mypy
- `git diff --check`