### PR TITLE
[Feature][Torchrun] Add coordinator lease authority values

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -973,6 +973,11 @@ returns every committed value entry in mutation order, including overwritten
 values and values from earlier key lifetimes. Deletes do not invent a payload;
 their revision, mutation, transaction, and lifetime effects remain visible as
 gaps between adjacent immutable entries. Failed operations append nothing.
+Each retained coordinator-lease value is decoded into an immutable authority
+record only after validating canonical run-scoped lease bytes, authoritative
+commit time, unguarded lease storage, and possible mutation/value/lifetime
+sequence lineage. Complete history traversal and adjacent-transition validation
+build on this strict value boundary.
 
 Coordinator state that spans multiple keys uses one guarded store transaction.
 The transaction first checks the coordinator lease revision, then any

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -976,8 +976,9 @@ gaps between adjacent immutable entries. Failed operations append nothing.
 Each retained coordinator-lease value is decoded into an immutable authority
 record only after validating canonical run-scoped lease bytes, authoritative
 commit time, unguarded lease storage, and possible mutation/value/lifetime
-sequence lineage. Complete history traversal and adjacent-transition validation
-build on this strict value boundary.
+sequence lineage. A lease key's mutation count also cannot exceed the
+store-global transaction sequence. Complete history traversal and
+adjacent-transition validation build on this strict value boundary.
 
 Coordinator state that spans multiple keys uses one guarded store transaction.
 The transaction first checks the coordinator lease revision, then any

--- a/lm_resiliency/integrations/torchrun/_coordinator_lease_history.py
+++ b/lm_resiliency/integrations/torchrun/_coordinator_lease_history.py
@@ -40,6 +40,10 @@ class CoordinatorLeaseAuthority:
             self.value_sequence,
             self.lifetime_sequence,
         )
