### PR TITLE
[Feature][Torchrun] Read persisted restart intent opening

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -638,6 +638,15 @@ verified generation history. Preparation obtains that history through one
 stable reader traversal rather than rereading the full predecessor chain for
 each generation.
 
+A read-only `RestartIntentOpenStateReader` reconstructs the same
+`CommittedInitialRestartIntentOpen` contract after coordinator failover. It
+stably reads the current-intent head and immutable intent, requires the
+intent's generation to remain current, locates the exact opening authority in
+verified durable coordinator-lease history, and reuses the existing
+prepared/committed validators. Missing records, noncanonical bytes,
+contradictory lifecycle state, deleted heads, and lease provenance absent from
+durable history fail closed. The reader performs no mutation.
+
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be
 absent from the next assignment. Policy may additionally quarantine a removed

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -645,7 +645,11 @@ intent's generation to remain current, locates the exact opening authority in
 verified durable coordinator-lease history, and reuses the existing
 prepared/committed validators. Missing records, noncanonical bytes,
 contradictory lifecycle state, deleted heads, and lease provenance absent from
-durable history fail closed. The reader performs no mutation.
+durable history fail closed. When the current head is a closed marker, the
+reader raises `RestartIntentOpenStateClosed` instead of treating the opening as
+absent. That signal does not authenticate the closure; the lifecycle reader
+must verify the linked closure records separately. The open-state reader
+performs no mutation.
 
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be

--- a/lm_resiliency/integrations/torchrun/_restart_intent_open_reader.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_open_reader.py
@@ -29,8 +29,6 @@ from lm_resiliency.integrations.torchrun._restart_intent_open_records import (
 from lm_resiliency.integrations.torchrun._restart_intent_records import (
     RestartIntentClosedHeadRecord,
     RestartIntentHeadRecord,
-    RestartIntentLifecycleHeadRecord,
-    RestartIntentLifecycleRecord,
     RestartIntentRecord,
 )
 
@@ -44,6 +42,14 @@ class RestartIntentOpenStateError(RuntimeError):
 
 class RestartIntentOpenStateCorrupt(RestartIntentOpenStateError):
     """Raised when persisted opening state is malformed or contradictory."""
+
+
+class RestartIntentOpenStateClosed(RestartIntentOpenStateError):
+    """Raised when a closed marker prevents reconstructing a current opening.
+
+    This error does not authenticate the closure. Callers must use the
+    lifecycle reader before treating the intent as validly closed.
+    """
 
 
 class RestartIntentOpenStateReader:
@@ -75,12 +81,8 @@ class RestartIntentOpenStateReader:
         intent_digest = hashlib.sha256(normalized_intent_id.encode("utf-8")).hexdigest()
         return f"{self._run_prefix}/restart-intents/{intent_digest}"
 
-    def closure_key(self, closure_index: int) -> str:
-        normalized_index = _positive_integer(closure_index, "closure_index")
-        return f"{self._run_prefix}/restart-intent-closures/{normalized_index}"
-
     def read(self) -> CommittedInitialRestartIntentOpen | None:
-        """Return one stable, verified opening or ``None`` when none is current."""
+        """Return one stable, verified opening or ``None`` before first open."""
 
         for _ in range(_MAX_READ_ATTEMPTS):
             head_entry = self._store.get(self._intent_head_key)
@@ -110,56 +112,10 @@ class RestartIntentOpenStateReader:
                 )
             head = self._decode_head(head_entry)
             if isinstance(head, RestartIntentClosedHeadRecord):
-                closure_key = self.closure_key(head.closure_index)
-                closure_entry = self._store.get(closure_key)
-                closure_has_history = self._store.has_history(closure_key)
-                intent_key = self.intent_key(head.intent_id)
-                intent_entry = self._store.get(intent_key)
-                intent_has_history = self._store.has_history(intent_key)
-                head_history = self._store.get_history(self._intent_head_key)
-                intent_history = self._store.get_history(intent_key)
-                lifecycle_history = self._store.get_history(self._lifecycle_head_key)
-                closure_history = self._store.get_history(closure_key)
-                try:
-                    lease_history = self._lease_history_reader.read()
-                except CoordinatorLeaseHistoryCorrupt as error:
-                    raise RestartIntentOpenStateCorrupt(
-                        "restart-intent closure lease history is corrupt"
-                    ) from error
-                if not self._state_is_stable(
-                    head_entry,
-                    head_has_history,
-                    lifecycle_entry,
-                    lifecycle_has_history,
-                    intent_key=intent_key,
-                    intent_entry=intent_entry,
-                    intent_has_history=intent_has_history,
-                    closure_key=closure_key,
-                    closure_entry=closure_entry,
-                    closure_has_history=closure_has_history,
-                ) or (
-                    self._store.get_history(self._intent_head_key) != head_history
-                    or self._store.get_history(intent_key) != intent_history
-                    or self._store.get_history(self._lifecycle_head_key) != lifecycle_history
-                    or self._store.get_history(closure_key) != closure_history
-                ):
-                    continue
-                self._validate_closed_state(
-                    head,
-                    head_entry,
-                    head_history,
-                    intent_entry,
-                    intent_has_history,
-                    intent_history,
-                    lifecycle_entry,
-                    lifecycle_has_history,
-                    lifecycle_history,
-                    closure_entry,
-                    closure_has_history,
-                    closure_history,
-                    lease_history,
+                raise RestartIntentOpenStateClosed(
+                    "current restart-intent head is a closed marker; "
+                    "closure evidence is not verified by this reader"
                 )
-                return None
             if lifecycle_entry is not None or lifecycle_has_history:
                 raise RestartIntentOpenStateCorrupt(
                     "open restart-intent head coexists with lifecycle state"
@@ -247,9 +203,9 @@ class RestartIntentOpenStateReader:
                         record.intent.generation
                     ),
                     coordinator_lease_transaction_sequence=(opening_authority.transaction_sequence),
-                    coordinator_lease_mutation_sequence=opening_authority.mutation_sequence,
-                    coordinator_lease_value_sequence=opening_authority.value_sequence,
-                    coordinator_lease_lifetime_sequence=opening_authority.lifetime_sequence,
+                    coordinator_lease_mutation_sequence=(opening_authority.mutation_sequence),
+                    coordinator_lease_value_sequence=(opening_authority.value_sequence),
+                    coordinator_lease_lifetime_sequence=(opening_authority.lifetime_sequence),
                     generation_lease_id_history=tuple(
                         snapshot.record.lease_id for snapshot in generation_history
                     ),
@@ -298,264 +254,6 @@ class RestartIntentOpenStateReader:
                 "current restart-intent head belongs to another run"
             )
         return head
