### PR TITLE
[Feature][Torchrun] Add initial restart intent transaction descriptors

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -597,7 +597,10 @@ transactions are separate control-plane components. A frozen
 current-intent head, exact generation revisions, coordinator fencing token,
 canonical run-scoped keys, and lease/intent commit window. It exposes immutable
 create-once writes and side-effect-free generation conditions but performs no
-store reads or mutations.
+store reads or mutations. The descriptor carries the complete held coordinator
+lease and requires the intent record to match its identity, duration, fencing
+token, and authoritative grant time. A later preparer authenticates that handle
+against persisted ownership before constructing the descriptor.
 
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -592,7 +592,12 @@ atomically replaces the open current-intent head with this marker while
 advancing the lifecycle head and creating the immutable closure record. The
 next intent replaces the marker instead of relying on deletion, so a restarted
 reader can prove closure from persisted state. Atomic opening and closure
-transactions are separate control-plane components.
+transactions are separate control-plane components. A frozen
+`PreparedInitialRestartIntentOpen` descriptor binds the first intent record,
+current-intent head, exact generation revisions, coordinator fencing token,
+canonical run-scoped keys, and lease/intent commit window. It exposes immutable
+create-once writes and side-effect-free generation conditions but performs no
+store reads or mutations.
 
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be

