### PR TITLE
[Bugfix][GEMINI] Publish checkpoint shards atomically

### DIFF
--- a/docs/gemini.md
+++ b/docs/gemini.md
@@ -148,6 +148,9 @@ SDC. An SDC in one group therefore rejects the candidate on every rank.
 ## Persistence and Recovery
 
 GEMINI serializes only completed slots.
+Each shard is written to a same-directory temporary file, flushed, and atomically renamed before it becomes visible to recovery.
+Restart mirrors use the same publication rule.
+Temporary files left by a terminated writer are ignored and removed before the next write to that shard, while latest-mode recovery walks older generations until it finds the newest shard set that every rank can load and validate.
 At a dense accepted boundary, it persists the latest local CPU checkpoint and received peer replica as recovery-verified.
 At a dynamic recipe-cycle boundary, it persists them as the new candidate and records candidate and recovery-verified steps separately.
 Each rank owns its status sidecar; several workers on one node never update the same mutable trust record.

--- a/lm_resiliency/checkpointing/disk.py
+++ b/lm_resiliency/checkpointing/disk.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import tempfile
 import threading
 import zlib
@@ -41,6 +42,84 @@ _CRC_WORKERS = min(8, os.cpu_count() or 1)
 
 class ChecksumMismatch(Exception):
     """Raised when a loaded shard fails its stored checksum."""
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _cleanup_dead_process_temps(path: Path) -> None:
+    """Remove abandoned temp files while leaving live writers untouched."""
+    prefix = f".{path.name}.pid-"
+    for temporary in path.parent.glob(f"{prefix}*.tmp"):
+        pid_text = temporary.name[len(prefix) :].split(".", 1)[0]
+        try:
+            pid = int(pid_text)
+        except ValueError:
+            continue
+        if pid == os.getpid():
+            continue
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            try:
+                temporary.unlink()
+            except FileNotFoundError:
+                pass
+        except PermissionError:
+            continue
+
+
+def _atomic_torch_save(payload: object, path: Path) -> None:
+    """Durably replace ``path`` without exposing a partially written archive."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _fsync_directory(path.parent.parent)
+    _cleanup_dead_process_temps(path)
+    descriptor, temporary = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.pid-{os.getpid()}.",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            torch.save(payload, handle)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        _fsync_directory(path.parent)
+    finally:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+
+
+def atomic_copy_file(source: Path, destination: Path) -> None:
+    """Durably copy a checkpoint file without exposing partial destination bytes."""
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    _fsync_directory(destination.parent.parent)
+    _cleanup_dead_process_temps(destination)
+    descriptor, temporary = tempfile.mkstemp(
+        dir=destination.parent,
+        prefix=f".{destination.name}.pid-{os.getpid()}.",
+        suffix=".tmp",
+    )
+    os.close(descriptor)
+    try:
+        shutil.copy2(source, temporary)
+        with open(temporary, "rb") as handle:
+            os.fsync(handle.fileno())
+        os.replace(temporary, destination)
+        _fsync_directory(destination.parent)
+    finally:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
 
 
 @dataclass(frozen=True, slots=True)
@@ -241,7 +320,9 @@ class DiskSerializer:
                 step_dir = self._folder / f"step-{step}"
                 step_dir.mkdir(parents=True, exist_ok=True)
                 save_path = step_dir / f"rank-{self._rank}.pt"
-                torch.save(_checkpoint_payload(metadata, tensors_copy, checksums), save_path)
+                _atomic_torch_save(
+                    _checkpoint_payload(metadata, tensors_copy, checksums), save_path
+                )
                 self._latest_flushed_step = step
                 logger.info(f"Flushed checkpoint step {step} to {save_path}")
             except BaseException as e:
@@ -283,7 +364,7 @@ class DiskSerializer:
         save_path = step_dir / f"rank-{target_rank}.pt"
         tensors_copy = [t.clone() for t in tensors]
         checksums = shard_checksums(tensors_copy) if self._integrity else None
-        torch.save(_checkpoint_payload(metadata, tensors_copy, checksums), save_path)
+        _atomic_torch_save(_checkpoint_payload(metadata, tensors_copy, checksums), save_path)
         self._latest_flushed_step = max(self._latest_flushed_step, step)
         logger.info(f"Flushed checkpoint step {step} (rank {target_rank}) to {save_path}")
         return save_path
@@ -333,20 +414,33 @@ class DiskSerializer:
         """Whether a shard file for the given step and rank exists on this node."""
         return (self._folder / f"step-{step}" / f"rank-{rank}.pt").exists()
 
-    def find_latest_on_disk(self) -> int:
-        """Scan the checkpoint folder and return the latest step, or -1."""
+    def find_steps_on_disk(
+        self,
+        rank: int | None = None,
+        *,
+        before_step: int | None = None,
+    ) -> list[int]:
+        """Return published shard generations in descending order."""
         if not self._folder.exists():
-            return -1
+            return []
 
-        latest = -1
+        target_rank = self._rank if rank is None else rank
+        steps: list[int] = []
         for entry in self._folder.iterdir():
             match = _STEP_DIR_PATTERN.fullmatch(entry.name)
-            if match and entry.is_dir():
-                rank_file = entry / f"rank-{self._rank}.pt"
-                if rank_file.exists():
-                    step = int(match.group(1))
-                    latest = max(latest, step)
-        return latest
+            if not match or not entry.is_dir():
+                continue
+            step = int(match.group(1))
+            if before_step is not None and step >= before_step:
+                continue
+            if (entry / f"rank-{target_rank}.pt").is_file():
+                steps.append(step)
+        return sorted(steps, reverse=True)
+
+    def find_latest_on_disk(self, *, before_step: int | None = None) -> int:
+        """Scan the checkpoint folder and return the latest step, or -1."""
+        steps = self.find_steps_on_disk(before_step=before_step)
+        return steps[0] if steps else -1
 
     def cleanup_older_than(self, keep_step: int) -> None:
         """Remove disk checkpoints older than keep_step."""

--- a/lm_resiliency/checkpointing/manager.py
+++ b/lm_resiliency/checkpointing/manager.py
@@ -7,7 +7,6 @@ import atexit
 import enum
 import logging
 import pickle
-import shutil
 import signal
 import threading
 from pathlib import Path
@@ -23,6 +22,7 @@ from lm_resiliency.checkpointing.disk import (
     CheckpointStatus,
     CheckpointStatusStore,
     DiskSerializer,
+    atomic_copy_file,
 )
 from lm_resiliency.checkpointing.replication import ChunkedGlooBackend, PeerReplicator
 from lm_resiliency.checkpointing.state_dict import (
@@ -335,9 +335,25 @@ class InMemoryCheckpointManager:
         dist.all_reduce(tensor, op=dist.ReduceOp.MIN, group=self._process_group)
         return int(tensor.item())
 
-    def _consistent_step(self, disk: DiskSerializer) -> int:
-        """Latest step for which *every* rank has a shard on this disk tier."""
-        return self._collective_min_step(disk.find_latest_on_disk())
+    def _consistent_step(
+        self,
+        disk: DiskSerializer,
+        *,
+        before_step: int | None = None,
+    ) -> int:
+        """Newest exact generation present on every rank below ``before_step``."""
+        candidate = self._collective_min_step(disk.find_latest_on_disk(before_step=before_step))
+        while candidate > 0:
+            local_step = (
+                candidate
+                if disk.has_rank(candidate, self._rank)
+                else disk.find_latest_on_disk(before_step=candidate)
+            )
+            agreed = self._collective_min_step(local_step)
+            if agreed == candidate:
+                return candidate
+            candidate = agreed
+        return -1
 
     def _latest_memory_step(self) -> int:
         """Latest complete own checkpoint currently resident in local memory."""
@@ -429,7 +445,15 @@ class InMemoryCheckpointManager:
         """
         if not self.config.enable:
             return -1