+        if self.transaction_sequence < self.mutation_sequence:
+            raise ValueError(
+                "CoordinatorLeaseAuthority.transaction_sequence is too small for mutation_sequence"
+            )
 
     @classmethod
     def from_entry(

--- a/lm_resiliency/integrations/torchrun/_coordinator_lease_history.py
+++ b/lm_resiliency/integrations/torchrun/_coordinator_lease_history.py
@@ -1,0 +1,125 @@
+"""Coordinator lease authority values reconstructed from control-store history."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from lm_resiliency.integrations.torchrun._control_store import ControlStoreEntry
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseRecord,
+    HeldCoordinatorLease,
+)
+
+
+class CoordinatorLeaseAuthorityCorrupt(RuntimeError):
+    """Raised when one persisted coordinator lease authority is invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class CoordinatorLeaseAuthority:
+    """One canonical, store-stamped coordinator lease value."""
+
+    lease: HeldCoordinatorLease
+    transaction_sequence: int
+    mutation_sequence: int
+    value_sequence: int
+    lifetime_sequence: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.lease, HeldCoordinatorLease):
+            raise TypeError("CoordinatorLeaseAuthority.lease must be HeldCoordinatorLease")
+        for path, value in (
+            ("transaction_sequence", self.transaction_sequence),
+            ("mutation_sequence", self.mutation_sequence),
+            ("value_sequence", self.value_sequence),
+            ("lifetime_sequence", self.lifetime_sequence),
+        ):
+            _positive_integer(value, f"CoordinatorLeaseAuthority.{path}")
+        _validate_sequence_lineage(
+            self.mutation_sequence,
+            self.value_sequence,
+            self.lifetime_sequence,
+        )
+
+    @classmethod
+    def from_entry(
+        cls,
+        entry: ControlStoreEntry,
+        *,
+        run_id: str,
+    ) -> CoordinatorLeaseAuthority:
+        """Decode one authoritative coordinator lease store entry."""
+
+        if not isinstance(entry, ControlStoreEntry):
+            raise TypeError("entry must be ControlStoreEntry")
+        normalized_run_id = _nonempty_string(run_id, "run_id")
+        try:
+            record = CoordinatorLeaseRecord.from_json(entry.value)
+        except (TypeError, ValueError) as error:
+            raise CoordinatorLeaseAuthorityCorrupt(
+                "coordinator lease authority contains a malformed record"
+            ) from error
+        if record.run_id != normalized_run_id:
+            raise CoordinatorLeaseAuthorityCorrupt(
+                "coordinator lease authority belongs to another run"
+            )
+        if entry.value != record.to_json():
+            raise CoordinatorLeaseAuthorityCorrupt(
+                "coordinator lease authority contains noncanonical record bytes"
+            )
+        if entry.committed_at_unix_ms is None:
+            raise CoordinatorLeaseAuthorityCorrupt(
+                "coordinator lease authority has no authoritative commit time"
+            )
+        if entry.guard_key is not None:
+            raise CoordinatorLeaseAuthorityCorrupt(
+                "coordinator lease authority unexpectedly carries guard provenance"
+            )
+        return cls(
+            lease=HeldCoordinatorLease(
+                record=record,
+                fencing_token=entry.revision,
+                granted_at_unix_ms=entry.committed_at_unix_ms,
+            ),
+            transaction_sequence=entry.transaction_sequence,
+            mutation_sequence=entry.mutation_sequence,
+            value_sequence=entry.value_sequence,
+            lifetime_sequence=entry.lifetime_sequence,
+        )
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+def _positive_integer(value: object, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{path} must be a positive integer")
+    return value
+
+
+def _validate_sequence_lineage(
+    mutation_sequence: int,
+    value_sequence: int,
+    lifetime_sequence: int,
+) -> None:
+    if mutation_sequence < 2 * lifetime_sequence - 1:
+        raise ValueError(
+            "CoordinatorLeaseAuthority.mutation_sequence is too small for lifetime_sequence"
+        )
+    if value_sequence < lifetime_sequence:
+        raise ValueError(
+            "CoordinatorLeaseAuthority.value_sequence is too small for lifetime_sequence"
+        )
+    if value_sequence > mutation_sequence - lifetime_sequence + 1:
+        raise ValueError(
+            "CoordinatorLeaseAuthority.value_sequence is too large for mutation_sequence"
+        )
+
+
+__all__ = [
+    "CoordinatorLeaseAuthority",
+    "CoordinatorLeaseAuthorityCorrupt",
+]

--- a/tests/unit/test_torchrun_coordinator_lease_history.py
+++ b/tests/unit/test_torchrun_coordinator_lease_history.py
@@ -102,6 +102,17 @@ def test_coordinator_lease_authority_rejects_impossible_sequences(
         )
 
 
+def test_coordinator_lease_authority_rejects_transaction_before_mutation():
+    with pytest.raises(ValueError, match="transaction_sequence is too small"):
+        CoordinatorLeaseAuthority.from_entry(
+            dataclasses.replace(
+                _entry(mutation_sequence=2, value_sequence=1),
+                transaction_sequence=1,
+            ),
+            run_id="training-run",
+        )
+
+
 def test_coordinator_lease_authority_rejects_malformed_or_wrong_run():
     with pytest.raises(CoordinatorLeaseAuthorityCorrupt, match="malformed"):
         CoordinatorLeaseAuthority.from_entry(

--- a/tests/unit/test_torchrun_coordinator_lease_history.py
+++ b/tests/unit/test_torchrun_coordinator_lease_history.py
@@ -1,0 +1,173 @@
+"""Contract tests for torchrun coordinator lease authority values."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._control_store import ControlStoreEntry
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseRecord,
+    HeldCoordinatorLease,
+)
+from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
+    CoordinatorLeaseAuthority,
+    CoordinatorLeaseAuthorityCorrupt,
+)
+
+
+def _record(*, run_id: str = "training-run") -> CoordinatorLeaseRecord:
+    return CoordinatorLeaseRecord(
+        run_id=run_id,
+        coordinator_id="coordinator-a",
+        lease_id="lease-a",
+        lease_duration_ms=100,
+    )
+
+
+def _entry(
+    *,
+    record: CoordinatorLeaseRecord | None = None,
+    committed_at_unix_ms: int | None = 1_000,
+    mutation_sequence: int = 1,
+    value_sequence: int = 1,
+    lifetime_sequence: int = 1,
+) -> ControlStoreEntry:
+    lease_record = record or _record()
+    return ControlStoreEntry(
+        value=lease_record.to_json(),
+        revision=7,
+        committed_at_unix_ms=committed_at_unix_ms,
+        transaction_sequence=11,
+        mutation_sequence=mutation_sequence,
+        value_sequence=value_sequence,
+        lifetime_sequence=lifetime_sequence,
+    )
+
+
+def test_coordinator_lease_authority_decodes_canonical_entry():
+    entry = _entry()
+
+    authority = CoordinatorLeaseAuthority.from_entry(
+        entry,
+        run_id="training-run",
+    )
+
+    assert authority == CoordinatorLeaseAuthority(
+        lease=HeldCoordinatorLease(
+            record=_record(),
+            fencing_token=7,
+            granted_at_unix_ms=1_000,
+        ),
+        transaction_sequence=11,
+        mutation_sequence=1,
+        value_sequence=1,
+        lifetime_sequence=1,
+    )
+
+
+def test_coordinator_lease_authority_is_immutable():
+    authority = CoordinatorLeaseAuthority.from_entry(
+        _entry(),
+        run_id="training-run",
+    )
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        authority.mutation_sequence = 2
+
+
+@pytest.mark.parametrize(
+    ("mutation_sequence", "value_sequence", "lifetime_sequence", "message"),
+    [
+        (2, 1, 2, "mutation_sequence is too small"),
+        (3, 1, 2, "value_sequence is too small"),
+        (3, 3, 2, "value_sequence is too large"),
+    ],
+)
+def test_coordinator_lease_authority_rejects_impossible_sequences(
+    mutation_sequence: int,
+    value_sequence: int,
+    lifetime_sequence: int,
+    message: str,
+):
+    with pytest.raises(ValueError, match=message):
+        CoordinatorLeaseAuthority.from_entry(
+            _entry(
+                mutation_sequence=mutation_sequence,
+                value_sequence=value_sequence,
+                lifetime_sequence=lifetime_sequence,
+            ),
+            run_id="training-run",
+        )
+
+
+def test_coordinator_lease_authority_rejects_malformed_or_wrong_run():
+    with pytest.raises(CoordinatorLeaseAuthorityCorrupt, match="malformed"):
+        CoordinatorLeaseAuthority.from_entry(
+            dataclasses.replace(_entry(), value=b"not-json"),
+            run_id="training-run",
+        )
+
+    with pytest.raises(CoordinatorLeaseAuthorityCorrupt, match="another run"):
+        CoordinatorLeaseAuthority.from_entry(
+            _entry(record=_record(run_id="other-run")),
+            run_id="training-run",
+        )
+
+
+def test_coordinator_lease_authority_rejects_noncanonical_bytes():
+    entry = _entry()
+
+    with pytest.raises(CoordinatorLeaseAuthorityCorrupt, match="noncanonical"):
+        CoordinatorLeaseAuthority.from_entry(
+            dataclasses.replace(
+                entry,
+                value=entry.value.replace(b",", b", "),
+            ),
+            run_id="training-run",
+        )
+
+
+def test_coordinator_lease_authority_requires_authoritative_commit_time():
+    with pytest.raises(CoordinatorLeaseAuthorityCorrupt, match="commit time"):
+        CoordinatorLeaseAuthority.from_entry(
+            _entry(committed_at_unix_ms=None),
+            run_id="training-run",
+        )
+
+
+def test_coordinator_lease_authority_rejects_guarded_entry():
+    entry = dataclasses.replace(
+        _entry(),
+        guard_key="guard",
+        guard_revision=1,
+        guard_value_digest="a" * 64,
+        guard_mutation_sequence=1,
+        guard_value_sequence=1,
+        guard_lifetime_sequence=1,
+        guard_committed_at_unix_ms=1_000,
+    )
+
+    with pytest.raises(CoordinatorLeaseAuthorityCorrupt, match="guard provenance"):
+        CoordinatorLeaseAuthority.from_entry(
+            entry,
+            run_id="training-run",
+        )
+
+
+@pytest.mark.parametrize("run_id", ("", " ", None, 1))
+def test_coordinator_lease_authority_rejects_invalid_expected_run_id(run_id: object):
+    with pytest.raises(ValueError, match="run_id"):
+        CoordinatorLeaseAuthority.from_entry(
+            _entry(),
+            run_id=run_id,  # type: ignore[arg-type]
+        )
+
+
+def test_coordinator_lease_authority_rejects_wrong_entry_type():
+    with pytest.raises(TypeError, match="ControlStoreEntry"):
+        CoordinatorLeaseAuthority.from_entry(
+            object(),
+            run_id="training-run",
+        )


### PR DESCRIPTION
## Summary

- add an immutable `CoordinatorLeaseAuthority` value for one persisted lease observation
- decode strict canonical `CoordinatorLeaseRecord` bytes with authoritative store metadata
- reject wrong-run, malformed, noncanonical, guarded, or impossible sequence entries
- require the store-global transaction sequence to cover every lease-key mutation

## Why

The control store now retains every coordinator lease value. Higher-level restart-intent closure logic needs a strict single-entry trust boundary before it can reconstruct and validate the complete lease transition history after coordinator failover.

## Scope

This PR does not traverse lease history, compare adjacent transitions, mutate the store, or activate torchrun runtime behavior. The history reader is the next PR after this value contract merges.

## Validation

- `72 passed` focused control-store/coordinator-lease tests
- `1662 passed, 1 warning` complete CUDA-hidden CPU suite
- `ruff check .`
- `ruff format --check .`
- targeted `mypy`
- `git diff --check`