### PR TITLE
[Feature][Torchrun] Add initial restart intent closure records

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -593,6 +593,11 @@ advancing the lifecycle head and creating the immutable closure record. The
 next intent replaces the marker instead of relying on deletion, so a restarted
 reader can prove closure from persisted state. Atomic opening and closure
 transactions are separate control-plane components. A frozen
+`InitialRestartIntentClosureRecords` value links the first committed intent to
+its immutable closure record, first lifecycle head, and durable closed marker.
+It exposes create-once closure/lifecycle writes, a revision-guarded
+current-head update, and an exact immutable-intent condition, but does not
+authenticate a closing lease or mutate the store. A frozen
 `PreparedInitialRestartIntentOpen` descriptor binds the first intent record,
 current-intent head, exact generation revisions, coordinator fencing token,
 canonical run-scoped keys, and lease/intent commit window. It exposes immutable

--- a/lm_resiliency/integrations/torchrun/_restart_intent_close_records.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_close_records.py
@@ -1,0 +1,125 @@
+"""Immutable record writes for closing the first restart intent."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+
+from lm_resiliency.integrations.torchrun._control_store import ControlStoreWrite
+from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
+    CommittedInitialRestartIntentOpen,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_records import (
+    RestartIntentClosedHeadRecord,
+    RestartIntentLifecycleHeadRecord,
+    RestartIntentLifecycleRecord,
+)
+
+_CONTROL_PREFIX = "lm_resiliency/torchrun/v1"
+
+
+@dataclass(frozen=True, slots=True)
+class InitialRestartIntentClosureRecords:
+    """Linked records and store inputs for closing the first restart intent."""
+
+    opened: CommittedInitialRestartIntentOpen
+    lifecycle: RestartIntentLifecycleRecord
+    lifecycle_head: RestartIntentLifecycleHeadRecord
+    closed_head: RestartIntentClosedHeadRecord
+    intent_key: str
+    intent_head_key: str
+    closure_key: str
+    lifecycle_head_key: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.opened, CommittedInitialRestartIntentOpen):
+            raise TypeError(
+                "InitialRestartIntentClosureRecords.opened must be "
+                "CommittedInitialRestartIntentOpen"
+            )
+        if not isinstance(self.lifecycle, RestartIntentLifecycleRecord):
+            raise TypeError(
+                "InitialRestartIntentClosureRecords.lifecycle must be RestartIntentLifecycleRecord"
+            )
+        if not isinstance(self.lifecycle_head, RestartIntentLifecycleHeadRecord):
+            raise TypeError(
+                "InitialRestartIntentClosureRecords.lifecycle_head must be "
+                "RestartIntentLifecycleHeadRecord"
+            )
+        if not isinstance(self.closed_head, RestartIntentClosedHeadRecord):
+            raise TypeError(
+                "InitialRestartIntentClosureRecords.closed_head must be "
+                "RestartIntentClosedHeadRecord"
+            )
+        open_head = self.opened.prepared.head
+        if self.lifecycle.closed_intent != open_head:
+            raise ValueError(
+                "InitialRestartIntentClosureRecords lifecycle does not close its open intent"
+            )
+        if (
+            self.lifecycle_head.run_id != open_head.run_id
+            or self.lifecycle_head.closure_index != 1
+            or self.lifecycle_head.generation != open_head.generation
+            or self.lifecycle_head.intent_id != open_head.intent_id
+            or self.lifecycle_head.lifecycle_digest != self.lifecycle.digest
+        ):
+            raise ValueError(
+                "InitialRestartIntentClosureRecords lifecycle head does not identify its closure"
+            )
+        if (
+            self.closed_head.run_id != self.lifecycle_head.run_id
+            or self.closed_head.closure_index != self.lifecycle_head.closure_index
+            or self.closed_head.generation != self.lifecycle_head.generation
+            or self.closed_head.intent_id != self.lifecycle_head.intent_id
+            or self.closed_head.lifecycle_head_digest != self.lifecycle_head.digest
+        ):
+            raise ValueError(
+                "InitialRestartIntentClosureRecords closed head does not identify its lifecycle"
+            )
+        run_digest = hashlib.sha256(open_head.run_id.encode("utf-8")).hexdigest()
+        run_prefix = f"{_CONTROL_PREFIX}/runs/{run_digest}"
+        expected_keys = {
+            "intent_key": self.opened.prepared.intent_key,
+            "intent_head_key": self.opened.prepared.intent_head_key,
+            "closure_key": f"{run_prefix}/restart-intent-closures/1",
+            "lifecycle_head_key": self.opened.prepared.lifecycle_head_key,
+        }
+        for path, expected_key in expected_keys.items():
+            if getattr(self, path) != expected_key:
+                raise ValueError(f"InitialRestartIntentClosureRecords.{path} is not canonical")
+        if len(set(expected_keys.values())) != len(expected_keys):
+            raise ValueError("InitialRestartIntentClosureRecords key roles must be distinct")
+
+    @property
+    def writes(self) -> Mapping[str, ControlStoreWrite]:
+        return MappingProxyType(
+            {
+                self.intent_head_key: ControlStoreWrite(
+                    expected_revision=self.opened.head_entry.revision,
+                    value=self.closed_head.to_json(),
+                ),
+                self.lifecycle_head_key: ControlStoreWrite(
+                    expected_revision=None,
+                    value=self.lifecycle_head.to_json(),
+                    require_never_created=True,
+                ),
+                self.closure_key: ControlStoreWrite(
+                    expected_revision=None,
+                    value=self.lifecycle.to_json(),
+                    require_never_created=True,
+                ),
+            }
+        )
+
+    @property
+    def conditions(self) -> Mapping[str, int]:
+        return MappingProxyType(
+            {
+                self.intent_key: self.opened.intent_entry.revision,
+            }
+        )
+
+
+__all__ = ["InitialRestartIntentClosureRecords"]

--- a/tests/unit/test_torchrun_restart_intent_close_records.py
+++ b/tests/unit/test_torchrun_restart_intent_close_records.py
@@ -1,0 +1,209 @@
+"""Contract tests for initial restart-intent closure records."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import replace
+from typing import Any, cast
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseManager,
+)
+from lm_resiliency.integrations.torchrun._generation_state import GenerationStateManager
+from lm_resiliency.integrations.torchrun._protocol import (
+    RankAssignment,
+    RestartIntent,
+    SlotAssignment,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_close_records import (
+    InitialRestartIntentClosureRecords,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open import (
+    RestartIntentOpenPreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
+    RestartIntentOpenExecutor,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_records import (
+    RestartIntentClosedHeadRecord,
+    RestartIntentLifecycleHeadRecord,
+    RestartIntentLifecycleRecord,
+)
+
+RUN_ID = "training-run"
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+
+def _records() -> InitialRestartIntentClosureRecords:
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    lease_manager = CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id="coordinator-a",
+        lease_duration_ms=100,
+        clock=clock,
+    )
+    generation_manager = GenerationStateManager(store, run_id=RUN_ID)
+    open_preparer = RestartIntentOpenPreparer(store, run_id=RUN_ID, clock=clock)
+    open_executor = RestartIntentOpenExecutor(store, run_id=RUN_ID)
+    lease = lease_manager.acquire()
+    generation_manager.initialize(
+        lease,
+        RankAssignment.from_assignments(
+            run_id=RUN_ID,
+            generation=0,
+            assignments=(
+                SlotAssignment(0, "node-a", 0, 2),
+                SlotAssignment(1, "node-b", 2, 2),
+            ),
+            topology_digest="topology-v1",
+        ),
+    )
+    current = generation_manager.current()
+    assert current is not None
+    opened = open_executor.execute_initial_open(
+        open_preparer.prepare_initial_open(
+            lease,
+            current,
+            RestartIntent(
+                intent_id="intent-a",
+                run_id=RUN_ID,
+                generation=0,
+                incident_ids=("incident-a",),
+                reason_code="attributed_sdc",
+                minimum_recovery_mode="recovery_verified",
+                suspected_node_ids=("node-b",),
+                prepare_deadline_unix_ms=1_050,
+            ),
+        )
+    )
+    lifecycle = RestartIntentLifecycleRecord(
+        closed_intent=opened.prepared.head,
+        coordinator_id=lease.record.coordinator_id,
+        lease_id=lease.record.lease_id,
+        coordinator_lease_duration_ms=lease.record.lease_duration_ms,
+        coordinator_fencing_token=lease.fencing_token,
+    )
+    lifecycle_head = RestartIntentLifecycleHeadRecord(
+        run_id=RUN_ID,
+        closure_index=1,
+        generation=0,
+        intent_id="intent-a",
+        lifecycle_digest=lifecycle.digest,
+    )
+    run_prefix = opened.prepared.intent_head_key.rsplit("/", 1)[0]
+    return InitialRestartIntentClosureRecords(
+        opened=opened,
+        lifecycle=lifecycle,
+        lifecycle_head=lifecycle_head,
+        closed_head=RestartIntentClosedHeadRecord(
+            run_id=RUN_ID,
+            closure_index=1,
+            generation=0,
+            intent_id="intent-a",
+            lifecycle_head_digest=lifecycle_head.digest,
+        ),
+        intent_key=opened.prepared.intent_key,
+        intent_head_key=opened.prepared.intent_head_key,
+        closure_key=f"{run_prefix}/restart-intent-closures/1",
+        lifecycle_head_key=opened.prepared.lifecycle_head_key,
+    )
+
+
+def test_initial_closure_records_build_immutable_store_inputs():
+    records = _records()
+
+    assert set(records.writes) == {
+        records.intent_head_key,
+        records.lifecycle_head_key,
+        records.closure_key,
+    }
+    assert (
+        records.writes[records.intent_head_key].expected_revision
+        == records.opened.head_entry.revision
+    )
+    assert not records.writes[records.intent_head_key].require_never_created
+    assert records.writes[records.intent_head_key].value == records.closed_head.to_json()
+    assert records.writes[records.lifecycle_head_key].require_never_created
+    assert records.writes[records.lifecycle_head_key].value == records.lifecycle_head.to_json()
+    assert records.writes[records.closure_key].require_never_created
+    assert records.writes[records.closure_key].value == records.lifecycle.to_json()
+    assert records.conditions == {
+        records.intent_key: records.opened.intent_entry.revision,
+    }
+    with pytest.raises(TypeError):
+        cast(Any, records.writes)["other"] = next(iter(records.writes.values()))
+    with pytest.raises(TypeError):
+        cast(Any, records.conditions)["other"] = 1
+
+
+def test_initial_closure_records_are_immutable():
+    records = _records()
+
+    with pytest.raises(AttributeError):
+        records.intent_key = "other"
+
+
+def test_initial_closure_records_require_expected_types():
+    records = _records()
+
+    for field, value, message in (
+        ("opened", {}, "CommittedInitialRestartIntentOpen"),
+        ("lifecycle", {}, "RestartIntentLifecycleRecord"),
+        ("lifecycle_head", {}, "RestartIntentLifecycleHeadRecord"),
+        ("closed_head", {}, "RestartIntentClosedHeadRecord"),
+    ):
+        with pytest.raises(TypeError, match=message):
+            replace(records, **{field: value})
+
+
+def test_initial_closure_records_reject_unlinked_values():
+    records = _records()
+    wrong_intent = replace(records.lifecycle.closed_intent, intent_id="other")
+    wrong_lifecycle = replace(records.lifecycle, closed_intent=wrong_intent)
+    wrong_lifecycle_head = replace(records.lifecycle_head, closure_index=2)
+    wrong_closed_head = replace(records.closed_head, lifecycle_head_digest="0" * 64)
+
+    for field, value, message in (
+        ("lifecycle", wrong_lifecycle, "does not close"),
+        ("lifecycle_head", wrong_lifecycle_head, "does not identify"),
+        ("closed_head", wrong_closed_head, "does not identify"),
+    ):
+        with pytest.raises(ValueError, match=message):
+            replace(records, **{field: value})
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "intent_key",
+        "intent_head_key",
+        "closure_key",
+        "lifecycle_head_key",
+    ],
+)
+def test_initial_closure_records_require_canonical_keys(field):
+    records = _records()
+
+    with pytest.raises(ValueError, match="canonical"):
+        replace(records, **{field: "other"})
+
+
+def test_initial_closure_records_hide_plaintext_identity():
+    records = _records()
+
+    assert RUN_ID not in records.closure_key
+    assert "intent-a" not in records.closure_key


### PR DESCRIPTION
## Problem

Closing the first restart intent requires three linked persisted values: an immutable closure record, a monotonic lifecycle head, and a durable closed value for the current-intent key. Their write roles and cross-record digests need one immutable contract before lease authentication or store execution is added.

## Implementation

- add `InitialRestartIntentClosureRecords` as a frozen internal value contract
- bind the first committed intent to its closure record, lifecycle head, and closed marker
- derive canonical run-scoped closure keys
- expose create-once closure/lifecycle writes, a revision-guarded current-head update, and an exact immutable-intent condition
- keep closing-lease authentication, deadlines, and mutation execution out of this PR

## Compatibility

The component is internal and newly introduced. Public APIs and optional dependency behavior are unchanged.

## Validation

- 131 focused restart-intent record/execution tests
- 1,646 full CPU tests with CUDA hidden
- targeted Ruff check and format check
- targeted mypy
- `git diff --check`
