### PR TITLE
[Feature][Torchrun] Verify coordinator lease history

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -979,6 +979,13 @@ commit time, unguarded lease storage, and possible mutation/value/lifetime
 sequence lineage. A lease key's mutation count also cannot exceed the
 store-global transaction sequence. Complete history traversal and
 adjacent-transition validation build on this strict value boundary.
+The history reader obtains a stable immutable snapshot, requires the live value
+to be its final retained entry, and validates every adjacent renewal,
+replacement, and delete/recreate transition. Renewals must commit before
+expiry, in-place replacements cannot overlap, no value or lifetime may be
+skipped, and lease identities and fencing tokens cannot recur after
+replacement. Higher layers can therefore reconstruct coordinator authority
+after process loss without trusting process-local observations.
 
 Coordinator state that spans multiple keys uses one guarded store transaction.
 The transaction first checks the coordinator lease revision, then any

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -982,11 +982,14 @@ adjacent-transition validation build on this strict value boundary.
 The history reader obtains a stable immutable snapshot, requires the live value
 to be its final retained entry, requires empty/nonempty values to agree with the
 durable history marker, and validates every adjacent renewal, replacement, and
-delete/recreate transition. Renewals must commit before expiry, in-place
-replacements cannot overlap, no value or lifetime may be skipped, and lease
-identities and fencing tokens cannot recur after replacement. Higher layers can
-therefore reconstruct coordinator authority after process loss without
-trusting process-local observations.
+delete/recreate transition. A never-created lease has empty history; retained
+history with no live lease fails closed because the current store contract has
+no authoritative tombstone proving which retained value was deleted last.
+Renewals must commit before expiry, in-place replacements cannot overlap, no
+value or lifetime may be skipped, and lease identities and fencing tokens
+cannot recur after replacement. Higher layers can therefore reconstruct live
+coordinator authority after process loss without trusting process-local
+observations.
 
 Coordinator state that spans multiple keys uses one guarded store transaction.
 The transaction first checks the coordinator lease revision, then any

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -980,12 +980,13 @@ sequence lineage. A lease key's mutation count also cannot exceed the
 store-global transaction sequence. Complete history traversal and
 adjacent-transition validation build on this strict value boundary.
 The history reader obtains a stable immutable snapshot, requires the live value
-to be its final retained entry, and validates every adjacent renewal,
-replacement, and delete/recreate transition. Renewals must commit before
-expiry, in-place replacements cannot overlap, no value or lifetime may be
-skipped, and lease identities and fencing tokens cannot recur after
-replacement. Higher layers can therefore reconstruct coordinator authority
-after process loss without trusting process-local observations.
+to be its final retained entry, requires empty/nonempty values to agree with the
+durable history marker, and validates every adjacent renewal, replacement, and
+delete/recreate transition. Renewals must commit before expiry, in-place
+replacements cannot overlap, no value or lifetime may be skipped, and lease
+identities and fencing tokens cannot recur after replacement. Higher layers can
+therefore reconstruct coordinator authority after process loss without
+trusting process-local observations.
 
 Coordinator state that spans multiple keys uses one guarded store transaction.
 The transaction first checks the coordinator lease revision, then any

--- a/lm_resiliency/integrations/torchrun/_coordinator_lease_history.py
+++ b/lm_resiliency/integrations/torchrun/_coordinator_lease_history.py
@@ -2,17 +2,32 @@
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass
 
-from lm_resiliency.integrations.torchrun._control_store import ControlStoreEntry
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStore,
+    ControlStoreEntry,
+)
 from lm_resiliency.integrations.torchrun._coordinator_lease import (
     CoordinatorLeaseRecord,
     HeldCoordinatorLease,
 )
 
+_CONTROL_PREFIX = "lm_resiliency/torchrun/v1"
+_MAX_READ_ATTEMPTS = 8
+
 
 class CoordinatorLeaseAuthorityCorrupt(RuntimeError):
     """Raised when one persisted coordinator lease authority is invalid."""