--- a/lm_resiliency/integrations/torchrun/_restart_intent_open_records.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_open_records.py
@@ -1,0 +1,152 @@
+"""Immutable transaction inputs for opening the first restart intent."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+
+from lm_resiliency.integrations.torchrun._control_store import ControlStoreWrite
+from lm_resiliency.integrations.torchrun._generation_reader import CurrentGeneration
+from lm_resiliency.integrations.torchrun._restart_intent_records import (
+    RestartIntentHeadRecord,
+    RestartIntentRecord,
+)
+
+_CONTROL_PREFIX = "lm_resiliency/torchrun/v1"
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedInitialRestartIntentOpen:
+    """Immutable inputs for the first restart-intent guarded transaction."""
+
+    record: RestartIntentRecord
+    head: RestartIntentHeadRecord
+    current: CurrentGeneration
+    intent_key: str
+    intent_head_key: str
+    coordinator_lease_key: str
+    expected_guard_revision: int
+    generation_head_key: str
+    generation_snapshot_key: str
+    coordinator_lease_granted_at_unix_ms: int
+    not_before_unix_ms: int
+    deadline_unix_ms: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.record, RestartIntentRecord):
+            raise TypeError("PreparedInitialRestartIntentOpen.record must be RestartIntentRecord")
+        if not isinstance(self.head, RestartIntentHeadRecord):
+            raise TypeError("PreparedInitialRestartIntentOpen.head must be RestartIntentHeadRecord")
+        if not isinstance(self.current, CurrentGeneration):
+            raise TypeError("PreparedInitialRestartIntentOpen.current must be CurrentGeneration")
+        if (
+            self.head.run_id != self.record.intent.run_id
+            or self.head.generation != self.record.intent.generation
+            or self.head.intent_id != self.record.intent.intent_id
+            or self.head.intent_digest != self.record.digest
+        ):
+            raise ValueError(
+                "PreparedInitialRestartIntentOpen head does not identify its intent record"
+            )
+        assignment = self.current.snapshot.record.assignment
+        if (
+            assignment.run_id != self.record.intent.run_id
+            or assignment.generation != self.record.intent.generation
+            or self.current.snapshot.record.digest != self.record.generation_snapshot_digest
+        ):
+            raise ValueError(
+                "PreparedInitialRestartIntentOpen generation does not identify its intent record"
+            )
+        run_digest = hashlib.sha256(self.record.intent.run_id.encode("utf-8")).hexdigest()
+        run_prefix = f"{_CONTROL_PREFIX}/runs/{run_digest}"
+        intent_digest = hashlib.sha256(self.record.intent.intent_id.encode("utf-8")).hexdigest()
+        expected_keys = {
+            "intent_key": f"{run_prefix}/restart-intents/{intent_digest}",
+            "intent_head_key": f"{run_prefix}/restart-intent-head",
+            "coordinator_lease_key": f"{run_prefix}/coordinator-lease",
+            "generation_head_key": f"{run_prefix}/generation-head",
+            "generation_snapshot_key": (
+                f"{run_prefix}/generations/{self.record.intent.generation}"
+            ),
+        }
+        for path, expected_key in expected_keys.items():
+            if getattr(self, path) != expected_key:
+                raise ValueError(f"PreparedInitialRestartIntentOpen.{path} is not canonical")
+        for path, integer_value in (
+            ("expected_guard_revision", self.expected_guard_revision),
+            ("generation_head_revision", self.current.head_revision),
+            ("generation_snapshot_revision", self.current.snapshot.revision),
+            (
+                "generation_snapshot_committed_at_unix_ms",
+                self.current.snapshot.committed_at_unix_ms,
+            ),
+            (
+                "coordinator_lease_granted_at_unix_ms",
+                self.coordinator_lease_granted_at_unix_ms,
+            ),
+            ("not_before_unix_ms", self.not_before_unix_ms),
+            ("deadline_unix_ms", self.deadline_unix_ms),
+        ):
+            _positive_integer(integer_value, f"PreparedInitialRestartIntentOpen.{path}")
+        if self.expected_guard_revision != self.record.coordinator_fencing_token:
+            raise ValueError(
+                "PreparedInitialRestartIntentOpen guard revision does not match its intent record"
+            )
+        if self.not_before_unix_ms < self.coordinator_lease_granted_at_unix_ms:
+            raise ValueError(
+                "PreparedInitialRestartIntentOpen cannot precede its coordinator lease grant"
+            )
+        if self.not_before_unix_ms < self.current.snapshot.committed_at_unix_ms:
+            raise ValueError(
+                "PreparedInitialRestartIntentOpen cannot precede its generation snapshot"
+            )
+        if self.not_before_unix_ms >= self.deadline_unix_ms:
+            raise ValueError(
+                "PreparedInitialRestartIntentOpen.not_before_unix_ms must precede its deadline"
+            )
+        lease_expiry_unix_ms = (
+            self.coordinator_lease_granted_at_unix_ms + self.record.coordinator_lease_duration_ms
+        )
+        if self.deadline_unix_ms > lease_expiry_unix_ms:
+            raise ValueError(
+                "PreparedInitialRestartIntentOpen deadline exceeds its coordinator lease"
+            )
+        if self.deadline_unix_ms > self.record.intent.prepare_deadline_unix_ms:
+            raise ValueError("PreparedInitialRestartIntentOpen deadline exceeds its restart intent")
+
+    @property
+    def writes(self) -> Mapping[str, ControlStoreWrite]:
+        return MappingProxyType(
+            {
+                self.intent_head_key: ControlStoreWrite(
+                    expected_revision=None,
+                    value=self.head.to_json(),
+                    require_never_created=True,
+                ),
+                self.intent_key: ControlStoreWrite(
+                    expected_revision=None,
+                    value=self.record.to_json(),
+                    require_never_created=True,
+                ),
+            }
+        )
+
+    @property
+    def conditions(self) -> Mapping[str, int]:
+        return MappingProxyType(
+            {
+                self.generation_head_key: self.current.head_revision,
+                self.generation_snapshot_key: self.current.snapshot.revision,
+            }
+        )
+
+
+def _positive_integer(value: object, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{path} must be a positive integer")
+    return value
+
+
+__all__ = ["PreparedInitialRestartIntentOpen"]

--- a/lm_resiliency/integrations/torchrun/_restart_intent_open_records.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_open_records.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from types import MappingProxyType
 
 from lm_resiliency.integrations.torchrun._control_store import ControlStoreWrite
+from lm_resiliency.integrations.torchrun._coordinator_lease import HeldCoordinatorLease
 from lm_resiliency.integrations.torchrun._generation_reader import CurrentGeneration
 from lm_resiliency.integrations.torchrun._restart_intent_records import (
     RestartIntentHeadRecord,
@@ -24,13 +25,12 @@ class PreparedInitialRestartIntentOpen:
     record: RestartIntentRecord
     head: RestartIntentHeadRecord
     current: CurrentGeneration
+    lease: HeldCoordinatorLease
     intent_key: str
     intent_head_key: str
     coordinator_lease_key: str
-    expected_guard_revision: int
     generation_head_key: str
     generation_snapshot_key: str
-    coordinator_lease_granted_at_unix_ms: int
     not_before_unix_ms: int
     deadline_unix_ms: int
 
@@ -41,6 +41,8 @@ class PreparedInitialRestartIntentOpen:
             raise TypeError("PreparedInitialRestartIntentOpen.head must be RestartIntentHeadRecord")
         if not isinstance(self.current, CurrentGeneration):
             raise TypeError("PreparedInitialRestartIntentOpen.current must be CurrentGeneration")
+        if not isinstance(self.lease, HeldCoordinatorLease):
+            raise TypeError("PreparedInitialRestartIntentOpen.lease must be HeldCoordinatorLease")
         if (
             self.head.run_id != self.record.intent.run_id
             or self.head.generation != self.record.intent.generation
@@ -59,6 +61,23 @@ class PreparedInitialRestartIntentOpen:
             raise ValueError(
                 "PreparedInitialRestartIntentOpen generation does not identify its intent record"
             )
+        active_nodes = set(assignment.slot_to_node_id.values())
+        unknown_nodes = sorted(set(self.record.intent.suspected_node_ids) - active_nodes)
+        if unknown_nodes:
+            raise ValueError(
+                "PreparedInitialRestartIntentOpen suspects nodes outside its "
+                f"generation: {unknown_nodes!r}"
+            )
+        if (
+            self.lease.record.run_id != self.record.intent.run_id
+            or self.lease.record.coordinator_id != self.record.coordinator_id
+            or self.lease.record.lease_id != self.record.lease_id
+            or self.lease.record.lease_duration_ms != self.record.coordinator_lease_duration_ms
+            or self.lease.fencing_token != self.record.coordinator_fencing_token
+        ):
+            raise ValueError(
+                "PreparedInitialRestartIntentOpen lease does not authorize its intent record"
+            )
         run_digest = hashlib.sha256(self.record.intent.run_id.encode("utf-8")).hexdigest()
         run_prefix = f"{_CONTROL_PREFIX}/runs/{run_digest}"
         intent_digest = hashlib.sha256(self.record.intent.intent_id.encode("utf-8")).hexdigest()
@@ -75,26 +94,18 @@ class PreparedInitialRestartIntentOpen:
             if getattr(self, path) != expected_key:
                 raise ValueError(f"PreparedInitialRestartIntentOpen.{path} is not canonical")
         for path, integer_value in (
-            ("expected_guard_revision", self.expected_guard_revision),
             ("generation_head_revision", self.current.head_revision),
             ("generation_snapshot_revision", self.current.snapshot.revision),
             (
                 "generation_snapshot_committed_at_unix_ms",
                 self.current.snapshot.committed_at_unix_ms,
             ),
-            (
-                "coordinator_lease_granted_at_unix_ms",
-                self.coordinator_lease_granted_at_unix_ms,
-            ),
+            ("coordinator_lease_granted_at_unix_ms", self.lease.granted_at_unix_ms),
             ("not_before_unix_ms", self.not_before_unix_ms),
             ("deadline_unix_ms", self.deadline_unix_ms),
         ):
             _positive_integer(integer_value, f"PreparedInitialRestartIntentOpen.{path}")
-        if self.expected_guard_revision != self.record.coordinator_fencing_token:
-            raise ValueError(
-                "PreparedInitialRestartIntentOpen guard revision does not match its intent record"
-            )
-        if self.not_before_unix_ms < self.coordinator_lease_granted_at_unix_ms:
+        if self.not_before_unix_ms < self.lease.granted_at_unix_ms:
             raise ValueError(
                 "PreparedInitialRestartIntentOpen cannot precede its coordinator lease grant"
             )
@@ -106,15 +117,16 @@ class PreparedInitialRestartIntentOpen:
             raise ValueError(
                 "PreparedInitialRestartIntentOpen.not_before_unix_ms must precede its deadline"
             )
-        lease_expiry_unix_ms = (
-            self.coordinator_lease_granted_at_unix_ms + self.record.coordinator_lease_duration_ms
-        )
-        if self.deadline_unix_ms > lease_expiry_unix_ms:
+        if self.deadline_unix_ms > self.lease.expires_at_unix_ms:
             raise ValueError(
                 "PreparedInitialRestartIntentOpen deadline exceeds its coordinator lease"
             )
         if self.deadline_unix_ms > self.record.intent.prepare_deadline_unix_ms:
             raise ValueError("PreparedInitialRestartIntentOpen deadline exceeds its restart intent")
+
+    @property
+    def expected_guard_revision(self) -> int:
+        return self.lease.fencing_token
 
     @property
     def writes(self) -> Mapping[str, ControlStoreWrite]:

--- a/tests/unit/test_torchrun_restart_intent_open_records.py
+++ b/tests/unit/test_torchrun_restart_intent_open_records.py
@@ -8,6 +8,10 @@ from typing import Any, cast
 
 import pytest
 
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseRecord,
+    HeldCoordinatorLease,
+)
 from lm_resiliency.integrations.torchrun._generation_reader import (
     CurrentGeneration,
     StoredGenerationSnapshot,
@@ -33,7 +37,10 @@ RUN_DIGEST = hashlib.sha256(RUN_ID.encode("utf-8")).hexdigest()
 RUN_PREFIX = f"lm_resiliency/torchrun/v1/runs/{RUN_DIGEST}"
 
 
-def _intent() -> RestartIntent:
+def _intent(
+    *,
+    suspected_node_ids: tuple[str, ...] = ("node-b",),
+) -> RestartIntent:
     return RestartIntent(
         intent_id="intent-a",
         run_id=RUN_ID,
@@ -41,7 +48,7 @@ def _intent() -> RestartIntent:
         incident_ids=("incident-a",),
         reason_code="attributed_sdc",
         minimum_recovery_mode="recovery_verified",
-        suspected_node_ids=("node-b",),
+        suspected_node_ids=suspected_node_ids,
         prepare_deadline_unix_ms=1_050,
     )
 
@@ -100,13 +107,21 @@ def _prepared() -> PreparedInitialRestartIntentOpen:
         record=record,
         head=head,
         current=current,
+        lease=HeldCoordinatorLease(
+            record=CoordinatorLeaseRecord(
+                run_id=RUN_ID,
+                coordinator_id="coordinator-a",
+                lease_id="lease-a",
+                lease_duration_ms=100,
+            ),
+            fencing_token=7,
+            granted_at_unix_ms=1_000,
+        ),
         intent_key=f"{RUN_PREFIX}/restart-intents/{intent_digest}",
         intent_head_key=f"{RUN_PREFIX}/restart-intent-head",
         coordinator_lease_key=f"{RUN_PREFIX}/coordinator-lease",
-        expected_guard_revision=7,
         generation_head_key=f"{RUN_PREFIX}/generation-head",
         generation_snapshot_key=f"{RUN_PREFIX}/generations/0",
-        coordinator_lease_granted_at_unix_ms=1_000,
         not_before_unix_ms=1_000,
         deadline_unix_ms=1_050,
     )
@@ -141,13 +156,13 @@ def test_prepared_initial_open_is_immutable():
     "changes",
     [
         {"head": replace(_prepared().head, intent_id="other")},
-        {"expected_guard_revision": 8},
+        {"lease": replace(_prepared().lease, fencing_token=8)},
         {"intent_key": "other"},
         {"intent_head_key": "other"},
         {"coordinator_lease_key": "other"},
         {"generation_head_key": "other"},
         {"generation_snapshot_key": "other"},
-        {"coordinator_lease_granted_at_unix_ms": 1_001},
+        {"lease": replace(_prepared().lease, granted_at_unix_ms=1_001)},
         {"not_before_unix_ms": 999},
         {"deadline_unix_ms": 1_051},
     ],
@@ -166,6 +181,8 @@ def test_prepared_initial_open_requires_expected_record_types():
         replace(prepared, head={})
     with pytest.raises(TypeError, match="CurrentGeneration"):
         replace(prepared, current={})
+    with pytest.raises(TypeError, match="HeldCoordinatorLease"):
+        replace(prepared, lease={})
 
 
 def test_prepared_initial_open_binds_exact_generation_snapshot():
@@ -185,11 +202,38 @@ def test_prepared_initial_open_binds_exact_generation_snapshot():
         )
 
 
+def test_prepared_initial_open_rejects_suspects_outside_generation():
+    prepared = _prepared()
+    record = replace(
+        prepared.record,
+        intent=_intent(suspected_node_ids=("node-c",)),
+    )
+    head = replace(
+        prepared.head,
+        intent_digest=record.digest,
+    )
+
+    with pytest.raises(ValueError, match="outside"):
+        replace(prepared, record=record, head=head)
+
+
+def test_prepared_initial_open_binds_complete_held_lease():
+    prepared = _prepared()
+    longer_lease = replace(
+        prepared.lease,
+        record=replace(
+            prepared.lease.record,
+            lease_duration_ms=1_000,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="lease does not authorize"):
+        replace(prepared, lease=longer_lease)
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     [
-        ("expected_guard_revision", False),
-        ("coordinator_lease_granted_at_unix_ms", 0),
         ("not_before_unix_ms", 0),
         ("deadline_unix_ms", 0),
     ],

--- a/tests/unit/test_torchrun_restart_intent_open_records.py
+++ b/tests/unit/test_torchrun_restart_intent_open_records.py
@@ -1,0 +1,246 @@
+"""Contract tests for prepared initial restart-intent transaction inputs."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import replace
+from typing import Any, cast
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._generation_reader import (
+    CurrentGeneration,
+    StoredGenerationSnapshot,
+)
+from lm_resiliency.integrations.torchrun._generation_records import (
+    GenerationSnapshotRecord,
+)
+from lm_resiliency.integrations.torchrun._protocol import (
+    RankAssignment,
+    RestartIntent,
+    SlotAssignment,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_records import (
+    PreparedInitialRestartIntentOpen,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_records import (
+    RestartIntentHeadRecord,
+    RestartIntentRecord,
+)
+
+RUN_ID = "training-run"
+RUN_DIGEST = hashlib.sha256(RUN_ID.encode("utf-8")).hexdigest()
+RUN_PREFIX = f"lm_resiliency/torchrun/v1/runs/{RUN_DIGEST}"
+
+
+def _intent() -> RestartIntent:
+    return RestartIntent(
+        intent_id="intent-a",
+        run_id=RUN_ID,
+        generation=0,
+        incident_ids=("incident-a",),
+        reason_code="attributed_sdc",
+        minimum_recovery_mode="recovery_verified",
+        suspected_node_ids=("node-b",),
+        prepare_deadline_unix_ms=1_050,
+    )
+
+
+def _current() -> CurrentGeneration:
+    assignment = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=0,
+        assignments=(
+            SlotAssignment(0, "node-a", 0, 2),
+            SlotAssignment(1, "node-b", 2, 2),
+        ),
+        topology_digest="topology-v1",
+    )
+    record = GenerationSnapshotRecord(
+        assignment=assignment,
+        previous_snapshot_digest=None,
+        coordinator_id="coordinator-a",
+        lease_id="lease-a",
+        coordinator_lease_duration_ms=100,
+        coordinator_fencing_token=7,
+    )
+    return CurrentGeneration(
+        snapshot=StoredGenerationSnapshot(
+            record=record,
+            revision=11,
+            committed_at_unix_ms=1_000,
+            transaction_sequence=4,
+            guard_mutation_sequence=1,
+            guard_value_sequence=1,
+            guard_lifetime_sequence=1,
+            guard_committed_at_unix_ms=1_000,
+        ),
+        head_revision=12,
+    )
+
+
+def _prepared() -> PreparedInitialRestartIntentOpen:
+    current = _current()
+    record = RestartIntentRecord(
+        intent=_intent(),
+        generation_snapshot_digest=current.snapshot.record.digest,
+        coordinator_id="coordinator-a",
+        lease_id="lease-a",
+        coordinator_lease_duration_ms=100,
+        coordinator_fencing_token=7,
+    )
+    head = RestartIntentHeadRecord(
+        run_id=RUN_ID,
+        generation=0,
+        intent_id="intent-a",
+        intent_digest=record.digest,
+    )
+    intent_digest = hashlib.sha256(b"intent-a").hexdigest()
+    return PreparedInitialRestartIntentOpen(
+        record=record,
+        head=head,
+        current=current,
+        intent_key=f"{RUN_PREFIX}/restart-intents/{intent_digest}",
+        intent_head_key=f"{RUN_PREFIX}/restart-intent-head",
+        coordinator_lease_key=f"{RUN_PREFIX}/coordinator-lease",
+        expected_guard_revision=7,
+        generation_head_key=f"{RUN_PREFIX}/generation-head",
+        generation_snapshot_key=f"{RUN_PREFIX}/generations/0",
+        coordinator_lease_granted_at_unix_ms=1_000,
+        not_before_unix_ms=1_000,
+        deadline_unix_ms=1_050,
+    )
+
+
+def test_prepared_initial_open_builds_immutable_create_once_transaction_inputs():
+    prepared = _prepared()
+
+    assert set(prepared.writes) == {prepared.intent_head_key, prepared.intent_key}
+    assert all(write.expected_revision is None for write in prepared.writes.values())
+    assert all(write.require_never_created for write in prepared.writes.values())
+    assert prepared.writes[prepared.intent_head_key].value == prepared.head.to_json()
+    assert prepared.writes[prepared.intent_key].value == prepared.record.to_json()
+    assert prepared.conditions == {
+        prepared.generation_head_key: prepared.current.head_revision,
+        prepared.generation_snapshot_key: prepared.current.snapshot.revision,
+    }
+    with pytest.raises(TypeError):
+        cast(Any, prepared.writes)["other"] = next(iter(prepared.writes.values()))
+    with pytest.raises(TypeError):
+        cast(Any, prepared.conditions)["other"] = 1
+
+
+def test_prepared_initial_open_is_immutable():
+    prepared = _prepared()
+
+    with pytest.raises(AttributeError):
+        prepared.intent_key = "other"
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"head": replace(_prepared().head, intent_id="other")},
+        {"expected_guard_revision": 8},
+        {"intent_key": "other"},
+        {"intent_head_key": "other"},
+        {"coordinator_lease_key": "other"},
+        {"generation_head_key": "other"},
+        {"generation_snapshot_key": "other"},
+        {"coordinator_lease_granted_at_unix_ms": 1_001},
+        {"not_before_unix_ms": 999},
+        {"deadline_unix_ms": 1_051},
+    ],
+)
+def test_prepared_initial_open_rejects_inconsistent_authority(changes):
+    with pytest.raises(ValueError):
+        replace(_prepared(), **changes)
+
+
+def test_prepared_initial_open_requires_expected_record_types():
+    prepared = _prepared()
+
+    with pytest.raises(TypeError, match="RestartIntentRecord"):
+        replace(prepared, record={})
+    with pytest.raises(TypeError, match="RestartIntentHeadRecord"):
+        replace(prepared, head={})
+    with pytest.raises(TypeError, match="CurrentGeneration"):
+        replace(prepared, current={})
+
+
+def test_prepared_initial_open_binds_exact_generation_snapshot():
+    prepared = _prepared()
+    changed_snapshot = replace(
+        prepared.current.snapshot,
+        record=replace(
+            prepared.current.snapshot.record,
+            coordinator_id="other-coordinator",
+        ),
+    )
+
+    with pytest.raises(ValueError, match="generation"):
+        replace(
+            prepared,
+            current=replace(prepared.current, snapshot=changed_snapshot),
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("expected_guard_revision", False),
+        ("coordinator_lease_granted_at_unix_ms", 0),
+        ("not_before_unix_ms", 0),
+        ("deadline_unix_ms", 0),
+    ],
+)
+def test_prepared_initial_open_rejects_invalid_integer_fields(field, value):
+    with pytest.raises(ValueError, match="positive integer"):
+        replace(_prepared(), **{field: value})
+
+
+def test_prepared_initial_open_rejects_invalid_generation_revisions():
+    prepared = _prepared()
+
+    with pytest.raises(ValueError, match="positive integer"):
+        replace(
+            prepared,
+            current=replace(prepared.current, head_revision=False),
+        )
+    with pytest.raises(ValueError, match="positive integer"):
+        replace(
+            prepared,
+            current=replace(
+                prepared.current,
+                snapshot=replace(prepared.current.snapshot, revision=0),
+            ),
+        )
+
+
+def test_prepared_initial_open_rejects_invalid_time_ordering():
+    prepared = _prepared()
+
+    with pytest.raises(ValueError, match="generation snapshot"):
+        replace(
+            prepared,
+            current=replace(
+                prepared.current,
+                snapshot=replace(
+                    prepared.current.snapshot,
+                    committed_at_unix_ms=1_001,
+                ),
+            ),
+        )
+    with pytest.raises(ValueError, match="precede its deadline"):
+        replace(
+            prepared,
+            not_before_unix_ms=prepared.deadline_unix_ms,
+        )
+
+
+def test_prepared_initial_open_uses_canonical_hashed_keys():
+    prepared = _prepared()
+
+    assert RUN_ID not in prepared.intent_key
+    assert "intent-a" not in prepared.intent_key
+    assert prepared.intent_key.startswith(f"{RUN_PREFIX}/restart-intents/")


### PR DESCRIPTION
## Problem

The restart-intent open path needs immutable transaction inputs that cannot redirect a future executor to another run, intent, or generation and cannot outlive the authenticated held lease or preparation deadline.

## Implementation

- add frozen `PreparedInitialRestartIntentOpen`
- bind the intent/head records to the exact verified generation snapshot
- bind the complete `HeldCoordinatorLease` identity, duration, fencing token, and grant time
- reject suspected nodes outside the committed generation
- derive and validate canonical hashed control-store keys
- expose immutable create-once writes for the intent record and current head
- expose exact generation head/snapshot revision conditions
- validate lease/intent time-window consistency

This PR adds only the transaction descriptor. It performs no store reads or mutations. A later preparer authenticates the held lease against persisted ownership before constructing it.

## Compatibility

The component is internal and newly introduced. Public APIs and optional dependency behavior are unchanged.

## Validation

- 191 focused torchrun descriptor/lease/record/generation tests
- 1,578 full CPU tests with CUDA hidden
- repository-wide Ruff check and format check
- targeted mypy
- `git diff --check`