### PR TITLE
[Feature][Torchrun] Execute initial restart intent transactions

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -608,8 +608,11 @@ transaction's lower time bound; the store remains authoritative at execution.
 The prepared transaction also carries a never-created lifecycle-head
 condition. The store checks both current absence and durable key history at the
 same linearization point as the lease, generation conditions, and intent
-writes. The preparer performs no mutation. The following execution component
-owns the guarded transaction and verifies the returned store metadata.
+writes. The preparer performs no mutation. The initial-open executor submits
+that guarded transaction, translates lease, deadline, clock, generation, and
+lifecycle conflicts, and verifies that both returned entries share the expected
+bytes, commit time, transaction sequence, generation order, and lease
+provenance.
 
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -612,9 +612,12 @@ writes. The preparer performs no mutation. The initial-open executor submits
 that guarded transaction, translates lease, deadline, clock, generation, and
 lifecycle conflicts, and verifies that both returned entries share the expected
 bytes, commit time, transaction sequence, generation order, and lease
-provenance. The committed lease sequence must equal the generation snapshot's
-sequence for the same fencing token or advance consistently for a renewed or
-replacement lease.
+provenance. Preparation preserves the authenticated lease entry's transaction,
+mutation, value, and lifetime sequences. Those sequences must equal the
+generation snapshot's authority for the same fencing token or advance
+consistently for a nonexpired renewal or nonoverlapping replacement. Execution
+requires both committed entries to match that exact lease provenance and to
+follow both the generation snapshot and the authenticated lease transaction.
 
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -612,7 +612,9 @@ writes. The preparer performs no mutation. The initial-open executor submits
 that guarded transaction, translates lease, deadline, clock, generation, and
 lifecycle conflicts, and verifies that both returned entries share the expected
 bytes, commit time, transaction sequence, generation order, and lease
-provenance.
+provenance. The committed lease sequence must equal the generation snapshot's
+sequence for the same fencing token or advance consistently for a renewed or
+replacement lease.
 
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -618,6 +618,10 @@ generation snapshot's authority for the same fencing token or advance
 consistently for a nonexpired renewal or nonoverlapping replacement. Execution
 requires both committed entries to match that exact lease provenance and to
 follow both the generation snapshot and the authenticated lease transaction.
+The lease mutation count cannot exceed the store-global transaction gap, a
+post-generation lease grant cannot predate the generation commit, and a lease
+ID or fencing token cannot reappear after a different acquisition in the
+verified generation history.
 
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -621,7 +621,9 @@ follow both the generation snapshot and the authenticated lease transaction.
 The lease mutation count cannot exceed the store-global transaction gap, a
 post-generation lease grant cannot predate the generation commit, and a lease
 ID or fencing token cannot reappear after a different acquisition in the
-verified generation history.
+verified generation history. Preparation obtains that history through one
+stable reader traversal rather than rereading the full predecessor chain for
+each generation.
 
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be

--- a/lm_resiliency/integrations/torchrun/_generation_reader.py
+++ b/lm_resiliency/integrations/torchrun/_generation_reader.py
@@ -77,14 +77,22 @@ class GenerationStateReader:
         return f"{self._run_prefix}/generations/{normalized_generation}"
 
     def current(self) -> CurrentGeneration | None:
+        result = self.current_with_history()
+        return None if result is None else result[0]
+
+    def current_with_history(
+        self,
+    ) -> tuple[CurrentGeneration, tuple[StoredGenerationSnapshot, ...]] | None:
+        """Return the stable current generation and its verified history."""
+
         generation_zero_key = self.snapshot_key(0)
         for _ in range(_MAX_READ_ATTEMPTS):
             result = self._read_current_history()
             if result is not None:
-                current, _ = result
+                current, history = result
                 if self._head_changed_while_checking_successor(current):
                     continue
-                return current
+                return current, tuple(history[generation] for generation in range(len(history)))
             generation_zero = self._store.get(generation_zero_key)
             observed_head = self._store.get(self._head_key)
             if observed_head is not None:

--- a/lm_resiliency/integrations/torchrun/_restart_intent_open.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_open.py
@@ -6,7 +6,10 @@ import hashlib
 import threading
 from collections.abc import Callable
 
-from lm_resiliency.integrations.torchrun._control_store import ControlStore
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStore,
+    ControlStoreEntry,
+)
 from lm_resiliency.integrations.torchrun._coordinator_lease import (
     CoordinatorLeaseRecord,
     HeldCoordinatorLease,
@@ -101,7 +104,7 @@ class RestartIntentOpenPreparer:
         current: CurrentGeneration,
         intent: RestartIntent,
     ) -> PreparedInitialRestartIntentOpen:
-        self._validate_lease(lease)
+        lease_entry = self._validate_lease(lease)
         self._validate_current(current)
         self._validate_intent(intent, current)
         self._require_never_opened()
@@ -131,30 +134,39 @@ class RestartIntentOpenPreparer:
             coordinator_lease_duration_ms=lease.record.lease_duration_ms,
             coordinator_fencing_token=lease.fencing_token,
         )
-        return PreparedInitialRestartIntentOpen(
-            record=record,
-            head=RestartIntentHeadRecord(
-                run_id=self._run_id,
-                generation=intent.generation,
-                intent_id=intent.intent_id,
-                intent_digest=record.digest,
-            ),
-            current=current,
-            lease=lease,
-            intent_key=self.intent_key(intent.intent_id),
-            intent_head_key=self._intent_head_key,
-            lifecycle_head_key=self._lifecycle_head_key,
-            coordinator_lease_key=self.coordinator_lease_key,
-            generation_head_key=self.generation_head_key,
-            generation_snapshot_key=self._generation_reader.snapshot_key(intent.generation),
-            not_before_unix_ms=not_before_unix_ms,
-            deadline_unix_ms=min(
-                lease.expires_at_unix_ms,
-                intent.prepare_deadline_unix_ms,
-            ),
-        )
+        try:
+            return PreparedInitialRestartIntentOpen(
+                record=record,
+                head=RestartIntentHeadRecord(
+                    run_id=self._run_id,
+                    generation=intent.generation,
+                    intent_id=intent.intent_id,
+                    intent_digest=record.digest,
+                ),
+                current=current,
+                lease=lease,
+                intent_key=self.intent_key(intent.intent_id),
+                intent_head_key=self._intent_head_key,
+                lifecycle_head_key=self._lifecycle_head_key,
+                coordinator_lease_key=self.coordinator_lease_key,
+                generation_head_key=self.generation_head_key,
+                generation_snapshot_key=self._generation_reader.snapshot_key(intent.generation),
+                coordinator_lease_transaction_sequence=lease_entry.transaction_sequence,
+                coordinator_lease_mutation_sequence=lease_entry.mutation_sequence,
+                coordinator_lease_value_sequence=lease_entry.value_sequence,
+                coordinator_lease_lifetime_sequence=lease_entry.lifetime_sequence,
+                not_before_unix_ms=not_before_unix_ms,
+                deadline_unix_ms=min(
+                    lease.expires_at_unix_ms,
+                    intent.prepare_deadline_unix_ms,
+                ),
+            )
+        except ValueError as error:
+            raise RestartIntentOpenPreparationCorrupt(
+                "coordinator lease lineage contradicts the current generation"
+            ) from error
 
-    def _validate_lease(self, lease: HeldCoordinatorLease) -> None:
+    def _validate_lease(self, lease: HeldCoordinatorLease) -> ControlStoreEntry:
         if not isinstance(lease, HeldCoordinatorLease):
             raise TypeError("lease must be HeldCoordinatorLease")
         if lease.record.run_id != self._run_id:
@@ -176,6 +188,7 @@ class RestartIntentOpenPreparer:
             raise RestartIntentOpenPreparationLeaseLost(
                 "coordinator lease handle does not match persisted ownership"
             )
+        return entry
 
     def _validate_current(self, current: CurrentGeneration) -> None:
         if not isinstance(current, CurrentGeneration):

--- a/lm_resiliency/integrations/torchrun/_restart_intent_open.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_open.py
@@ -107,6 +107,7 @@ class RestartIntentOpenPreparer:
         lease_entry = self._validate_lease(lease)
         self._validate_current(current)
         self._validate_intent(intent, current)
+        lease_id_history, fencing_token_history = self._generation_lease_history(current)
         self._require_never_opened()
         now_unix_ms = self._now_unix_ms()
         if now_unix_ms < lease.granted_at_unix_ms:
@@ -155,6 +156,8 @@ class RestartIntentOpenPreparer:
                 coordinator_lease_mutation_sequence=lease_entry.mutation_sequence,
                 coordinator_lease_value_sequence=lease_entry.value_sequence,
                 coordinator_lease_lifetime_sequence=lease_entry.lifetime_sequence,