+
+
+class CoordinatorLeaseHistoryError(RuntimeError):
+    """Base error for coordinator lease history reads."""
+
+
+class CoordinatorLeaseHistoryCorrupt(CoordinatorLeaseHistoryError):
+    """Raised when persisted coordinator lease history is contradictory."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -92,6 +107,133 @@ class CoordinatorLeaseAuthority:
         )
 
 
+class CoordinatorLeaseHistoryReader:
+    """Read and verify one run's complete coordinator lease value history."""
+
+    def __init__(self, store: ControlStore, *, run_id: str) -> None:
+        self._store = store
+        self._run_id = _nonempty_string(run_id, "run_id")
+        run_digest = hashlib.sha256(self._run_id.encode("utf-8")).hexdigest()
+        self._lease_key = f"{_CONTROL_PREFIX}/runs/{run_digest}/coordinator-lease"
+
+    @property
+    def lease_key(self) -> str:
+        return self._lease_key
+
+    def read(self) -> tuple[CoordinatorLeaseAuthority, ...]:
+        """Return one stable, verified snapshot of all committed lease values."""
+
+        for _ in range(_MAX_READ_ATTEMPTS):
+            history = self._store.get_history(self._lease_key)
+            current = self._store.get(self._lease_key)
+            confirmed_history = self._store.get_history(self._lease_key)
+            confirmed_current = self._store.get(self._lease_key)
+            if history != confirmed_history or current != confirmed_current:
+                continue
+            if current is not None and (not history or history[-1] != current):
+                raise CoordinatorLeaseHistoryCorrupt(
+                    "current coordinator lease is absent from its value history"
+                )
+            try:
+                authorities = tuple(
+                    CoordinatorLeaseAuthority.from_entry(
+                        entry,
+                        run_id=self._run_id,
+                    )
+                    for entry in history
+                )
+            except (CoordinatorLeaseAuthorityCorrupt, TypeError, ValueError) as error:
+                raise CoordinatorLeaseHistoryCorrupt(
+                    "coordinator lease history contains an invalid authority"
+                ) from error
+            self._validate_history(authorities)
+            return authorities
+        raise CoordinatorLeaseHistoryError(
+            "coordinator lease history changed repeatedly during read"
+        )
+
+    def _validate_history(
+        self,
+        authorities: tuple[CoordinatorLeaseAuthority, ...],
+    ) -> None:
+        if not authorities:
+            return
+        first = authorities[0]
+        if (
+            first.mutation_sequence != 1
+            or first.value_sequence != 1
+            or first.lifetime_sequence != 1
+        ):
+            raise CoordinatorLeaseHistoryCorrupt(
+                "coordinator lease history does not begin at initial store sequences"
+            )
+        seen_lease_ids = {first.lease.record.lease_id}
+        seen_fencing_tokens = {first.lease.fencing_token}
+        for previous, current in zip(authorities, authorities[1:], strict=False):
+            self._validate_transition(previous, current)
+            if current.lease.fencing_token in seen_fencing_tokens:
+                raise CoordinatorLeaseHistoryCorrupt(
+                    "coordinator lease fencing token reappears in history"
+                )
+            seen_fencing_tokens.add(current.lease.fencing_token)
+            if current.lease.record.lease_id != previous.lease.record.lease_id:
+                if current.lease.record.lease_id in seen_lease_ids:
+                    raise CoordinatorLeaseHistoryCorrupt(
+                        "coordinator lease identity reappears after replacement"
+                    )
+                seen_lease_ids.add(current.lease.record.lease_id)
+
+    def _validate_transition(
+        self,
+        previous: CoordinatorLeaseAuthority,
+        current: CoordinatorLeaseAuthority,
+    ) -> None:
+        if current.transaction_sequence <= previous.transaction_sequence:
+            raise CoordinatorLeaseHistoryCorrupt(
+                "coordinator lease transaction sequences do not advance"
+            )
+        if current.lease.granted_at_unix_ms < previous.lease.granted_at_unix_ms:
+            raise CoordinatorLeaseHistoryCorrupt("coordinator lease grant times move backward")
+        mutation_delta = current.mutation_sequence - previous.mutation_sequence
+        value_delta = current.value_sequence - previous.value_sequence
+        lifetime_delta = current.lifetime_sequence - previous.lifetime_sequence
+        transaction_delta = current.transaction_sequence - previous.transaction_sequence
+        if transaction_delta < mutation_delta:
+            raise CoordinatorLeaseHistoryCorrupt(
+                "coordinator lease mutation count exceeds transaction ordering"
+            )
+        if lifetime_delta not in (0, 1):
+            raise CoordinatorLeaseHistoryCorrupt("coordinator lease history omits a key lifetime")
+        expected_mutation_delta = 1 if lifetime_delta == 0 else 2
+        if mutation_delta != expected_mutation_delta:
+            raise CoordinatorLeaseHistoryCorrupt("coordinator lease history omits a key mutation")
+        same_record = current.lease.record == previous.lease.record
+        expected_value_delta = 0 if lifetime_delta == 0 and same_record else 1
+        if value_delta != expected_value_delta:
+            raise CoordinatorLeaseHistoryCorrupt(
+                "coordinator lease value sequence contradicts its records"
+            )
+        if same_record:
+            if lifetime_delta != 0:
+                raise CoordinatorLeaseHistoryCorrupt(
+                    "one coordinator lease crosses a recreated key lifetime"
+                )
+            if current.lease.granted_at_unix_ms >= previous.lease.expires_at_unix_ms:
+                raise CoordinatorLeaseHistoryCorrupt(
+                    "coordinator lease history renews an expired lease"
+                )
+            return
+        if current.lease.record.lease_id == previous.lease.record.lease_id:
+            raise CoordinatorLeaseHistoryCorrupt(
+                "one coordinator lease identity changes its persisted record"
+            )
+        if (
+            lifetime_delta == 0
+            and current.lease.granted_at_unix_ms < previous.lease.expires_at_unix_ms
+        ):
+            raise CoordinatorLeaseHistoryCorrupt("coordinator lease replacements overlap")
+
+
 def _nonempty_string(value: object, path: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"{path} must be a non-empty string")