-
-    def _validate_closed_state(
-        self,
-        closed: RestartIntentClosedHeadRecord,
-        head_entry: ControlStoreEntry,
-        head_history: tuple[ControlStoreEntry, ...],
-        intent_entry: ControlStoreEntry | None,
-        intent_has_history: bool,
-        intent_history: tuple[ControlStoreEntry, ...],
-        lifecycle_entry: ControlStoreEntry | None,
-        lifecycle_has_history: bool,
-        lifecycle_history: tuple[ControlStoreEntry, ...],
-        closure_entry: ControlStoreEntry | None,
-        closure_has_history: bool,
-        closure_history: tuple[ControlStoreEntry, ...],
-        lease_history: tuple[CoordinatorLeaseAuthority, ...],
-    ) -> None:
-        if closed.closure_index != 1:
-            raise RestartIntentOpenStateCorrupt("initial restart-intent closure index is not one")
-        if lifecycle_entry is None or not lifecycle_has_history:
-            raise RestartIntentOpenStateCorrupt("closed restart-intent head has no lifecycle state")
-        if closure_entry is None or not closure_has_history:
-            raise RestartIntentOpenStateCorrupt(
-                "closed restart-intent head has no immutable closure record"
-            )
-        if (
-            len(head_history) != 2
-            or head_history[-1] != head_entry
-            or head_history[0].mutation_sequence != 1
-            or head_history[0].value_sequence != 1
-            or head_history[0].lifetime_sequence != 1
-        ):
-            raise RestartIntentOpenStateCorrupt(
-                "closed restart-intent head has invalid predecessor history"
-            )
-        predecessor_entry = head_history[0]
-        try:
-            predecessor = RestartIntentHeadRecord.from_json(predecessor_entry.value)
-        except (TypeError, ValueError) as error:
-            raise RestartIntentOpenStateCorrupt(
-                "predecessor restart-intent head is malformed"
-            ) from error
-        if (
-            predecessor_entry.value != predecessor.to_json()
-            or predecessor != self._closed_intent_head(closed, closure_entry)
-        ):
-            raise RestartIntentOpenStateCorrupt(
-                "restart-intent closure does not match its predecessor head"
-            )
-        if intent_entry is None or not intent_has_history or intent_history != (intent_entry,):
-            raise RestartIntentOpenStateCorrupt(
-                "closed restart intent has no immutable intent record"
-            )
-        try:
-            intent = RestartIntentRecord.from_json(intent_entry.value)
-        except (TypeError, ValueError) as error:
-            raise RestartIntentOpenStateCorrupt(
-                "closed restart intent has a malformed immutable record"
-            ) from error
-        if (
-            intent_entry.value != intent.to_json()
-            or predecessor.run_id != intent.intent.run_id
-            or predecessor.generation != intent.intent.generation
-            or predecessor.intent_id != intent.intent.intent_id
-            or predecessor.intent_digest != intent.digest
-        ):
-            raise RestartIntentOpenStateCorrupt(
-                "predecessor head does not identify its immutable intent"
-            )
-        if (
-            intent_entry.mutation_sequence != 1
-            or intent_entry.value_sequence != 1
-            or intent_entry.lifetime_sequence != 1
-            or intent_entry.committed_at_unix_ms is None
-            or predecessor_entry.committed_at_unix_ms is None
-            or intent_entry.committed_at_unix_ms != predecessor_entry.committed_at_unix_ms
-            or intent_entry.transaction_sequence != predecessor_entry.transaction_sequence
-            or _guard_provenance(intent_entry) != _guard_provenance(predecessor_entry)
-        ):
-            raise RestartIntentOpenStateCorrupt(
-                "predecessor intent records do not share one guarded transaction"
-            )
-        opening_authority = self._opening_authority(
-            intent,
-            intent_entry,
-            lease_history,
-        )
-        open_committed_at_unix_ms = intent_entry.committed_at_unix_ms
-        if open_committed_at_unix_ms is None:
-            raise RestartIntentOpenStateCorrupt(
-                "restart-intent opening has no authoritative commit time"
-            )
-        if (
-            intent_entry.transaction_sequence <= opening_authority.transaction_sequence
-            or open_committed_at_unix_ms < opening_authority.lease.granted_at_unix_ms
-            or open_committed_at_unix_ms
-            >= min(
-                opening_authority.lease.expires_at_unix_ms,
-                intent.intent.prepare_deadline_unix_ms,
-            )
-        ):
-            raise RestartIntentOpenStateCorrupt(
-                "restart-intent opening is outside its lease and intent window"
-            )
-        if lifecycle_history != (lifecycle_entry,):
-            raise RestartIntentOpenStateCorrupt(
-                "restart-intent lifecycle head is not an immutable initial creation"
-            )
-        if closure_history != (closure_entry,):
-            raise RestartIntentOpenStateCorrupt(
-                "restart-intent closure record is not an immutable initial creation"
-            )
-        try:
-            lifecycle = RestartIntentLifecycleHeadRecord.from_json(lifecycle_entry.value)
-        except (TypeError, ValueError) as error:
-            raise RestartIntentOpenStateCorrupt(
-                "restart-intent lifecycle head is malformed"
-            ) from error
-        if lifecycle_entry.value != lifecycle.to_json():
-            raise RestartIntentOpenStateCorrupt("restart-intent lifecycle head is noncanonical")
-        try:
-            closure = RestartIntentLifecycleRecord.from_json(closure_entry.value)
-        except (TypeError, ValueError) as error:
-            raise RestartIntentOpenStateCorrupt(
-                "immutable restart-intent closure record is malformed"
-            ) from error
-        if closure_entry.value != closure.to_json():
-            raise RestartIntentOpenStateCorrupt(
-                "immutable restart-intent closure record is noncanonical"
-            )
-        if (
-            lifecycle.run_id != closed.run_id
-            or lifecycle.closure_index != closed.closure_index
-            or lifecycle.generation != closed.generation
-            or lifecycle.intent_id != closed.intent_id
-            or lifecycle.digest != closed.lifecycle_head_digest
-        ):
-            raise RestartIntentOpenStateCorrupt(
-                "closed restart-intent head does not match its lifecycle head"
-            )
-        if (
-            closure.closed_intent.run_id != lifecycle.run_id
-            or closure.closed_intent.generation != lifecycle.generation
-            or closure.closed_intent.intent_id != lifecycle.intent_id
-            or closure.digest != lifecycle.lifecycle_digest
-        ):
-            raise RestartIntentOpenStateCorrupt(
-                "restart-intent lifecycle head does not match its closure record"
-            )
-        if (
-            head_entry.mutation_sequence != 2
-            or head_entry.value_sequence != 2
-            or head_entry.lifetime_sequence != 1
-            or lifecycle_entry.mutation_sequence != 1
-            or lifecycle_entry.value_sequence != 1
-            or lifecycle_entry.lifetime_sequence != 1
-            or closure_entry.mutation_sequence != 1
-            or closure_entry.value_sequence != 1
-            or closure_entry.lifetime_sequence != 1
-        ):
-            raise RestartIntentOpenStateCorrupt(
-                "restart-intent closure has invalid store sequences"
-            )
-        if (
-            head_entry.committed_at_unix_ms is None
-            or lifecycle_entry.committed_at_unix_ms is None
-            or closure_entry.committed_at_unix_ms is None
-            or head_entry.committed_at_unix_ms != lifecycle_entry.committed_at_unix_ms
-            or head_entry.committed_at_unix_ms != closure_entry.committed_at_unix_ms
-            or head_entry.transaction_sequence != lifecycle_entry.transaction_sequence
-            or head_entry.transaction_sequence != closure_entry.transaction_sequence
-            or _guard_provenance(head_entry) != _guard_provenance(lifecycle_entry)
-            or _guard_provenance(head_entry) != _guard_provenance(closure_entry)
-            or closure.coordinator_fencing_token != head_entry.guard_revision
-            or closure.coordinator_lease_digest != head_entry.guard_value_digest
-        ):
-            raise RestartIntentOpenStateCorrupt(
-                "restart-intent closure records do not share one guarded transaction"
-            )
-        closing_authority = self._closing_authority(
-            closure,
-            head_entry,
-            lease_history,
-        )
-        closed_at_unix_ms = head_entry.committed_at_unix_ms
-        if closed_at_unix_ms is None:
-            raise RestartIntentOpenStateCorrupt(
-                "restart-intent closure has no authoritative commit time"
-            )
-        if (
-            head_entry.transaction_sequence
-            <= max(
-                predecessor_entry.transaction_sequence,
-                closing_authority.transaction_sequence,
-            )
-            or closed_at_unix_ms < predecessor_entry.committed_at_unix_ms
-            or closed_at_unix_ms < closing_authority.lease.granted_at_unix_ms
-            or closed_at_unix_ms >= closing_authority.lease.expires_at_unix_ms
-        ):
-            raise RestartIntentOpenStateCorrupt(
-                "restart-intent closure is outside its causal lease window"
-            )
-
-    def _closed_intent_head(
-        self,
-        closed: RestartIntentClosedHeadRecord,
-        closure_entry: ControlStoreEntry | None,
-    ) -> RestartIntentHeadRecord:
-        if closure_entry is None:
-            raise RestartIntentOpenStateCorrupt(
-                "closed restart-intent head has no immutable closure record"
-            )
-        try:
-            closure = RestartIntentLifecycleRecord.from_json(closure_entry.value)
-        except (TypeError, ValueError) as error:
-            raise RestartIntentOpenStateCorrupt(
-                "immutable restart-intent closure record is malformed"
-            ) from error
-        if closure.closed_intent.run_id != closed.run_id:
-            raise RestartIntentOpenStateCorrupt(
-                "immutable restart-intent closure belongs to another run"
-            )
-        return closure.closed_intent
-
-    def _closing_authority(
-        self,
-        closure: RestartIntentLifecycleRecord,
-        entry: ControlStoreEntry,
-        lease_history: tuple[CoordinatorLeaseAuthority, ...],
-    ) -> CoordinatorLeaseAuthority:
-        if entry.guard_key != self._generation_reader.coordinator_lease_key:
-            raise RestartIntentOpenStateCorrupt(
-                "restart-intent closure used a noncanonical coordinator lease key"
-            )
-        lease_record = CoordinatorLeaseRecord(
-            run_id=closure.closed_intent.run_id,
-            coordinator_id=closure.coordinator_id,
-            lease_id=closure.lease_id,
-            lease_duration_ms=closure.coordinator_lease_duration_ms,
-        )
-        matches = tuple(
-            authority
-            for authority in lease_history
-            if (
-                authority.lease.record == lease_record
-                and authority.lease.fencing_token == closure.coordinator_fencing_token
-                and authority.lease.fencing_token == entry.guard_revision
-                and authority.lease.granted_at_unix_ms == entry.guard_committed_at_unix_ms
-                and authority.mutation_sequence == entry.guard_mutation_sequence
-                and authority.value_sequence == entry.guard_value_sequence
-                and authority.lifetime_sequence == entry.guard_lifetime_sequence
-            )
-        )
-        if len(matches) != 1:
-            raise RestartIntentOpenStateCorrupt(
-                "closing coordinator lease is absent from durable lease history"
-            )
-        return matches[0]
 
     def _opening_authority(
         self,
@@ -627,9 +325,6 @@ class RestartIntentOpenStateReader:
         intent_key: str | None = None,
         intent_entry: ControlStoreEntry | None = None,
         intent_has_history: bool | None = None,
-        closure_key: str | None = None,
-        closure_entry: ControlStoreEntry | None = None,
-        closure_has_history: bool | None = None,
     ) -> bool:
         if (
             self._store.get(self._intent_head_key) != head_entry
@@ -638,14 +333,11 @@ class RestartIntentOpenStateReader:
             or self._store.has_history(self._lifecycle_head_key) != lifecycle_has_history
         ):
             return False
