### PR TITLE
[Docs] Document private conduct reporting channel

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -40,18 +40,20 @@ Examples of representing the community include using an official email address, 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately by email to `lm.resiliency.dev@gmail.com`.
-This project mailbox is restricted to the [current maintainers](MAINTAINERS.md).
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately by email to `lm.resiliency.dev@gmail.com`, which is monitored by `@lmresiliencydev`.
 Do not file a public issue containing sensitive conduct details.
 
-A maintainer will acknowledge a report within three business days and will review and investigate it promptly and fairly.
+Reports received through this mailbox or the conflict mailbox below will be acknowledged within three business days and reviewed and investigated promptly and fairly.
 Report details will be shared only with the people needed to investigate and respond.
 Except when required by law or needed to address an immediate safety risk, maintainers will obtain the reporter's consent before sharing details outside that group.
 
-If a report concerns a current maintainer, or the reporter does not want any current maintainer to access it, do not use the project mailbox.
+If a report concerns `@lmresiliencydev`, do not use the project mailbox; email `wangzhuangowl@gmail.com`, which is monitored by `@zhuangwang93`.
+If a report concerns `@zhuangwang93`, use the project mailbox so `@lmresiliencydev` can handle it.
+If both maintainers are conflicted, do not use either mailbox.
 For conduct on GitHub, use GitHub's private [abuse-reporting process](https://docs.github.com/en/communities/maintaining-your-safety-on-github/reporting-abuse-or-spam) and choose the option to report to GitHub Support rather than repository administrators.
-For conduct in another project community space, use that platform operator's private safety or abuse-reporting channel and identify the maintainer conflict.
-These external routes are the conflict-safe escalation path because the project does not currently have an independent moderation team.
+For conduct in another hosted project space or at an event, use the platform operator's, event organizer's, or venue's private safety or abuse-reporting channel and identify the maintainer conflict.
+These external routes follow the receiving organization's response policy and timeline.
+They are the conflict-safe escalation path because the project does not currently have an independent moderation team.
 The project will cooperate with an external reviewer only with the reporter's consent, except when required by law or needed to address an immediate safety risk.
 
 This mailbox is for conduct reports, not security vulnerabilities.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -40,9 +40,20 @@ Examples of representing the community include using an official email address, 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately using a maintainer's private contact method on GitHub.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately by email to `lm.resiliency.dev@gmail.com`.
+This project mailbox is restricted to the [current maintainers](MAINTAINERS.md).
 Do not file a public issue containing sensitive conduct details.
-All complaints will be reviewed and investigated promptly and fairly.
+
+A maintainer will acknowledge a report within three business days and will review and investigate it promptly and fairly.
+Report details will be shared only with the people needed to investigate and respond.
+Except when required by law or needed to address an immediate safety risk, maintainers will ask the reporter before sharing details outside that group.
+
+If a report concerns a maintainer, identify the conflict in the email subject so that maintainer can be excluded from the investigation and response.
+The remaining conflict-free maintainer will handle the report.
+If no conflict-free project maintainer remains, the acknowledging maintainer will offer to engage a mutually acceptable independent reviewer and will not share report details with that reviewer without the reporter's consent.
+
+This mailbox is for conduct reports, not security vulnerabilities.
+Report vulnerabilities through the separate private process in [SECURITY.md](SECURITY.md).
 
 Community leaders must respect the privacy and security of the reporter of any incident.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -46,11 +46,13 @@ Do not file a public issue containing sensitive conduct details.
 
 A maintainer will acknowledge a report within three business days and will review and investigate it promptly and fairly.
 Report details will be shared only with the people needed to investigate and respond.
-Except when required by law or needed to address an immediate safety risk, maintainers will ask the reporter before sharing details outside that group.
+Except when required by law or needed to address an immediate safety risk, maintainers will obtain the reporter's consent before sharing details outside that group.
 
-If a report concerns a maintainer, identify the conflict in the email subject so that maintainer can be excluded from the investigation and response.
-The remaining conflict-free maintainer will handle the report.
-If no conflict-free project maintainer remains, the acknowledging maintainer will offer to engage a mutually acceptable independent reviewer and will not share report details with that reviewer without the reporter's consent.
+If a report concerns a current maintainer, or the reporter does not want any current maintainer to access it, do not use the project mailbox.
+For conduct on GitHub, use GitHub's private [abuse-reporting process](https://docs.github.com/en/communities/maintaining-your-safety-on-github/reporting-abuse-or-spam) and choose the option to report to GitHub Support rather than repository administrators.
+For conduct in another project community space, use that platform operator's private safety or abuse-reporting channel and identify the maintainer conflict.
+These external routes are the conflict-safe escalation path because the project does not currently have an independent moderation team.
+The project will cooperate with an external reviewer only with the reporter's consent, except when required by law or needed to address an immediate safety risk.
 
 This mailbox is for conduct reports, not security vulnerabilities.
 Report vulnerabilities through the separate private process in [SECURITY.md](SECURITY.md).


### PR DESCRIPTION
## Summary

Document a concrete private conduct-reporting channel and the response, confidentiality, and conflict-handling process.

Closes #27.

## Problem

The Code of Conduct referred contributors to an unspecified private GitHub contact method, but GitHub does not provide a general direct-message channel. A contributor therefore had no concrete place to submit a sensitive report.

## Changes

- Direct conduct reports to the project mailbox `lm.resiliency.dev@gmail.com`.
- State that access is restricted to the maintainers listed in `MAINTAINERS.md`.
- Commit to acknowledging reports within three business days.
- Limit disclosure to people needed for investigation and response, with reporter consent before broader sharing except for legal or immediate-safety requirements.
- Define conflict handling and an independent-reviewer fallback when no conflict-free maintainer remains.
- Keep conduct reports separate from the private vulnerability-reporting process in `SECURITY.md`.

## Impact

Contributors gain a concrete, private reporting route and clear expectations for acknowledgment, confidentiality, and escalation. No runtime or API behavior changes.

Because this PR documents an operational mailbox commitment, maintainers should confirm before merge that the mailbox is monitored by all maintainers named in `MAINTAINERS.md` and can meet the stated acknowledgment target.

## Validation

- `python -m pytest -q tests/unit/test_documentation.py` — 2 passed.
- `mkdocs build --strict` — passed.
- `git diff --check` — passed.

GPU or distributed validation is not applicable.