@@ -126,4 +268,7 @@ def _validate_sequence_lineage(
 __all__ = [
     "CoordinatorLeaseAuthority",
     "CoordinatorLeaseAuthorityCorrupt",
+    "CoordinatorLeaseHistoryCorrupt",
+    "CoordinatorLeaseHistoryError",
+    "CoordinatorLeaseHistoryReader",
 ]

--- a/lm_resiliency/integrations/torchrun/_coordinator_lease_history.py
+++ b/lm_resiliency/integrations/torchrun/_coordinator_lease_history.py
@@ -144,6 +144,10 @@ class CoordinatorLeaseHistoryReader:
                 raise CoordinatorLeaseHistoryCorrupt(
                     "coordinator lease was deleted without an authoritative retained tail"
                 )
+            if current is not None and not history:
+                raise CoordinatorLeaseHistoryCorrupt(
+                    "live coordinator lease has no retained value history"
+                )
             if current is not None and history[-1] != current:
                 raise CoordinatorLeaseHistoryCorrupt(
                     "current coordinator lease is absent from its value history"

--- a/lm_resiliency/integrations/torchrun/_coordinator_lease_history.py
+++ b/lm_resiliency/integrations/torchrun/_coordinator_lease_history.py
@@ -126,10 +126,20 @@ class CoordinatorLeaseHistoryReader:
         for _ in range(_MAX_READ_ATTEMPTS):
             history = self._store.get_history(self._lease_key)
             current = self._store.get(self._lease_key)
+            has_history = self._store.has_history(self._lease_key)
             confirmed_history = self._store.get_history(self._lease_key)
             confirmed_current = self._store.get(self._lease_key)
-            if history != confirmed_history or current != confirmed_current:
+            confirmed_has_history = self._store.has_history(self._lease_key)
+            if (
+                history != confirmed_history
+                or current != confirmed_current
+                or has_history != confirmed_has_history
+            ):
                 continue
+            if bool(history) != has_history:
+                raise CoordinatorLeaseHistoryCorrupt(
+                    "coordinator lease value history contradicts its durable history marker"
+                )
             if current is not None and (not history or history[-1] != current):
                 raise CoordinatorLeaseHistoryCorrupt(
                     "current coordinator lease is absent from its value history"

--- a/lm_resiliency/integrations/torchrun/_coordinator_lease_history.py
+++ b/lm_resiliency/integrations/torchrun/_coordinator_lease_history.py
@@ -140,7 +140,11 @@ class CoordinatorLeaseHistoryReader:
                 raise CoordinatorLeaseHistoryCorrupt(
                     "coordinator lease value history contradicts its durable history marker"
                 )
-            if current is not None and (not history or history[-1] != current):
+            if current is None and history:
+                raise CoordinatorLeaseHistoryCorrupt(
+                    "coordinator lease was deleted without an authoritative retained tail"
+                )
+            if current is not None and history[-1] != current:
                 raise CoordinatorLeaseHistoryCorrupt(
                     "current coordinator lease is absent from its value history"
                 )

--- a/tests/unit/test_torchrun_coordinator_lease_history.py
+++ b/tests/unit/test_torchrun_coordinator_lease_history.py
@@ -283,7 +283,7 @@ def test_coordinator_lease_history_reads_renewal_and_replacement():
     assert tuple(authority.lifetime_sequence for authority in history) == (1, 1, 1)
 
 
-def test_coordinator_lease_history_preserves_delete_recreate_and_final_delete():
+def test_coordinator_lease_history_preserves_delete_and_recreate():
     clock = ManualClock()
     store = InMemoryControlStore(clock=clock)
     first = _manager(store, clock, "coordinator-a")
@@ -293,13 +293,23 @@ def test_coordinator_lease_history_preserves_delete_recreate_and_final_delete():
     clock.set(1_010)
     first.release(opened)
     replacement = second.acquire()
-    second.release(replacement)
 
     history = CoordinatorLeaseHistoryReader(store, run_id="training-run").read()
 
     assert tuple(authority.lease for authority in history) == (opened, replacement)
     assert tuple(authority.mutation_sequence for authority in history) == (1, 3)
     assert tuple(authority.lifetime_sequence for authority in history) == (1, 2)
+
+
+def test_coordinator_lease_history_rejects_deleted_current_lease():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    manager = _manager(store, clock, "coordinator-a")
+    lease = manager.acquire()
+    manager.release(lease)
+
+    with pytest.raises(CoordinatorLeaseHistoryCorrupt, match="deleted"):
+        CoordinatorLeaseHistoryReader(store, run_id="training-run").read()
 
 
 def test_coordinator_lease_history_reads_empty_store():

--- a/tests/unit/test_torchrun_coordinator_lease_history.py
+++ b/tests/unit/test_torchrun_coordinator_lease_history.py
@@ -462,6 +462,12 @@ def test_coordinator_lease_history_rejects_noninitial_or_incomplete_history():
             run_id="training-run",
         ).read()
 
+    with pytest.raises(CoordinatorLeaseHistoryCorrupt, match="no retained value history"):
+        CoordinatorLeaseHistoryReader(
+            StaticHistoryStore((), current=_entry()),
+            run_id="training-run",
+        ).read()
+
 
 def test_coordinator_lease_history_fails_after_repeatedly_unstable_reads():
     with pytest.raises(CoordinatorLeaseHistoryError, match="changed repeatedly"):

--- a/tests/unit/test_torchrun_coordinator_lease_history.py
+++ b/tests/unit/test_torchrun_coordinator_lease_history.py
@@ -45,15 +45,20 @@ class StaticHistoryStore(InMemoryControlStore):
         history: tuple[ControlStoreEntry, ...],
         *,
         current: ControlStoreEntry | None = None,
+        has_history: bool | None = None,
     ) -> None:
         self._history = history
         self._current = history[-1] if current is None and history else current
+        self._has_history = bool(history) if has_history is None else has_history
 
     def get(self, key: str) -> ControlStoreEntry | None:
         return self._current
 
     def get_history(self, key: str) -> tuple[ControlStoreEntry, ...]:
         return self._history
+
+    def has_history(self, key: str) -> bool:
+        return self._has_history
 
 
 class UnstableHistoryStore(StaticHistoryStore):
@@ -426,9 +431,24 @@ def test_coordinator_lease_history_rejects_noninitial_or_incomplete_history():
             run_id="training-run",
         ).read()
 
