### PR TITLE
[CI/Release] Check external documentation links weekly

### DIFF
--- a/.github/workflows/docs-online-links.yml
+++ b/.github/workflows/docs-online-links.yml
@@ -1,0 +1,55 @@
+name: Online Documentation Links
+
+on:
+  schedule:
+    - cron: "23 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-online-links
+  cancel-in-progress: false
+
+jobs:
+  links:
+    name: Check external links
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install verified link checker
+        env:
+          LYCHEE_VERSION: "0.24.2"
+        run: |
+          archive="lychee-x86_64-unknown-linux-gnu.tar.gz"
+          release_url="https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}"
+          curl -fsSL -o "$RUNNER_TEMP/$archive" "$release_url/$archive"
+          curl -fsSL -o "$RUNNER_TEMP/$archive.sha256" "$release_url/$archive.sha256"
+          (
+            cd "$RUNNER_TEMP"
+            sha256sum --check "$archive.sha256"
+            tar -xzf "$archive"
+          )
+
+      - name: Check local and external documentation links
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          "$RUNNER_TEMP/lychee-x86_64-unknown-linux-gnu/lychee" \
+            --exclude-all-private \
+            --exclude '^https://doi\.org/10\.1145/3600006\.3613145$' \
+            --github-token "$GH_TOKEN" \
+            --include-fragments \
+            --max-concurrency 32 \
+            --max-retries 3 \
+            --no-progress \
+            --retry-wait-time 2 \
+            --timeout 30 \
+            './**/*.md'

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,4 +25,4 @@ Before the first stable documentation tree is published, the site root redirects
 
 Publication workflows stage the complete versioned static tree on `gh-pages`. A dedicated trusted workflow then uploads the current staged tree as a GitHub Pages artifact and deploys it through GitHub's Pages deployment API. Repository Pages settings therefore need to use **GitHub Actions** as the publishing source rather than building directly from the `gh-pages` branch.
 
-The repository Markdown remains the source of truth for documentation changes. CI builds the site with warnings treated as errors before changes can satisfy the required CI gate.
+The repository Markdown remains the source of truth for documentation changes. CI builds the site with warnings treated as errors before changes can satisfy the required CI gate. A weekly workflow checks external links online with bounded retries, complementing the deterministic offline link and anchor check that runs on every pull request.

--- a/tests/unit/test_documentation.py
+++ b/tests/unit/test_documentation.py
@@ -60,7 +60,7 @@ def test_deployment_contracts_cover_every_destination():
     assert "pull_request:" not in online_links
     assert "--exclude-all-private" in online_links
     assert "--exclude '^https://doi\\.org/10\\.1145/3600006\\.3613145$'" in online_links
-    assert "--github-token \"$GH_TOKEN\"" in online_links
+    assert '--github-token "$GH_TOKEN"' in online_links
     assert "--max-retries 3" in online_links
     assert "--offline" not in online_links
 

--- a/tests/unit/test_documentation.py
+++ b/tests/unit/test_documentation.py
@@ -29,6 +29,7 @@ def test_source_links_use_checked_out_revision(monkeypatch):
 def test_deployment_contracts_cover_every_destination():
     mkdocs = (ROOT / "mkdocs.yml").read_text()
     development = (ROOT / ".github/workflows/docs.yml").read_text()
+    online_links = (ROOT / ".github/workflows/docs-online-links.yml").read_text()
     release = (ROOT / ".github/workflows/release.yml").read_text()
     pages = (ROOT / ".github/workflows/pages.yml").read_text()
 
@@ -53,6 +54,15 @@ def test_deployment_contracts_cover_every_destination():
     assert 'python "$RELEASE_VERSION_HELPER" latest-stable-tag' in release
     assert "sort -V" not in release
     assert '"torch==2.13.0"' in release
+
+    assert "schedule:" in online_links
+    assert "workflow_dispatch:" in online_links
+    assert "pull_request:" not in online_links
+    assert "--exclude-all-private" in online_links
+    assert "--exclude '^https://doi\\.org/10\\.1145/3600006\\.3613145$'" in online_links
+    assert "--github-token \"$GH_TOKEN\"" in online_links
+    assert "--max-retries 3" in online_links
+    assert "--offline" not in online_links
 
     assert "workflow_run:" in pages
     assert "- Documentation" in pages


### PR DESCRIPTION
## Summary

Add a scheduled online documentation-link check to complement the deterministic offline link and anchor validation that runs on every pull request.

Closes #26.

## Context

PR #42 added strict MkDocs builds, versioned development and release trees, and trusted GitHub Pages publication. GitHub Pages is now enabled with the Actions build type, and recent Documentation and Pages deployments are succeeding. The remaining suggested repository-side validation in #26 is periodic checking of external framework and paper links.

## Changes

- Add a weekly and maintainer-dispatched `Online Documentation Links` workflow.
- Download Lychee 0.24.2 and verify its published SHA-256 checksum before execution.
- Keep repository permissions read-only and prevent overlapping scheduled scans.
- Check Markdown links online with bounded concurrency, timeouts, and retries.
- Pass the scoped GitHub token only through Lychee's GitHub-specific option to avoid anonymous API rate limits.
- Exclude private and link-local addresses from network access.
- Narrowly exclude the ACM GEMINI DOI that resolves correctly but rejects automated clients with HTTP 403.
- Add a contract test for the workflow's schedule, security boundary, retry behavior, and online mode.
- Document how the weekly check complements required pull-request validation.

## Impact

Broken external documentation links are detected periodically without adding network flakiness to the required pull-request gate. No runtime, framework, topology, or public API behavior changes.

## Validation

- `python -m pytest -q tests/unit/test_documentation.py` — 2 passed.
- `mkdocs build --strict` — passed.
- Live Lychee scan — 131 links checked, 72 unique, 128 valid occurrences, 3 exact ACM DOI occurrences excluded, 0 errors.
- `git diff --check` — passed.

GPU or distributed validation is not applicable.