-        if intent_key is not None and (
-            self._store.get(intent_key) != intent_entry
-            or self._store.has_history(intent_key) != intent_has_history
-        ):
-            return False
-        return closure_key is None or (
-            self._store.get(closure_key) == closure_entry
-            and self._store.has_history(closure_key) == closure_has_history
+        if intent_key is None:
+            return True
+        return (
+            self._store.get(intent_key) == intent_entry
+            and self._store.has_history(intent_key) == intent_has_history
         )
 
 
@@ -655,36 +347,14 @@ def _commit_time(entry: ControlStoreEntry) -> int:
     return entry.committed_at_unix_ms
 
 
-def _guard_provenance(entry: ControlStoreEntry) -> tuple[object, ...]:
-    provenance = (
-        entry.guard_key,
-        entry.guard_revision,
-        entry.guard_value_digest,
-        entry.guard_mutation_sequence,
-        entry.guard_value_sequence,
-        entry.guard_lifetime_sequence,
-        entry.guard_committed_at_unix_ms,
-    )
-    if any(value is None for value in provenance):
-        raise RestartIntentOpenStateCorrupt(
-            "restart-intent closure has incomplete guard provenance"
-        )
-    return provenance
-
-
 def _nonempty_string(value: object, path: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"{path} must be a non-empty string")
     return value
 
 
-def _positive_integer(value: object, path: str) -> int:
-    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
-        raise ValueError(f"{path} must be a positive integer")
-    return value
-
-
 __all__ = [
+    "RestartIntentOpenStateClosed",
     "RestartIntentOpenStateCorrupt",
     "RestartIntentOpenStateError",
     "RestartIntentOpenStateReader",

--- a/lm_resiliency/integrations/torchrun/_restart_intent_open_reader.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_open_reader.py
@@ -14,12 +14,10 @@ from lm_resiliency.integrations.torchrun._coordinator_lease import (
 from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
     CoordinatorLeaseAuthority,
     CoordinatorLeaseHistoryCorrupt,
-    CoordinatorLeaseHistoryError,
     CoordinatorLeaseHistoryReader,
 )
 from lm_resiliency.integrations.torchrun._generation_reader import (
     GenerationStateCorrupt,
-    GenerationStateError,
     GenerationStateReader,
 )
 from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
@@ -31,6 +29,7 @@ from lm_resiliency.integrations.torchrun._restart_intent_open_records import (
 from lm_resiliency.integrations.torchrun._restart_intent_records import (
     RestartIntentClosedHeadRecord,
     RestartIntentHeadRecord,
+    RestartIntentLifecycleHeadRecord,
     RestartIntentRecord,
 )
 
@@ -83,14 +82,14 @@ class RestartIntentOpenStateReader:
             head_has_history = self._store.has_history(self._intent_head_key)
             lifecycle_entry = self._store.get(self._lifecycle_head_key)
             lifecycle_has_history = self._store.has_history(self._lifecycle_head_key)
+            if not self._state_is_stable(
+                head_entry,
+                head_has_history,
+                lifecycle_entry,
+                lifecycle_has_history,
+            ):
+                continue
             if head_entry is None:
-                if not self._state_is_stable(
-                    head_entry,
-                    head_has_history,
-                    lifecycle_entry,
-                    lifecycle_has_history,
-                ):
-                    continue
                 if head_has_history:
                     raise RestartIntentOpenStateCorrupt(
                         "current restart-intent head disappeared after lifecycle creation"
@@ -104,19 +103,14 @@ class RestartIntentOpenStateReader:
                 raise RestartIntentOpenStateCorrupt(
                     "live restart-intent head has no durable history"
                 )
-            head = self._decode_open_head(head_entry)
-            if head is None:
-                if not self._state_is_stable(
+            head = self._decode_head(head_entry)
+            if isinstance(head, RestartIntentClosedHeadRecord):
+                self._validate_closed_state(
+                    head,
                     head_entry,
-                    head_has_history,
                     lifecycle_entry,
                     lifecycle_has_history,
-                ):
-                    continue
-                if lifecycle_entry is None or not lifecycle_has_history:
-                    raise RestartIntentOpenStateCorrupt(
-                        "closed restart-intent head has no lifecycle state"
-                    )
+                )
                 return None
             if lifecycle_entry is not None or lifecycle_has_history:
                 raise RestartIntentOpenStateCorrupt(
@@ -128,14 +122,17 @@ class RestartIntentOpenStateReader:
                 raise RestartIntentOpenStateCorrupt(
                     "current restart-intent head references a missing intent"
                 )
+            intent_has_history = self._store.has_history(intent_key)
+            if not intent_has_history:
+                raise RestartIntentOpenStateCorrupt(
+                    "live immutable restart intent has no durable history"
+                )
             try:
                 generation_result = self._generation_reader.current_with_history()
                 lease_history = self._lease_history_reader.read()
             except (
                 CoordinatorLeaseHistoryCorrupt,
-                CoordinatorLeaseHistoryError,
                 GenerationStateCorrupt,
-                GenerationStateError,
             ) as error:
                 raise RestartIntentOpenStateCorrupt(
                     "restart-intent opening dependencies are corrupt"
@@ -147,6 +144,7 @@ class RestartIntentOpenStateReader:
                 lifecycle_has_history,
                 intent_key=intent_key,
                 intent_entry=intent_entry,
+                intent_has_history=intent_has_history,
             ):
                 continue
             if generation_result is None:
@@ -227,10 +225,10 @@ class RestartIntentOpenStateReader:
                 ) from error
         raise RestartIntentOpenStateError("restart-intent opening changed repeatedly during read")
 
-    def _decode_open_head(
+    def _decode_head(
         self,
         entry: ControlStoreEntry,
-    ) -> RestartIntentHeadRecord | None:
+    ) -> RestartIntentHeadRecord | RestartIntentClosedHeadRecord:
         try:
             head = RestartIntentHeadRecord.from_json(entry.value)
         except (TypeError, ValueError) as open_error:
@@ -244,12 +242,63 @@ class RestartIntentOpenStateReader:
                 raise RestartIntentOpenStateCorrupt(
                     "closed restart-intent head belongs to another run"
                 ) from open_error
-            return None
+            if entry.value != closed.to_json():
+                raise RestartIntentOpenStateCorrupt("closed restart-intent head is noncanonical")
+            return closed
         if head.run_id != self._run_id:
             raise RestartIntentOpenStateCorrupt(
                 "current restart-intent head belongs to another run"
             )
         return head
+
+    def _validate_closed_state(
+        self,
+        closed: RestartIntentClosedHeadRecord,
+        head_entry: ControlStoreEntry,
+        lifecycle_entry: ControlStoreEntry | None,
+        lifecycle_has_history: bool,
+    ) -> None:
+        if lifecycle_entry is None or not lifecycle_has_history:
+            raise RestartIntentOpenStateCorrupt("closed restart-intent head has no lifecycle state")
+        try:
+            lifecycle = RestartIntentLifecycleHeadRecord.from_json(lifecycle_entry.value)
+        except (TypeError, ValueError) as error:
+            raise RestartIntentOpenStateCorrupt(
+                "restart-intent lifecycle head is malformed"
+            ) from error
+        if lifecycle_entry.value != lifecycle.to_json():
+            raise RestartIntentOpenStateCorrupt("restart-intent lifecycle head is noncanonical")
+        if (
+            lifecycle.run_id != closed.run_id
+            or lifecycle.closure_index != closed.closure_index
+            or lifecycle.generation != closed.generation
+            or lifecycle.intent_id != closed.intent_id
+            or lifecycle.digest != closed.lifecycle_head_digest
+        ):
+            raise RestartIntentOpenStateCorrupt(
+                "closed restart-intent head does not match its lifecycle head"
+            )
+        if (
+            head_entry.mutation_sequence != 2
+            or head_entry.value_sequence != 2
+            or head_entry.lifetime_sequence != 1
+            or lifecycle_entry.mutation_sequence != 1
+            or lifecycle_entry.value_sequence != 1
+            or lifecycle_entry.lifetime_sequence != 1
+        ):
+            raise RestartIntentOpenStateCorrupt(
+                "restart-intent closure has invalid store sequences"
+            )
+        if (
+            head_entry.committed_at_unix_ms is None
+            or lifecycle_entry.committed_at_unix_ms is None
+            or head_entry.committed_at_unix_ms != lifecycle_entry.committed_at_unix_ms
+            or head_entry.transaction_sequence != lifecycle_entry.transaction_sequence
+            or _guard_provenance(head_entry) != _guard_provenance(lifecycle_entry)
+        ):
+            raise RestartIntentOpenStateCorrupt(
+                "restart-intent closure records do not share one guarded transaction"
+            )
 
     def _opening_authority(
         self,
@@ -320,6 +369,7 @@ class RestartIntentOpenStateReader:
         *,
         intent_key: str | None = None,
         intent_entry: ControlStoreEntry | None = None,
+        intent_has_history: bool | None = None,
     ) -> bool:
         if (
             self._store.get(self._intent_head_key) != head_entry
@@ -328,13 +378,35 @@ class RestartIntentOpenStateReader:
             or self._store.has_history(self._lifecycle_head_key) != lifecycle_has_history
         ):
             return False
-        return intent_key is None or self._store.get(intent_key) == intent_entry
+        if intent_key is None:
+            return True
+        return (
+            self._store.get(intent_key) == intent_entry
+            and self._store.has_history(intent_key) == intent_has_history
+        )
 
 
 def _commit_time(entry: ControlStoreEntry) -> int:
     if entry.committed_at_unix_ms is None:
         raise RestartIntentOpenStateCorrupt("restart-intent entry has no authoritative commit time")
     return entry.committed_at_unix_ms
+
+
+def _guard_provenance(entry: ControlStoreEntry) -> tuple[object, ...]:
+    provenance = (
+        entry.guard_key,
+        entry.guard_revision,
+        entry.guard_value_digest,
+        entry.guard_mutation_sequence,
+        entry.guard_value_sequence,
+        entry.guard_lifetime_sequence,
+        entry.guard_committed_at_unix_ms,
+    )
+    if any(value is None for value in provenance):
+        raise RestartIntentOpenStateCorrupt(
+            "restart-intent closure has incomplete guard provenance"
+        )
+    return provenance
 
 
 def _nonempty_string(value: object, path: str) -> str:

--- a/lm_resiliency/integrations/torchrun/_restart_intent_open_reader.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_open_reader.py
@@ -30,6 +30,7 @@ from lm_resiliency.integrations.torchrun._restart_intent_records import (
     RestartIntentClosedHeadRecord,
     RestartIntentHeadRecord,
     RestartIntentLifecycleHeadRecord,
+    RestartIntentLifecycleRecord,
     RestartIntentRecord,
 )
 
@@ -74,6 +75,10 @@ class RestartIntentOpenStateReader:
         intent_digest = hashlib.sha256(normalized_intent_id.encode("utf-8")).hexdigest()
         return f"{self._run_prefix}/restart-intents/{intent_digest}"
 
+    def closure_key(self, closure_index: int) -> str:
+        normalized_index = _positive_integer(closure_index, "closure_index")
+        return f"{self._run_prefix}/restart-intent-closures/{normalized_index}"
+
     def read(self) -> CommittedInitialRestartIntentOpen | None:
         """Return one stable, verified opening or ``None`` when none is current."""
 
@@ -105,11 +110,26 @@ class RestartIntentOpenStateReader:
                 )
             head = self._decode_head(head_entry)
             if isinstance(head, RestartIntentClosedHeadRecord):
+                closure_key = self.closure_key(head.closure_index)
+                closure_entry = self._store.get(closure_key)
+                closure_has_history = self._store.has_history(closure_key)
+                if not self._state_is_stable(
+                    head_entry,
+                    head_has_history,
+                    lifecycle_entry,
+                    lifecycle_has_history,
+                    closure_key=closure_key,
+                    closure_entry=closure_entry,
+                    closure_has_history=closure_has_history,
+                ):
+                    continue
                 self._validate_closed_state(
                     head,
                     head_entry,
                     lifecycle_entry,
                     lifecycle_has_history,
+                    closure_entry,
+                    closure_has_history,
                 )
                 return None
             if lifecycle_entry is not None or lifecycle_has_history:
@@ -257,9 +277,15 @@ class RestartIntentOpenStateReader:
         head_entry: ControlStoreEntry,
         lifecycle_entry: ControlStoreEntry | None,
         lifecycle_has_history: bool,
+        closure_entry: ControlStoreEntry | None,
+        closure_has_history: bool,
     ) -> None:
         if lifecycle_entry is None or not lifecycle_has_history:
             raise RestartIntentOpenStateCorrupt("closed restart-intent head has no lifecycle state")
+        if closure_entry is None or not closure_has_history:
+            raise RestartIntentOpenStateCorrupt(
+                "closed restart-intent head has no immutable closure record"
+            )
         try:
             lifecycle = RestartIntentLifecycleHeadRecord.from_json(lifecycle_entry.value)
         except (TypeError, ValueError) as error:
@@ -268,6 +294,16 @@ class RestartIntentOpenStateReader:
             ) from error
         if lifecycle_entry.value != lifecycle.to_json():
             raise RestartIntentOpenStateCorrupt("restart-intent lifecycle head is noncanonical")
+        try:
+            closure = RestartIntentLifecycleRecord.from_json(closure_entry.value)
+        except (TypeError, ValueError) as error:
+            raise RestartIntentOpenStateCorrupt(
+                "immutable restart-intent closure record is malformed"
+            ) from error
+        if closure_entry.value != closure.to_json():
+            raise RestartIntentOpenStateCorrupt(
+                "immutable restart-intent closure record is noncanonical"
+            )
         if (
             lifecycle.run_id != closed.run_id
             or lifecycle.closure_index != closed.closure_index
@@ -279,12 +315,24 @@ class RestartIntentOpenStateReader:
                 "closed restart-intent head does not match its lifecycle head"
             )
         if (
+            closure.closed_intent.run_id != lifecycle.run_id
+            or closure.closed_intent.generation != lifecycle.generation
+            or closure.closed_intent.intent_id != lifecycle.intent_id
+            or closure.digest != lifecycle.lifecycle_digest
+        ):
+            raise RestartIntentOpenStateCorrupt(
+                "restart-intent lifecycle head does not match its closure record"
+            )
+        if (
             head_entry.mutation_sequence != 2
             or head_entry.value_sequence != 2
             or head_entry.lifetime_sequence != 1
             or lifecycle_entry.mutation_sequence != 1
             or lifecycle_entry.value_sequence != 1
             or lifecycle_entry.lifetime_sequence != 1
+            or closure_entry.mutation_sequence != 1
+            or closure_entry.value_sequence != 1
+            or closure_entry.lifetime_sequence != 1
         ):
             raise RestartIntentOpenStateCorrupt(
                 "restart-intent closure has invalid store sequences"
@@ -292,9 +340,15 @@ class RestartIntentOpenStateReader:
         if (
             head_entry.committed_at_unix_ms is None
             or lifecycle_entry.committed_at_unix_ms is None
+            or closure_entry.committed_at_unix_ms is None
             or head_entry.committed_at_unix_ms != lifecycle_entry.committed_at_unix_ms
+            or head_entry.committed_at_unix_ms != closure_entry.committed_at_unix_ms
             or head_entry.transaction_sequence != lifecycle_entry.transaction_sequence
+            or head_entry.transaction_sequence != closure_entry.transaction_sequence
             or _guard_provenance(head_entry) != _guard_provenance(lifecycle_entry)
+            or _guard_provenance(head_entry) != _guard_provenance(closure_entry)
+            or closure.coordinator_fencing_token != head_entry.guard_revision
+            or closure.coordinator_lease_digest != head_entry.guard_value_digest
         ):
             raise RestartIntentOpenStateCorrupt(
                 "restart-intent closure records do not share one guarded transaction"
@@ -370,6 +424,9 @@ class RestartIntentOpenStateReader:
         intent_key: str | None = None,
         intent_entry: ControlStoreEntry | None = None,
         intent_has_history: bool | None = None,
+        closure_key: str | None = None,
+        closure_entry: ControlStoreEntry | None = None,
+        closure_has_history: bool | None = None,
     ) -> bool:
         if (
             self._store.get(self._intent_head_key) != head_entry
@@ -378,11 +435,14 @@ class RestartIntentOpenStateReader:
             or self._store.has_history(self._lifecycle_head_key) != lifecycle_has_history
         ):
             return False
-        if intent_key is None:
-            return True
-        return (
-            self._store.get(intent_key) == intent_entry
-            and self._store.has_history(intent_key) == intent_has_history
+        if intent_key is not None and (
+            self._store.get(intent_key) != intent_entry
+            or self._store.has_history(intent_key) != intent_has_history
+        ):
+            return False
+        return closure_key is None or (
+            self._store.get(closure_key) == closure_entry
+            and self._store.has_history(closure_key) == closure_has_history
         )
 
 
@@ -412,6 +472,12 @@ def _guard_provenance(entry: ControlStoreEntry) -> tuple[object, ...]:
 def _nonempty_string(value: object, path: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+def _positive_integer(value: object, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{path} must be a positive integer")
     return value
 
 

--- a/lm_resiliency/integrations/torchrun/_restart_intent_open_reader.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_open_reader.py
@@ -1,0 +1,350 @@
+"""Fail-closed reads of the current initial restart-intent opening."""
+
+from __future__ import annotations
+
+import hashlib
+
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStore,
+    ControlStoreEntry,
+)
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseRecord,
+)
+from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
+    CoordinatorLeaseAuthority,
+    CoordinatorLeaseHistoryCorrupt,
+    CoordinatorLeaseHistoryError,
+    CoordinatorLeaseHistoryReader,
+)
+from lm_resiliency.integrations.torchrun._generation_reader import (
+    GenerationStateCorrupt,
+    GenerationStateError,
+    GenerationStateReader,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
+    CommittedInitialRestartIntentOpen,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_records import (
+    PreparedInitialRestartIntentOpen,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_records import (
+    RestartIntentClosedHeadRecord,
+    RestartIntentHeadRecord,
+    RestartIntentRecord,
+)
+
+_CONTROL_PREFIX = "lm_resiliency/torchrun/v1"
+_MAX_READ_ATTEMPTS = 8
+
+
+class RestartIntentOpenStateError(RuntimeError):
+    """Base error for persisted restart-intent opening reads."""
+
+
+class RestartIntentOpenStateCorrupt(RestartIntentOpenStateError):
+    """Raised when persisted opening state is malformed or contradictory."""
+
+
+class RestartIntentOpenStateReader:
+    """Read and verify the current initial restart-intent opening."""
+
+    def __init__(self, store: ControlStore, *, run_id: str) -> None:
+        self._store = store
+        self._run_id = _nonempty_string(run_id, "run_id")
+        run_digest = hashlib.sha256(self._run_id.encode("utf-8")).hexdigest()
+        self._run_prefix = f"{_CONTROL_PREFIX}/runs/{run_digest}"
+        self._intent_head_key = f"{self._run_prefix}/restart-intent-head"
+        self._lifecycle_head_key = f"{self._run_prefix}/restart-intent-lifecycle-head"
+        self._generation_reader = GenerationStateReader(store, run_id=self._run_id)
+        self._lease_history_reader = CoordinatorLeaseHistoryReader(
+            store,
+            run_id=self._run_id,
+        )
+
+    @property
+    def intent_head_key(self) -> str:
+        return self._intent_head_key
+
+    @property
+    def lifecycle_head_key(self) -> str:
+        return self._lifecycle_head_key
+
+    def intent_key(self, intent_id: str) -> str:
+        normalized_intent_id = _nonempty_string(intent_id, "intent_id")
+        intent_digest = hashlib.sha256(normalized_intent_id.encode("utf-8")).hexdigest()
+        return f"{self._run_prefix}/restart-intents/{intent_digest}"
+
+    def read(self) -> CommittedInitialRestartIntentOpen | None:
+        """Return one stable, verified opening or ``None`` when none is current."""
+
+        for _ in range(_MAX_READ_ATTEMPTS):
+            head_entry = self._store.get(self._intent_head_key)
+            head_has_history = self._store.has_history(self._intent_head_key)
+            lifecycle_entry = self._store.get(self._lifecycle_head_key)
+            lifecycle_has_history = self._store.has_history(self._lifecycle_head_key)
+            if head_entry is None:
+                if not self._state_is_stable(
+                    head_entry,
+                    head_has_history,
+                    lifecycle_entry,
+                    lifecycle_has_history,
+                ):
+                    continue
+                if head_has_history:
+                    raise RestartIntentOpenStateCorrupt(
+                        "current restart-intent head disappeared after lifecycle creation"
+                    )
+                if lifecycle_entry is not None or lifecycle_has_history:
+                    raise RestartIntentOpenStateCorrupt(
+                        "restart-intent lifecycle exists without current-head history"
+                    )
+                return None
+            if not head_has_history:
+                raise RestartIntentOpenStateCorrupt(
+                    "live restart-intent head has no durable history"
+                )
+            head = self._decode_open_head(head_entry)
+            if head is None:
+                if not self._state_is_stable(
+                    head_entry,
+                    head_has_history,
+                    lifecycle_entry,
+                    lifecycle_has_history,
+                ):
+                    continue
+                if lifecycle_entry is None or not lifecycle_has_history:
+                    raise RestartIntentOpenStateCorrupt(
+                        "closed restart-intent head has no lifecycle state"
+                    )
+                return None
+            if lifecycle_entry is not None or lifecycle_has_history:
+                raise RestartIntentOpenStateCorrupt(
+                    "open restart-intent head coexists with lifecycle state"
+                )
+            intent_key = self.intent_key(head.intent_id)
+            intent_entry = self._store.get(intent_key)
+            if intent_entry is None:
+                raise RestartIntentOpenStateCorrupt(
+                    "current restart-intent head references a missing intent"
+                )
+            try:
+                generation_result = self._generation_reader.current_with_history()
+                lease_history = self._lease_history_reader.read()
+            except (
+                CoordinatorLeaseHistoryCorrupt,
+                CoordinatorLeaseHistoryError,
+                GenerationStateCorrupt,
+                GenerationStateError,
+            ) as error:
+                raise RestartIntentOpenStateCorrupt(
+                    "restart-intent opening dependencies are corrupt"
+                ) from error
+            if not self._state_is_stable(
+                head_entry,
+                head_has_history,
+                lifecycle_entry,
+                lifecycle_has_history,
+                intent_key=intent_key,
+                intent_entry=intent_entry,
+            ):
+                continue
+            if generation_result is None:
+                raise RestartIntentOpenStateCorrupt(
+                    "restart intent exists without committed generation state"
+                )
+            current, generation_history = generation_result
+            try:
+                record = RestartIntentRecord.from_json(intent_entry.value)
+            except (TypeError, ValueError) as error:
+                raise RestartIntentOpenStateCorrupt(
+                    "immutable restart-intent record is malformed"
+                ) from error
+            if intent_entry.value != record.to_json():
+                raise RestartIntentOpenStateCorrupt(
+                    "immutable restart-intent record is noncanonical"
+                )
+            if (
+                head.run_id != self._run_id
+                or record.intent.run_id != self._run_id
+                or head.generation != record.intent.generation
+                or head.intent_id != record.intent.intent_id
+                or head.intent_digest != record.digest
+            ):
+                raise RestartIntentOpenStateCorrupt(
+                    "current restart-intent head does not identify its immutable record"
+                )
+            if (
+                current.snapshot.record.assignment.generation != record.intent.generation
+                or current.snapshot.record.digest != record.generation_snapshot_digest
+            ):
+                raise RestartIntentOpenStateCorrupt(
+                    "current generation does not match the open restart intent"
+                )
+            opening_authority = self._opening_authority(
+                record,
+                intent_entry,
+                lease_history,
+            )
+            try:
+                prepared = PreparedInitialRestartIntentOpen(
+                    record=record,
+                    head=head,
+                    current=current,
+                    lease=opening_authority.lease,
+                    intent_key=intent_key,
+                    intent_head_key=self._intent_head_key,
+                    lifecycle_head_key=self._lifecycle_head_key,
+                    coordinator_lease_key=self._generation_reader.coordinator_lease_key,
+                    generation_head_key=self._generation_reader.head_key,
+                    generation_snapshot_key=self._generation_reader.snapshot_key(
+                        record.intent.generation
+                    ),
+                    coordinator_lease_transaction_sequence=(opening_authority.transaction_sequence),
+                    coordinator_lease_mutation_sequence=opening_authority.mutation_sequence,
+                    coordinator_lease_value_sequence=opening_authority.value_sequence,
+                    coordinator_lease_lifetime_sequence=opening_authority.lifetime_sequence,
+                    generation_lease_id_history=tuple(
+                        snapshot.record.lease_id for snapshot in generation_history
+                    ),
+                    generation_fencing_token_history=tuple(
+                        snapshot.record.coordinator_fencing_token for snapshot in generation_history
+                    ),
+                    not_before_unix_ms=_commit_time(intent_entry),
+                    deadline_unix_ms=min(
+                        opening_authority.lease.expires_at_unix_ms,
+                        record.intent.prepare_deadline_unix_ms,
+                    ),
+                )
+                return CommittedInitialRestartIntentOpen(
+                    prepared=prepared,
+                    intent_entry=intent_entry,
+                    head_entry=head_entry,
+                )
+            except (TypeError, ValueError) as error:
+                raise RestartIntentOpenStateCorrupt(
+                    "persisted restart-intent opening is contradictory"
+                ) from error
+        raise RestartIntentOpenStateError("restart-intent opening changed repeatedly during read")
+
+    def _decode_open_head(
+        self,
+        entry: ControlStoreEntry,
+    ) -> RestartIntentHeadRecord | None:
+        try:
+            head = RestartIntentHeadRecord.from_json(entry.value)
+        except (TypeError, ValueError) as open_error:
+            try:
+                closed = RestartIntentClosedHeadRecord.from_json(entry.value)
+            except (TypeError, ValueError) as closed_error:
+                raise RestartIntentOpenStateCorrupt(
+                    "current restart-intent head is malformed"
+                ) from closed_error
+            if closed.run_id != self._run_id:
+                raise RestartIntentOpenStateCorrupt(
+                    "closed restart-intent head belongs to another run"
+                ) from open_error
+            return None
+        if head.run_id != self._run_id:
+            raise RestartIntentOpenStateCorrupt(
+                "current restart-intent head belongs to another run"
+            )
+        return head
+
+    def _opening_authority(
+        self,
+        record: RestartIntentRecord,
+        entry: ControlStoreEntry,
+        lease_history: tuple[CoordinatorLeaseAuthority, ...],
+    ) -> CoordinatorLeaseAuthority:
+        provenance = (
+            entry.guard_key,
+            entry.guard_revision,
+            entry.guard_value_digest,
+            entry.guard_mutation_sequence,
+            entry.guard_value_sequence,
+            entry.guard_lifetime_sequence,
+            entry.guard_committed_at_unix_ms,
+        )
+        if any(value is None for value in provenance):
+            raise RestartIntentOpenStateCorrupt(
+                "immutable restart intent has incomplete lease provenance"
+            )
+        (
+            guard_key,
+            guard_revision,
+            guard_value_digest,
+            guard_mutation_sequence,
+            guard_value_sequence,
+            guard_lifetime_sequence,
+            guard_committed_at_unix_ms,
+        ) = provenance
+        if (
+            guard_key != self._generation_reader.coordinator_lease_key
+            or guard_revision != record.coordinator_fencing_token
+            or guard_value_digest != record.coordinator_lease_digest
+        ):
+            raise RestartIntentOpenStateCorrupt(
+                "immutable restart intent has invalid lease provenance"
+            )
+        lease_record = CoordinatorLeaseRecord(
+            run_id=record.intent.run_id,
+            coordinator_id=record.coordinator_id,
+            lease_id=record.lease_id,
+            lease_duration_ms=record.coordinator_lease_duration_ms,
+        )
+        matches = tuple(
+            authority
+            for authority in lease_history
+            if (
+                authority.lease.record == lease_record
+                and authority.lease.fencing_token == guard_revision
+                and authority.lease.granted_at_unix_ms == guard_committed_at_unix_ms
+                and authority.mutation_sequence == guard_mutation_sequence
+                and authority.value_sequence == guard_value_sequence
+                and authority.lifetime_sequence == guard_lifetime_sequence
+            )
+        )
+        if len(matches) != 1:
+            raise RestartIntentOpenStateCorrupt(
+                "opening coordinator lease is absent from durable lease history"
+            )
+        return matches[0]
+
+    def _state_is_stable(
+        self,
+        head_entry: ControlStoreEntry | None,
+        head_has_history: bool,
+        lifecycle_entry: ControlStoreEntry | None,
+        lifecycle_has_history: bool,
+        *,
+        intent_key: str | None = None,
+        intent_entry: ControlStoreEntry | None = None,
+    ) -> bool:
+        if (
+            self._store.get(self._intent_head_key) != head_entry
+            or self._store.has_history(self._intent_head_key) != head_has_history
+            or self._store.get(self._lifecycle_head_key) != lifecycle_entry
+            or self._store.has_history(self._lifecycle_head_key) != lifecycle_has_history
+        ):
+            return False
+        return intent_key is None or self._store.get(intent_key) == intent_entry
+
+
+def _commit_time(entry: ControlStoreEntry) -> int:
+    if entry.committed_at_unix_ms is None:
+        raise RestartIntentOpenStateCorrupt("restart-intent entry has no authoritative commit time")
+    return entry.committed_at_unix_ms
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+__all__ = [
+    "RestartIntentOpenStateCorrupt",
+    "RestartIntentOpenStateError",
+    "RestartIntentOpenStateReader",
+]

--- a/lm_resiliency/integrations/torchrun/_restart_intent_open_reader.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_open_reader.py
@@ -113,23 +113,51 @@ class RestartIntentOpenStateReader:
                 closure_key = self.closure_key(head.closure_index)
                 closure_entry = self._store.get(closure_key)
                 closure_has_history = self._store.has_history(closure_key)
+                intent_key = self.intent_key(head.intent_id)
+                intent_entry = self._store.get(intent_key)
+                intent_has_history = self._store.has_history(intent_key)
+                head_history = self._store.get_history(self._intent_head_key)
+                intent_history = self._store.get_history(intent_key)
+                lifecycle_history = self._store.get_history(self._lifecycle_head_key)
+                closure_history = self._store.get_history(closure_key)
+                try:
+                    lease_history = self._lease_history_reader.read()
+                except CoordinatorLeaseHistoryCorrupt as error:
+                    raise RestartIntentOpenStateCorrupt(
+                        "restart-intent closure lease history is corrupt"
+                    ) from error
                 if not self._state_is_stable(
                     head_entry,
                     head_has_history,
                     lifecycle_entry,
                     lifecycle_has_history,
+                    intent_key=intent_key,
+                    intent_entry=intent_entry,
+                    intent_has_history=intent_has_history,
                     closure_key=closure_key,
                     closure_entry=closure_entry,
                     closure_has_history=closure_has_history,
+                ) or (
+                    self._store.get_history(self._intent_head_key) != head_history
+                    or self._store.get_history(intent_key) != intent_history
+                    or self._store.get_history(self._lifecycle_head_key) != lifecycle_history
+                    or self._store.get_history(closure_key) != closure_history
                 ):
                     continue
                 self._validate_closed_state(
                     head,
                     head_entry,
+                    head_history,
+                    intent_entry,
+                    intent_has_history,
+                    intent_history,
                     lifecycle_entry,
                     lifecycle_has_history,
+                    lifecycle_history,
                     closure_entry,
                     closure_has_history,
+                    closure_history,
+                    lease_history,
                 )
                 return None
             if lifecycle_entry is not None or lifecycle_has_history:
@@ -275,16 +303,112 @@ class RestartIntentOpenStateReader:
         self,
         closed: RestartIntentClosedHeadRecord,
         head_entry: ControlStoreEntry,
+        head_history: tuple[ControlStoreEntry, ...],
+        intent_entry: ControlStoreEntry | None,
+        intent_has_history: bool,
+        intent_history: tuple[ControlStoreEntry, ...],
         lifecycle_entry: ControlStoreEntry | None,
         lifecycle_has_history: bool,
+        lifecycle_history: tuple[ControlStoreEntry, ...],
         closure_entry: ControlStoreEntry | None,
         closure_has_history: bool,
+        closure_history: tuple[ControlStoreEntry, ...],
+        lease_history: tuple[CoordinatorLeaseAuthority, ...],
     ) -> None:
+        if closed.closure_index != 1:
+            raise RestartIntentOpenStateCorrupt("initial restart-intent closure index is not one")
         if lifecycle_entry is None or not lifecycle_has_history:
             raise RestartIntentOpenStateCorrupt("closed restart-intent head has no lifecycle state")
         if closure_entry is None or not closure_has_history:
             raise RestartIntentOpenStateCorrupt(
                 "closed restart-intent head has no immutable closure record"
+            )
+        if (
+            len(head_history) != 2
+            or head_history[-1] != head_entry
+            or head_history[0].mutation_sequence != 1
+            or head_history[0].value_sequence != 1
+            or head_history[0].lifetime_sequence != 1
+        ):
+            raise RestartIntentOpenStateCorrupt(
+                "closed restart-intent head has invalid predecessor history"
+            )
+        predecessor_entry = head_history[0]
+        try:
+            predecessor = RestartIntentHeadRecord.from_json(predecessor_entry.value)
+        except (TypeError, ValueError) as error:
+            raise RestartIntentOpenStateCorrupt(
+                "predecessor restart-intent head is malformed"
+            ) from error
+        if (
+            predecessor_entry.value != predecessor.to_json()
+            or predecessor != self._closed_intent_head(closed, closure_entry)
+        ):
+            raise RestartIntentOpenStateCorrupt(
+                "restart-intent closure does not match its predecessor head"
+            )
+        if intent_entry is None or not intent_has_history or intent_history != (intent_entry,):
+            raise RestartIntentOpenStateCorrupt(
+                "closed restart intent has no immutable intent record"
+            )
+        try:
+            intent = RestartIntentRecord.from_json(intent_entry.value)
+        except (TypeError, ValueError) as error:
+            raise RestartIntentOpenStateCorrupt(
+                "closed restart intent has a malformed immutable record"
+            ) from error
+        if (
+            intent_entry.value != intent.to_json()
+            or predecessor.run_id != intent.intent.run_id
+            or predecessor.generation != intent.intent.generation
+            or predecessor.intent_id != intent.intent.intent_id
+            or predecessor.intent_digest != intent.digest
+        ):
+            raise RestartIntentOpenStateCorrupt(
+                "predecessor head does not identify its immutable intent"
+            )
+        if (
+            intent_entry.mutation_sequence != 1
+            or intent_entry.value_sequence != 1
+            or intent_entry.lifetime_sequence != 1
+            or intent_entry.committed_at_unix_ms is None
+            or predecessor_entry.committed_at_unix_ms is None
+            or intent_entry.committed_at_unix_ms != predecessor_entry.committed_at_unix_ms
+            or intent_entry.transaction_sequence != predecessor_entry.transaction_sequence
+            or _guard_provenance(intent_entry) != _guard_provenance(predecessor_entry)
+        ):
+            raise RestartIntentOpenStateCorrupt(
+                "predecessor intent records do not share one guarded transaction"
+            )
+        opening_authority = self._opening_authority(
+            intent,
+            intent_entry,
+            lease_history,
+        )
+        open_committed_at_unix_ms = intent_entry.committed_at_unix_ms
+        if open_committed_at_unix_ms is None:
+            raise RestartIntentOpenStateCorrupt(
+                "restart-intent opening has no authoritative commit time"
+            )
+        if (
+            intent_entry.transaction_sequence <= opening_authority.transaction_sequence
+            or open_committed_at_unix_ms < opening_authority.lease.granted_at_unix_ms
+            or open_committed_at_unix_ms
+            >= min(
+                opening_authority.lease.expires_at_unix_ms,
+                intent.intent.prepare_deadline_unix_ms,
+            )
+        ):
+            raise RestartIntentOpenStateCorrupt(
+                "restart-intent opening is outside its lease and intent window"
+            )
+        if lifecycle_history != (lifecycle_entry,):
+            raise RestartIntentOpenStateCorrupt(
+                "restart-intent lifecycle head is not an immutable initial creation"
+            )
+        if closure_history != (closure_entry,):
+            raise RestartIntentOpenStateCorrupt(
+                "restart-intent closure record is not an immutable initial creation"
             )
         try:
             lifecycle = RestartIntentLifecycleHeadRecord.from_json(lifecycle_entry.value)
@@ -353,6 +477,85 @@ class RestartIntentOpenStateReader:
             raise RestartIntentOpenStateCorrupt(
                 "restart-intent closure records do not share one guarded transaction"
             )
+        closing_authority = self._closing_authority(
+            closure,
+            head_entry,
+            lease_history,
+        )
+        closed_at_unix_ms = head_entry.committed_at_unix_ms
+        if closed_at_unix_ms is None:
+            raise RestartIntentOpenStateCorrupt(
+                "restart-intent closure has no authoritative commit time"
+            )
+        if (
+            head_entry.transaction_sequence
+            <= max(
+                predecessor_entry.transaction_sequence,
+                closing_authority.transaction_sequence,
+            )
+            or closed_at_unix_ms < predecessor_entry.committed_at_unix_ms
+            or closed_at_unix_ms < closing_authority.lease.granted_at_unix_ms
+            or closed_at_unix_ms >= closing_authority.lease.expires_at_unix_ms
+        ):
+            raise RestartIntentOpenStateCorrupt(
+                "restart-intent closure is outside its causal lease window"
+            )
+
+    def _closed_intent_head(
+        self,
+        closed: RestartIntentClosedHeadRecord,
+        closure_entry: ControlStoreEntry | None,
+    ) -> RestartIntentHeadRecord:
+        if closure_entry is None:
+            raise RestartIntentOpenStateCorrupt(
+                "closed restart-intent head has no immutable closure record"
+            )
+        try:
+            closure = RestartIntentLifecycleRecord.from_json(closure_entry.value)
+        except (TypeError, ValueError) as error:
+            raise RestartIntentOpenStateCorrupt(
+                "immutable restart-intent closure record is malformed"
+            ) from error
+        if closure.closed_intent.run_id != closed.run_id:
+            raise RestartIntentOpenStateCorrupt(
+                "immutable restart-intent closure belongs to another run"
+            )
+        return closure.closed_intent
+
+    def _closing_authority(
+        self,
+        closure: RestartIntentLifecycleRecord,
+        entry: ControlStoreEntry,
+        lease_history: tuple[CoordinatorLeaseAuthority, ...],
+    ) -> CoordinatorLeaseAuthority:
+        if entry.guard_key != self._generation_reader.coordinator_lease_key:
+            raise RestartIntentOpenStateCorrupt(
+                "restart-intent closure used a noncanonical coordinator lease key"
+            )
+        lease_record = CoordinatorLeaseRecord(
+            run_id=closure.closed_intent.run_id,
+            coordinator_id=closure.coordinator_id,
+            lease_id=closure.lease_id,
+            lease_duration_ms=closure.coordinator_lease_duration_ms,
+        )
+        matches = tuple(
+            authority
+            for authority in lease_history
+            if (
+                authority.lease.record == lease_record
+                and authority.lease.fencing_token == closure.coordinator_fencing_token
+                and authority.lease.fencing_token == entry.guard_revision
+                and authority.lease.granted_at_unix_ms == entry.guard_committed_at_unix_ms
+                and authority.mutation_sequence == entry.guard_mutation_sequence
+                and authority.value_sequence == entry.guard_value_sequence
+                and authority.lifetime_sequence == entry.guard_lifetime_sequence
+            )
+        )
+        if len(matches) != 1:
+            raise RestartIntentOpenStateCorrupt(
+                "closing coordinator lease is absent from durable lease history"
+            )
+        return matches[0]
 
     def _opening_authority(
         self,

--- a/tests/unit/test_torchrun_restart_intent_open_reader.py
+++ b/tests/unit/test_torchrun_restart_intent_open_reader.py
@@ -7,7 +7,10 @@ from dataclasses import replace
 
 import pytest
 
-from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStoreWrite,
+    InMemoryControlStore,
+)
 from lm_resiliency.integrations.torchrun._coordinator_lease import (
     CoordinatorLeaseManager,
     HeldCoordinatorLease,
@@ -421,6 +424,153 @@ def test_open_reader_rejects_unverified_immutable_closure(tamper):
         RestartIntentOpenStateCorrupt,
         match="closure|lifecycle|transaction",
     ):
+        reader.read()
+
+
+def test_open_reader_rejects_noncanonical_closing_lease_provenance():
+    clock, store, _, _, lease, opened, reader = _state()
+    records = _closure_records(opened, lease)
+    clock.set(1_010)
+    store.compare_set_many_guarded(
+        records.writes,
+        guard_key=opened.prepared.coordinator_lease_key,
+        expected_guard_revision=lease.fencing_token,
+        not_before_unix_ms=1_010,
+        deadline_unix_ms=lease.expires_at_unix_ms,
+        conditions=records.conditions,
+    )
+    for key in (
+        records.intent_head_key,
+        records.lifecycle_head_key,
+        records.closure_key,
+    ):
+        substituted = replace(
+            store._entries[key],
+            guard_key="other/coordinator-lease",
+        )
+        store._entries[key] = substituted
+        store._histories[key][-1] = substituted
+
+    with pytest.raises(RestartIntentOpenStateCorrupt, match="noncanonical"):
+        reader.read()
+
+
+def test_open_reader_rejects_closure_of_another_persisted_head():
+    clock, store, _, _, lease, opened, reader = _state()
+    records = _closure_records(opened, lease)
+    clock.set(1_010)
+    store.compare_set_many_guarded(
+        records.writes,
+        guard_key=opened.prepared.coordinator_lease_key,
+        expected_guard_revision=lease.fencing_token,
+        not_before_unix_ms=1_010,
+        deadline_unix_ms=lease.expires_at_unix_ms,
+        conditions=records.conditions,
+    )
+    other_head = replace(
+        opened.prepared.head,
+        intent_id="intent-b",
+    )
+    other_closure = replace(
+        records.lifecycle,
+        closed_intent=other_head,
+    )
+    other_lifecycle_head = replace(
+        records.lifecycle_head,
+        intent_id="intent-b",
+        lifecycle_digest=other_closure.digest,
+    )
+    substitutions = {
+        records.intent_head_key: replace(
+            records.closed_head,
+            intent_id="intent-b",
+            lifecycle_head_digest=other_lifecycle_head.digest,
+        ).to_json(),
+        records.lifecycle_head_key: other_lifecycle_head.to_json(),
+        records.closure_key: other_closure.to_json(),
+    }
+    for key, value in substitutions.items():
+        substituted = replace(store._entries[key], value=value)
+        store._entries[key] = substituted
+        store._histories[key][-1] = substituted
+
+    with pytest.raises(RestartIntentOpenStateCorrupt, match="predecessor"):
+        reader.read()
+
+
+def test_open_reader_rejects_skipped_initial_closure_index():
+    clock, store, _, _, lease, opened, reader = _state()
+    records = _closure_records(opened, lease)
+    lifecycle_head = replace(records.lifecycle_head, closure_index=2)
+    closed_head = replace(
+        records.closed_head,
+        closure_index=2,
+        lifecycle_head_digest=lifecycle_head.digest,
+    )
+    closure_key = reader.closure_key(2)
+    clock.set(1_010)
+    store.compare_set_many_guarded(
+        {
+            records.intent_head_key: ControlStoreWrite(
+                expected_revision=opened.head_entry.revision,
+                value=closed_head.to_json(),
+            ),
+            records.lifecycle_head_key: ControlStoreWrite(
+                expected_revision=None,
+                value=lifecycle_head.to_json(),
+                require_never_created=True,
+            ),
+            closure_key: ControlStoreWrite(
+                expected_revision=None,
+                value=records.lifecycle.to_json(),
+                require_never_created=True,
+            ),
+        },
+        guard_key=opened.prepared.coordinator_lease_key,
+        expected_guard_revision=lease.fencing_token,
+        not_before_unix_ms=1_010,
+        deadline_unix_ms=lease.expires_at_unix_ms,
+        conditions={opened.prepared.intent_key: opened.intent_entry.revision},
+    )
+
+    with pytest.raises(RestartIntentOpenStateCorrupt, match="index"):
+        reader.read()
+
+
+@pytest.mark.parametrize("tamper", ["transaction_order", "lease_window"])
+def test_open_reader_rejects_closure_outside_causal_lease_window(tamper):
+    clock, store, _, _, lease, opened, reader = _state()
+    records = _closure_records(opened, lease)
+    clock.set(1_010)
+    store.compare_set_many_guarded(
+        records.writes,
+        guard_key=opened.prepared.coordinator_lease_key,
+        expected_guard_revision=lease.fencing_token,
+        not_before_unix_ms=1_010,
+        deadline_unix_ms=lease.expires_at_unix_ms,
+        conditions=records.conditions,
+    )
+    for key in (
+        records.intent_head_key,
+        records.lifecycle_head_key,
+        records.closure_key,
+    ):
+        entry = store._entries[key]
+        substituted = (
+            replace(
+                entry,
+                transaction_sequence=opened.transaction_sequence,
+            )
+            if tamper == "transaction_order"
+            else replace(
+                entry,
+                committed_at_unix_ms=lease.expires_at_unix_ms,
+            )
+        )
+        store._entries[key] = substituted
+        store._histories[key][-1] = substituted
+
+    with pytest.raises(RestartIntentOpenStateCorrupt, match="causal lease window"):
         reader.read()
 
 

--- a/tests/unit/test_torchrun_restart_intent_open_reader.py
+++ b/tests/unit/test_torchrun_restart_intent_open_reader.py
@@ -7,10 +7,7 @@ from dataclasses import replace
 
 import pytest
 
-from lm_resiliency.integrations.torchrun._control_store import (
-    ControlStoreWrite,
-    InMemoryControlStore,
-)
+from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
 from lm_resiliency.integrations.torchrun._coordinator_lease import (
     CoordinatorLeaseManager,
     HeldCoordinatorLease,
@@ -36,6 +33,7 @@ from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
     RestartIntentOpenExecutor,
 )
 from lm_resiliency.integrations.torchrun._restart_intent_open_reader import (
+    RestartIntentOpenStateClosed,
     RestartIntentOpenStateCorrupt,
     RestartIntentOpenStateReader,
 )
@@ -175,9 +173,26 @@ def _closure_records(
     )
 
 
+def _commit_closure(
+    clock: ManualClock,
+    store: InMemoryControlStore,
+    lease: HeldCoordinatorLease,
+    opened: CommittedInitialRestartIntentOpen,
+) -> None:
+    records = _closure_records(opened, lease)
+    clock.set(1_010)
+    store.compare_set_many_guarded(
+        records.writes,
+        guard_key=opened.prepared.coordinator_lease_key,
+        expected_guard_revision=lease.fencing_token,
+        not_before_unix_ms=1_010,
+        deadline_unix_ms=lease.expires_at_unix_ms,
+        conditions=records.conditions,
+    )
+
+
 def test_open_reader_returns_none_before_initial_open():
-    clock = ManualClock()
-    store = InMemoryControlStore(clock=clock)
+    store = InMemoryControlStore(clock=ManualClock())
 
     assert RestartIntentOpenStateReader(store, run_id=RUN_ID).read() is None
 
@@ -185,9 +200,7 @@ def test_open_reader_returns_none_before_initial_open():
 def test_open_reader_reconstructs_committed_open_from_persisted_state():
     _, _, _, _, _, opened, reader = _state()
 
-    observed = reader.read()
-
-    assert observed == opened
+    assert reader.read() == opened
 
 
 def test_open_reader_survives_lease_renewal_and_replacement_after_open():
@@ -197,9 +210,7 @@ def test_open_reader_survives_lease_renewal_and_replacement_after_open():
     clock.set(renewed.expires_at_unix_ms)
     replacement = _manager(store, clock, "coordinator-b").acquire()
 
-    observed = reader.read()
-
-    assert observed == opened
+    assert reader.read() == opened
     assert replacement.fencing_token != opened.prepared.lease.fencing_token
 
 
@@ -208,16 +219,9 @@ def test_open_reader_rejects_generation_advance_while_intent_is_open():
     current = generation_manager.current()
     assert current is not None
     clock.set(1_010)
-    generation_manager.commit_successor(
-        lease,
-        current,
-        _assignment(generation=1),
-    )
+    generation_manager.commit_successor(lease, current, _assignment(generation=1))
 
-    with pytest.raises(
-        RestartIntentOpenStateCorrupt,
-        match="current generation",
-    ):
+    with pytest.raises(RestartIntentOpenStateCorrupt, match="current generation"):
         reader.read()
 
 
@@ -273,32 +277,24 @@ def test_open_reader_rejects_deleted_current_head():
         reader.read()
 
 
-def test_open_reader_rejects_live_head_without_durable_history():
+def test_open_reader_rejects_live_records_without_durable_history():
     _, store, _, _, _, opened, reader = _state()
     del store._last_revisions[opened.prepared.intent_head_key]
 
-    with pytest.raises(RestartIntentOpenStateCorrupt, match="no durable history"):
+    with pytest.raises(RestartIntentOpenStateCorrupt, match="head has no durable history"):
         reader.read()
 
-
-def test_open_reader_rejects_live_intent_without_durable_history():
-    _, store, _, _, _, opened, reader = _state()
+    store._last_revisions[opened.prepared.intent_head_key] = opened.head_entry.revision
     del store._last_revisions[opened.prepared.intent_key]
-
     with pytest.raises(RestartIntentOpenStateCorrupt, match="intent has no durable history"):
         reader.read()
 
 
-def test_open_reader_rejects_closed_head_without_lifecycle_state():
-    _, store, _, _, _, opened, reader = _state()
-    records = _closure_records(opened, opened.prepared.lease)
-    store.compare_set(
-        opened.prepared.intent_head_key,
-        expected_revision=opened.head_entry.revision,
-        value=records.closed_head.to_json(),
-    )
+def test_open_reader_reports_closed_marker_without_authenticating_closure():
+    clock, store, _, _, lease, opened, reader = _state()
+    _commit_closure(clock, store, lease, opened)
 
-    with pytest.raises(RestartIntentOpenStateCorrupt, match="no lifecycle state"):
+    with pytest.raises(RestartIntentOpenStateClosed, match="not verified"):
         reader.read()
 
 
@@ -308,7 +304,7 @@ def test_open_reader_retries_atomic_closure_between_initial_reads(monkeypatch):
     original_get = store.get
     triggered = False
 
-    def racing_get(key):
+    def racing_get(key: str):
         nonlocal triggered
         if key == reader.lifecycle_head_key and not triggered:
             triggered = True
@@ -325,252 +321,7 @@ def test_open_reader_retries_atomic_closure_between_initial_reads(monkeypatch):
 
     monkeypatch.setattr(store, "get", racing_get)
 
-    assert reader.read() is None
-
-
-def test_open_reader_returns_none_after_atomic_initial_closure():
-    clock, store, _, _, lease, opened, reader = _state()
-    records = _closure_records(opened, lease)
-    clock.set(1_010)
-    store.compare_set_many_guarded(
-        records.writes,
-        guard_key=opened.prepared.coordinator_lease_key,
-        expected_guard_revision=lease.fencing_token,
-        not_before_unix_ms=1_010,
-        deadline_unix_ms=lease.expires_at_unix_ms,
-        conditions=records.conditions,
-    )
-
-    assert reader.read() is None
-
-
-@pytest.mark.parametrize("tamper", ["value", "link", "metadata"])
-def test_open_reader_rejects_unverified_lifecycle_state(tamper):
-    clock, store, _, _, lease, opened, reader = _state()
-    records = _closure_records(opened, lease)
-    clock.set(1_010)
-    committed = store.compare_set_many_guarded(
-        records.writes,
-        guard_key=opened.prepared.coordinator_lease_key,
-        expected_guard_revision=lease.fencing_token,
-        not_before_unix_ms=1_010,
-        deadline_unix_ms=lease.expires_at_unix_ms,
-        conditions=records.conditions,
-    )
-    lifecycle_entry = committed[records.lifecycle_head_key]
-    if tamper == "value":
-        lifecycle_entry = replace(lifecycle_entry, value=b"invalid")
-    elif tamper == "link":
-        lifecycle_entry = replace(
-            lifecycle_entry,
-            value=replace(
-                records.lifecycle_head,
-                intent_id="intent-b",
-            ).to_json(),
-        )
-    else:
-        lifecycle_entry = replace(
-            lifecycle_entry,
-            transaction_sequence=lifecycle_entry.transaction_sequence + 1,
-        )
-    store._entries[records.lifecycle_head_key] = lifecycle_entry
-
-    with pytest.raises(RestartIntentOpenStateCorrupt, match="lifecycle|transaction"):
-        reader.read()
-
-
-@pytest.mark.parametrize("tamper", ["deleted", "value", "link", "metadata"])
-def test_open_reader_rejects_unverified_immutable_closure(tamper):
-    clock, store, _, _, lease, opened, reader = _state()
-    records = _closure_records(opened, lease)
-    clock.set(1_010)
-    committed = store.compare_set_many_guarded(
-        records.writes,
-        guard_key=opened.prepared.coordinator_lease_key,
-        expected_guard_revision=lease.fencing_token,
-        not_before_unix_ms=1_010,
-        deadline_unix_ms=lease.expires_at_unix_ms,
-        conditions=records.conditions,
-    )
-    closure_entry = committed[records.closure_key]
-    if tamper == "deleted":
-        store.compare_delete(
-            records.closure_key,
-            expected_revision=closure_entry.revision,
-        )
-    elif tamper == "value":
-        store._entries[records.closure_key] = replace(
-            closure_entry,
-            value=b"invalid",
-        )
-    elif tamper == "link":
-        store._entries[records.closure_key] = replace(
-            closure_entry,
-            value=replace(
-                records.lifecycle,
-                closed_intent=replace(
-                    records.lifecycle.closed_intent,
-                    intent_id="intent-b",
-                ),
-            ).to_json(),
-        )
-    else:
-        store._entries[records.closure_key] = replace(
-            closure_entry,
-            transaction_sequence=closure_entry.transaction_sequence + 1,
-        )
-
-    with pytest.raises(
-        RestartIntentOpenStateCorrupt,
-        match="closure|lifecycle|transaction",
-    ):
-        reader.read()
-
-
-def test_open_reader_rejects_noncanonical_closing_lease_provenance():
-    clock, store, _, _, lease, opened, reader = _state()
-    records = _closure_records(opened, lease)
-    clock.set(1_010)
-    store.compare_set_many_guarded(
-        records.writes,
-        guard_key=opened.prepared.coordinator_lease_key,
-        expected_guard_revision=lease.fencing_token,
-        not_before_unix_ms=1_010,
-        deadline_unix_ms=lease.expires_at_unix_ms,
-        conditions=records.conditions,
-    )
-    for key in (
-        records.intent_head_key,
-        records.lifecycle_head_key,
-        records.closure_key,
-    ):
-        substituted = replace(
-            store._entries[key],
-            guard_key="other/coordinator-lease",
-        )
-        store._entries[key] = substituted
-        store._histories[key][-1] = substituted
-
-    with pytest.raises(RestartIntentOpenStateCorrupt, match="noncanonical"):
-        reader.read()
-
-
-def test_open_reader_rejects_closure_of_another_persisted_head():
-    clock, store, _, _, lease, opened, reader = _state()
-    records = _closure_records(opened, lease)
-    clock.set(1_010)
-    store.compare_set_many_guarded(
-        records.writes,
-        guard_key=opened.prepared.coordinator_lease_key,
-        expected_guard_revision=lease.fencing_token,
-        not_before_unix_ms=1_010,
-        deadline_unix_ms=lease.expires_at_unix_ms,
-        conditions=records.conditions,
-    )
-    other_head = replace(
-        opened.prepared.head,
-        intent_id="intent-b",
-    )
-    other_closure = replace(
-        records.lifecycle,
-        closed_intent=other_head,
-    )
-    other_lifecycle_head = replace(
-        records.lifecycle_head,
-        intent_id="intent-b",
-        lifecycle_digest=other_closure.digest,
-    )
-    substitutions = {
-        records.intent_head_key: replace(
-            records.closed_head,
-            intent_id="intent-b",
-            lifecycle_head_digest=other_lifecycle_head.digest,
-        ).to_json(),
-        records.lifecycle_head_key: other_lifecycle_head.to_json(),
-        records.closure_key: other_closure.to_json(),
-    }
-    for key, value in substitutions.items():
-        substituted = replace(store._entries[key], value=value)
-        store._entries[key] = substituted
-        store._histories[key][-1] = substituted
-
-    with pytest.raises(RestartIntentOpenStateCorrupt, match="predecessor"):
-        reader.read()
-
-
-def test_open_reader_rejects_skipped_initial_closure_index():
-    clock, store, _, _, lease, opened, reader = _state()
-    records = _closure_records(opened, lease)
-    lifecycle_head = replace(records.lifecycle_head, closure_index=2)
-    closed_head = replace(
-        records.closed_head,
-        closure_index=2,
-        lifecycle_head_digest=lifecycle_head.digest,
-    )
-    closure_key = reader.closure_key(2)
-    clock.set(1_010)
-    store.compare_set_many_guarded(
-        {
-            records.intent_head_key: ControlStoreWrite(
-                expected_revision=opened.head_entry.revision,
-                value=closed_head.to_json(),
-            ),
-            records.lifecycle_head_key: ControlStoreWrite(
-                expected_revision=None,
-                value=lifecycle_head.to_json(),
-                require_never_created=True,
-            ),
-            closure_key: ControlStoreWrite(
-                expected_revision=None,
-                value=records.lifecycle.to_json(),
-                require_never_created=True,
-            ),
-        },
-        guard_key=opened.prepared.coordinator_lease_key,
-        expected_guard_revision=lease.fencing_token,
-        not_before_unix_ms=1_010,
-        deadline_unix_ms=lease.expires_at_unix_ms,
-        conditions={opened.prepared.intent_key: opened.intent_entry.revision},
-    )
-
-    with pytest.raises(RestartIntentOpenStateCorrupt, match="index"):
-        reader.read()
-
-
-@pytest.mark.parametrize("tamper", ["transaction_order", "lease_window"])
-def test_open_reader_rejects_closure_outside_causal_lease_window(tamper):
-    clock, store, _, _, lease, opened, reader = _state()
-    records = _closure_records(opened, lease)
-    clock.set(1_010)
-    store.compare_set_many_guarded(
-        records.writes,
-        guard_key=opened.prepared.coordinator_lease_key,
-        expected_guard_revision=lease.fencing_token,
-        not_before_unix_ms=1_010,
-        deadline_unix_ms=lease.expires_at_unix_ms,
-        conditions=records.conditions,
-    )
-    for key in (
-        records.intent_head_key,
-        records.lifecycle_head_key,
-        records.closure_key,
-    ):
-        entry = store._entries[key]
-        substituted = (
-            replace(
-                entry,
-                transaction_sequence=opened.transaction_sequence,
-            )
-            if tamper == "transaction_order"
-            else replace(
-                entry,
-                committed_at_unix_ms=lease.expires_at_unix_ms,
-            )
-        )
-        store._entries[key] = substituted
-        store._histories[key][-1] = substituted
-
-    with pytest.raises(RestartIntentOpenStateCorrupt, match="causal lease window"):
+    with pytest.raises(RestartIntentOpenStateClosed, match="not verified"):
         reader.read()
 
 
@@ -582,7 +333,7 @@ def test_open_reader_rejects_closure_outside_causal_lease_window(tamper):
     ],
 )
 def test_open_reader_preserves_retryable_dependency_errors(
-    dependency_error,
+    dependency_error: RuntimeError,
     monkeypatch,
 ):
     _, _, _, _, _, _, reader = _state()
@@ -602,9 +353,11 @@ def test_open_reader_preserves_retryable_dependency_errors(
 def test_open_reader_rejects_opening_authority_missing_from_history():
     clock, store, lease_manager, _, lease, _, reader = _state()
     clock.set(lease.expires_at_unix_ms)
-    lease_manager = _manager(store, clock, "coordinator-b")
-    lease_manager.acquire()
-    store._histories[lease_manager.lease_key] = store._histories[lease_manager.lease_key][1:]
+    replacement_manager = _manager(store, clock, "coordinator-b")
+    replacement_manager.acquire()
+    store._histories[replacement_manager.lease_key] = store._histories[
+        replacement_manager.lease_key
+    ][1:]
 
     with pytest.raises(RestartIntentOpenStateCorrupt, match="dependencies"):
         reader.read()

--- a/tests/unit/test_torchrun_restart_intent_open_reader.py
+++ b/tests/unit/test_torchrun_restart_intent_open_reader.py
@@ -376,6 +376,54 @@ def test_open_reader_rejects_unverified_lifecycle_state(tamper):
         reader.read()
 
 
+@pytest.mark.parametrize("tamper", ["deleted", "value", "link", "metadata"])
+def test_open_reader_rejects_unverified_immutable_closure(tamper):
+    clock, store, _, _, lease, opened, reader = _state()
+    records = _closure_records(opened, lease)
+    clock.set(1_010)
+    committed = store.compare_set_many_guarded(
+        records.writes,
+        guard_key=opened.prepared.coordinator_lease_key,
+        expected_guard_revision=lease.fencing_token,
+        not_before_unix_ms=1_010,
+        deadline_unix_ms=lease.expires_at_unix_ms,
+        conditions=records.conditions,
+    )
+    closure_entry = committed[records.closure_key]
+    if tamper == "deleted":
+        store.compare_delete(
+            records.closure_key,
+            expected_revision=closure_entry.revision,
+        )
+    elif tamper == "value":
+        store._entries[records.closure_key] = replace(
+            closure_entry,
+            value=b"invalid",
+        )
+    elif tamper == "link":
+        store._entries[records.closure_key] = replace(
+            closure_entry,
+            value=replace(
+                records.lifecycle,
+                closed_intent=replace(
+                    records.lifecycle.closed_intent,
+                    intent_id="intent-b",
+                ),
+            ).to_json(),
+        )
+    else:
+        store._entries[records.closure_key] = replace(
+            closure_entry,
+            transaction_sequence=closure_entry.transaction_sequence + 1,
+        )
+
+    with pytest.raises(
+        RestartIntentOpenStateCorrupt,
+        match="closure|lifecycle|transaction",
+    ):
+        reader.read()
+
+
 @pytest.mark.parametrize(
     "dependency_error",
     [

--- a/tests/unit/test_torchrun_restart_intent_open_reader.py
+++ b/tests/unit/test_torchrun_restart_intent_open_reader.py
@@ -12,6 +12,10 @@ from lm_resiliency.integrations.torchrun._coordinator_lease import (
     CoordinatorLeaseManager,
     HeldCoordinatorLease,
 )
+from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
+    CoordinatorLeaseHistoryError,
+)
+from lm_resiliency.integrations.torchrun._generation_reader import GenerationStateError
 from lm_resiliency.integrations.torchrun._generation_state import GenerationStateManager
 from lm_resiliency.integrations.torchrun._protocol import (
     RankAssignment,
@@ -274,6 +278,14 @@ def test_open_reader_rejects_live_head_without_durable_history():
         reader.read()
 
 
+def test_open_reader_rejects_live_intent_without_durable_history():
+    _, store, _, _, _, opened, reader = _state()
+    del store._last_revisions[opened.prepared.intent_key]
+
+    with pytest.raises(RestartIntentOpenStateCorrupt, match="intent has no durable history"):
+        reader.read()
+
+
 def test_open_reader_rejects_closed_head_without_lifecycle_state():
     _, store, _, _, _, opened, reader = _state()
     records = _closure_records(opened, opened.prepared.lease)
@@ -285,6 +297,32 @@ def test_open_reader_rejects_closed_head_without_lifecycle_state():
 
     with pytest.raises(RestartIntentOpenStateCorrupt, match="no lifecycle state"):
         reader.read()
+
+
+def test_open_reader_retries_atomic_closure_between_initial_reads(monkeypatch):
+    clock, store, _, _, lease, opened, reader = _state()
+    records = _closure_records(opened, lease)
+    original_get = store.get
+    triggered = False
+
+    def racing_get(key):
+        nonlocal triggered
+        if key == reader.lifecycle_head_key and not triggered:
+            triggered = True
+            clock.set(1_010)
+            store.compare_set_many_guarded(
+                records.writes,
+                guard_key=opened.prepared.coordinator_lease_key,
+                expected_guard_revision=lease.fencing_token,
+                not_before_unix_ms=1_010,
+                deadline_unix_ms=lease.expires_at_unix_ms,
+                conditions=records.conditions,
+            )
+        return original_get(key)
+
+    monkeypatch.setattr(store, "get", racing_get)
+
+    assert reader.read() is None
 
 
 def test_open_reader_returns_none_after_atomic_initial_closure():
@@ -301,6 +339,66 @@ def test_open_reader_returns_none_after_atomic_initial_closure():
     )
 
     assert reader.read() is None
+
+
+@pytest.mark.parametrize("tamper", ["value", "link", "metadata"])
+def test_open_reader_rejects_unverified_lifecycle_state(tamper):
+    clock, store, _, _, lease, opened, reader = _state()
+    records = _closure_records(opened, lease)
+    clock.set(1_010)
+    committed = store.compare_set_many_guarded(
+        records.writes,
+        guard_key=opened.prepared.coordinator_lease_key,
+        expected_guard_revision=lease.fencing_token,
+        not_before_unix_ms=1_010,
+        deadline_unix_ms=lease.expires_at_unix_ms,
+        conditions=records.conditions,
+    )
+    lifecycle_entry = committed[records.lifecycle_head_key]
+    if tamper == "value":
+        lifecycle_entry = replace(lifecycle_entry, value=b"invalid")
+    elif tamper == "link":
+        lifecycle_entry = replace(
+            lifecycle_entry,
+            value=replace(
+                records.lifecycle_head,
+                intent_id="intent-b",
+            ).to_json(),
+        )
+    else:
+        lifecycle_entry = replace(
+            lifecycle_entry,
+            transaction_sequence=lifecycle_entry.transaction_sequence + 1,
+        )
+    store._entries[records.lifecycle_head_key] = lifecycle_entry
+
+    with pytest.raises(RestartIntentOpenStateCorrupt, match="lifecycle|transaction"):
+        reader.read()
+
+
+@pytest.mark.parametrize(
+    "dependency_error",
+    [
+        CoordinatorLeaseHistoryError("lease history changed"),
+        GenerationStateError("generation changed"),
+    ],
+)
+def test_open_reader_preserves_retryable_dependency_errors(
+    dependency_error,
+    monkeypatch,
+):
+    _, _, _, _, _, _, reader = _state()
+
+    def fail():
+        raise dependency_error
+
+    if isinstance(dependency_error, CoordinatorLeaseHistoryError):
+        monkeypatch.setattr(reader._lease_history_reader, "read", fail)
+    else:
+        monkeypatch.setattr(reader._generation_reader, "current_with_history", fail)
+
+    with pytest.raises(type(dependency_error), match="changed"):
+        reader.read()
 
 
 def test_open_reader_rejects_opening_authority_missing_from_history():

--- a/tests/unit/test_torchrun_restart_intent_open_reader.py
+++ b/tests/unit/test_torchrun_restart_intent_open_reader.py
@@ -1,0 +1,322 @@
+"""Contract tests for persisted initial restart-intent opening reads."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import replace
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseManager,
+    HeldCoordinatorLease,
+)
+from lm_resiliency.integrations.torchrun._generation_state import GenerationStateManager
+from lm_resiliency.integrations.torchrun._protocol import (
+    RankAssignment,
+    RestartIntent,
+    SlotAssignment,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_close_records import (
+    InitialRestartIntentClosureRecords,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open import (
+    RestartIntentOpenPreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
+    CommittedInitialRestartIntentOpen,
+    RestartIntentOpenExecutor,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_reader import (
+    RestartIntentOpenStateCorrupt,
+    RestartIntentOpenStateReader,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_records import (
+    RestartIntentClosedHeadRecord,
+    RestartIntentLifecycleHeadRecord,
+    RestartIntentLifecycleRecord,
+)
+
+RUN_ID = "training-run"
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+    def set(self, now_unix_ms: int) -> None:
+        with self._lock:
+            self.now_unix_ms = now_unix_ms
+
+
+def _manager(
+    store: InMemoryControlStore,
+    clock: ManualClock,
+    coordinator_id: str,
+) -> CoordinatorLeaseManager:
+    return CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id=coordinator_id,
+        lease_duration_ms=100,
+        clock=clock,
+    )
+
+
+def _assignment(generation: int = 0) -> RankAssignment:
+    return RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=generation,
+        assignments=(
+            SlotAssignment(0, "node-a", 0, 2),
+            SlotAssignment(1, "node-b", 2, 2),
+        ),
+        topology_digest="topology-v1",
+    )
+
+
+def _intent() -> RestartIntent:
+    return RestartIntent(
+        intent_id="intent-a",
+        run_id=RUN_ID,
+        generation=0,
+        incident_ids=("incident-a",),
+        reason_code="attributed_sdc",
+        minimum_recovery_mode="recovery_verified",
+        suspected_node_ids=("node-b",),
+        prepare_deadline_unix_ms=1_200,
+    )
+
+
+def _state() -> tuple[
+    ManualClock,
+    InMemoryControlStore,
+    CoordinatorLeaseManager,
+    GenerationStateManager,
+    HeldCoordinatorLease,
+    CommittedInitialRestartIntentOpen,
+    RestartIntentOpenStateReader,
+]:
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    lease_manager = _manager(store, clock, "coordinator-a")
+    generation_manager = GenerationStateManager(store, run_id=RUN_ID)
+    lease = lease_manager.acquire()
+    generation_manager.initialize(lease, _assignment())
+    current = generation_manager.current()
+    assert current is not None
+    prepared = RestartIntentOpenPreparer(
+        store,
+        run_id=RUN_ID,
+        clock=clock,
+    ).prepare_initial_open(lease, current, _intent())
+    opened = RestartIntentOpenExecutor(
+        store,
+        run_id=RUN_ID,
+    ).execute_initial_open(prepared)
+    return (
+        clock,
+        store,
+        lease_manager,
+        generation_manager,
+        lease,
+        opened,
+        RestartIntentOpenStateReader(store, run_id=RUN_ID),
+    )
+
+
+def _closure_records(
+    opened: CommittedInitialRestartIntentOpen,
+    lease: HeldCoordinatorLease,
+) -> InitialRestartIntentClosureRecords:
+    lifecycle = RestartIntentLifecycleRecord(
+        closed_intent=opened.prepared.head,
+        coordinator_id=lease.record.coordinator_id,
+        lease_id=lease.record.lease_id,
+        coordinator_lease_duration_ms=lease.record.lease_duration_ms,
+        coordinator_fencing_token=lease.fencing_token,
+    )
+    lifecycle_head = RestartIntentLifecycleHeadRecord(
+        run_id=RUN_ID,
+        closure_index=1,
+        generation=opened.prepared.record.intent.generation,
+        intent_id=opened.prepared.record.intent.intent_id,
+        lifecycle_digest=lifecycle.digest,
+    )
+    run_prefix = opened.prepared.intent_head_key.rsplit("/", 1)[0]
+    return InitialRestartIntentClosureRecords(
+        opened=opened,
+        lifecycle=lifecycle,
+        lifecycle_head=lifecycle_head,
+        closed_head=RestartIntentClosedHeadRecord(
+            run_id=RUN_ID,
+            closure_index=1,
+            generation=lifecycle_head.generation,
+            intent_id=lifecycle_head.intent_id,
+            lifecycle_head_digest=lifecycle_head.digest,
+        ),
+        intent_key=opened.prepared.intent_key,
+        intent_head_key=opened.prepared.intent_head_key,
+        closure_key=f"{run_prefix}/restart-intent-closures/1",
+        lifecycle_head_key=opened.prepared.lifecycle_head_key,
+    )
+
+
+def test_open_reader_returns_none_before_initial_open():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+
+    assert RestartIntentOpenStateReader(store, run_id=RUN_ID).read() is None
+
+
+def test_open_reader_reconstructs_committed_open_from_persisted_state():
+    _, _, _, _, _, opened, reader = _state()
+
+    observed = reader.read()
+
+    assert observed == opened
+
+
+def test_open_reader_survives_lease_renewal_and_replacement_after_open():
+    clock, store, lease_manager, _, lease, opened, reader = _state()
+    clock.set(1_010)
+    renewed = lease_manager.renew(lease)
+    clock.set(renewed.expires_at_unix_ms)
+    replacement = _manager(store, clock, "coordinator-b").acquire()
+
+    observed = reader.read()
+
+    assert observed == opened
+    assert replacement.fencing_token != opened.prepared.lease.fencing_token
+
+
+def test_open_reader_rejects_generation_advance_while_intent_is_open():
+    clock, _, _, generation_manager, lease, _, reader = _state()
+    current = generation_manager.current()
+    assert current is not None
+    clock.set(1_010)
+    generation_manager.commit_successor(
+        lease,
+        current,
+        _assignment(generation=1),
+    )
+
+    with pytest.raises(
+        RestartIntentOpenStateCorrupt,
+        match="current generation",
+    ):
+        reader.read()
+
+
+def test_open_reader_rejects_missing_or_malformed_intent_state():
+    _, store, _, _, _, opened, reader = _state()
+    del store._entries[opened.prepared.intent_key]
+
+    with pytest.raises(RestartIntentOpenStateCorrupt, match="missing intent"):
+        reader.read()
+
+    store._entries[opened.prepared.intent_key] = replace(
+        opened.intent_entry,
+        value=b"invalid",
+    )
+    with pytest.raises(RestartIntentOpenStateCorrupt, match="malformed"):
+        reader.read()
+
+
+def test_open_reader_rejects_head_or_intent_link_substitution():
+    _, store, _, _, _, opened, reader = _state()
+    store._entries[opened.prepared.intent_head_key] = replace(
+        opened.head_entry,
+        value=replace(
+            opened.prepared.head,
+            intent_digest="0" * 64,
+        ).to_json(),
+    )
+
+    with pytest.raises(RestartIntentOpenStateCorrupt, match="does not identify"):
+        reader.read()
+
+
+def test_open_reader_rejects_open_head_with_lifecycle_state():
+    _, store, _, _, _, _, reader = _state()
+    store.compare_set(
+        reader.lifecycle_head_key,
+        expected_revision=None,
+        value=b"lifecycle",
+    )
+
+    with pytest.raises(RestartIntentOpenStateCorrupt, match="coexists"):
+        reader.read()
+
+
+def test_open_reader_rejects_deleted_current_head():
+    _, store, _, _, _, opened, reader = _state()
+    store.compare_delete(
+        opened.prepared.intent_head_key,
+        expected_revision=opened.head_entry.revision,
+    )
+
+    with pytest.raises(RestartIntentOpenStateCorrupt, match="disappeared"):
+        reader.read()
+
+
+def test_open_reader_rejects_live_head_without_durable_history():
+    _, store, _, _, _, opened, reader = _state()
+    del store._last_revisions[opened.prepared.intent_head_key]
+
+    with pytest.raises(RestartIntentOpenStateCorrupt, match="no durable history"):
+        reader.read()
+
+
+def test_open_reader_rejects_closed_head_without_lifecycle_state():
+    _, store, _, _, _, opened, reader = _state()
+    records = _closure_records(opened, opened.prepared.lease)
+    store.compare_set(
+        opened.prepared.intent_head_key,
+        expected_revision=opened.head_entry.revision,
+        value=records.closed_head.to_json(),
+    )
+
+    with pytest.raises(RestartIntentOpenStateCorrupt, match="no lifecycle state"):
+        reader.read()
+
+
+def test_open_reader_returns_none_after_atomic_initial_closure():
+    clock, store, _, _, lease, opened, reader = _state()
+    records = _closure_records(opened, lease)
+    clock.set(1_010)
+    store.compare_set_many_guarded(
+        records.writes,
+        guard_key=opened.prepared.coordinator_lease_key,
+        expected_guard_revision=lease.fencing_token,
+        not_before_unix_ms=1_010,
+        deadline_unix_ms=lease.expires_at_unix_ms,
+        conditions=records.conditions,
+    )
+
+    assert reader.read() is None
+
+
+def test_open_reader_rejects_opening_authority_missing_from_history():
+    clock, store, lease_manager, _, lease, _, reader = _state()
+    clock.set(lease.expires_at_unix_ms)
+    lease_manager = _manager(store, clock, "coordinator-b")
+    lease_manager.acquire()
+    store._histories[lease_manager.lease_key] = store._histories[lease_manager.lease_key][1:]
+
+    with pytest.raises(RestartIntentOpenStateCorrupt, match="dependencies"):
+        reader.read()
+
+
+def test_open_reader_is_run_scoped():
+    _, store, _, _, _, _, _ = _state()
+
+    assert RestartIntentOpenStateReader(store, run_id="other-run").read() is None
+    with pytest.raises(ValueError, match="non-empty"):
+        RestartIntentOpenStateReader(store, run_id="")


### PR DESCRIPTION
## Summary

- reconstruct the current initial restart-intent opening from authoritative persisted state
- verify the current head, immutable intent, current generation, durable opening-lease provenance, and store history fail closed
- retry mixed snapshots during concurrent atomic closure and preserve retryable dependency-read errors
- report a closed marker through `RestartIntentOpenStateClosed` without treating it as authenticated closure proof
- reuse the existing prepared and committed opening contracts rather than defining a second interpretation

## Scope

This PR is read-only. It authenticates only an opening that is currently live. Closure validation belongs to the separate lifecycle reader; this component adds no store mutation, lifecycle closure, plan publication, rendezvous behavior, or runtime activation.

## Validation

- `129` focused and adjacent torchrun tests pass
- `1698` CUDA-hidden CPU tests pass
- targeted Ruff and mypy pass
- `git diff --check` passes