+                generation_lease_id_history=lease_id_history,
+                generation_fencing_token_history=fencing_token_history,
                 not_before_unix_ms=not_before_unix_ms,
                 deadline_unix_ms=min(
                     lease.expires_at_unix_ms,
@@ -216,6 +219,23 @@ class RestartIntentOpenPreparer:
             raise ValueError(
                 f"restart intent suspects nodes outside the current generation: {unknown_nodes!r}"
             )
+
+    def _generation_lease_history(
+        self,
+        current: CurrentGeneration,
+    ) -> tuple[tuple[str, ...], tuple[int, ...]]:
+        generation = current.snapshot.record.assignment.generation
+        lease_ids: list[str] = []
+        fencing_tokens: list[int] = []
+        for predecessor_generation in range(generation + 1):
+            snapshot = self._generation_reader.get(predecessor_generation)
+            if snapshot is None:
+                raise RestartIntentOpenPreparationCorrupt(
+                    "current generation has an incomplete predecessor history"
+                )
+            lease_ids.append(snapshot.record.lease_id)
+            fencing_tokens.append(snapshot.record.coordinator_fencing_token)
+        return tuple(lease_ids), tuple(fencing_tokens)
 
     def _require_never_opened(self) -> None:
         if self._store.get(self._intent_head_key) is not None:

--- a/lm_resiliency/integrations/torchrun/_restart_intent_open.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_open.py
@@ -17,6 +17,7 @@ from lm_resiliency.integrations.torchrun._coordinator_lease import (
 from lm_resiliency.integrations.torchrun._generation_reader import (
     CurrentGeneration,
     GenerationStateReader,
+    StoredGenerationSnapshot,
 )
 from lm_resiliency.integrations.torchrun._protocol import RestartIntent
 from lm_resiliency.integrations.torchrun._restart_intent_open_records import (
@@ -105,9 +106,8 @@ class RestartIntentOpenPreparer:
         intent: RestartIntent,
     ) -> PreparedInitialRestartIntentOpen:
         lease_entry = self._validate_lease(lease)
-        self._validate_current(current)
+        generation_history = self._validate_current(current)
         self._validate_intent(intent, current)
-        lease_id_history, fencing_token_history = self._generation_lease_history(current)
         self._require_never_opened()
         now_unix_ms = self._now_unix_ms()
         if now_unix_ms < lease.granted_at_unix_ms:
@@ -156,8 +156,12 @@ class RestartIntentOpenPreparer:
                 coordinator_lease_mutation_sequence=lease_entry.mutation_sequence,
                 coordinator_lease_value_sequence=lease_entry.value_sequence,
                 coordinator_lease_lifetime_sequence=lease_entry.lifetime_sequence,
-                generation_lease_id_history=lease_id_history,
-                generation_fencing_token_history=fencing_token_history,
+                generation_lease_id_history=tuple(
+                    snapshot.record.lease_id for snapshot in generation_history
+                ),
+                generation_fencing_token_history=tuple(
+                    snapshot.record.coordinator_fencing_token for snapshot in generation_history
+                ),
                 not_before_unix_ms=not_before_unix_ms,
                 deadline_unix_ms=min(
                     lease.expires_at_unix_ms,
@@ -193,13 +197,18 @@ class RestartIntentOpenPreparer:
             )
         return entry
 
-    def _validate_current(self, current: CurrentGeneration) -> None:
+    def _validate_current(
+        self,
+        current: CurrentGeneration,
+    ) -> tuple[StoredGenerationSnapshot, ...]:
         if not isinstance(current, CurrentGeneration):
             raise TypeError("current must be CurrentGeneration")
-        if self._generation_reader.current() != current:
+        observed = self._generation_reader.current_with_history()
+        if observed is None or observed[0] != current:
             raise RestartIntentOpenPreparationConflict(
                 "current generation does not match the committed generation head"
             )
+        return observed[1]
 
     def _validate_intent(
         self,
@@ -219,23 +228,6 @@ class RestartIntentOpenPreparer:
             raise ValueError(
                 f"restart intent suspects nodes outside the current generation: {unknown_nodes!r}"
             )
-
-    def _generation_lease_history(
-        self,
-        current: CurrentGeneration,
-    ) -> tuple[tuple[str, ...], tuple[int, ...]]:
-        generation = current.snapshot.record.assignment.generation
-        lease_ids: list[str] = []
-        fencing_tokens: list[int] = []
-        for predecessor_generation in range(generation + 1):
-            snapshot = self._generation_reader.get(predecessor_generation)
-            if snapshot is None:
-                raise RestartIntentOpenPreparationCorrupt(
-                    "current generation has an incomplete predecessor history"
-                )
-            lease_ids.append(snapshot.record.lease_id)
-            fencing_tokens.append(snapshot.record.coordinator_fencing_token)
-        return tuple(lease_ids), tuple(fencing_tokens)
 
     def _require_never_opened(self) -> None:
         if self._store.get(self._intent_head_key) is not None:

--- a/lm_resiliency/integrations/torchrun/_restart_intent_open_execution.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_open_execution.py
@@ -1,0 +1,224 @@
+"""Guarded execution of prepared initial restart-intent openings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStore,
+    ControlStoreClockError,
+    ControlStoreConflict,
+    ControlStoreDeadlineExceeded,
+    ControlStoreEntry,
+    ControlStoreHistoryConflict,
+    ControlStoreTooEarly,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_records import (
+    PreparedInitialRestartIntentOpen,
+)
+
+
+class RestartIntentOpenExecutionError(RuntimeError):
+    """Base error for committing a prepared initial restart intent."""
+
+
+class RestartIntentOpenExecutionConflict(RestartIntentOpenExecutionError):
+    """Raised when generation or lifecycle state changed before commit."""
+
+
+class RestartIntentOpenExecutionLeaseLost(RestartIntentOpenExecutionError):
+    """Raised when the coordinator lease changed or expired before commit."""
+
+
+class RestartIntentOpenExecutionDeadlineElapsed(RestartIntentOpenExecutionError):
+    """Raised when the restart-intent preparation deadline elapsed."""
+
+
+class RestartIntentOpenExecutionClockError(RestartIntentOpenExecutionError):
+    """Raised when authoritative store time contradicts preparation time."""
+
+
+class RestartIntentOpenExecutionCorrupt(RestartIntentOpenExecutionError):
+    """Raised when the transaction returns contradictory committed state."""
+
+
+@dataclass(frozen=True, slots=True)
+class CommittedInitialRestartIntentOpen:
+    """Verified committed entries for one initial restart-intent opening."""
+
+    prepared: PreparedInitialRestartIntentOpen
+    intent_entry: ControlStoreEntry
+    head_entry: ControlStoreEntry
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.prepared, PreparedInitialRestartIntentOpen):
+            raise TypeError(
+                "CommittedInitialRestartIntentOpen.prepared must be "
+                "PreparedInitialRestartIntentOpen"
+            )
+        if not isinstance(self.intent_entry, ControlStoreEntry):
+            raise TypeError(
+                "CommittedInitialRestartIntentOpen.intent_entry must be ControlStoreEntry"
+            )
+        if not isinstance(self.head_entry, ControlStoreEntry):
+            raise TypeError(
+                "CommittedInitialRestartIntentOpen.head_entry must be ControlStoreEntry"
+            )
+        if self.intent_entry.value != self.prepared.record.to_json():
+            raise ValueError(
+                "CommittedInitialRestartIntentOpen intent entry does not match its preparation"
+            )
+        if self.head_entry.value != self.prepared.head.to_json():
+            raise ValueError(
+                "CommittedInitialRestartIntentOpen head entry does not match its preparation"
+            )
+        for path, entry in (
+            ("intent_entry", self.intent_entry),
+            ("head_entry", self.head_entry),
+        ):
+            if (
+                entry.mutation_sequence != 1
+                or entry.value_sequence != 1
+                or entry.lifetime_sequence != 1
+            ):
+                raise ValueError(
+                    f"CommittedInitialRestartIntentOpen.{path} is not an immutable creation"
+                )
+            if entry.committed_at_unix_ms is None:
+                raise ValueError(
+                    f"CommittedInitialRestartIntentOpen.{path} has no authoritative commit time"
+                )
+            if (
+                entry.guard_key != self.prepared.coordinator_lease_key
+                or entry.guard_revision != self.prepared.expected_guard_revision
+                or entry.guard_value_digest != self.prepared.record.coordinator_lease_digest
+                or entry.guard_committed_at_unix_ms != self.prepared.lease.granted_at_unix_ms
+            ):
+                raise ValueError(
+                    f"CommittedInitialRestartIntentOpen.{path} has invalid lease provenance"
+                )
+        intent_committed_at_unix_ms = self.intent_entry.committed_at_unix_ms
+        head_committed_at_unix_ms = self.head_entry.committed_at_unix_ms
+        if intent_committed_at_unix_ms is None or head_committed_at_unix_ms is None:
+            raise ValueError(
+                "CommittedInitialRestartIntentOpen entries have no authoritative commit time"
+            )
+        if (
+            intent_committed_at_unix_ms != head_committed_at_unix_ms
+            or self.intent_entry.transaction_sequence != self.head_entry.transaction_sequence
+            or self.intent_entry.guard_mutation_sequence != self.head_entry.guard_mutation_sequence
+            or self.intent_entry.guard_value_sequence != self.head_entry.guard_value_sequence
+            or self.intent_entry.guard_lifetime_sequence != self.head_entry.guard_lifetime_sequence
+        ):
+            raise ValueError(
+                "CommittedInitialRestartIntentOpen entries do not share one transaction"
+            )
+        if (
+            intent_committed_at_unix_ms < self.prepared.not_before_unix_ms
+            or intent_committed_at_unix_ms >= self.prepared.deadline_unix_ms
+        ):
+            raise ValueError(
+                "CommittedInitialRestartIntentOpen commit is outside its prepared time window"
+            )
+        if (
+            self.intent_entry.transaction_sequence
+            <= self.prepared.current.snapshot.transaction_sequence
+        ):
+            raise ValueError(
+                "CommittedInitialRestartIntentOpen does not follow its generation snapshot"
+            )
+
+    @property
+    def committed_at_unix_ms(self) -> int:
+        committed_at_unix_ms = self.intent_entry.committed_at_unix_ms
+        if committed_at_unix_ms is None:
+            raise AssertionError("validated committed result lost its commit time")
+        return committed_at_unix_ms
+
+    @property
+    def transaction_sequence(self) -> int:
+        return self.intent_entry.transaction_sequence
+
+
+class RestartIntentOpenExecutor:
+    """Commit and verify one prepared initial restart-intent opening."""
+
+    def __init__(self, store: ControlStore, *, run_id: str) -> None:
+        self._store = store
+        self._run_id = _nonempty_string(run_id, "run_id")
+
+    def execute_initial_open(
+        self,
+        prepared: PreparedInitialRestartIntentOpen,
+    ) -> CommittedInitialRestartIntentOpen:
+        if not isinstance(prepared, PreparedInitialRestartIntentOpen):
+            raise TypeError("prepared must be PreparedInitialRestartIntentOpen")
+        if prepared.record.intent.run_id != self._run_id:
+            raise ValueError("prepared restart intent belongs to another run")
+        try:
+            committed = self._store.compare_set_many_guarded(
+                prepared.writes,
+                guard_key=prepared.coordinator_lease_key,
+                expected_guard_revision=prepared.expected_guard_revision,
+                not_before_unix_ms=prepared.not_before_unix_ms,
+                deadline_unix_ms=prepared.deadline_unix_ms,
+                conditions=prepared.conditions,
+                never_created_conditions=prepared.never_created_conditions,
+            )
+        except ControlStoreConflict as error:
+            if error.key == prepared.coordinator_lease_key:
+                raise RestartIntentOpenExecutionLeaseLost(
+                    "coordinator lease changed before restart-intent commit"
+                ) from error
+            raise RestartIntentOpenExecutionConflict(
+                f"restart-intent transaction state changed at {error.key!r}"
+            ) from error
+        except ControlStoreHistoryConflict as error:
+            raise RestartIntentOpenExecutionConflict(
+                f"restart-intent transaction key {error.key!r} has prior history"
+            ) from error
+        except ControlStoreDeadlineExceeded as error:
+            if prepared.lease.expires_at_unix_ms <= prepared.record.intent.prepare_deadline_unix_ms:
+                raise RestartIntentOpenExecutionLeaseLost(
+                    "coordinator lease expired before restart-intent commit"
+                ) from error
+            raise RestartIntentOpenExecutionDeadlineElapsed(
+                "restart-intent preparation deadline elapsed before commit"
+            ) from error
+        except (ControlStoreTooEarly, ControlStoreClockError) as error:
+            raise RestartIntentOpenExecutionClockError(
+                "control-store time contradicts restart-intent preparation"
+            ) from error
+        expected_keys = {prepared.intent_key, prepared.intent_head_key}
+        if set(committed) != expected_keys:
+            raise RestartIntentOpenExecutionCorrupt(
+                "restart-intent transaction returned an unexpected committed key set"
+            )
+        try:
+            return CommittedInitialRestartIntentOpen(
+                prepared=prepared,
+                intent_entry=committed[prepared.intent_key],
+                head_entry=committed[prepared.intent_head_key],
+            )
+        except (TypeError, ValueError) as error:
+            raise RestartIntentOpenExecutionCorrupt(
+                "restart-intent transaction returned contradictory committed state"
+            ) from error
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+__all__ = [
+    "CommittedInitialRestartIntentOpen",
+    "RestartIntentOpenExecutionClockError",
+    "RestartIntentOpenExecutionConflict",
+    "RestartIntentOpenExecutionCorrupt",
+    "RestartIntentOpenExecutionDeadlineElapsed",
+    "RestartIntentOpenExecutionError",
+    "RestartIntentOpenExecutionLeaseLost",
+    "RestartIntentOpenExecutor",
+]

--- a/lm_resiliency/integrations/torchrun/_restart_intent_open_execution.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_open_execution.py
@@ -93,6 +93,11 @@ class CommittedInitialRestartIntentOpen:
                 or entry.guard_revision != self.prepared.expected_guard_revision
                 or entry.guard_value_digest != self.prepared.record.coordinator_lease_digest
                 or entry.guard_committed_at_unix_ms != self.prepared.lease.granted_at_unix_ms
+                or entry.guard_mutation_sequence
+                != self.prepared.coordinator_lease_mutation_sequence
+                or entry.guard_value_sequence != self.prepared.coordinator_lease_value_sequence
+                or entry.guard_lifetime_sequence
+                != self.prepared.coordinator_lease_lifetime_sequence
             ):
                 raise ValueError(
                     f"CommittedInitialRestartIntentOpen.{path} has invalid lease provenance"
@@ -113,7 +118,6 @@ class CommittedInitialRestartIntentOpen:
             raise ValueError(
                 "CommittedInitialRestartIntentOpen entries do not share one transaction"
             )
-        self._validate_guard_lineage()
         if (
             intent_committed_at_unix_ms < self.prepared.not_before_unix_ms
             or intent_committed_at_unix_ms >= self.prepared.deadline_unix_ms
@@ -121,64 +125,12 @@ class CommittedInitialRestartIntentOpen:
             raise ValueError(
                 "CommittedInitialRestartIntentOpen commit is outside its prepared time window"
             )
-        if (
-            self.intent_entry.transaction_sequence
-            <= self.prepared.current.snapshot.transaction_sequence
+        if self.intent_entry.transaction_sequence <= max(
+            self.prepared.current.snapshot.transaction_sequence,
+            self.prepared.coordinator_lease_transaction_sequence,
         ):
             raise ValueError(
-                "CommittedInitialRestartIntentOpen does not follow its generation snapshot"
-            )
-
-    def _validate_guard_lineage(self) -> None:
-        guard_mutation_sequence = self.intent_entry.guard_mutation_sequence
-        guard_value_sequence = self.intent_entry.guard_value_sequence
-        guard_lifetime_sequence = self.intent_entry.guard_lifetime_sequence
-        if (
-            guard_mutation_sequence is None
-            or guard_value_sequence is None
-            or guard_lifetime_sequence is None
-        ):
-            raise ValueError(
-                "CommittedInitialRestartIntentOpen has incomplete guard sequence provenance"
-            )
-        snapshot = self.prepared.current.snapshot
-        if self.prepared.expected_guard_revision == snapshot.record.coordinator_fencing_token:
-            if (
-                guard_mutation_sequence != snapshot.guard_mutation_sequence
-                or guard_value_sequence != snapshot.guard_value_sequence
-                or guard_lifetime_sequence != snapshot.guard_lifetime_sequence
-            ):
-                raise ValueError(
-                    "CommittedInitialRestartIntentOpen changed one fencing token's lineage"
-                )
-            return
-        if (
-            guard_mutation_sequence <= snapshot.guard_mutation_sequence
-            or guard_value_sequence < snapshot.guard_value_sequence
-            or guard_lifetime_sequence < snapshot.guard_lifetime_sequence
-        ):
-            raise ValueError(
-                "CommittedInitialRestartIntentOpen guard lineage predates its generation"
-            )
-        mutation_delta = guard_mutation_sequence - snapshot.guard_mutation_sequence
-        value_delta = guard_value_sequence - snapshot.guard_value_sequence
-        lifetime_delta = guard_lifetime_sequence - snapshot.guard_lifetime_sequence
-        if (
-            mutation_delta < 2 * lifetime_delta
-            or value_delta < lifetime_delta
-            or value_delta > mutation_delta - lifetime_delta
-        ):
-            raise ValueError(
-                "CommittedInitialRestartIntentOpen guard lineage has impossible sequence deltas"
-            )
-        current_lease_digest = self.prepared.record.coordinator_lease_digest
-        snapshot_lease_digest = snapshot.record.coordinator_lease_digest
-        if current_lease_digest == snapshot_lease_digest:
-            if value_delta != 0 or lifetime_delta != 0:
-                raise ValueError("CommittedInitialRestartIntentOpen resurrects a prior lease value")
-        elif value_delta == 0:
-            raise ValueError(
-                "CommittedInitialRestartIntentOpen changes lease identity without a new value"
+                "CommittedInitialRestartIntentOpen does not follow its generation and lease"
             )
 
     @property

--- a/lm_resiliency/integrations/torchrun/_restart_intent_open_execution.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_open_execution.py
@@ -113,6 +113,7 @@ class CommittedInitialRestartIntentOpen:
             raise ValueError(
                 "CommittedInitialRestartIntentOpen entries do not share one transaction"
             )
+        self._validate_guard_lineage()
         if (
             intent_committed_at_unix_ms < self.prepared.not_before_unix_ms
             or intent_committed_at_unix_ms >= self.prepared.deadline_unix_ms
@@ -126,6 +127,58 @@ class CommittedInitialRestartIntentOpen:
         ):
             raise ValueError(
                 "CommittedInitialRestartIntentOpen does not follow its generation snapshot"
+            )
+
+    def _validate_guard_lineage(self) -> None:
+        guard_mutation_sequence = self.intent_entry.guard_mutation_sequence
+        guard_value_sequence = self.intent_entry.guard_value_sequence
+        guard_lifetime_sequence = self.intent_entry.guard_lifetime_sequence
+        if (
+            guard_mutation_sequence is None
+            or guard_value_sequence is None
+            or guard_lifetime_sequence is None
+        ):
+            raise ValueError(
+                "CommittedInitialRestartIntentOpen has incomplete guard sequence provenance"
+            )
+        snapshot = self.prepared.current.snapshot
+        if self.prepared.expected_guard_revision == snapshot.record.coordinator_fencing_token:
+            if (
+                guard_mutation_sequence != snapshot.guard_mutation_sequence
+                or guard_value_sequence != snapshot.guard_value_sequence
+                or guard_lifetime_sequence != snapshot.guard_lifetime_sequence
+            ):
+                raise ValueError(
+                    "CommittedInitialRestartIntentOpen changed one fencing token's lineage"
+                )
+            return
+        if (
+            guard_mutation_sequence <= snapshot.guard_mutation_sequence
+            or guard_value_sequence < snapshot.guard_value_sequence
+            or guard_lifetime_sequence < snapshot.guard_lifetime_sequence
+        ):
+            raise ValueError(
+                "CommittedInitialRestartIntentOpen guard lineage predates its generation"
+            )
+        mutation_delta = guard_mutation_sequence - snapshot.guard_mutation_sequence
+        value_delta = guard_value_sequence - snapshot.guard_value_sequence
+        lifetime_delta = guard_lifetime_sequence - snapshot.guard_lifetime_sequence
+        if (
+            mutation_delta < 2 * lifetime_delta
+            or value_delta < lifetime_delta
+            or value_delta > mutation_delta - lifetime_delta
+        ):
+            raise ValueError(
+                "CommittedInitialRestartIntentOpen guard lineage has impossible sequence deltas"
+            )
+        current_lease_digest = self.prepared.record.coordinator_lease_digest
+        snapshot_lease_digest = snapshot.record.coordinator_lease_digest
+        if current_lease_digest == snapshot_lease_digest:
+            if value_delta != 0 or lifetime_delta != 0:
+                raise ValueError("CommittedInitialRestartIntentOpen resurrects a prior lease value")
+        elif value_delta == 0:
+            raise ValueError(
+                "CommittedInitialRestartIntentOpen changes lease identity without a new value"
             )
 
     @property

--- a/lm_resiliency/integrations/torchrun/_restart_intent_open_records.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_open_records.py
@@ -32,6 +32,10 @@ class PreparedInitialRestartIntentOpen:
     coordinator_lease_key: str
     generation_head_key: str
     generation_snapshot_key: str
+    coordinator_lease_transaction_sequence: int
+    coordinator_lease_mutation_sequence: int
+    coordinator_lease_value_sequence: int
+    coordinator_lease_lifetime_sequence: int
     not_before_unix_ms: int
     deadline_unix_ms: int
 
@@ -102,11 +106,28 @@ class PreparedInitialRestartIntentOpen:
                 "generation_snapshot_committed_at_unix_ms",
                 self.current.snapshot.committed_at_unix_ms,
             ),
+            (
+                "coordinator_lease_transaction_sequence",
+                self.coordinator_lease_transaction_sequence,
+            ),
+            (
+                "coordinator_lease_mutation_sequence",
+                self.coordinator_lease_mutation_sequence,
+            ),
+            (
+                "coordinator_lease_value_sequence",
+                self.coordinator_lease_value_sequence,
+            ),
+            (
+                "coordinator_lease_lifetime_sequence",
+                self.coordinator_lease_lifetime_sequence,
+            ),
             ("coordinator_lease_granted_at_unix_ms", self.lease.granted_at_unix_ms),
             ("not_before_unix_ms", self.not_before_unix_ms),
             ("deadline_unix_ms", self.deadline_unix_ms),
         ):
             _positive_integer(integer_value, f"PreparedInitialRestartIntentOpen.{path}")
+        self._validate_lease_lineage()
         if self.not_before_unix_ms < self.lease.granted_at_unix_ms:
             raise ValueError(
                 "PreparedInitialRestartIntentOpen cannot precede its coordinator lease grant"
@@ -125,6 +146,77 @@ class PreparedInitialRestartIntentOpen:
             )
         if self.deadline_unix_ms > self.record.intent.prepare_deadline_unix_ms:
             raise ValueError("PreparedInitialRestartIntentOpen deadline exceeds its restart intent")
+
+    def _validate_lease_lineage(self) -> None:
+        snapshot = self.current.snapshot
+        snapshot_record = snapshot.record
+        if self.lease.fencing_token == snapshot_record.coordinator_fencing_token:
+            if (
+                self.coordinator_lease_transaction_sequence >= snapshot.transaction_sequence
+                or self.coordinator_lease_mutation_sequence != snapshot.guard_mutation_sequence
+                or self.coordinator_lease_value_sequence != snapshot.guard_value_sequence
+                or self.coordinator_lease_lifetime_sequence != snapshot.guard_lifetime_sequence
+                or self.lease.granted_at_unix_ms != snapshot.guard_committed_at_unix_ms
+                or self.record.coordinator_lease_digest != snapshot_record.coordinator_lease_digest
+            ):
+                raise ValueError(
+                    "PreparedInitialRestartIntentOpen lease lineage contradicts its generation"
+                )
+            return
+        if self.coordinator_lease_transaction_sequence <= snapshot.transaction_sequence:
+            raise ValueError(
+                "PreparedInitialRestartIntentOpen lease mutation does not follow its generation"
+            )
+        if (
+            self.coordinator_lease_mutation_sequence <= snapshot.guard_mutation_sequence
+            or self.coordinator_lease_value_sequence < snapshot.guard_value_sequence
+            or self.coordinator_lease_lifetime_sequence < snapshot.guard_lifetime_sequence
+            or self.lease.granted_at_unix_ms < snapshot.guard_committed_at_unix_ms
+        ):
+            raise ValueError(
+                "PreparedInitialRestartIntentOpen lease lineage predates its generation"
+            )
+        mutation_delta = self.coordinator_lease_mutation_sequence - snapshot.guard_mutation_sequence
+        value_delta = self.coordinator_lease_value_sequence - snapshot.guard_value_sequence
+        lifetime_delta = self.coordinator_lease_lifetime_sequence - snapshot.guard_lifetime_sequence
+        if (
+            mutation_delta < 2 * lifetime_delta
+            or value_delta < lifetime_delta
+            or value_delta > mutation_delta - lifetime_delta
+        ):
+            raise ValueError(
+                "PreparedInitialRestartIntentOpen lease lineage has impossible sequence deltas"
+            )
+        same_lease_id = self.lease.record.lease_id == snapshot_record.lease_id
+        if same_lease_id:
+            if self.lease.record.coordinator_id != snapshot_record.coordinator_id:
+                raise ValueError("PreparedInitialRestartIntentOpen changes one lease's coordinator")
+            if self.lease.record.lease_duration_ms != snapshot_record.coordinator_lease_duration_ms:
+                raise ValueError("PreparedInitialRestartIntentOpen changes one lease's duration")
+            if lifetime_delta != 0 or value_delta != 0:
+                raise ValueError(
+                    "PreparedInitialRestartIntentOpen changes one lease's store identity"
+                )
+            latest_valid_grant = snapshot.guard_committed_at_unix_ms + mutation_delta * (
+                snapshot_record.coordinator_lease_duration_ms - 1
+            )
+            if self.lease.granted_at_unix_ms > latest_valid_grant:
+                raise ValueError(
+                    "PreparedInitialRestartIntentOpen renews an expired coordinator lease"
+                )
+            return
+        if value_delta == 0:
+            raise ValueError(
+                "PreparedInitialRestartIntentOpen changes lease identity without a new value"
+            )
+        if lifetime_delta == 0 and mutation_delta != 1:
+            raise ValueError(
+                "PreparedInitialRestartIntentOpen lease replacement has ambiguous mutations"
+            )
+        if lifetime_delta == 0 and self.lease.granted_at_unix_ms < (
+            snapshot.guard_committed_at_unix_ms + snapshot_record.coordinator_lease_duration_ms
+        ):
+            raise ValueError("PreparedInitialRestartIntentOpen coordinator leases overlap")
 
     @property
     def expected_guard_revision(self) -> int:

--- a/lm_resiliency/integrations/torchrun/_restart_intent_open_records.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_open_records.py
@@ -36,6 +36,8 @@ class PreparedInitialRestartIntentOpen:
     coordinator_lease_mutation_sequence: int
     coordinator_lease_value_sequence: int
     coordinator_lease_lifetime_sequence: int
+    generation_lease_id_history: tuple[str, ...]
+    generation_fencing_token_history: tuple[int, ...]
     not_before_unix_ms: int
     deadline_unix_ms: int
 
@@ -127,6 +129,41 @@ class PreparedInitialRestartIntentOpen:
             ("deadline_unix_ms", self.deadline_unix_ms),
         ):
             _positive_integer(integer_value, f"PreparedInitialRestartIntentOpen.{path}")
+        generation = self.current.snapshot.record.assignment.generation
+        if len(self.generation_lease_id_history) != generation + 1:
+            raise ValueError(
+                "PreparedInitialRestartIntentOpen lease-ID history does not cover its generation"
+            )
+        if len(self.generation_fencing_token_history) != generation + 1:
+            raise ValueError(
+                "PreparedInitialRestartIntentOpen fencing-token history does not cover its generation"
+            )
+        for lease_id in self.generation_lease_id_history:
+            if not isinstance(lease_id, str) or not lease_id.strip():
+                raise ValueError(
+                    "PreparedInitialRestartIntentOpen lease-ID history contains an invalid value"
+                )
+        for fencing_token in self.generation_fencing_token_history:
+            _positive_integer(
+                fencing_token,
+                "PreparedInitialRestartIntentOpen generation fencing token",
+            )
+        if (
+            self.generation_lease_id_history[-1] != self.current.snapshot.record.lease_id
+            or self.generation_fencing_token_history[-1]
+            != self.current.snapshot.record.coordinator_fencing_token
+        ):
+            raise ValueError(
+                "PreparedInitialRestartIntentOpen lease history does not end at its generation"
+            )
+        _reject_noncontiguous_recurrence(
+            self.generation_lease_id_history,
+            "lease identity",
+        )
+        _reject_noncontiguous_recurrence(
+            self.generation_fencing_token_history,
+            "fencing token",
+        )
         self._validate_lease_lineage()
         if self.not_before_unix_ms < self.lease.granted_at_unix_ms:
             raise ValueError(
@@ -177,15 +214,37 @@ class PreparedInitialRestartIntentOpen:
                 "PreparedInitialRestartIntentOpen lease lineage predates its generation"
             )
         mutation_delta = self.coordinator_lease_mutation_sequence - snapshot.guard_mutation_sequence
+        transaction_delta = (
+            self.coordinator_lease_transaction_sequence - snapshot.transaction_sequence
+        )
         value_delta = self.coordinator_lease_value_sequence - snapshot.guard_value_sequence
         lifetime_delta = self.coordinator_lease_lifetime_sequence - snapshot.guard_lifetime_sequence
         if (
-            mutation_delta < 2 * lifetime_delta
+            transaction_delta < mutation_delta
+            or mutation_delta < 2 * lifetime_delta
             or value_delta < lifetime_delta
             or value_delta > mutation_delta - lifetime_delta
         ):
             raise ValueError(
                 "PreparedInitialRestartIntentOpen lease lineage has impossible sequence deltas"
+            )
+        if self.lease.granted_at_unix_ms < snapshot.committed_at_unix_ms:
+            raise ValueError(
+                "PreparedInitialRestartIntentOpen lease grant predates its generation commit"
+            )
+        if (
+            self.lease.record.lease_id != snapshot_record.lease_id
+            and self.lease.record.lease_id in self.generation_lease_id_history[:-1]
+        ):
+            raise ValueError(
+                "PreparedInitialRestartIntentOpen reuses an older generation lease identity"
+            )
+        if (
+            self.lease.fencing_token != snapshot_record.coordinator_fencing_token
+            and self.lease.fencing_token in self.generation_fencing_token_history[:-1]
+        ):
+            raise ValueError(
+                "PreparedInitialRestartIntentOpen reuses an older generation fencing token"
             )
         same_lease_id = self.lease.record.lease_id == snapshot_record.lease_id
         if same_lease_id:
@@ -257,6 +316,17 @@ def _positive_integer(value: object, path: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value < 1:
         raise ValueError(f"{path} must be a positive integer")
     return value
+
+
+def _reject_noncontiguous_recurrence(values: tuple[object, ...], label: str) -> None:
+    seen: set[object] = set()
+    previous: object | None = None
+    for value in values:
+        if value != previous:
+            if value in seen:
+                raise ValueError(f"PreparedInitialRestartIntentOpen generation {label} reappears")
+            seen.add(value)
+        previous = value
 
 
 __all__ = ["PreparedInitialRestartIntentOpen"]

--- a/tests/unit/test_torchrun_generation_reader.py
+++ b/tests/unit/test_torchrun_generation_reader.py
@@ -414,7 +414,7 @@ def test_generation_reader_retries_concurrent_head_advance(monkeypatch):
     assert current.snapshot.record.assignment.generation == 1
 
 
-def test_generation_reader_reads_current_and_historical_snapshots():
+def test_generation_reader_reads_current_and_historical_snapshots(monkeypatch):
     clock, store, lease, reader = _state()
     generation_zero = _commit(
         store,
@@ -436,10 +436,26 @@ def test_generation_reader_reads_current_and_historical_snapshots():
         expected_head_revision=generation_zero[reader.head_key].revision,
     )
 
-    current = reader.current()
+    original_get = store.get
+    snapshot_reads = {reader.snapshot_key(0): 0, reader.snapshot_key(1): 0}
 
+    def counting_get(key):
+        if key in snapshot_reads:
+            snapshot_reads[key] += 1
+        return original_get(key)
+
+    monkeypatch.setattr(store, "get", counting_get)
+    observed = reader.current_with_history()
+
+    assert observed is not None
+    current, history = observed
     assert current is not None
     assert current.snapshot.record.assignment.generation == 1
+    assert history == (current_zero.snapshot, current.snapshot)
+    assert snapshot_reads == {
+        reader.snapshot_key(0): 1,
+        reader.snapshot_key(1): 1,
+    }
     assert (
         current_zero.snapshot.transaction_sequence
         == generation_zero[reader.snapshot_key(0)].transaction_sequence

--- a/tests/unit/test_torchrun_restart_intent_open.py
+++ b/tests/unit/test_torchrun_restart_intent_open.py
@@ -128,6 +128,8 @@ def test_prepare_initial_open_authenticates_and_builds_descriptor_without_writes
     assert prepared.coordinator_lease_mutation_sequence == 1
     assert prepared.coordinator_lease_value_sequence == 1
     assert prepared.coordinator_lease_lifetime_sequence == 1
+    assert prepared.generation_lease_id_history == (lease.record.lease_id,)
+    assert prepared.generation_fencing_token_history == (lease.fencing_token,)
     assert prepared.not_before_unix_ms == 1_000
     assert prepared.deadline_unix_ms == 1_050
     assert prepared.never_created_conditions == frozenset({preparer.lifecycle_head_key})
@@ -271,6 +273,64 @@ def test_prepare_initial_open_accepts_nonoverlapping_replacement_lease():
     assert prepared.coordinator_lease_mutation_sequence == 2
     assert prepared.coordinator_lease_value_sequence == 2
     assert prepared.coordinator_lease_lifetime_sequence == 1
+
+
+@pytest.mark.parametrize("reused_identity", ["lease_id", "fencing_token"])
+def test_prepare_initial_open_rejects_identity_reused_from_generation_history(
+    reused_identity,
+):
+    clock, store, _, generation_manager, preparer, lease_a, generation_zero = _state()
+    replacement_manager = CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id="coordinator-b",
+        lease_duration_ms=100,
+        clock=clock,
+    )
+    clock.set(1_100)
+    lease_b = replacement_manager.acquire()
+    generation_one = generation_manager.commit_successor(
+        lease_b,
+        generation_zero,
+        _assignment(generation=1),
+    )
+    clock.set(1_200)
+    candidate_record = CoordinatorLeaseRecord(
+        run_id=RUN_ID,
+        coordinator_id="coordinator-c",
+        lease_id=(lease_a.record.lease_id if reused_identity == "lease_id" else "lease-c"),
+        lease_duration_ms=100,
+    )
+    candidate_entry = store.compare_set_in_window(
+        preparer.coordinator_lease_key,
+        expected_revision=lease_b.fencing_token,
+        not_before_unix_ms=1_200,
+        deadline_unix_ms=None,
+        value=candidate_record.to_json(),
+    )
+    candidate_token = (
+        lease_a.fencing_token if reused_identity == "fencing_token" else candidate_entry.revision
+    )
+    if candidate_token != candidate_entry.revision:
+        store._entries[preparer.coordinator_lease_key] = replace(
+            candidate_entry,
+            revision=candidate_token,
+        )
+    candidate = HeldCoordinatorLease(
+        record=candidate_record,
+        fencing_token=candidate_token,
+        granted_at_unix_ms=1_200,
+    )
+
+    with pytest.raises(RestartIntentOpenPreparationCorrupt, match="lineage"):
+        preparer.prepare_initial_open(
+            candidate,
+            generation_one,
+            _intent(
+                generation=1,
+                prepare_deadline_unix_ms=1_300,
+            ),
+        )
 
 
 def test_prepare_initial_open_rejects_malformed_or_untimed_lease():

--- a/tests/unit/test_torchrun_restart_intent_open.py
+++ b/tests/unit/test_torchrun_restart_intent_open.py
@@ -13,6 +13,8 @@ from lm_resiliency.integrations.torchrun._control_store import (
 )
 from lm_resiliency.integrations.torchrun._coordinator_lease import (
     CoordinatorLeaseManager,
+    CoordinatorLeaseRecord,
+    HeldCoordinatorLease,
 )
 from lm_resiliency.integrations.torchrun._generation_state import GenerationStateManager
 from lm_resiliency.integrations.torchrun._protocol import (
@@ -122,6 +124,10 @@ def test_prepare_initial_open_authenticates_and_builds_descriptor_without_writes
     )
     assert prepared.current == current
     assert prepared.lease == lease
+    assert prepared.coordinator_lease_transaction_sequence == 1
+    assert prepared.coordinator_lease_mutation_sequence == 1
+    assert prepared.coordinator_lease_value_sequence == 1
+    assert prepared.coordinator_lease_lifetime_sequence == 1
     assert prepared.not_before_unix_ms == 1_000
     assert prepared.deadline_unix_ms == 1_050
     assert prepared.never_created_conditions == frozenset({preparer.lifecycle_head_key})
@@ -213,6 +219,58 @@ def test_prepare_initial_open_rejects_stale_or_fabricated_lease():
         preparer.prepare_initial_open(fabricated, current, _intent())
 
     assert store.get(preparer.intent_head_key) is None
+
+
+def test_prepare_initial_open_rejects_overlapping_replacement_lease():
+    clock, store, _, _, preparer, lease, current = _state()
+    clock.set(1_010)
+    replacement_record = CoordinatorLeaseRecord(
+        run_id=RUN_ID,
+        coordinator_id="coordinator-b",
+        lease_id="lease-b",
+        lease_duration_ms=100,
+    )
+    replacement_entry = store.compare_set_in_window(
+        preparer.coordinator_lease_key,
+        expected_revision=lease.fencing_token,
+        not_before_unix_ms=1_010,
+        deadline_unix_ms=None,
+        value=replacement_record.to_json(),
+    )
+    replacement = HeldCoordinatorLease(
+        record=replacement_record,
+        fencing_token=replacement_entry.revision,
+        granted_at_unix_ms=1_010,
+    )
+
+    with pytest.raises(RestartIntentOpenPreparationCorrupt, match="lineage"):
+        preparer.prepare_initial_open(replacement, current, _intent())
+
+    assert store.get(preparer.intent_head_key) is None
+
+
+def test_prepare_initial_open_accepts_nonoverlapping_replacement_lease():
+    clock, store, _, _, preparer, _, current = _state()
+    replacement_manager = CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id="coordinator-b",
+        lease_duration_ms=100,
+        clock=clock,
+    )
+    clock.set(1_100)
+    replacement = replacement_manager.acquire()
+
+    prepared = preparer.prepare_initial_open(
+        replacement,
+        current,
+        _intent(prepare_deadline_unix_ms=1_200),
+    )
+
+    assert prepared.coordinator_lease_transaction_sequence > current.snapshot.transaction_sequence
+    assert prepared.coordinator_lease_mutation_sequence == 2
+    assert prepared.coordinator_lease_value_sequence == 2
+    assert prepared.coordinator_lease_lifetime_sequence == 1
 
 
 def test_prepare_initial_open_rejects_malformed_or_untimed_lease():

--- a/tests/unit/test_torchrun_restart_intent_open_execution.py
+++ b/tests/unit/test_torchrun_restart_intent_open_execution.py
@@ -120,6 +120,12 @@ class TamperedTransactionResultStore(InMemoryControlStore):
                     guard_value_sequence=1,
                     guard_lifetime_sequence=1,
                 )
+        elif self._tamper == "lease_order":
+            for key in (intent_key, head_key):
+                committed[key] = replace(
+                    committed[key],
+                    transaction_sequence=3,
+                )
         else:
             raise AssertionError(f"unsupported tamper {self._tamper!r}")
         return committed
@@ -221,6 +227,11 @@ def test_execute_initial_open_accepts_lease_renewed_after_generation_commit():
 
     committed = executor.execute_initial_open(prepared)
 
+    assert committed.transaction_sequence > prepared.coordinator_lease_transaction_sequence
+    assert (
+        committed.intent_entry.guard_mutation_sequence
+        == prepared.coordinator_lease_mutation_sequence
+    )
     assert committed.intent_entry.guard_mutation_sequence > current.snapshot.guard_mutation_sequence
     assert committed.intent_entry.guard_value_sequence == current.snapshot.guard_value_sequence
     assert (
@@ -322,12 +333,13 @@ def test_execute_initial_open_rejects_store_time_before_preparation():
         "commit_time",
         "generation_order",
         "guard_lineage",
+        "lease_order",
     ],
 )
 def test_execute_initial_open_rejects_tampered_transaction_results(tamper):
     _, _, _, _, executor, _, _, prepared = _state(
         store_tamper=tamper,
-        renew_before_prepare=tamper == "guard_lineage",
+        renew_before_prepare=tamper in {"guard_lineage", "lease_order"},
     )
 
     with pytest.raises(RestartIntentOpenExecutionCorrupt, match="transaction"):

--- a/tests/unit/test_torchrun_restart_intent_open_execution.py
+++ b/tests/unit/test_torchrun_restart_intent_open_execution.py
@@ -112,6 +112,14 @@ class TamperedTransactionResultStore(InMemoryControlStore):
                 committed[head_key],
                 transaction_sequence=2,
             )
+        elif self._tamper == "guard_lineage":
+            for key in (intent_key, head_key):
+                committed[key] = replace(
+                    committed[key],
+                    guard_mutation_sequence=1,
+                    guard_value_sequence=1,
+                    guard_lifetime_sequence=1,
+                )
         else:
             raise AssertionError(f"unsupported tamper {self._tamper!r}")
         return committed
@@ -147,6 +155,7 @@ def _state(
     store_tamper: str | None = None,
     preparation_clock: ManualClock | None = None,
     prepare_deadline_unix_ms: int = 1_050,
+    renew_before_prepare: bool = False,
 ):
     store_clock = ManualClock()
     if store_tamper is None:
@@ -174,6 +183,9 @@ def _state(
     generation_manager.initialize(lease, _assignment())
     current = generation_manager.current()
     assert current is not None
+    if renew_before_prepare:
+        store_clock.set(1_010)
+        lease = lease_manager.renew(lease)
     prepared = preparer.prepare_initial_open(
         lease,
         current,
@@ -202,6 +214,18 @@ def test_execute_initial_open_commits_and_verifies_both_records():
     assert committed.committed_at_unix_ms == 1_000
     assert committed.transaction_sequence > current.snapshot.transaction_sequence
     assert committed.intent_entry.transaction_sequence == committed.head_entry.transaction_sequence
+
+
+def test_execute_initial_open_accepts_lease_renewed_after_generation_commit():
+    _, _, _, _, executor, _, current, prepared = _state(renew_before_prepare=True)
+
+    committed = executor.execute_initial_open(prepared)
+
+    assert committed.intent_entry.guard_mutation_sequence > current.snapshot.guard_mutation_sequence
+    assert committed.intent_entry.guard_value_sequence == current.snapshot.guard_value_sequence
+    assert (
+        committed.intent_entry.guard_lifetime_sequence == current.snapshot.guard_lifetime_sequence
+    )
 
 
 def test_execute_initial_open_rejects_changed_generation():
@@ -297,10 +321,14 @@ def test_execute_initial_open_rejects_store_time_before_preparation():
         "guard_digest",
         "commit_time",
         "generation_order",
+        "guard_lineage",
     ],
 )
 def test_execute_initial_open_rejects_tampered_transaction_results(tamper):
-    _, _, _, _, executor, _, _, prepared = _state(store_tamper=tamper)
+    _, _, _, _, executor, _, _, prepared = _state(
+        store_tamper=tamper,
+        renew_before_prepare=tamper == "guard_lineage",
+    )
 
     with pytest.raises(RestartIntentOpenExecutionCorrupt, match="transaction"):
         executor.execute_initial_open(prepared)

--- a/tests/unit/test_torchrun_restart_intent_open_execution.py
+++ b/tests/unit/test_torchrun_restart_intent_open_execution.py
@@ -1,0 +1,316 @@
+"""Contract tests for guarded initial restart-intent execution."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Collection, Mapping
+from dataclasses import replace
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStoreEntry,
+    ControlStoreWrite,
+    InMemoryControlStore,
+)
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseManager,
+)
+from lm_resiliency.integrations.torchrun._generation_state import GenerationStateManager
+from lm_resiliency.integrations.torchrun._protocol import (
+    RankAssignment,
+    RestartIntent,
+    SlotAssignment,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open import (
+    RestartIntentOpenPreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
+    RestartIntentOpenExecutionClockError,
+    RestartIntentOpenExecutionConflict,
+    RestartIntentOpenExecutionCorrupt,
+    RestartIntentOpenExecutionDeadlineElapsed,
+    RestartIntentOpenExecutionLeaseLost,
+    RestartIntentOpenExecutor,
+)
+
+RUN_ID = "training-run"
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+    def set(self, now_unix_ms: int) -> None:
+        with self._lock:
+            self.now_unix_ms = now_unix_ms
+
+
+class TamperedTransactionResultStore(InMemoryControlStore):
+    def __init__(self, *, clock: ManualClock, tamper: str) -> None:
+        super().__init__(clock=clock)
+        self._tamper = tamper
+
+    def compare_set_many_guarded(
+        self,
+        writes: Mapping[str, ControlStoreWrite],
+        *,
+        guard_key: str,
+        expected_guard_revision: int,
+        not_before_unix_ms: int,
+        deadline_unix_ms: int,
+        conditions: Mapping[str, int | None] | None = None,
+        never_created_conditions: Collection[str] | None = None,
+    ) -> Mapping[str, ControlStoreEntry]:
+        committed = dict(
+            super().compare_set_many_guarded(
+                writes,
+                guard_key=guard_key,
+                expected_guard_revision=expected_guard_revision,
+                not_before_unix_ms=not_before_unix_ms,
+                deadline_unix_ms=deadline_unix_ms,
+                conditions=conditions,
+                never_created_conditions=never_created_conditions,
+            )
+        )
+        if not any("/restart-intents/" in key for key in committed):
+            return committed
+        intent_key = next(key for key in committed if "/restart-intents/" in key)
+        head_key = next(key for key in committed if key.endswith("/restart-intent-head"))
+        if self._tamper == "missing_head":
+            return {intent_key: committed[intent_key]}
+        if self._tamper == "intent_value":
+            committed[intent_key] = replace(committed[intent_key], value=b"{}")
+        elif self._tamper == "transaction_sequence":
+            committed[head_key] = replace(
+                committed[head_key],
+                transaction_sequence=committed[head_key].transaction_sequence + 1,
+            )
+        elif self._tamper == "guard_digest":
+            committed[intent_key] = replace(
+                committed[intent_key],
+                guard_value_digest="0" * 64,
+            )
+        elif self._tamper == "commit_time":
+            committed_at_unix_ms = committed[head_key].committed_at_unix_ms
+            assert committed_at_unix_ms is not None
+            committed[head_key] = replace(
+                committed[head_key],
+                committed_at_unix_ms=committed_at_unix_ms + 1,
+            )
+        elif self._tamper == "generation_order":
+            committed[intent_key] = replace(
+                committed[intent_key],
+                transaction_sequence=2,
+            )
+            committed[head_key] = replace(
+                committed[head_key],
+                transaction_sequence=2,
+            )
+        else:
+            raise AssertionError(f"unsupported tamper {self._tamper!r}")
+        return committed
+
+
+def _assignment(generation: int = 0) -> RankAssignment:
+    return RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=generation,
+        assignments=(
+            SlotAssignment(0, "node-a", 0, 2),
+            SlotAssignment(1, "node-b", 2, 2),
+        ),
+        topology_digest="topology-v1",
+    )
+
+
+def _intent(*, prepare_deadline_unix_ms: int = 1_050) -> RestartIntent:
+    return RestartIntent(
+        intent_id="intent-a",
+        run_id=RUN_ID,
+        generation=0,
+        incident_ids=("incident-a",),
+        reason_code="attributed_sdc",
+        minimum_recovery_mode="recovery_verified",
+        suspected_node_ids=("node-b",),
+        prepare_deadline_unix_ms=prepare_deadline_unix_ms,
+    )
+
+
+def _state(
+    *,
+    store_tamper: str | None = None,
+    preparation_clock: ManualClock | None = None,
+    prepare_deadline_unix_ms: int = 1_050,
+):
+    store_clock = ManualClock()
+    if store_tamper is None:
+        store = InMemoryControlStore(clock=store_clock)
+    else:
+        store = TamperedTransactionResultStore(
+            clock=store_clock,
+            tamper=store_tamper,
+        )
+    lease_manager = CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id="coordinator-a",
+        lease_duration_ms=100,
+        clock=store_clock,
+    )
+    generation_manager = GenerationStateManager(store, run_id=RUN_ID)
+    preparer = RestartIntentOpenPreparer(
+        store,
+        run_id=RUN_ID,
+        clock=preparation_clock or store_clock,
+    )
+    executor = RestartIntentOpenExecutor(store, run_id=RUN_ID)
+    lease = lease_manager.acquire()
+    generation_manager.initialize(lease, _assignment())
+    current = generation_manager.current()
+    assert current is not None
+    prepared = preparer.prepare_initial_open(
+        lease,
+        current,
+        _intent(prepare_deadline_unix_ms=prepare_deadline_unix_ms),
+    )
+    return (
+        store_clock,
+        store,
+        lease_manager,
+        generation_manager,
+        executor,
+        lease,
+        current,
+        prepared,
+    )
+
+
+def test_execute_initial_open_commits_and_verifies_both_records():
+    _, store, _, _, executor, _, current, prepared = _state()
+
+    committed = executor.execute_initial_open(prepared)
+
+    assert committed.prepared == prepared
+    assert committed.intent_entry == store.get(prepared.intent_key)
+    assert committed.head_entry == store.get(prepared.intent_head_key)
+    assert committed.committed_at_unix_ms == 1_000
+    assert committed.transaction_sequence > current.snapshot.transaction_sequence
+    assert committed.intent_entry.transaction_sequence == committed.head_entry.transaction_sequence
+
+
+def test_execute_initial_open_rejects_changed_generation():
+    clock, store, _, generation_manager, executor, lease, current, prepared = _state()
+    clock.set(1_010)
+    generation_manager.commit_successor(
+        lease,
+        current,
+        _assignment(generation=1),
+    )
+
+    with pytest.raises(RestartIntentOpenExecutionConflict, match="generation-head"):
+        executor.execute_initial_open(prepared)
+
+    assert store.get(prepared.intent_key) is None
+    assert store.get(prepared.intent_head_key) is None
+
+
+def test_execute_initial_open_rejects_stale_lease():
+    clock, store, lease_manager, _, executor, lease, _, prepared = _state()
+    clock.set(1_010)
+    lease_manager.renew(lease)
+
+    with pytest.raises(RestartIntentOpenExecutionLeaseLost, match="changed"):
+        executor.execute_initial_open(prepared)
+
+    assert store.get(prepared.intent_key) is None
+
+
+def test_execute_initial_open_rejects_lifecycle_history_created_after_preparation():
+    _, store, _, _, executor, _, _, prepared = _state()
+    lifecycle = store.compare_set(
+        prepared.lifecycle_head_key,
+        expected_revision=None,
+        value=b"closed",
+    )
+    store.compare_delete(
+        prepared.lifecycle_head_key,
+        expected_revision=lifecycle.revision,
+    )
+
+    with pytest.raises(RestartIntentOpenExecutionConflict, match="prior history"):
+        executor.execute_initial_open(prepared)
+
+    assert store.get(prepared.intent_key) is None
+    assert store.get(prepared.intent_head_key) is None
+
+
+def test_execute_initial_open_rejects_duplicate_execution():
+    _, _, _, _, executor, _, _, prepared = _state()
+    executor.execute_initial_open(prepared)
+
+    with pytest.raises(RestartIntentOpenExecutionConflict):
+        executor.execute_initial_open(prepared)
+
+
+def test_execute_initial_open_reports_intent_deadline():
+    clock, store, _, _, executor, _, _, prepared = _state()
+    clock.set(1_050)
+
+    with pytest.raises(RestartIntentOpenExecutionDeadlineElapsed, match="deadline"):
+        executor.execute_initial_open(prepared)
+
+    assert store.get(prepared.intent_key) is None
+
+
+def test_execute_initial_open_reports_expired_lease():
+    clock, store, _, _, executor, _, _, prepared = _state(prepare_deadline_unix_ms=2_000)
+    clock.set(1_100)
+
+    with pytest.raises(RestartIntentOpenExecutionLeaseLost, match="expired"):
+        executor.execute_initial_open(prepared)
+
+    assert store.get(prepared.intent_key) is None
+
+
+def test_execute_initial_open_rejects_store_time_before_preparation():
+    preparation_clock = ManualClock(1_010)
+    _, store, _, _, executor, _, _, prepared = _state(preparation_clock=preparation_clock)
+
+    with pytest.raises(RestartIntentOpenExecutionClockError, match="time"):
+        executor.execute_initial_open(prepared)
+
+    assert store.get(prepared.intent_key) is None
+
+
+@pytest.mark.parametrize(
+    "tamper",
+    [
+        "missing_head",
+        "intent_value",
+        "transaction_sequence",
+        "guard_digest",
+        "commit_time",
+        "generation_order",
+    ],
+)
+def test_execute_initial_open_rejects_tampered_transaction_results(tamper):
+    _, _, _, _, executor, _, _, prepared = _state(store_tamper=tamper)
+
+    with pytest.raises(RestartIntentOpenExecutionCorrupt, match="transaction"):
+        executor.execute_initial_open(prepared)
+
+
+def test_execute_initial_open_is_run_scoped_and_type_checked():
+    _, store, _, _, _, _, _, prepared = _state()
+    executor = RestartIntentOpenExecutor(store, run_id="other-run")
+
+    with pytest.raises(ValueError, match="another run"):
+        executor.execute_initial_open(prepared)
+    with pytest.raises(TypeError, match="PreparedInitialRestartIntentOpen"):
+        executor.execute_initial_open({})