-        step = max(self._recovery_steps(mode))
+        resolved = self._resolved_recovery_mode(mode)
+        memory_step, disk_step = self._recovery_steps(resolved)
+        if disk_step > memory_step:
+            loaded = self._load_latest_collectively_validated_disk_shard(
+                disk_step,
+                allow_older=resolved is RecoveryMode.LATEST_GEMINI,
+            )
+            disk_step = loaded[2] if loaded is not None else -1
+        step = max(memory_step, disk_step)
         return step if step > 0 else -1
 
     def local_recovery_step(self, mode: RecoveryMode | str | None = None) -> int:
@@ -480,10 +504,13 @@ class InMemoryCheckpointManager:
         latest = disk_step
         if latest <= 0:
             return None
-        loaded = self._load_collectively_validated_disk_shard(latest)
+        loaded = self._load_latest_collectively_validated_disk_shard(
+            latest,
+            allow_older=resolved is RecoveryMode.LATEST_GEMINI,
+        )
         if loaded is None:
             return None
-        metadata, tensors = loaded
+        metadata, tensors, latest = loaded
         state_dict = unflatten(metadata, tensors)
         self._metadata = metadata
         logger.info(f"Loaded checkpoint from {self._disk._folder} at step {latest}")
@@ -517,10 +544,13 @@ class InMemoryCheckpointManager:
         latest = disk_step
         if latest <= 0:
             return None
