### PR TITLE
[Feature][Torchrun] Prepare authenticated initial restart intents

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -602,9 +602,11 @@ lease and requires the intent record to match its identity, duration, fencing
 token, and authoritative grant time. A later preparer authenticates that handle
 against persisted ownership before constructing the descriptor. The initial
 preparer also revalidates the exact generation, intent scope, never-opened
-lifecycle state, and remaining lease/intent window. It performs no mutation;
-the following execution component owns the guarded transaction and verifies
-the returned store metadata.
+lifecycle state, and remaining lease/intent window against a monotonic
+coordinator clock sampled after those reads. The observation becomes the
+transaction's lower time bound; the store remains authoritative at execution.
+The preparer performs no mutation. The following execution component owns the
+guarded transaction and verifies the returned store metadata.
 
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -600,7 +600,11 @@ create-once writes and side-effect-free generation conditions but performs no
 store reads or mutations. The descriptor carries the complete held coordinator
 lease and requires the intent record to match its identity, duration, fencing
 token, and authoritative grant time. A later preparer authenticates that handle
-against persisted ownership before constructing the descriptor.
+against persisted ownership before constructing the descriptor. The initial
+preparer also revalidates the exact generation, intent scope, never-opened
+lifecycle state, and remaining lease/intent window. It performs no mutation;
+the following execution component owns the guarded transaction and verifies
+the returned store metadata.
 
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -605,8 +605,11 @@ preparer also revalidates the exact generation, intent scope, never-opened
 lifecycle state, and remaining lease/intent window against a monotonic
 coordinator clock sampled after those reads. The observation becomes the
 transaction's lower time bound; the store remains authoritative at execution.
-The preparer performs no mutation. The following execution component owns the
-guarded transaction and verifies the returned store metadata.
+The prepared transaction also carries a never-created lifecycle-head
+condition. The store checks both current absence and durable key history at the
+same linearization point as the lease, generation conditions, and intent
+writes. The preparer performs no mutation. The following execution component
+owns the guarded transaction and verifies the returned store metadata.
 
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be

--- a/lm_resiliency/integrations/torchrun/_control_store.py
+++ b/lm_resiliency/integrations/torchrun/_control_store.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import threading
 import time
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Collection, Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Protocol
@@ -288,6 +288,7 @@ class ControlStore(Protocol):
         not_before_unix_ms: int,
         deadline_unix_ms: int,
         conditions: Mapping[str, int | None] | None = None,