+    retained = _entry(transaction_sequence=1, revision=1)
+    different_current = _entry(
+        record=_record(coordinator_id="coordinator-b", lease_id="lease-b"),
+        transaction_sequence=2,
+        mutation_sequence=2,
+        value_sequence=2,
+        revision=2,
+        committed_at_unix_ms=1_100,
+    )
     with pytest.raises(CoordinatorLeaseHistoryCorrupt, match="absent from"):
         CoordinatorLeaseHistoryReader(
-            StaticHistoryStore((), current=_entry()),
+            StaticHistoryStore((retained,), current=different_current),
+            run_id="training-run",
+        ).read()
+
+    with pytest.raises(CoordinatorLeaseHistoryCorrupt, match="durable history marker"):
+        CoordinatorLeaseHistoryReader(
+            StaticHistoryStore((), has_history=True),
             run_id="training-run",
         ).read()
 

--- a/tests/unit/test_torchrun_coordinator_lease_history.py
+++ b/tests/unit/test_torchrun_coordinator_lease_history.py
@@ -3,25 +3,79 @@
 from __future__ import annotations
 
 import dataclasses
+import threading
 
 import pytest
 
-from lm_resiliency.integrations.torchrun._control_store import ControlStoreEntry
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStoreEntry,
+    InMemoryControlStore,
+)
 from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseManager,
     CoordinatorLeaseRecord,
     HeldCoordinatorLease,
 )
 from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
     CoordinatorLeaseAuthority,
     CoordinatorLeaseAuthorityCorrupt,