-        loaded = self._load_collectively_validated_disk_shard(latest)
+        loaded = self._load_latest_collectively_validated_disk_shard(
+            latest,
+            allow_older=resolved is RecoveryMode.LATEST_GEMINI,
+        )
         if loaded is None:
             return None
-        metadata, tensors = loaded
+        metadata, tensors, latest = loaded
         self._metadata = metadata
         extra = (metadata.non_tensor_data or {}).get(_EXTRA_KEY)
         logger.info(f"Loaded checkpoint tensors from {self._disk._folder} at step {latest}")
@@ -544,17 +574,34 @@ class InMemoryCheckpointManager:
 
         if local_error is not None:
             logger.error(
-                "Checkpoint validation failed at step %s: %s — all ranks are "
-                "falling back to framework recovery",
+                "Checkpoint validation failed at step %s: %s — all ranks will "
+                "consider an older eligible generation",
                 step,
                 local_error,
             )
         else:
             logger.error(
-                "A peer rejected its checkpoint shard at step %s — all ranks are "
-                "falling back to framework recovery",
+                "A peer rejected its checkpoint shard at step %s — all ranks will "
+                "consider an older eligible generation",
                 step,
             )
+        return None
+
+    def _load_latest_collectively_validated_disk_shard(
+        self,
+        step: int,
+        *,
+        allow_older: bool,
+    ) -> tuple[FlatStateDictMetadata, list[torch.Tensor], int] | None:
+        """Load the newest collectively valid generation, optionally descending."""
+        candidate = step
+        while candidate > 0:
+            loaded = self._load_collectively_validated_disk_shard(candidate)
+            if loaded is not None:
+                return loaded[0], loaded[1], candidate
+            if not allow_older:
+                break
+            candidate = self._consistent_step(self._disk, before_step=candidate)
         return None
 
     @property
@@ -748,7 +795,7 @@ class InMemoryCheckpointManager:
                     continue
                 output = destination / step_dir.name / shard.name
                 output.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(shard, output)
+                atomic_copy_file(shard, output)
                 latest = max(latest, step)
         status = self.checkpoint_status
         for rank in ranks:

--- a/tests/unit/test_checkpoint_recovery.py
+++ b/tests/unit/test_checkpoint_recovery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 from collections import defaultdict
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -19,6 +20,7 @@ from lm_resiliency.checkpointing.disk import (
     CheckpointFormatError,
     ChecksumMismatch,
     DiskSerializer,
+    atomic_copy_file,
     shard_checksums,
 )
 from lm_resiliency.checkpointing.manager import InMemoryCheckpointManager
@@ -108,6 +110,64 @@ def test_disk_integrity_round_trip_and_corruption(tmp_path):
     torch.save(raw, path)
     with pytest.raises(ChecksumMismatch):
         serializer.load(3)
+
+
+def test_disk_save_does_not_publish_partial_replacement(tmp_path):
+    serializer = DiskSerializer(str(tmp_path), rank=0)
+    metadata, tensors = flatten({"w": torch.ones(2)})
+    path = serializer.save_sync(metadata, tensors, step=3)
+
+    def write_partial_then_fail(_payload, handle):
+        handle.write(b"partial checkpoint")
+        raise OSError("disk full")
+
+    replacement_metadata, replacement_tensors = flatten({"w": torch.full((2,), 9.0)})
+    with (
+        patch("lm_resiliency.checkpointing.disk.torch.save", side_effect=write_partial_then_fail),
+        pytest.raises(OSError, match="disk full"),
+    ):
+        serializer.save_sync(replacement_metadata, replacement_tensors, step=3)
+
+    loaded_metadata, loaded_tensors = serializer.load(3)
+    assert torch.equal(unflatten(loaded_metadata, loaded_tensors)["w"], torch.ones(2))
+    assert not list(path.parent.glob("*.tmp"))
+    assert not list(path.parent.glob(".*.tmp"))
+
+
+def test_disk_save_cleans_temp_file_from_dead_writer(tmp_path):
+    step_dir = tmp_path / "step-3"
+    step_dir.mkdir()
+    stale = step_dir / ".rank-0.pt.pid-999999999.stale.tmp"
+    stale.write_bytes(b"partial checkpoint")
+    metadata, tensors = flatten({"w": torch.ones(2)})
+
+    DiskSerializer(str(tmp_path), rank=0).save_sync(metadata, tensors, step=3)
+
+    assert not stale.exists()
+
+
+def test_atomic_copy_does_not_publish_partial_replacement(tmp_path):
+    metadata, tensors = flatten({"w": torch.ones(2)})
+    source = DiskSerializer(str(tmp_path / "source"), rank=0).save_sync(metadata, tensors, step=3)
+    destination_serializer = DiskSerializer(str(tmp_path / "destination"), rank=0)
+    destination = destination_serializer.save_sync(*flatten({"w": torch.full((2,), 7.0)}), step=3)
+
+    def copy_partial_then_fail(_source, temporary):
+        Path(temporary).write_bytes(b"partial checkpoint")
+        raise OSError("copy interrupted")
+
+    with (
+        patch(
+            "lm_resiliency.checkpointing.disk.shutil.copy2",
+            side_effect=copy_partial_then_fail,
+        ),
+        pytest.raises(OSError, match="copy interrupted"),
+    ):
+        atomic_copy_file(source, destination)
+
+    loaded_metadata, loaded_tensors = destination_serializer.load(3)
+    assert torch.equal(unflatten(loaded_metadata, loaded_tensors)["w"], torch.full((2,), 7.0))
+    assert not list(destination.parent.glob(".*.tmp"))
 
 
 def test_gemini_load_returns_none_on_corruption(tmp_path):
@@ -291,7 +351,7 @@ def test_manager_collectively_rejects_valid_shard_when_peer_is_invalid(tmp_path)
     ):
         assert manager.load() is None
 
-    collective.assert_called_once_with(1)
+    assert [entry.args[0] for entry in collective.call_args_list] == [1, -1]
     manager.close()
 
 
@@ -314,7 +374,7 @@ def test_load_tensors_collectively_rejects_invalid_local_shard(tmp_path):
     ):
         assert manager.load_tensors() is None
 