--- a/tests/unit/test_torchrun_restart_intent_open_records.py
+++ b/tests/unit/test_torchrun_restart_intent_open_records.py
@@ -127,8 +127,38 @@ def _prepared() -> PreparedInitialRestartIntentOpen:
         coordinator_lease_mutation_sequence=1,
         coordinator_lease_value_sequence=1,
         coordinator_lease_lifetime_sequence=1,
+        generation_lease_id_history=("lease-a",),
+        generation_fencing_token_history=(7,),
         not_before_unix_ms=1_000,
         deadline_unix_ms=1_050,
+    )
+
+
+def _with_renewed_lease(
+    prepared: PreparedInitialRestartIntentOpen,
+    *,
+    granted_at_unix_ms: int,
+    transaction_sequence: int,
+    mutation_sequence: int,
+    current: CurrentGeneration | None = None,
+) -> PreparedInitialRestartIntentOpen:
+    lease = replace(
+        prepared.lease,
+        fencing_token=8,
+        granted_at_unix_ms=granted_at_unix_ms,
+    )
+    record = replace(
+        prepared.record,
+        coordinator_fencing_token=lease.fencing_token,
+    )
+    return replace(
+        prepared,
+        record=record,
+        head=replace(prepared.head, intent_digest=record.digest),
+        current=current or prepared.current,
+        lease=lease,
+        coordinator_lease_transaction_sequence=transaction_sequence,
+        coordinator_lease_mutation_sequence=mutation_sequence,
     )
 
 
