### PR TITLE
[Feature][Torchrun] Add initial intent closure authority

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -598,6 +598,14 @@ its immutable closure record, first lifecycle head, and durable closed marker.
 It exposes create-once closure/lifecycle writes, a revision-guarded
 current-head update, and an exact immutable-intent condition, but does not
 authenticate a closing lease or mutate the store. A frozen
+`PreparedInitialRestartIntentClosure` descriptor binds those records to a
+contiguous coordinator-lease authority slice beginning at the exact lease that
+opened the intent. It accepts same-lease renewal, nonoverlapping replacement,
+and delete/recreate transitions, while rejecting skipped mutations, expired
+renewals, overlapping leases, and recurrence of any generation or opening
+lease identity or fencing token after replacement. It bounds the future
+transaction to the final live lease but performs no store reads or mutations.
+A later preparer selects the slice from verified durable lease history. A frozen
 `PreparedInitialRestartIntentOpen` descriptor binds the first intent record,
 current-intent head, exact generation revisions, coordinator fencing token,
 canonical run-scoped keys, and lease/intent commit window. It exposes immutable

--- a/lm_resiliency/integrations/torchrun/_restart_intent_close.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_close.py
@@ -1,0 +1,245 @@
+"""Lease authority for closing the first restart intent."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from lm_resiliency.integrations.torchrun._control_store import ControlStoreWrite
+from lm_resiliency.integrations.torchrun._coordinator_lease import HeldCoordinatorLease
+from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
+    CoordinatorLeaseAuthority,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_close_records import (
+    InitialRestartIntentClosureRecords,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedInitialRestartIntentClosure:
+    """Lease-fenced inputs for the first restart-intent closure transaction."""
+
+    records: InitialRestartIntentClosureRecords
+    lease_authority_chain: tuple[CoordinatorLeaseAuthority, ...]
+    not_before_unix_ms: int
+    deadline_unix_ms: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.records, InitialRestartIntentClosureRecords):
+            raise TypeError(
+                "PreparedInitialRestartIntentClosure.records must be "
+                "InitialRestartIntentClosureRecords"
+            )
+        if not isinstance(self.lease_authority_chain, tuple):
+            raise TypeError(
+                "PreparedInitialRestartIntentClosure.lease_authority_chain must be tuple"
+            )
+        if not self.lease_authority_chain:
+            raise ValueError(
+                "PreparedInitialRestartIntentClosure.lease_authority_chain must not be empty"
+            )
+        if not all(
+            isinstance(authority, CoordinatorLeaseAuthority)
+            for authority in self.lease_authority_chain
+        ):
+            raise TypeError(
+                "PreparedInitialRestartIntentClosure.lease_authority_chain must contain "
+                "CoordinatorLeaseAuthority values"
+            )
+        _positive_integer(
+            self.not_before_unix_ms,
+            "PreparedInitialRestartIntentClosure.not_before_unix_ms",
+        )
+        _positive_integer(
+            self.deadline_unix_ms,
+            "PreparedInitialRestartIntentClosure.deadline_unix_ms",
+        )
+        self._validate_lease_lineage()
+        lifecycle = self.records.lifecycle
+        if (
+            self.lease.record.run_id != lifecycle.closed_intent.run_id
+            or lifecycle.coordinator_id != self.lease.record.coordinator_id
+            or lifecycle.lease_id != self.lease.record.lease_id
+            or lifecycle.coordinator_lease_duration_ms != self.lease.record.lease_duration_ms
+            or lifecycle.coordinator_fencing_token != self.lease.fencing_token
+        ):
+            raise ValueError(
+                "PreparedInitialRestartIntentClosure lease does not authorize its lifecycle"
+            )
+        if self.not_before_unix_ms < self.records.opened.committed_at_unix_ms:
+            raise ValueError(
+                "PreparedInitialRestartIntentClosure cannot precede its open transaction"
+            )
+        if self.not_before_unix_ms < self.lease.granted_at_unix_ms:
+            raise ValueError(
+                "PreparedInitialRestartIntentClosure cannot precede its coordinator lease grant"
+            )
+        if self.not_before_unix_ms >= self.deadline_unix_ms:
+            raise ValueError(
+                "PreparedInitialRestartIntentClosure.not_before_unix_ms must precede its deadline"
+            )
+        if self.deadline_unix_ms > self.lease.expires_at_unix_ms:
+            raise ValueError(
+                "PreparedInitialRestartIntentClosure deadline exceeds its coordinator lease"
+            )
+
+    def _validate_lease_lineage(self) -> None:
+        opening = self.records.opened.prepared
+        expected_opening = CoordinatorLeaseAuthority(
+            lease=opening.lease,
+            transaction_sequence=opening.coordinator_lease_transaction_sequence,
+            mutation_sequence=opening.coordinator_lease_mutation_sequence,
+            value_sequence=opening.coordinator_lease_value_sequence,
+            lifetime_sequence=opening.coordinator_lease_lifetime_sequence,
+        )
+        if self.lease_authority_chain[0] != expected_opening:
+            raise ValueError(
+                "PreparedInitialRestartIntentClosure lease chain does not begin "
+                "with its opening authority"
+            )
+        lease_ids = list(opening.generation_lease_id_history)
+        fencing_tokens = list(opening.generation_fencing_token_history)
+        for authority in self.lease_authority_chain:
+            lease_ids.append(authority.lease.record.lease_id)
+            fencing_tokens.append(authority.lease.fencing_token)
+        _reject_noncontiguous_recurrence(
+            tuple(lease_ids),
+            "lease identity",
+        )
+        _reject_noncontiguous_recurrence(
+            tuple(fencing_tokens),
+            "fencing token",
+        )
+        for previous, current in zip(
+            self.lease_authority_chain,
+            self.lease_authority_chain[1:],
+            strict=False,
+        ):
+            self._validate_lease_transition(previous, current)
+
+    def _validate_lease_transition(
+        self,
+        previous: CoordinatorLeaseAuthority,
+        current: CoordinatorLeaseAuthority,
+    ) -> None:
+        opened = self.records.opened
+        if (
+            current.transaction_sequence <= opened.transaction_sequence
+            or current.transaction_sequence <= previous.transaction_sequence
+        ):
+            raise ValueError(
+                "PreparedInitialRestartIntentClosure lease mutation does not follow "
+                "its open and predecessor"
+            )
+        mutation_delta = current.mutation_sequence - previous.mutation_sequence
+        transaction_delta = current.transaction_sequence - previous.transaction_sequence
+        value_delta = current.value_sequence - previous.value_sequence
+        lifetime_delta = current.lifetime_sequence - previous.lifetime_sequence
+        if transaction_delta < mutation_delta:
+            raise ValueError(
+                "PreparedInitialRestartIntentClosure lease transition has impossible "
+                "transaction ordering"
+            )
+        if current.lease.granted_at_unix_ms < previous.lease.granted_at_unix_ms:
+            raise ValueError(
+                "PreparedInitialRestartIntentClosure lease transition moves backward in time"
+            )
+        if current.lease.fencing_token == previous.lease.fencing_token:
+            raise ValueError(
+                "PreparedInitialRestartIntentClosure lease transition reuses its fencing token"
+            )
+        if current.lease.record == previous.lease.record:
+            if mutation_delta != 1 or value_delta != 0 or lifetime_delta != 0:
+                raise ValueError(
+                    "PreparedInitialRestartIntentClosure renewal is not one lease-key mutation"
+                )
+            if current.lease.granted_at_unix_ms >= previous.lease.expires_at_unix_ms:
+                raise ValueError(
+                    "PreparedInitialRestartIntentClosure renews an expired coordinator lease"
+                )
+            return
+        if current.lease.record.lease_id == previous.lease.record.lease_id:
+            raise ValueError(
+                "PreparedInitialRestartIntentClosure changes one lease identity's record"
+            )
+        if lifetime_delta == 0:
+            if mutation_delta != 1 or value_delta != 1:
+                raise ValueError(
+                    "PreparedInitialRestartIntentClosure in-place replacement is not "
+                    "one lease-key mutation"
+                )
+            if current.lease.granted_at_unix_ms < previous.lease.expires_at_unix_ms:
+                raise ValueError("PreparedInitialRestartIntentClosure coordinator leases overlap")
+            return
+        if lifetime_delta == 1:
+            if mutation_delta != 2 or value_delta != 1:
+                raise ValueError(
+                    "PreparedInitialRestartIntentClosure recreated lease has invalid lineage"
+                )
+            return
+        raise ValueError(
+            "PreparedInitialRestartIntentClosure lease chain omits one or more "
+            "replacement authorities"
+        )
+
+    @property
+    def lease_authority(self) -> CoordinatorLeaseAuthority:
+        return self.lease_authority_chain[-1]
+
+    @property
+    def lease(self) -> HeldCoordinatorLease:
+        return self.lease_authority.lease
+
+    @property
+    def coordinator_lease_transaction_sequence(self) -> int:
+        return self.lease_authority.transaction_sequence
+
+    @property
+    def coordinator_lease_mutation_sequence(self) -> int:
+        return self.lease_authority.mutation_sequence
+
+    @property
+    def coordinator_lease_value_sequence(self) -> int:
+        return self.lease_authority.value_sequence
+
+    @property
+    def coordinator_lease_lifetime_sequence(self) -> int:
+        return self.lease_authority.lifetime_sequence
+
+    @property
+    def coordinator_lease_key(self) -> str:
+        return self.records.opened.prepared.coordinator_lease_key
+
+    @property
+    def expected_guard_revision(self) -> int:
+        return self.lease.fencing_token
+
+    @property
+    def writes(self) -> Mapping[str, ControlStoreWrite]:
+        return self.records.writes
+
+    @property
+    def conditions(self) -> Mapping[str, int]:
+        return self.records.conditions
+
+
+def _positive_integer(value: object, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{path} must be a positive integer")
+    return value
+
+
+def _reject_noncontiguous_recurrence(values: tuple[object, ...], label: str) -> None:
+    seen: set[object] = set()
+    previous: object | None = None
+    for value in values:
+        if value != previous:
+            if value in seen:
+                raise ValueError(
+                    f"PreparedInitialRestartIntentClosure {label} reappears after replacement"
+                )
+            seen.add(value)
+        previous = value
+
+
+__all__ = ["PreparedInitialRestartIntentClosure"]

--- a/tests/unit/test_torchrun_restart_intent_close.py
+++ b/tests/unit/test_torchrun_restart_intent_close.py
@@ -1,0 +1,379 @@
+"""Contract tests for initial restart-intent closure authority."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import replace
+from typing import Any, cast
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseManager,
+    HeldCoordinatorLease,
+)
+from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
+    CoordinatorLeaseAuthority,
+    CoordinatorLeaseHistoryReader,
+)
+from lm_resiliency.integrations.torchrun._generation_state import GenerationStateManager
+from lm_resiliency.integrations.torchrun._protocol import (
+    RankAssignment,
+    RestartIntent,
+    SlotAssignment,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_close import (
+    PreparedInitialRestartIntentClosure,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_close_records import (
+    InitialRestartIntentClosureRecords,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open import (
+    RestartIntentOpenPreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
+    CommittedInitialRestartIntentOpen,
+    RestartIntentOpenExecutor,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_records import (
+    RestartIntentClosedHeadRecord,
+    RestartIntentLifecycleHeadRecord,
+    RestartIntentLifecycleRecord,
+)
+
+RUN_ID = "training-run"
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+    def set(self, now_unix_ms: int) -> None:
+        with self._lock:
+            self.now_unix_ms = now_unix_ms
+
+
+def _manager(
+    store: InMemoryControlStore,
+    clock: ManualClock,
+    coordinator_id: str,
+) -> CoordinatorLeaseManager:
+    return CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id=coordinator_id,
+        lease_duration_ms=100,
+        clock=clock,
+    )
+
+
+def _assignment() -> RankAssignment:
+    return RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=0,
+        assignments=(
+            SlotAssignment(0, "node-a", 0, 2),
+            SlotAssignment(1, "node-b", 2, 2),
+        ),
+        topology_digest="topology-v1",
+    )
+
+
+def _intent(*, deadline_unix_ms: int = 1_050) -> RestartIntent:
+    return RestartIntent(
+        intent_id="intent-a",
+        run_id=RUN_ID,
+        generation=0,
+        incident_ids=("incident-a",),
+        reason_code="attributed_sdc",
+        minimum_recovery_mode="recovery_verified",
+        suspected_node_ids=("node-b",),
+        prepare_deadline_unix_ms=deadline_unix_ms,
+    )
+
+
+def _open_state(
+    *,
+    replace_before_open: bool = False,
+) -> tuple[
+    ManualClock,
+    InMemoryControlStore,
+    CommittedInitialRestartIntentOpen,
+    HeldCoordinatorLease,
+]:
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    first_manager = _manager(store, clock, "coordinator-a")
+    generation_manager = GenerationStateManager(store, run_id=RUN_ID)
+    lease = first_manager.acquire()
+    generation_manager.initialize(lease, _assignment())
+    if replace_before_open:
+        clock.set(lease.expires_at_unix_ms)
+        lease = _manager(store, clock, "coordinator-b").acquire()
+    current = generation_manager.current()
+    assert current is not None
+    opened = RestartIntentOpenExecutor(store, run_id=RUN_ID).execute_initial_open(
+        RestartIntentOpenPreparer(store, run_id=RUN_ID, clock=clock).prepare_initial_open(
+            lease,
+            current,
+            _intent(deadline_unix_ms=clock.now_unix_ms + 200),
+        )
+    )
+    return clock, store, opened, lease
+
+
+def _records(
+    opened: CommittedInitialRestartIntentOpen,
+    lease: HeldCoordinatorLease,
+) -> InitialRestartIntentClosureRecords:
+    lifecycle = RestartIntentLifecycleRecord(
+        closed_intent=opened.prepared.head,
+        coordinator_id=lease.record.coordinator_id,
+        lease_id=lease.record.lease_id,
+        coordinator_lease_duration_ms=lease.record.lease_duration_ms,
+        coordinator_fencing_token=lease.fencing_token,
+    )
+    lifecycle_head = RestartIntentLifecycleHeadRecord(
+        run_id=RUN_ID,
+        closure_index=1,
+        generation=opened.prepared.record.intent.generation,
+        intent_id=opened.prepared.record.intent.intent_id,
+        lifecycle_digest=lifecycle.digest,
+    )
+    run_prefix = opened.prepared.intent_head_key.rsplit("/", 1)[0]
+    return InitialRestartIntentClosureRecords(
+        opened=opened,
+        lifecycle=lifecycle,
+        lifecycle_head=lifecycle_head,
+        closed_head=RestartIntentClosedHeadRecord(
+            run_id=RUN_ID,
+            closure_index=1,
+            generation=lifecycle_head.generation,
+            intent_id=lifecycle_head.intent_id,
+            lifecycle_head_digest=lifecycle_head.digest,
+        ),
+        intent_key=opened.prepared.intent_key,
+        intent_head_key=opened.prepared.intent_head_key,
+        closure_key=f"{run_prefix}/restart-intent-closures/1",
+        lifecycle_head_key=opened.prepared.lifecycle_head_key,
+    )
+
+
+def _prepared(
+    opened: CommittedInitialRestartIntentOpen,
+    chain: tuple[CoordinatorLeaseAuthority, ...],
+) -> PreparedInitialRestartIntentClosure:
+    lease = chain[-1].lease
+    return PreparedInitialRestartIntentClosure(
+        records=_records(opened, lease),
+        lease_authority_chain=chain,
+        not_before_unix_ms=max(
+            opened.committed_at_unix_ms,
+            lease.granted_at_unix_ms,
+        ),
+        deadline_unix_ms=lease.expires_at_unix_ms,
+    )
+
+
+def _opening_prepared() -> PreparedInitialRestartIntentClosure:
+    _, store, opened, _ = _open_state()
+    return _prepared(
+        opened,
+        CoordinatorLeaseHistoryReader(store, run_id=RUN_ID).read(),
+    )
+
+
+def test_prepared_initial_closure_delegates_immutable_transaction_inputs():
+    prepared = _opening_prepared()
+
+    assert prepared.expected_guard_revision == prepared.lease.fencing_token
+    assert prepared.writes == prepared.records.writes
+    assert prepared.conditions == prepared.records.conditions
+    with pytest.raises(TypeError):
+        cast(Any, prepared.writes)["other"] = next(iter(prepared.writes.values()))
+    with pytest.raises(TypeError):
+        cast(Any, prepared.conditions)["other"] = 1
+    with pytest.raises(AttributeError):
+        prepared.deadline_unix_ms = 1
+
+
+def test_prepared_initial_closure_requires_expected_types_and_opening_authority():
+    prepared = _opening_prepared()
+
+    with pytest.raises(TypeError, match="InitialRestartIntentClosureRecords"):
+        replace(prepared, records={})
+    with pytest.raises(TypeError, match="must be tuple"):
+        replace(prepared, lease_authority_chain=[])
+    with pytest.raises(TypeError, match="CoordinatorLeaseAuthority"):
+        replace(prepared, lease_authority_chain=({},))
+    with pytest.raises(ValueError, match="must not be empty"):
+        replace(prepared, lease_authority_chain=())
+    changed = replace(
+        prepared.lease_authority,
+        transaction_sequence=prepared.lease_authority.transaction_sequence + 1,
+    )
+    with pytest.raises(ValueError, match="does not begin"):
+        replace(prepared, lease_authority_chain=(changed,))
+
+
+def test_prepared_initial_closure_rejects_invalid_window_or_lifecycle_authority():
+    prepared = _opening_prepared()
+
+    with pytest.raises(ValueError, match="cannot precede its open"):
+        replace(
+            prepared,
+            not_before_unix_ms=prepared.records.opened.committed_at_unix_ms - 1,
+        )
+    with pytest.raises(ValueError, match="exceeds its coordinator lease"):
+        replace(prepared, deadline_unix_ms=prepared.lease.expires_at_unix_ms + 1)
+    lifecycle = replace(
+        prepared.records.lifecycle,
+        coordinator_fencing_token=prepared.lease.fencing_token + 1,
+    )
+    lifecycle_head = replace(
+        prepared.records.lifecycle_head,
+        lifecycle_digest=lifecycle.digest,
+    )
+    records = replace(
+        prepared.records,
+        lifecycle=lifecycle,
+        lifecycle_head=lifecycle_head,
+        closed_head=replace(
+            prepared.records.closed_head,
+            lifecycle_head_digest=lifecycle_head.digest,
+        ),
+    )
+    with pytest.raises(ValueError, match="does not authorize"):
+        replace(prepared, records=records)
+
+
+def test_prepared_initial_closure_accepts_renewal_and_multiple_replacements():
+    clock, store, opened, lease = _open_state()
+    clock.set(1_010)
+    renewed = _manager(store, clock, "coordinator-a").renew(lease)
+    clock.set(renewed.expires_at_unix_ms)
+    replacement_b = _manager(store, clock, "coordinator-b").acquire()
+    clock.set(replacement_b.expires_at_unix_ms)
+    replacement_c = _manager(store, clock, "coordinator-c").acquire()
+
+    prepared = _prepared(
+        opened,
+        CoordinatorLeaseHistoryReader(store, run_id=RUN_ID).read(),
+    )
+
+    assert prepared.lease == replacement_c
+    assert len(prepared.lease_authority_chain) == 4
+
+
+def test_prepared_initial_closure_accepts_delete_and_recreate():
+    clock, store, opened, lease = _open_state()
+    clock.set(1_010)
+    _manager(store, clock, "coordinator-a").release(lease)
+    replacement = _manager(store, clock, "coordinator-b").acquire()
+
+    prepared = _prepared(
+        opened,
+        CoordinatorLeaseHistoryReader(store, run_id=RUN_ID).read(),
+    )
+
+    assert prepared.lease == replacement
+    assert prepared.coordinator_lease_lifetime_sequence == 2
+
+
+def test_prepared_initial_closure_rejects_expired_renewal_and_overlap():
+    prepared = _opening_prepared()
+    opening = prepared.lease_authority
+    expired_lease = replace(
+        opening.lease,
+        fencing_token=opening.lease.fencing_token + 1,
+        granted_at_unix_ms=opening.lease.expires_at_unix_ms,
+    )
+    expired = CoordinatorLeaseAuthority(
+        lease=expired_lease,
+        transaction_sequence=prepared.records.opened.transaction_sequence + 1,
+        mutation_sequence=opening.mutation_sequence + 1,
+        value_sequence=opening.value_sequence,
+        lifetime_sequence=opening.lifetime_sequence,
+    )
+    with pytest.raises(ValueError, match="expired"):
+        _prepared(prepared.records.opened, (opening, expired))
+
+    _, store, opened, lease = _open_state()
+    clock_entry = CoordinatorLeaseHistoryReader(store, run_id=RUN_ID).read()[0]
+    overlapping_lease = HeldCoordinatorLease(
+        record=replace(
+            lease.record,
+            coordinator_id="coordinator-b",
+            lease_id="lease-b",
+        ),
+        fencing_token=lease.fencing_token + 1,
+        granted_at_unix_ms=lease.granted_at_unix_ms + 10,
+    )
+    overlapping = CoordinatorLeaseAuthority(
+        lease=overlapping_lease,
+        transaction_sequence=opened.transaction_sequence + 1,
+        mutation_sequence=clock_entry.mutation_sequence + 1,
+        value_sequence=clock_entry.value_sequence + 1,
+        lifetime_sequence=clock_entry.lifetime_sequence,
+    )
+    with pytest.raises(ValueError, match="overlap"):
+        _prepared(opened, (clock_entry, overlapping))
+
+
+def test_prepared_initial_closure_rejects_opening_lease_replay():
+    clock, store, opened, opening_lease = _open_state(replace_before_open=True)
+    history = CoordinatorLeaseHistoryReader(store, run_id=RUN_ID).read()
+    opening = history[-1]
+    assert opening.lease == opening_lease
+    clock.set(opening_lease.expires_at_unix_ms)
+    replacement = _manager(store, clock, "coordinator-c").acquire()
+    history = CoordinatorLeaseHistoryReader(store, run_id=RUN_ID).read()
+    replacement_authority = history[-1]
+    replayed_lease = HeldCoordinatorLease(
+        record=opening_lease.record,
+        fencing_token=replacement.fencing_token + 1,
+        granted_at_unix_ms=replacement.expires_at_unix_ms,
+    )
+    replayed = CoordinatorLeaseAuthority(
+        lease=replayed_lease,
+        transaction_sequence=replacement_authority.transaction_sequence + 1,
+        mutation_sequence=replacement_authority.mutation_sequence + 1,
+        value_sequence=replacement_authority.value_sequence + 1,
+        lifetime_sequence=replacement_authority.lifetime_sequence,
+    )
+
+    with pytest.raises(ValueError, match="lease identity reappears"):
+        _prepared(
+            opened,
+            (opening, replacement_authority, replayed),
+        )
+
+
+def test_prepared_initial_closure_rejects_omitted_transition():
+    prepared = _opening_prepared()
+    opening = prepared.lease_authority
+    skipped_lease = HeldCoordinatorLease(
+        record=replace(
+            opening.lease.record,
+            coordinator_id="coordinator-c",
+            lease_id="lease-c",
+        ),
+        fencing_token=opening.lease.fencing_token + 2,
+        granted_at_unix_ms=opening.lease.expires_at_unix_ms + 100,
+    )
+    skipped = CoordinatorLeaseAuthority(
+        lease=skipped_lease,
+        transaction_sequence=prepared.records.opened.transaction_sequence + 2,
+        mutation_sequence=opening.mutation_sequence + 2,
+        value_sequence=opening.value_sequence + 2,
+        lifetime_sequence=opening.lifetime_sequence,
+    )
+
+    with pytest.raises(ValueError, match="not one lease-key mutation"):
+        _prepared(prepared.records.opened, (opening, skipped))


### PR DESCRIPTION
## Summary

- add a frozen `PreparedInitialRestartIntentClosure` descriptor
- bind linked closure records to a contiguous coordinator lease authority slice beginning at the exact opening lease
- support renewal, nonoverlapping A→B→C replacement, and delete/recreate transitions
- reject skipped mutations, expired renewal, overlap, and recurring generation/opening lease identities or fencing tokens
- expose immutable writes and conditions without reading or mutating the store

## Why

The merged coordinator lease history reader makes failover authority reconstructible after process loss. This descriptor provides the next pure value boundary for closing the first restart intent while keeping store authentication and execution in separate PRs.

## Scope

This PR performs no control-store reads or mutations and does not activate torchrun runtime behavior. A later preparer selects the authority slice from verified live lease history and authenticates the closing lease.

## Validation

- `87 passed` focused closure/history/open transaction tests
- `1683 passed, 1 warning` complete CUDA-hidden CPU suite
- `ruff check .`
- `ruff format --check .`
- targeted `mypy`
- `git diff --check`