-    collective.assert_called_once_with(0)
+    assert [entry.args[0] for entry in collective.call_args_list] == [0, -1]
     manager.close()
 
 
@@ -335,7 +395,52 @@ def test_manager_votes_invalid_after_unexpected_local_load_error(tmp_path):
     ):
         assert manager.load() is None
 
-    collective.assert_called_once_with(0)
+    assert [entry.args[0] for entry in collective.call_args_list] == [0, -1]
+    manager.close()
+
+
+def test_manager_recovers_older_generation_when_newest_is_malformed(tmp_path):
+    metadata, tensors = flatten({"w": torch.full((2,), 3.0)})
+    DiskSerializer(str(tmp_path), rank=0).save_sync(metadata, tensors, step=3)
+    newest = tmp_path / "step-4" / "rank-0.pt"
+    newest.parent.mkdir()
+    newest.write_bytes(b"torn checkpoint")
+
+    manager = InMemoryCheckpointManager(
+        InMemoryCkptConfig(
+            enable=True,
+            interval=1,
+            disk_flush_interval=0,
+            disk_folder=str(tmp_path),
+        )
+    )
+
+    assert manager.find_latest() == 3
+    recovered = manager.load()
+    assert recovered is not None
+    state, step = recovered
+    assert step == 3
+    assert torch.equal(state["w"], torch.full((2,), 3.0))
+    manager.close()
+
+
+def test_consistent_disk_step_descends_to_exact_common_generation(tmp_path):
+    manager = InMemoryCheckpointManager(
+        InMemoryCkptConfig(
+            enable=True,
+            interval=1,
+            disk_flush_interval=0,
+            disk_folder=str(tmp_path),
+        )
+    )
+    metadata, tensors = flatten({"w": torch.ones(2)})
+    manager._disk.save_sync(metadata, tensors, step=8)
+    manager._disk.save_sync(metadata, tensors, step=10)
+
+    with patch.object(manager, "_collective_min_step", side_effect=[9, 8, 8]) as collective:
+        assert manager._consistent_step(manager._disk) == 8
+
+    assert [entry.args[0] for entry in collective.call_args_list] == [10, 8, 8]
     manager.close()
 
 


### PR DESCRIPTION
## What changed

- publish node-local shards through same-directory temp files, file fsync, atomic rename, and directory fsync
- apply the same atomic publication contract to restart-destination copies
- clean abandoned temp files from dead writers without touching live writers
- enumerate exact rank-common generations instead of assuming the minimum latest step exists everywhere
- walk older latest-mode generations until every rank can load and validate the same shard generation
- document the crash-publication and recovery contract

## Why

Direct writes and copies exposed final `.pt` paths before their archives were complete. Recovery also stopped after rejecting the newest malformed generation, even if an older coherent checkpoint was available. A crash during persistence could therefore turn a recoverable node-local tier into an unnecessary framework fallback.

## Compatibility and impact

The checkpoint payload schema and stable public API are unchanged. Existing final shard files remain readable. Recovery-verified mode continues to use only its explicitly trusted generation; descending fallback applies to latest-mode recovery.

## Validation

- `python -m pytest -q tests/unit/test_checkpoint_recovery.py tests/unit/test_gemini_checkpoint.py tests/unit/test_checkpoint_safe_recovery.py tests/integration/core/test_recovery_equivalence.py` — 59 passed
- `ruff check lm_resiliency/checkpointing/disk.py lm_resiliency/checkpointing/manager.py tests/unit/test_checkpoint_recovery.py`
- `ruff format --check lm_resiliency/checkpointing/disk.py lm_resiliency/checkpointing/manager.py tests/unit/test_checkpoint_recovery.py`
- `git diff --check`

GPU/distributed hardware validation remains outstanding; the exact-generation agreement path is covered with deterministic collective simulations.

Closes #82.