@@ -174,6 +204,10 @@ def test_prepared_initial_open_is_immutable():
         {"coordinator_lease_mutation_sequence": 2},
         {"coordinator_lease_value_sequence": 2},
         {"coordinator_lease_lifetime_sequence": 2},
+        {"generation_lease_id_history": ()},
+        {"generation_fencing_token_history": ()},
+        {"generation_lease_id_history": ("",)},
+        {"generation_fencing_token_history": (False,)},
         {"not_before_unix_ms": 999},
         {"deadline_unix_ms": 1_051},
     ],
@@ -240,6 +274,38 @@ def test_prepared_initial_open_binds_complete_held_lease():
 
     with pytest.raises(ValueError, match="lease does not authorize"):
         replace(prepared, lease=longer_lease)
+
+
+def test_prepared_initial_open_bounds_lease_mutations_by_transaction_gap():
+    prepared = _prepared()
+
+    with pytest.raises(ValueError, match="sequence deltas"):
+        _with_renewed_lease(
+            prepared,
+            granted_at_unix_ms=1_001,
+            transaction_sequence=5,
+            mutation_sequence=3,
+        )
+
+
+def test_prepared_initial_open_rejects_lease_grant_before_generation_commit():
+    prepared = _prepared()
+    current = replace(
+        prepared.current,
+        snapshot=replace(
+            prepared.current.snapshot,
+            committed_at_unix_ms=1_010,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="grant predates"):
+        _with_renewed_lease(
+            prepared,
+            granted_at_unix_ms=1_005,
+            transaction_sequence=5,
+            mutation_sequence=2,
+            current=current,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_torchrun_restart_intent_open_records.py
+++ b/tests/unit/test_torchrun_restart_intent_open_records.py
@@ -123,6 +123,10 @@ def _prepared() -> PreparedInitialRestartIntentOpen:
         coordinator_lease_key=f"{RUN_PREFIX}/coordinator-lease",
         generation_head_key=f"{RUN_PREFIX}/generation-head",
         generation_snapshot_key=f"{RUN_PREFIX}/generations/0",
+        coordinator_lease_transaction_sequence=1,
+        coordinator_lease_mutation_sequence=1,
+        coordinator_lease_value_sequence=1,
+        coordinator_lease_lifetime_sequence=1,
         not_before_unix_ms=1_000,
         deadline_unix_ms=1_050,
     )
@@ -166,6 +170,10 @@ def test_prepared_initial_open_is_immutable():
         {"generation_head_key": "other"},
         {"generation_snapshot_key": "other"},
         {"lease": replace(_prepared().lease, granted_at_unix_ms=1_001)},
+        {"coordinator_lease_transaction_sequence": 4},
+        {"coordinator_lease_mutation_sequence": 2},
+        {"coordinator_lease_value_sequence": 2},
+        {"coordinator_lease_lifetime_sequence": 2},
         {"not_before_unix_ms": 999},
         {"deadline_unix_ms": 1_051},
     ],