+    CoordinatorLeaseHistoryCorrupt,
+    CoordinatorLeaseHistoryError,
+    CoordinatorLeaseHistoryReader,
 )
 
 
-def _record(*, run_id: str = "training-run") -> CoordinatorLeaseRecord:
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+    def set(self, now_unix_ms: int) -> None:
+        with self._lock:
+            self.now_unix_ms = now_unix_ms
+
+
+class StaticHistoryStore(InMemoryControlStore):
+    def __init__(
+        self,
+        history: tuple[ControlStoreEntry, ...],
+        *,
+        current: ControlStoreEntry | None = None,
+    ) -> None:
+        self._history = history
+        self._current = history[-1] if current is None and history else current
+
+    def get(self, key: str) -> ControlStoreEntry | None:
+        return self._current
+
+    def get_history(self, key: str) -> tuple[ControlStoreEntry, ...]:
+        return self._history
+
+
+class UnstableHistoryStore(StaticHistoryStore):
+    def __init__(self, history: tuple[ControlStoreEntry, ...]) -> None:
+        super().__init__(history)
+        self._reads = 0
+
+    def get_history(self, key: str) -> tuple[ControlStoreEntry, ...]:
+        self._reads += 1
+        return self._history[:-1] if self._reads % 2 else self._history
+
+
+def _record(
+    *,
+    run_id: str = "training-run",
+    coordinator_id: str = "coordinator-a",
+    lease_id: str = "lease-a",
+) -> CoordinatorLeaseRecord:
     return CoordinatorLeaseRecord(
         run_id=run_id,
-        coordinator_id="coordinator-a",
-        lease_id="lease-a",
+        coordinator_id=coordinator_id,
+        lease_id=lease_id,
         lease_duration_ms=100,
     )
 
