### PR TITLE
[Bugfix][GEMINI] Require checksums when integrity is enabled

### DIFF
--- a/docs/gemini.md
+++ b/docs/gemini.md
@@ -153,8 +153,10 @@ At a dynamic recipe-cycle boundary, it persists them as the new candidate and re
 Each rank owns its status sidecar; several workers on one node never update the same mutable trust record.
 A persisted peer shard carries the corresponding peer status so recovery can reconstruct the verified generation after node loss.
 If newer status cannot be established, recovery selects the common verified step conservatively.
-With `verify_integrity=True`, it stores a CRC-32 for each shard and treats a checksum failure as an unavailable shard.
+With `verify_integrity=True`, it stores a CRC-32 for each shard and treats a checksum failure or missing checksum metadata as an unavailable shard.
 Checksums detect stored-byte corruption; they cannot prove that the source GPU state was numerically correct.
+Enabling integrity verification is therefore a fail-closed configuration change:
+node-local checkpoints written earlier with `verify_integrity=False` are not eligible for recovery until a new checksummed generation is persisted.
 
 Node-local files use checkpoint format version 2. Tensors are loaded through PyTorch's `weights_only=True` path, while reconstruction metadata is represented by a schema-constrained JSON document. The metadata schema supports the built-in containers and scalar types used by framework state, NumPy RNG values, and dense CPU tensors such as PyTorch RNG state. GEMINI validates the payload fields, metadata types, tensor count, shapes, dtypes, reconstruction paths, and optional CRC values before recovery can apply state. Unsupported caller-owned metadata fails the checkpoint write instead of falling back to unrestricted pickle deserialization.
 

--- a/lm_resiliency/checkpointing/disk.py
+++ b/lm_resiliency/checkpointing/disk.py
@@ -320,13 +320,17 @@ class DiskSerializer:
                     f"{load_path}: checkpoint tensor {index} must be dense, strided, and non-quantized"
                 )
         if self._integrity:
-            if stored is not None:
-                actual = shard_checksums(tensors)
-                if actual != stored:
-                    bad = sum(1 for a, b in zip(actual, stored) if a != b) + abs(
-                        len(actual) - len(stored)
-                    )
-                    raise ChecksumMismatch(f"{load_path}: {bad} shard chunk(s) failed checksum")
+            if stored is None:
+                raise ChecksumMismatch(
+                    f"{load_path}: integrity verification is enabled but the checkpoint "
+                    "does not contain checksums"
+                )
+            actual = shard_checksums(tensors)
+            if actual != stored:
+                bad = sum(1 for a, b in zip(actual, stored) if a != b) + abs(
+                    len(actual) - len(stored)
+                )
+                raise ChecksumMismatch(f"{load_path}: {bad} shard chunk(s) failed checksum")
         return metadata, tensors
 
     def has_rank(self, step: int, rank: int) -> bool:

--- a/tests/unit/test_checkpoint_recovery.py
+++ b/tests/unit/test_checkpoint_recovery.py
@@ -110,6 +110,41 @@ def test_disk_integrity_round_trip_and_corruption(tmp_path):
         serializer.load(3)
 
 
+def test_disk_integrity_rejects_checkpoint_without_checksums(tmp_path):
+    metadata, tensors = flatten({"w": torch.arange(4, dtype=torch.float32)})
+    DiskSerializer(str(tmp_path), rank=0, integrity=False).save_sync(metadata, tensors, step=3)
+
+    with pytest.raises(ChecksumMismatch, match="does not contain checksums"):
+        DiskSerializer(str(tmp_path), rank=0, integrity=True).load(3)
+
+
+def test_disk_without_integrity_accepts_checkpoint_without_checksums(tmp_path):
+    metadata, tensors = flatten({"w": torch.arange(4, dtype=torch.float32)})
+    serializer = DiskSerializer(str(tmp_path), rank=0, integrity=False)
+    serializer.save_sync(metadata, tensors, step=3)
+
+    loaded_metadata, loaded_tensors = serializer.load(3)
+
+    assert loaded_metadata == metadata
+    assert torch.equal(loaded_tensors[0], tensors[0])
+
+
+def test_gemini_falls_back_when_integrity_is_enabled_for_unsigned_checkpoint(tmp_path):
+    metadata, tensors = flatten({"w": torch.arange(4, dtype=torch.float32)})
+    DiskSerializer(str(tmp_path), rank=0, integrity=False).save_sync(metadata, tensors, step=3)
+    manager = InMemoryCheckpointManager(
+        InMemoryCkptConfig(
+            disk_folder=str(tmp_path),
+            disk_flush_interval=0,
+            verify_integrity=True,
+        )
+    )
+
+    assert manager.find_latest() == 3
+    assert manager.load() is None
+    manager.close()
+
+
 def test_gemini_load_returns_none_on_corruption(tmp_path):
     config = InMemoryCkptConfig(
         enable=True,


### PR DESCRIPTION
## What changed

- reject node-local shards without checksum metadata when `verify_integrity=True`
- preserve existing permissive loading when integrity verification is disabled
- document the fail-closed configuration transition
- add serializer and manager-level regression coverage

## Why

A checkpoint written with `verify_integrity=False` stores `checksums: null`. Before this change, a reader configured with `verify_integrity=True` silently skipped verification and could accept corrupted values. Integrity-enabled recovery must treat missing evidence as an unavailable shard.

## Compatibility and impact

The on-disk schema is unchanged. Enabling integrity verification now intentionally excludes older unsigned node-local generations until GEMINI writes a new checksummed generation. Integrity-disabled readers remain backward compatible.

## Validation

- `python -m pytest -q tests/unit/test_checkpoint_recovery.py` — 26 passed
- `ruff check lm_resiliency/checkpointing/disk.py tests/unit/test_checkpoint_recovery.py`
- `ruff format --check lm_resiliency/checkpointing/disk.py tests/unit/test_checkpoint_recovery.py`
- `git diff --check`

Closes #78.