@@ -237,6 +245,10 @@ def test_prepared_initial_open_binds_complete_held_lease():
 @pytest.mark.parametrize(
     ("field", "value"),
     [
+        ("coordinator_lease_transaction_sequence", 0),
+        ("coordinator_lease_mutation_sequence", 0),
+        ("coordinator_lease_value_sequence", 0),
+        ("coordinator_lease_lifetime_sequence", 0),
         ("not_before_unix_ms", 0),
         ("deadline_unix_ms", 0),
     ],


### PR DESCRIPTION
## Problem

A prepared initial restart intent must be committed atomically under the authenticated coordinator lease and exact generation/lifecycle conditions, then verified fail closed before callers trust it.

## Implementation

- add `RestartIntentOpenExecutor` for guarded transaction execution
- translate lease, generation/lifecycle, deadline, and clock failures into intent-specific errors
- add `CommittedInitialRestartIntentOpen` to verify exact record bytes, create-once lineage, shared commit time and transaction sequence, generation order, and lease provenance
- preserve the authenticated lease entry's transaction, mutation, value, and lifetime sequences during preparation and read verified generation lease history in one traversal
- reject expired renewals, overlapping replacements, reused historical lease IDs/tokens, impossible mutation/transaction gaps, missing/substituted results, and commits that do not follow both the generation snapshot and authenticated lease

This PR executes only the already-prepared initial-open transaction. Lifecycle closure, repeated intent reopening, acknowledgements, and plan publication remain separate components.

## Compatibility

The component is internal and newly introduced. Public APIs and optional dependency behavior are unchanged.

## Validation

- 186 focused torchrun execution/preparation/store/generation tests
- 1,637 full CPU tests with CUDA hidden
- targeted Ruff check and format check
- targeted mypy
- `git diff --check`