@@ -29,7 +83,9 @@ def _record(*, run_id: str = "training-run") -> CoordinatorLeaseRecord:
 def _entry(
     *,
     record: CoordinatorLeaseRecord | None = None,
+    revision: int = 7,
     committed_at_unix_ms: int | None = 1_000,
+    transaction_sequence: int = 11,
     mutation_sequence: int = 1,
     value_sequence: int = 1,
     lifetime_sequence: int = 1,
@@ -37,9 +93,9 @@ def _entry(
     lease_record = record or _record()
     return ControlStoreEntry(
         value=lease_record.to_json(),
-        revision=7,
+        revision=revision,
         committed_at_unix_ms=committed_at_unix_ms,
-        transaction_sequence=11,
+        transaction_sequence=transaction_sequence,
         mutation_sequence=mutation_sequence,
         value_sequence=value_sequence,
         lifetime_sequence=lifetime_sequence,
@@ -182,3 +238,204 @@ def test_coordinator_lease_authority_rejects_wrong_entry_type():
             object(),
             run_id="training-run",
         )
+
+
+def _manager(
+    store: InMemoryControlStore,
+    clock: ManualClock,
+    coordinator_id: str,
+) -> CoordinatorLeaseManager:
+    return CoordinatorLeaseManager(
+        store,
+        run_id="training-run",
+        coordinator_id=coordinator_id,
+        lease_duration_ms=100,
+        clock=clock,
+    )
+
+
+def test_coordinator_lease_history_reads_renewal_and_replacement():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    first = _manager(store, clock, "coordinator-a")
+    second = _manager(store, clock, "coordinator-b")
+
+    opened = first.acquire()
+    clock.set(1_050)
+    renewed = first.renew(opened)
+    clock.set(renewed.expires_at_unix_ms)
+    replacement = second.acquire()
+
+    history = CoordinatorLeaseHistoryReader(store, run_id="training-run").read()
+
+    assert tuple(authority.lease for authority in history) == (
+        opened,
+        renewed,
+        replacement,
+    )
+    assert tuple(authority.mutation_sequence for authority in history) == (1, 2, 3)
+    assert tuple(authority.value_sequence for authority in history) == (1, 1, 2)
+    assert tuple(authority.lifetime_sequence for authority in history) == (1, 1, 1)
+
+
+def test_coordinator_lease_history_preserves_delete_recreate_and_final_delete():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    first = _manager(store, clock, "coordinator-a")
+    second = _manager(store, clock, "coordinator-b")
+
+    opened = first.acquire()
+    clock.set(1_010)
+    first.release(opened)
+    replacement = second.acquire()
+    second.release(replacement)
+
+    history = CoordinatorLeaseHistoryReader(store, run_id="training-run").read()
+
+    assert tuple(authority.lease for authority in history) == (opened, replacement)
+    assert tuple(authority.mutation_sequence for authority in history) == (1, 3)
+    assert tuple(authority.lifetime_sequence for authority in history) == (1, 2)
+
+
+def test_coordinator_lease_history_reads_empty_store():
+    assert (
+        CoordinatorLeaseHistoryReader(
+            InMemoryControlStore(),
+            run_id="training-run",
+        ).read()
+        == ()
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        "transaction_sequence",
+        "mutation_sequence",
+        "value_sequence",
+        "lifetime_sequence",
+        "committed_at_unix_ms",
+        "message",
+    ),
+    [
+        (1, 1, 1, 1, 1_100, "transaction sequences"),
+        (3, 3, 2, 1, 1_100, "omits a key mutation"),
+        (2, 2, 1, 1, 1_100, "value sequence"),
+        (5, 5, 3, 3, 1_100, "lifetime"),
+        (2, 2, 2, 1, 900, "grant times"),
+    ],
+)
+def test_coordinator_lease_history_rejects_impossible_transition(
+    transaction_sequence: int,
+    mutation_sequence: int,
+    value_sequence: int,
+    lifetime_sequence: int,
+    committed_at_unix_ms: int,
+    message: str,
+):
+    first = _entry(transaction_sequence=1, revision=10)
+    second = _entry(
+        record=_record(coordinator_id="coordinator-b", lease_id="lease-b"),
+        revision=20,
+        committed_at_unix_ms=committed_at_unix_ms,
+        transaction_sequence=transaction_sequence,
+        mutation_sequence=mutation_sequence,
+        value_sequence=value_sequence,
+        lifetime_sequence=lifetime_sequence,
+    )
+
+    with pytest.raises(CoordinatorLeaseHistoryCorrupt, match=message):
+        CoordinatorLeaseHistoryReader(
+            StaticHistoryStore((first, second)),
+            run_id="training-run",
+        ).read()
+
+
+def test_coordinator_lease_history_rejects_expired_renewal_and_overlap():
+    first = _entry(transaction_sequence=1, revision=10)
+    expired = _entry(
+        revision=20,
+        committed_at_unix_ms=1_100,
+        transaction_sequence=2,
+        mutation_sequence=2,
+    )
+    with pytest.raises(CoordinatorLeaseHistoryCorrupt, match="expired lease"):
+        CoordinatorLeaseHistoryReader(
+            StaticHistoryStore((first, expired)),
+            run_id="training-run",
+        ).read()
+
+    overlapping = dataclasses.replace(
+        expired,
+        value=_record(
+            coordinator_id="coordinator-b",
+            lease_id="lease-b",
+        ).to_json(),
+        committed_at_unix_ms=1_099,
+        value_sequence=2,
+    )
+    with pytest.raises(CoordinatorLeaseHistoryCorrupt, match="overlap"):
+        CoordinatorLeaseHistoryReader(
+            StaticHistoryStore((first, overlapping)),
+            run_id="training-run",
+        ).read()
+
+
+def test_coordinator_lease_history_rejects_identity_and_token_replay():
+    records = (
+        _record(),
+        _record(coordinator_id="coordinator-b", lease_id="lease-b"),
+        _record(coordinator_id="coordinator-c", lease_id="lease-a"),
+    )
+    history = tuple(
+        _entry(
+            record=record,
+            revision=revision,
+            committed_at_unix_ms=committed_at,
+            transaction_sequence=index,
+            mutation_sequence=index,
+            value_sequence=index,
+        )
+        for index, (record, revision, committed_at) in enumerate(
+            zip(records, (10, 20, 30), (1_000, 1_100, 1_200), strict=True),
+            start=1,
+        )
+    )
+    with pytest.raises(CoordinatorLeaseHistoryCorrupt, match="identity reappears"):
+        CoordinatorLeaseHistoryReader(
+            StaticHistoryStore(history),
+            run_id="training-run",
+        ).read()
+
+    with pytest.raises(CoordinatorLeaseHistoryCorrupt, match="fencing token reappears"):
+        CoordinatorLeaseHistoryReader(
+            StaticHistoryStore((*history[:2], dataclasses.replace(history[2], revision=10))),
+            run_id="training-run",
+        ).read()
+
+
+def test_coordinator_lease_history_rejects_noninitial_or_incomplete_history():
+    noninitial = _entry(
+        transaction_sequence=3,
+        mutation_sequence=3,
+        value_sequence=2,
+        lifetime_sequence=2,
+    )
+    with pytest.raises(CoordinatorLeaseHistoryCorrupt, match="does not begin"):
+        CoordinatorLeaseHistoryReader(
+            StaticHistoryStore((noninitial,)),
+            run_id="training-run",
+        ).read()
+
+    with pytest.raises(CoordinatorLeaseHistoryCorrupt, match="absent from"):
+        CoordinatorLeaseHistoryReader(
+            StaticHistoryStore((), current=_entry()),
+            run_id="training-run",
+        ).read()
+
+
+def test_coordinator_lease_history_fails_after_repeatedly_unstable_reads():
+    with pytest.raises(CoordinatorLeaseHistoryError, match="changed repeatedly"):
+        CoordinatorLeaseHistoryReader(
+            UnstableHistoryStore((_entry(),)),
+            run_id="training-run",
+        ).read()


### PR DESCRIPTION
## Summary

- read one stable immutable snapshot of retained coordinator lease values
- require the current live value to be the final retained history entry
- require empty/nonempty retained values to agree with the durable `has_history()` marker
- fail closed when retained history has no live lease because no authoritative tail tombstone exists
- validate exact renewal, in-place replacement, and delete/recreate transitions
- reject skipped mutations/lifetimes, expired renewals, overlapping replacements, and recurring lease IDs or fencing tokens

## Why

Restart-intent closure must reconstruct live coordinator authority after process loss. The merged store retains every lease value and the merged authority value validates each entry; this reader verifies the complete live transition chain without relying on process-local observations.

## Scope

This PR is read-only. It does not prepare or execute restart-intent closure transactions and does not activate torchrun runtime behavior. Authoritative reads after final lease deletion require a separate tombstone/tail contract.

## Validation

- `85 passed` focused authority/lease/control-store tests
- `1675 passed, 1 warning` complete CUDA-hidden CPU suite
- `ruff check .`
- `ruff format --check .`
- targeted `mypy`
- `git diff --check`