+        never_created_conditions: Collection[str] | None = None,
     ) -> Mapping[str, ControlStoreEntry]:
         """Atomically publish writes while a guard and read conditions hold.
 
@@ -443,18 +444,41 @@ class InMemoryControlStore:
         not_before_unix_ms: int,
         deadline_unix_ms: int,
         conditions: Mapping[str, int | None] | None = None,
+        never_created_conditions: Collection[str] | None = None,
     ) -> Mapping[str, ControlStoreEntry]:
         normalized_writes = _control_writes(writes)
         normalized_conditions = _control_conditions(conditions)
+        normalized_never_created_conditions = _control_key_collection(
+            never_created_conditions,
+            "never_created_conditions",
+        )
         normalized_guard_key = _control_key(guard_key)
         if normalized_guard_key in normalized_writes:
             raise ValueError("guard_key must not also be a transaction target")
         if normalized_guard_key in normalized_conditions:
             raise ValueError("guard_key must not also be a transaction condition")
+        if normalized_guard_key in normalized_never_created_conditions:
+            raise ValueError("guard_key must not also be a never-created condition")
         overlapping_keys = sorted(set(normalized_writes) & set(normalized_conditions))
         if overlapping_keys:
             raise ValueError(
                 f"transaction conditions must not also be targets: {overlapping_keys!r}"
+            )
+        overlapping_never_created_targets = sorted(
+            set(normalized_writes) & normalized_never_created_conditions
+        )
+        if overlapping_never_created_targets:
+            raise ValueError(
+                "never-created conditions must not also be targets: "
+                f"{overlapping_never_created_targets!r}"
+            )
+        overlapping_conditions = sorted(
+            set(normalized_conditions) & normalized_never_created_conditions
+        )
+        if overlapping_conditions:
+            raise ValueError(
+                "never-created conditions must not also be revision conditions: "
+                f"{overlapping_conditions!r}"
             )
         normalized_guard_revision = _required_revision(expected_guard_revision)
         normalized_not_before = _positive_integer(
@@ -473,6 +497,10 @@ class InMemoryControlStore:
             guard_value_digest = hashlib.sha256(guard_entry.value).hexdigest()
             for key, expected_revision in normalized_conditions.items():
                 self._require_revision(key, expected_revision)
+            for key in sorted(normalized_never_created_conditions):
+                self._require_revision(key, None)
+                if key in self._last_revisions:
+                    raise ControlStoreHistoryConflict(key)
             for key, write in normalized_writes.items():
                 self._require_revision(key, write.expected_revision)
                 if write.require_never_created and key in self._last_revisions:
@@ -625,6 +653,17 @@ def _control_conditions(
     if len(result) != len(value):
         raise ValueError("condition keys must be unique")
     return dict(sorted(result.items()))
+
+
+def _control_key_collection(value: object, path: str) -> frozenset[str]:
+    if value is None:
+        return frozenset()
+    if isinstance(value, (str, bytes)) or not isinstance(value, Collection):
+        raise TypeError(f"{path} must be a collection of control-store keys")
+    normalized_keys = tuple(_control_key(key) for key in value)
+    if len(set(normalized_keys)) != len(normalized_keys):
+        raise ValueError(f"{path} keys must be unique")
+    return frozenset(normalized_keys)
 
 
 def _expected_revision(value: object, *, allow_absent: bool) -> int | None:

--- a/lm_resiliency/integrations/torchrun/_restart_intent_open.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_open.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import hashlib
+import threading
+from collections.abc import Callable
 
 from lm_resiliency.integrations.torchrun._control_store import ControlStore
 from lm_resiliency.integrations.torchrun._coordinator_lease import (
@@ -45,12 +47,27 @@ class RestartIntentOpenPreparationCorrupt(RestartIntentOpenPreparationError):
     """Raised when persisted ownership or lifecycle state is malformed."""
 
 
+class RestartIntentOpenPreparationClockError(RestartIntentOpenPreparationError):
+    """Raised when the coordinator preparation clock moves backward."""
+
+
 class RestartIntentOpenPreparer:
     """Authenticate and prepare the first restart intent for one run."""
 
-    def __init__(self, store: ControlStore, *, run_id: str) -> None:
+    def __init__(
+        self,
+        store: ControlStore,
+        *,
+        run_id: str,
+        clock: Callable[[], int],
+    ) -> None:
         self._store = store
         self._run_id = _nonempty_string(run_id, "run_id")
+        if not callable(clock):
+            raise TypeError("clock must be callable")
+        self._clock = clock
+        self._clock_lock = threading.Lock()
+        self._last_now_unix_ms = 0
         self._generation_reader = GenerationStateReader(store, run_id=self._run_id)
         run_digest = hashlib.sha256(self._run_id.encode("utf-8")).hexdigest()
         self._run_prefix = f"{_CONTROL_PREFIX}/runs/{run_digest}"
@@ -88,15 +105,17 @@ class RestartIntentOpenPreparer:
         self._validate_current(current)
         self._validate_intent(intent, current)
         self._require_never_opened()
+        now_unix_ms = self._now_unix_ms()
         not_before_unix_ms = max(
             lease.granted_at_unix_ms,
             current.snapshot.committed_at_unix_ms,
+            now_unix_ms,
         )
-        if lease.expires_at_unix_ms <= not_before_unix_ms:
+        if lease.expires_at_unix_ms <= now_unix_ms:
             raise RestartIntentOpenPreparationLeaseLost(
                 "coordinator lease expired before restart-intent preparation"
             )
-        if intent.prepare_deadline_unix_ms <= not_before_unix_ms:
+        if intent.prepare_deadline_unix_ms <= now_unix_ms:
             raise RestartIntentOpenPreparationDeadlineElapsed(
                 "restart-intent preparation deadline has already elapsed"
             )
@@ -194,6 +213,19 @@ class RestartIntentOpenPreparer:
                 "restart-intent lifecycle exists without current-head history"
             )
 
+    def _now_unix_ms(self) -> int:
+        with self._clock_lock:
+            now_unix_ms = _positive_integer(
+                self._clock(),
+                "restart-intent preparation clock",
+            )
+            if now_unix_ms < self._last_now_unix_ms:
+                raise RestartIntentOpenPreparationClockError(
+                    "restart-intent preparation clock moved backward"
+                )
+            self._last_now_unix_ms = now_unix_ms
+            return now_unix_ms
+
 
 def _nonempty_string(value: object, path: str) -> str:
     if not isinstance(value, str) or not value.strip():
@@ -201,7 +233,14 @@ def _nonempty_string(value: object, path: str) -> str:
     return value
 
 
+def _positive_integer(value: object, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{path} must be a positive integer")
+    return value
+
+
 __all__ = [
+    "RestartIntentOpenPreparationClockError",
     "RestartIntentOpenPreparationConflict",
     "RestartIntentOpenPreparationCorrupt",
     "RestartIntentOpenPreparationDeadlineElapsed",

--- a/lm_resiliency/integrations/torchrun/_restart_intent_open.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_open.py
@@ -1,0 +1,211 @@
+"""Authenticated preparation of the first torchrun restart-intent opening."""
+
+from __future__ import annotations
+
+import hashlib
+
+from lm_resiliency.integrations.torchrun._control_store import ControlStore
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseRecord,
+    HeldCoordinatorLease,
+)
+from lm_resiliency.integrations.torchrun._generation_reader import (
+    CurrentGeneration,
+    GenerationStateReader,
+)
+from lm_resiliency.integrations.torchrun._protocol import RestartIntent
+from lm_resiliency.integrations.torchrun._restart_intent_open_records import (
+    PreparedInitialRestartIntentOpen,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_records import (
+    RestartIntentHeadRecord,
+    RestartIntentRecord,
+)
+
+_CONTROL_PREFIX = "lm_resiliency/torchrun/v1"
+
+
+class RestartIntentOpenPreparationError(RuntimeError):
+    """Base error for preparing the first restart-intent opening."""
+
+
+class RestartIntentOpenPreparationConflict(RestartIntentOpenPreparationError):
+    """Raised when the supplied generation or lifecycle state changed."""
+
+
+class RestartIntentOpenPreparationLeaseLost(RestartIntentOpenPreparationError):
+    """Raised when the supplied coordinator lease is stale or foreign."""
+
+
+class RestartIntentOpenPreparationDeadlineElapsed(RestartIntentOpenPreparationError):
+    """Raised when no valid commit window remains."""
+
+
+class RestartIntentOpenPreparationCorrupt(RestartIntentOpenPreparationError):
+    """Raised when persisted ownership or lifecycle state is malformed."""
+
+
+class RestartIntentOpenPreparer:
+    """Authenticate and prepare the first restart intent for one run."""
+
+    def __init__(self, store: ControlStore, *, run_id: str) -> None:
+        self._store = store
+        self._run_id = _nonempty_string(run_id, "run_id")
+        self._generation_reader = GenerationStateReader(store, run_id=self._run_id)
+        run_digest = hashlib.sha256(self._run_id.encode("utf-8")).hexdigest()
+        self._run_prefix = f"{_CONTROL_PREFIX}/runs/{run_digest}"
+        self._intent_head_key = f"{self._run_prefix}/restart-intent-head"
+        self._lifecycle_head_key = f"{self._run_prefix}/restart-intent-lifecycle-head"
+
+    @property
+    def coordinator_lease_key(self) -> str:
+        return self._generation_reader.coordinator_lease_key
+
+    @property
+    def generation_head_key(self) -> str:
+        return self._generation_reader.head_key
+
+    @property
+    def intent_head_key(self) -> str:
+        return self._intent_head_key
+
+    @property
+    def lifecycle_head_key(self) -> str:
+        return self._lifecycle_head_key
+
+    def intent_key(self, intent_id: str) -> str:
+        normalized_intent_id = _nonempty_string(intent_id, "intent_id")
+        intent_digest = hashlib.sha256(normalized_intent_id.encode("utf-8")).hexdigest()
+        return f"{self._run_prefix}/restart-intents/{intent_digest}"
+
+    def prepare_initial_open(
+        self,
+        lease: HeldCoordinatorLease,
+        current: CurrentGeneration,
+        intent: RestartIntent,
+    ) -> PreparedInitialRestartIntentOpen:
+        self._validate_lease(lease)
+        self._validate_current(current)
+        self._validate_intent(intent, current)
+        self._require_never_opened()
+        not_before_unix_ms = max(
+            lease.granted_at_unix_ms,
+            current.snapshot.committed_at_unix_ms,
+        )
+        if lease.expires_at_unix_ms <= not_before_unix_ms:
+            raise RestartIntentOpenPreparationLeaseLost(
+                "coordinator lease expired before restart-intent preparation"
+            )
+        if intent.prepare_deadline_unix_ms <= not_before_unix_ms:
+            raise RestartIntentOpenPreparationDeadlineElapsed(
+                "restart-intent preparation deadline has already elapsed"
+            )
+        record = RestartIntentRecord(
+            intent=intent,
+            generation_snapshot_digest=current.snapshot.record.digest,
+            coordinator_id=lease.record.coordinator_id,
+            lease_id=lease.record.lease_id,
+            coordinator_lease_duration_ms=lease.record.lease_duration_ms,
+            coordinator_fencing_token=lease.fencing_token,
+        )
+        return PreparedInitialRestartIntentOpen(
+            record=record,
+            head=RestartIntentHeadRecord(
+                run_id=self._run_id,
+                generation=intent.generation,
+                intent_id=intent.intent_id,
+                intent_digest=record.digest,
+            ),
+            current=current,
+            lease=lease,
+            intent_key=self.intent_key(intent.intent_id),
+            intent_head_key=self._intent_head_key,
+            coordinator_lease_key=self.coordinator_lease_key,
+            generation_head_key=self.generation_head_key,
+            generation_snapshot_key=self._generation_reader.snapshot_key(intent.generation),
+            not_before_unix_ms=not_before_unix_ms,
+            deadline_unix_ms=min(
+                lease.expires_at_unix_ms,
+                intent.prepare_deadline_unix_ms,
+            ),
+        )
+
+    def _validate_lease(self, lease: HeldCoordinatorLease) -> None:
+        if not isinstance(lease, HeldCoordinatorLease):
+            raise TypeError("lease must be HeldCoordinatorLease")
+        if lease.record.run_id != self._run_id:
+            raise ValueError("coordinator lease belongs to another run")
+        entry = self._store.get(self.coordinator_lease_key)
+        if entry is None or entry.revision != lease.fencing_token:
+            raise RestartIntentOpenPreparationLeaseLost(
+                "coordinator lease changed before restart-intent preparation"
+            )
+        try:
+            record = CoordinatorLeaseRecord.from_json(entry.value)
+        except (TypeError, ValueError) as error:
+            raise RestartIntentOpenPreparationCorrupt("coordinator lease is malformed") from error
+        if entry.committed_at_unix_ms is None:
+            raise RestartIntentOpenPreparationCorrupt(
+                "coordinator lease has no authoritative grant time"
+            )
+        if record != lease.record or entry.committed_at_unix_ms != lease.granted_at_unix_ms:
+            raise RestartIntentOpenPreparationLeaseLost(
+                "coordinator lease handle does not match persisted ownership"
+            )
+
+    def _validate_current(self, current: CurrentGeneration) -> None:
+        if not isinstance(current, CurrentGeneration):
+            raise TypeError("current must be CurrentGeneration")
+        if self._generation_reader.current() != current:
+            raise RestartIntentOpenPreparationConflict(
+                "current generation does not match the committed generation head"
+            )
+
+    def _validate_intent(
+        self,
+        intent: RestartIntent,
+        current: CurrentGeneration,
+    ) -> None:
+        if not isinstance(intent, RestartIntent):
+            raise TypeError("intent must be RestartIntent")
+        if intent.run_id != self._run_id:
+            raise ValueError("restart intent belongs to another run")
+        assignment = current.snapshot.record.assignment
+        if intent.generation != assignment.generation:
+            raise ValueError("restart intent does not target the current generation")
+        active_nodes = set(assignment.slot_to_node_id.values())
+        unknown_nodes = sorted(set(intent.suspected_node_ids) - active_nodes)
+        if unknown_nodes:
+            raise ValueError(
+                f"restart intent suspects nodes outside the current generation: {unknown_nodes!r}"
+            )
+
+    def _require_never_opened(self) -> None:
+        if self._store.get(self._intent_head_key) is not None:
+            raise RestartIntentOpenPreparationConflict(
+                "a restart intent is already current or closed"
+            )
+        if self._store.has_history(self._intent_head_key):
+            raise RestartIntentOpenPreparationConflict("restart-intent lifecycle already exists")
+        if self._store.get(self._lifecycle_head_key) is not None or self._store.has_history(
+            self._lifecycle_head_key
+        ):
+            raise RestartIntentOpenPreparationCorrupt(
+                "restart-intent lifecycle exists without current-head history"
+            )
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+__all__ = [
+    "RestartIntentOpenPreparationConflict",
+    "RestartIntentOpenPreparationCorrupt",
+    "RestartIntentOpenPreparationDeadlineElapsed",
+    "RestartIntentOpenPreparationError",
+    "RestartIntentOpenPreparationLeaseLost",
+    "RestartIntentOpenPreparer",
+]

--- a/lm_resiliency/integrations/torchrun/_restart_intent_open.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_open.py
@@ -106,16 +106,20 @@ class RestartIntentOpenPreparer:
         self._validate_intent(intent, current)
         self._require_never_opened()
         now_unix_ms = self._now_unix_ms()
+        if now_unix_ms < lease.granted_at_unix_ms:
+            raise RestartIntentOpenPreparationClockError(
+                "restart-intent preparation clock precedes the authoritative lease grant"
+            )
         not_before_unix_ms = max(
             lease.granted_at_unix_ms,
             current.snapshot.committed_at_unix_ms,
             now_unix_ms,
         )
-        if lease.expires_at_unix_ms <= now_unix_ms:
+        if lease.expires_at_unix_ms <= not_before_unix_ms:
             raise RestartIntentOpenPreparationLeaseLost(
                 "coordinator lease expired before restart-intent preparation"
             )
-        if intent.prepare_deadline_unix_ms <= now_unix_ms:
+        if intent.prepare_deadline_unix_ms <= not_before_unix_ms:
             raise RestartIntentOpenPreparationDeadlineElapsed(
                 "restart-intent preparation deadline has already elapsed"
             )
@@ -139,6 +143,7 @@ class RestartIntentOpenPreparer:
             lease=lease,
             intent_key=self.intent_key(intent.intent_id),
             intent_head_key=self._intent_head_key,
+            lifecycle_head_key=self._lifecycle_head_key,
             coordinator_lease_key=self.coordinator_lease_key,
             generation_head_key=self.generation_head_key,
             generation_snapshot_key=self._generation_reader.snapshot_key(intent.generation),

--- a/lm_resiliency/integrations/torchrun/_restart_intent_open_records.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_open_records.py
@@ -28,6 +28,7 @@ class PreparedInitialRestartIntentOpen:
     lease: HeldCoordinatorLease
     intent_key: str
     intent_head_key: str
+    lifecycle_head_key: str
     coordinator_lease_key: str
     generation_head_key: str
     generation_snapshot_key: str
@@ -84,6 +85,7 @@ class PreparedInitialRestartIntentOpen:
         expected_keys = {
             "intent_key": f"{run_prefix}/restart-intents/{intent_digest}",
             "intent_head_key": f"{run_prefix}/restart-intent-head",
+            "lifecycle_head_key": f"{run_prefix}/restart-intent-lifecycle-head",
             "coordinator_lease_key": f"{run_prefix}/coordinator-lease",
             "generation_head_key": f"{run_prefix}/generation-head",
             "generation_snapshot_key": (
@@ -144,6 +146,10 @@ class PreparedInitialRestartIntentOpen:
                 ),
             }
         )
+
+    @property
+    def never_created_conditions(self) -> frozenset[str]:
+        return frozenset({self.lifecycle_head_key})
 
     @property
     def conditions(self) -> Mapping[str, int]:

--- a/tests/unit/test_torchrun_generation_state.py
+++ b/tests/unit/test_torchrun_generation_state.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import threading
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 
@@ -57,6 +57,7 @@ class TamperedTransactionResultStore(InMemoryControlStore):
         not_before_unix_ms: int,
         deadline_unix_ms: int,
         conditions: Mapping[str, int | None] | None = None,
+        never_created_conditions: Collection[str] | None = None,
     ) -> Mapping[str, ControlStoreEntry]:
         committed = dict(
             super().compare_set_many_guarded(
@@ -66,6 +67,7 @@ class TamperedTransactionResultStore(InMemoryControlStore):
                 not_before_unix_ms=not_before_unix_ms,
                 deadline_unix_ms=deadline_unix_ms,
                 conditions=conditions,
+                never_created_conditions=never_created_conditions,
             )
         )
         head_key = next(key for key in committed if key.endswith("/generation-head"))

--- a/tests/unit/test_torchrun_guarded_control_store.py
+++ b/tests/unit/test_torchrun_guarded_control_store.py
@@ -311,6 +311,62 @@ def test_guarded_transaction_can_condition_on_key_absence():
     assert store.get("run/restart-intent-head") is None
 
 
+def test_guarded_transaction_can_require_condition_to_have_no_history():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    guard = _guard(store)
+
+    committed = store.compare_set_many_guarded(
+        {
+            "run/restart-intents/intent-a": ControlStoreWrite(
+                expected_revision=None,
+                value=b"intent-a",
+            ),
+        },
+        guard_key="run/coordinator-lease",
+        expected_guard_revision=guard.revision,
+        not_before_unix_ms=1_000,
+        deadline_unix_ms=1_100,
+        never_created_conditions={"run/restart-intent-lifecycle-head"},
+    )
+
+    assert committed["run/restart-intents/intent-a"].value == b"intent-a"
+    assert store.get("run/restart-intent-lifecycle-head") is None
+
+
+def test_guarded_transaction_rejects_deleted_never_created_condition():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    guard = _guard(store)
+    lifecycle_head = store.compare_set(
+        "run/restart-intent-lifecycle-head",
+        expected_revision=None,
+        value=b"closed",
+    )
+    store.compare_delete(
+        "run/restart-intent-lifecycle-head",
+        expected_revision=lifecycle_head.revision,
+    )
+
+    with pytest.raises(ControlStoreHistoryConflict) as error:
+        store.compare_set_many_guarded(
+            {
+                "run/restart-intents/intent-a": ControlStoreWrite(
+                    expected_revision=None,
+                    value=b"intent-a",
+                ),
+            },
+            guard_key="run/coordinator-lease",
+            expected_guard_revision=guard.revision,
+            not_before_unix_ms=1_000,
+            deadline_unix_ms=1_100,
+            never_created_conditions={"run/restart-intent-lifecycle-head"},
+        )
+
+    assert error.value.key == "run/restart-intent-lifecycle-head"
+    assert store.get("run/restart-intents/intent-a") is None
+
+
 def test_guarded_transaction_can_require_target_to_have_no_history():
     store = InMemoryControlStore(clock=ManualClock())
     guard = _guard(store)
@@ -510,6 +566,43 @@ def test_guarded_transaction_rejects_invalid_write_sets():
             not_before_unix_ms=1,
             deadline_unix_ms=2,
             conditions={"run/restart-intent-head": False},
+        )
+    with pytest.raises(ValueError, match="never-created condition"):
+        store.compare_set_many_guarded(
+            _generation_writes(),
+            guard_key="run/coordinator-lease",
+            expected_guard_revision=guard.revision,
+            not_before_unix_ms=1,
+            deadline_unix_ms=2,
+            never_created_conditions={"run/coordinator-lease"},
+        )
+    with pytest.raises(ValueError, match="must not also be targets"):
+        store.compare_set_many_guarded(
+            _generation_writes(),
+            guard_key="run/coordinator-lease",
+            expected_guard_revision=guard.revision,
+            not_before_unix_ms=1,
+            deadline_unix_ms=2,
+            never_created_conditions={"run/generation-head"},
+        )
+    with pytest.raises(ValueError, match="revision conditions"):
+        store.compare_set_many_guarded(
+            _generation_writes(),
+            guard_key="run/coordinator-lease",
+            expected_guard_revision=guard.revision,
+            not_before_unix_ms=1,
+            deadline_unix_ms=2,
+            conditions={"run/restart-intent-lifecycle-head": None},
+            never_created_conditions={"run/restart-intent-lifecycle-head"},
+        )
+    with pytest.raises(TypeError, match="collection"):
+        store.compare_set_many_guarded(
+            _generation_writes(),
+            guard_key="run/coordinator-lease",
+            expected_guard_revision=guard.revision,
+            not_before_unix_ms=1,
+            deadline_unix_ms=2,
+            never_created_conditions="run/restart-intent-lifecycle-head",
         )
 
 

--- a/tests/unit/test_torchrun_restart_intent_open.py
+++ b/tests/unit/test_torchrun_restart_intent_open.py
@@ -7,7 +7,10 @@ from dataclasses import replace
 
 import pytest
 
-from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStoreHistoryConflict,
+    InMemoryControlStore,
+)
 from lm_resiliency.integrations.torchrun._coordinator_lease import (
     CoordinatorLeaseManager,
 )
@@ -121,6 +124,7 @@ def test_prepare_initial_open_authenticates_and_builds_descriptor_without_writes
     assert prepared.lease == lease
     assert prepared.not_before_unix_ms == 1_000
     assert prepared.deadline_unix_ms == 1_050
+    assert prepared.never_created_conditions == frozenset({preparer.lifecycle_head_key})
     assert store.get(prepared.intent_head_key) is None
     assert store.get(prepared.intent_key) is None
 
@@ -299,6 +303,48 @@ def test_prepare_initial_open_rejects_deadlines_elapsed_after_state_commit():
         )
 
 
+def test_prepare_initial_open_rejects_first_clock_sample_before_lease_grant():
+    _, store, _, _, _, lease, current = _state()
+    preparer = RestartIntentOpenPreparer(
+        store,
+        run_id=RUN_ID,
+        clock=ManualClock(999),
+    )
+
+    with pytest.raises(RestartIntentOpenPreparationClockError, match="lease grant"):
+        preparer.prepare_initial_open(lease, current, _intent())
+
+
+def test_prepare_initial_open_classifies_store_time_deadline_as_elapsed():
+    store_clock = ManualClock()
+    store = InMemoryControlStore(clock=store_clock)
+    lease_manager = CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id="coordinator-a",
+        lease_duration_ms=100,
+        clock=store_clock,
+    )
+    lease = lease_manager.acquire()
+    store_clock.set(1_020)
+    generation_manager = GenerationStateManager(store, run_id=RUN_ID)
+    generation_manager.initialize(lease, _assignment())
+    current = generation_manager.current()
+    assert current is not None
+    preparer = RestartIntentOpenPreparer(
+        store,
+        run_id=RUN_ID,
+        clock=ManualClock(1_010),
+    )
+
+    with pytest.raises(RestartIntentOpenPreparationDeadlineElapsed, match="elapsed"):
+        preparer.prepare_initial_open(
+            lease,
+            current,
+            _intent(prepare_deadline_unix_ms=1_015),
+        )
+
+
 def test_prepare_initial_open_uses_observed_time_as_transaction_lower_bound():
     clock, _, _, _, preparer, lease, current = _state()
     clock.set(1_020)
@@ -306,6 +352,35 @@ def test_prepare_initial_open_uses_observed_time_as_transaction_lower_bound():
     prepared = preparer.prepare_initial_open(lease, current, _intent())
 
     assert prepared.not_before_unix_ms == 1_020
+
+
+def test_prepared_initial_open_fences_lifecycle_history_at_transaction():
+    _, store, _, _, preparer, lease, current = _state()
+    prepared = preparer.prepare_initial_open(lease, current, _intent())
+    lifecycle_head = store.compare_set(
+        preparer.lifecycle_head_key,
+        expected_revision=None,
+        value=b"closed",
+    )
+    store.compare_delete(
+        preparer.lifecycle_head_key,
+        expected_revision=lifecycle_head.revision,
+    )
+
+    with pytest.raises(ControlStoreHistoryConflict) as error:
+        store.compare_set_many_guarded(
+            prepared.writes,
+            guard_key=prepared.coordinator_lease_key,
+            expected_guard_revision=prepared.expected_guard_revision,
+            not_before_unix_ms=prepared.not_before_unix_ms,
+            deadline_unix_ms=prepared.deadline_unix_ms,
+            conditions=prepared.conditions,
+            never_created_conditions=prepared.never_created_conditions,
+        )
+
+    assert error.value.key == preparer.lifecycle_head_key
+    assert store.get(prepared.intent_key) is None
+    assert store.get(prepared.intent_head_key) is None
 
 
 def test_prepare_initial_open_rejects_backward_clock():

--- a/tests/unit/test_torchrun_restart_intent_open.py
+++ b/tests/unit/test_torchrun_restart_intent_open.py
@@ -1,0 +1,293 @@
+"""Contract tests for authenticated initial restart-intent preparation."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import replace
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseManager,
+)
+from lm_resiliency.integrations.torchrun._generation_state import GenerationStateManager
+from lm_resiliency.integrations.torchrun._protocol import (
+    RankAssignment,
+    RestartIntent,
+    SlotAssignment,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open import (
+    RestartIntentOpenPreparationConflict,
+    RestartIntentOpenPreparationCorrupt,
+    RestartIntentOpenPreparationDeadlineElapsed,
+    RestartIntentOpenPreparationLeaseLost,
+    RestartIntentOpenPreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_records import (
+    RestartIntentHeadRecord,
+    RestartIntentRecord,
+)
+
+RUN_ID = "training-run"
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+    def set(self, now_unix_ms: int) -> None:
+        with self._lock:
+            self.now_unix_ms = now_unix_ms
+
+
+def _assignment(generation: int = 0) -> RankAssignment:
+    return RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=generation,
+        assignments=(
+            SlotAssignment(0, "node-a", 0, 2),
+            SlotAssignment(1, "node-b", 2, 2),
+        ),
+        topology_digest="topology-v1",
+    )
+
+
+def _intent(
+    *,
+    intent_id: str = "intent-a",
+    run_id: str = RUN_ID,
+    generation: int = 0,
+    suspected_node_ids: tuple[str, ...] = ("node-b",),
+    prepare_deadline_unix_ms: int = 1_050,
+) -> RestartIntent:
+    return RestartIntent(
+        intent_id=intent_id,
+        run_id=run_id,
+        generation=generation,
+        incident_ids=("incident-a",),
+        reason_code="attributed_sdc",
+        minimum_recovery_mode="recovery_verified",
+        suspected_node_ids=suspected_node_ids,
+        prepare_deadline_unix_ms=prepare_deadline_unix_ms,
+    )
+
+
+def _state():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    lease_manager = CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id="coordinator-a",
+        lease_duration_ms=100,
+        clock=clock,
+    )
+    generation_manager = GenerationStateManager(store, run_id=RUN_ID)
+    preparer = RestartIntentOpenPreparer(store, run_id=RUN_ID)
+    lease = lease_manager.acquire()
+    generation_manager.initialize(lease, _assignment())
+    current = generation_manager.current()
+    assert current is not None
+    return clock, store, lease_manager, generation_manager, preparer, lease, current
+
+
+def test_prepare_initial_open_authenticates_and_builds_descriptor_without_writes():
+    _, store, _, _, preparer, lease, current = _state()
+
+    prepared = preparer.prepare_initial_open(lease, current, _intent())
+
+    assert prepared.record == RestartIntentRecord(
+        intent=_intent(),
+        generation_snapshot_digest=current.snapshot.record.digest,
+        coordinator_id="coordinator-a",
+        lease_id=lease.record.lease_id,
+        coordinator_lease_duration_ms=100,
+        coordinator_fencing_token=lease.fencing_token,
+    )
+    assert prepared.head == RestartIntentHeadRecord(
+        run_id=RUN_ID,
+        generation=0,
+        intent_id="intent-a",
+        intent_digest=prepared.record.digest,
+    )
+    assert prepared.current == current
+    assert prepared.lease == lease
+    assert prepared.not_before_unix_ms == 1_000
+    assert prepared.deadline_unix_ms == 1_050
+    assert store.get(prepared.intent_head_key) is None
+    assert store.get(prepared.intent_key) is None
+
+
+def test_prepare_initial_open_uses_earlier_lease_deadline():
+    _, _, _, _, preparer, lease, current = _state()
+
+    prepared = preparer.prepare_initial_open(
+        lease,
+        current,
+        _intent(prepare_deadline_unix_ms=2_000),
+    )
+
+    assert prepared.deadline_unix_ms == lease.expires_at_unix_ms
+
+
+def test_prepare_initial_open_rejects_stale_current_generation():
+    clock, store, _, generation_manager, preparer, lease, stale = _state()
+    clock.set(1_010)
+    generation_manager.commit_successor(
+        lease,
+        stale,
+        RankAssignment.from_assignments(
+            run_id=RUN_ID,
+            generation=1,
+            assignments=(
+                SlotAssignment(0, "node-a", 0, 2),
+                SlotAssignment(1, "node-c", 2, 2),
+            ),
+            topology_digest="topology-v1",
+        ),
+    )
+
+    with pytest.raises(
+        RestartIntentOpenPreparationConflict,
+        match="current generation",
+    ):
+        preparer.prepare_initial_open(lease, stale, _intent())
+
+    assert store.get(preparer.intent_head_key) is None
+
+
+@pytest.mark.parametrize(
+    ("intent", "message"),
+    [
+        (_intent(run_id="other-run"), "another run"),
+        (_intent(generation=1), "current generation"),
+        (_intent(suspected_node_ids=("node-c",)), "outside"),
+    ],
+)
+def test_prepare_initial_open_rejects_invalid_intent_scope(intent, message):
+    _, store, _, _, preparer, lease, current = _state()
+
+    with pytest.raises(ValueError, match=message):
+        preparer.prepare_initial_open(lease, current, intent)
+
+    assert store.get(preparer.intent_head_key) is None
+
+
+def test_prepare_initial_open_requires_expected_types():
+    _, _, _, _, preparer, lease, current = _state()
+
+    with pytest.raises(TypeError, match="HeldCoordinatorLease"):
+        preparer.prepare_initial_open({}, current, _intent())
+    with pytest.raises(TypeError, match="CurrentGeneration"):
+        preparer.prepare_initial_open(lease, {}, _intent())
+    with pytest.raises(TypeError, match="RestartIntent"):
+        preparer.prepare_initial_open(lease, current, {})
+
+
+def test_prepare_initial_open_rejects_stale_or_fabricated_lease():
+    _, store, lease_manager, _, preparer, lease, current = _state()
+    renewed = lease_manager.renew(lease)
+
+    with pytest.raises(RestartIntentOpenPreparationLeaseLost, match="changed"):
+        preparer.prepare_initial_open(lease, current, _intent())
+
+    fabricated = replace(
+        renewed,
+        record=replace(renewed.record, lease_id="forged"),
+    )
+    with pytest.raises(
+        RestartIntentOpenPreparationLeaseLost,
+        match="persisted ownership",
+    ):
+        preparer.prepare_initial_open(fabricated, current, _intent())
+
+    assert store.get(preparer.intent_head_key) is None
+
+
+def test_prepare_initial_open_rejects_malformed_or_untimed_lease():
+    _, store, _, _, preparer, lease, current = _state()
+    entry = store.get(preparer.coordinator_lease_key)
+    assert entry is not None
+    store._entries[preparer.coordinator_lease_key] = replace(entry, value=b"invalid")
+
+    with pytest.raises(RestartIntentOpenPreparationCorrupt, match="malformed"):
+        preparer.prepare_initial_open(lease, current, _intent())
+
+    store._entries[preparer.coordinator_lease_key] = replace(
+        entry,
+        committed_at_unix_ms=None,
+    )
+    with pytest.raises(RestartIntentOpenPreparationCorrupt, match="grant time"):
+        preparer.prepare_initial_open(lease, current, _intent())
+
+
+def test_prepare_initial_open_rejects_current_or_prior_head_history():
+    _, store, _, _, preparer, lease, current = _state()
+    current_head = store.compare_set(
+        preparer.intent_head_key,
+        expected_revision=None,
+        value=b"open",
+    )
+
+    with pytest.raises(RestartIntentOpenPreparationConflict, match="already"):
+        preparer.prepare_initial_open(lease, current, _intent())
+
+    store.compare_delete(
+        preparer.intent_head_key,
+        expected_revision=current_head.revision,
+    )
+    with pytest.raises(RestartIntentOpenPreparationConflict, match="lifecycle"):
+        preparer.prepare_initial_open(lease, current, _intent())
+
+
+def test_prepare_initial_open_rejects_orphan_lifecycle_head():
+    _, store, _, _, preparer, lease, current = _state()
+    lifecycle_head = store.compare_set(
+        preparer.lifecycle_head_key,
+        expected_revision=None,
+        value=b"closed",
+    )
+
+    with pytest.raises(RestartIntentOpenPreparationCorrupt, match="without"):
+        preparer.prepare_initial_open(lease, current, _intent())
+
+    store.compare_delete(
+        preparer.lifecycle_head_key,
+        expected_revision=lifecycle_head.revision,
+    )
+    with pytest.raises(RestartIntentOpenPreparationCorrupt, match="without"):
+        preparer.prepare_initial_open(lease, current, _intent())
+
+
+def test_prepare_initial_open_requires_remaining_prepare_window():
+    _, _, _, _, preparer, lease, current = _state()
+
+    with pytest.raises(
+        RestartIntentOpenPreparationDeadlineElapsed,
+        match="elapsed",
+    ):
+        preparer.prepare_initial_open(
+            lease,
+            current,
+            _intent(prepare_deadline_unix_ms=1_000),
+        )
+
+
+def test_restart_intent_keys_hide_plaintext_identity():
+    store = InMemoryControlStore()
+    preparer_a = RestartIntentOpenPreparer(store, run_id="run-a")
+    preparer_b = RestartIntentOpenPreparer(store, run_id="run-b")
+
+    first = preparer_a.intent_key("intent-a")
+    second = preparer_a.intent_key("intent-b")
+    third = preparer_b.intent_key("intent-a")
+
+    assert len({first, second, third}) == 3
+    assert "run-a" not in first
+    assert "intent-a" not in first

--- a/tests/unit/test_torchrun_restart_intent_open.py
+++ b/tests/unit/test_torchrun_restart_intent_open.py
@@ -18,6 +18,7 @@ from lm_resiliency.integrations.torchrun._protocol import (
     SlotAssignment,
 )
 from lm_resiliency.integrations.torchrun._restart_intent_open import (
+    RestartIntentOpenPreparationClockError,
     RestartIntentOpenPreparationConflict,
     RestartIntentOpenPreparationCorrupt,
     RestartIntentOpenPreparationDeadlineElapsed,
@@ -89,7 +90,7 @@ def _state():
         clock=clock,
     )
     generation_manager = GenerationStateManager(store, run_id=RUN_ID)
-    preparer = RestartIntentOpenPreparer(store, run_id=RUN_ID)
+    preparer = RestartIntentOpenPreparer(store, run_id=RUN_ID, clock=clock)
     lease = lease_manager.acquire()
     generation_manager.initialize(lease, _assignment())
     current = generation_manager.current()
@@ -279,10 +280,48 @@ def test_prepare_initial_open_requires_remaining_prepare_window():
         )
 
 
+def test_prepare_initial_open_rejects_deadlines_elapsed_after_state_commit():
+    clock, _, _, _, preparer, lease, current = _state()
+    clock.set(1_050)
+
+    with pytest.raises(
+        RestartIntentOpenPreparationDeadlineElapsed,
+        match="elapsed",
+    ):
+        preparer.prepare_initial_open(lease, current, _intent())
+
+    clock.set(1_100)
+    with pytest.raises(RestartIntentOpenPreparationLeaseLost, match="expired"):
+        preparer.prepare_initial_open(
+            lease,
+            current,
+            _intent(prepare_deadline_unix_ms=2_000),
+        )
+
+
+def test_prepare_initial_open_uses_observed_time_as_transaction_lower_bound():
+    clock, _, _, _, preparer, lease, current = _state()
+    clock.set(1_020)
+
+    prepared = preparer.prepare_initial_open(lease, current, _intent())
+
+    assert prepared.not_before_unix_ms == 1_020
+
+
+def test_prepare_initial_open_rejects_backward_clock():
+    clock, _, _, _, preparer, lease, current = _state()
+    preparer.prepare_initial_open(lease, current, _intent())
+    clock.set(999)
+
+    with pytest.raises(RestartIntentOpenPreparationClockError, match="backward"):
+        preparer.prepare_initial_open(lease, current, _intent())
+
+
 def test_restart_intent_keys_hide_plaintext_identity():
     store = InMemoryControlStore()
-    preparer_a = RestartIntentOpenPreparer(store, run_id="run-a")
-    preparer_b = RestartIntentOpenPreparer(store, run_id="run-b")
+    clock = ManualClock()
+    preparer_a = RestartIntentOpenPreparer(store, run_id="run-a", clock=clock)
+    preparer_b = RestartIntentOpenPreparer(store, run_id="run-b", clock=clock)
 
     first = preparer_a.intent_key("intent-a")
     second = preparer_a.intent_key("intent-b")
@@ -291,3 +330,12 @@ def test_restart_intent_keys_hide_plaintext_identity():
     assert len({first, second, third}) == 3
     assert "run-a" not in first
     assert "intent-a" not in first
+
+
+def test_restart_intent_preparer_requires_clock():
+    with pytest.raises(TypeError, match="clock"):
+        RestartIntentOpenPreparer(
+            InMemoryControlStore(),
+            run_id=RUN_ID,
+            clock=None,
+        )

--- a/tests/unit/test_torchrun_restart_intent_open_records.py
+++ b/tests/unit/test_torchrun_restart_intent_open_records.py
@@ -119,6 +119,7 @@ def _prepared() -> PreparedInitialRestartIntentOpen:
         ),
         intent_key=f"{RUN_PREFIX}/restart-intents/{intent_digest}",
         intent_head_key=f"{RUN_PREFIX}/restart-intent-head",
+        lifecycle_head_key=f"{RUN_PREFIX}/restart-intent-lifecycle-head",
         coordinator_lease_key=f"{RUN_PREFIX}/coordinator-lease",
         generation_head_key=f"{RUN_PREFIX}/generation-head",
         generation_snapshot_key=f"{RUN_PREFIX}/generations/0",
@@ -135,6 +136,7 @@ def test_prepared_initial_open_builds_immutable_create_once_transaction_inputs()
     assert all(write.require_never_created for write in prepared.writes.values())
     assert prepared.writes[prepared.intent_head_key].value == prepared.head.to_json()
     assert prepared.writes[prepared.intent_key].value == prepared.record.to_json()
+    assert prepared.never_created_conditions == frozenset({prepared.lifecycle_head_key})
     assert prepared.conditions == {
         prepared.generation_head_key: prepared.current.head_revision,
         prepared.generation_snapshot_key: prepared.current.snapshot.revision,
@@ -159,6 +161,7 @@ def test_prepared_initial_open_is_immutable():
         {"lease": replace(_prepared().lease, fencing_token=8)},
         {"intent_key": "other"},
         {"intent_head_key": "other"},
+        {"lifecycle_head_key": "other"},
         {"coordinator_lease_key": "other"},
         {"generation_head_key": "other"},
         {"generation_snapshot_key": "other"},


### PR DESCRIPTION
## Problem

The initial restart-intent descriptor must be constructed only after authenticating the persisted coordinator lease, exact current generation, intent scope, and never-opened lifecycle state.

## Implementation

- add `RestartIntentOpenPreparer`
- authenticate the complete held lease against the persisted lease bytes, revision, and authoritative grant time
- revalidate the exact committed generation
- reject intents for another run/generation or suspects outside the active assignment
- reject current, deleted, or orphan lifecycle state
- observe a monotonic coordinator clock after validation, reject elapsed lease/intent deadlines, and use that observation as the transaction lower boundn- carry an atomic never-created lifecycle-head condition through the descriptor and guarded storen- derive the lease/intent commit window and return `PreparedInitialRestartIntentOpen`

This PR performs store reads only. It does not execute the guarded transaction or publish an intent.

## Compatibility

The component is internal and newly introduced. Public APIs and optional dependency behavior are unchanged.

## Validation

- 106 focused torchrun preparation/store/lease/generation tests
- 1,601 full CPU tests with CUDA hidden
- repository-wide Ruff check and format check
- targeted mypy
- `git diff --check`