### PR TITLE
[Bugfix][SCOUT] Isolate and supervise OOB channels

### DIFF
--- a/docs/scout.md
+++ b/docs/scout.md
@@ -120,6 +120,9 @@ Use `instrument_dataloader(...)` and `checkpoint_io(...)` for other boundaries.
 
 An explicit `hang_master_addr` or `hang_master_port` selects TCP rendezvous.
 `hang_state_dir` remains available for status files and is used for file rendezvous only when no TCP endpoint is configured.
+Each training publisher and daemon reader share an opaque run-, restart-generation-, process-, peer-group-, and rank-scoped shared-memory name plus an ownership token.
+A live publisher never attaches to or unlinks another owner's segment; a dead owner using the same exact channel can be reclaimed safely.
+Harness construction waits for the daemon's bounded readiness signal, and a supervisor reports unexpected post-start daemon exit as `oob_daemon_failure` while foreground step boundaries also fail explicitly if protection is unavailable.
 
 ## Checkpoint Certification and Recovery
 

--- a/lm_resiliency/detection/hang_detector.py
+++ b/lm_resiliency/detection/hang_detector.py
@@ -139,6 +139,8 @@ class HangDetectionDaemon:
         checkpoint_io_latency_threshold_s: float = 30.0,
         checkpoint_io_min_slowdown_ratio: float = 2.0,
         checkpoint_io_confirmation_rounds: int = 2,
+        tracker_name: str | None = None,
+        tracker_token: bytes | None = None,
     ) -> None:
         self._rank = rank
         self._world_size = world_size
@@ -175,7 +177,11 @@ class HangDetectionDaemon:
             raise ValueError("confirmation_interval_s must be positive")
 
         self._c3 = C3(group=group)
-        self._reader = OpTrackerReader(rank=rank)
+        self._reader = OpTrackerReader(
+            rank=rank,
+            shm_name=tracker_name,
+            owner_token=tracker_token,
+        )
         self._last_op_id: int = -1
         self._last_step: int = -1
         self._last_change_time: float = time.time()

--- a/lm_resiliency/detection/hang_instrumentation.py
+++ b/lm_resiliency/detection/hang_instrumentation.py
@@ -241,9 +241,16 @@ class HangInstrumentation:
         rank: int,
         *,
         progress_event: Any | None = None,
+        tracker_name: str | None = None,
+        tracker_token: bytes | None = None,
     ) -> None:
         del model
-        self._tracker = OpTracker(rank, progress_event=progress_event)
+        self._tracker = OpTracker(
+            rank,
+            progress_event=progress_event,
+            shm_name=tracker_name,
+            owner_token=tracker_token,
+        )
         self._hooks: list[Any] = []
         self._saved_collectives: dict[str, Any] = {}
         self._collective_wrappers: dict[str, Any] = {}

--- a/lm_resiliency/detection/oob_service.py
+++ b/lm_resiliency/detection/oob_service.py
@@ -4,11 +4,13 @@
 from __future__ import annotations
 
 import ctypes
+import hashlib
 import logging
 import multiprocessing
 import os
 import queue
 import re
+import secrets
 import signal
 import threading
 import traceback
@@ -64,18 +66,35 @@ class OOBHangService:
         self._progress_event = self._context.Event()
         self._ready_event = self._context.Event()
         self._process: multiprocessing.Process | None = None
+        self._tracker_name = _tracker_channel_name(global_rank, peer_ranks)
+        self._tracker_token = secrets.token_bytes(16)
         self._report_callback = report_callback
         self._report_queue = self._context.Queue() if report_callback is not None else None
         self._report_thread: threading.Thread | None = None
+        self._monitor_thread: threading.Thread | None = None
+        self._failure: RuntimeError | None = None
+        self._closing = False
 
     @property
     def progress_event(self):
         """Local training-to-daemon progress notification."""
         return self._progress_event
 
+    @property
+    def tracker_name(self) -> str:
+        """Opaque shared-memory channel passed to the training-side tracker."""
+        return self._tracker_name
+
+    @property
+    def tracker_token(self) -> bytes:
+        """Ownership token required by both publisher and daemon reader."""
+        return self._tracker_token
+
     def start(self) -> None:
         if self._process is not None:
             return
+        self._closing = False
+        self._failure = None
         if self._report_queue is not None:
             self._report_thread = threading.Thread(
                 target=self._dispatch_reports,
@@ -84,7 +103,7 @@ class OOBHangService:
             )
             self._report_thread.start()
         self._ready_event.clear()
-        self._process = self._context.Process(
+        process = self._context.Process(
             target=_daemon_main,
             args=(
                 self._global_rank,
@@ -93,11 +112,29 @@ class OOBHangService:
                 self._progress_event,
                 self._ready_event,
                 self._report_queue,
+                self._tracker_name,
+                self._tracker_token,
             ),
             name=f"scout-oob-rank-{self._global_rank}",
             daemon=True,
         )
-        self._process.start()
+        try:
+            process.start()
+        except BaseException:
+            if self._report_queue is not None:
+                self._report_queue.put(None)
+            if self._report_thread is not None:
+                self._report_thread.join(timeout=2.0)
+                self._report_thread = None
+            raise
+        self._process = process
+        self._monitor_thread = threading.Thread(
+            target=self._supervise_child,
+            args=(process,),
+            name=f"scout-oob-supervisor-rank-{self._global_rank}",
+            daemon=True,
+        )
+        self._monitor_thread.start()
 
     def wait_until_ready(self, timeout_s: float | None = None) -> None:
         """Wait until the child has joined its independent process group."""
@@ -111,8 +148,19 @@ class OOBHangService:
                     f"SCOUT OOB daemon exited before readiness with code {process.exitcode}"
                 )
             raise TimeoutError(f"SCOUT OOB daemon was not ready within {timeout:.1f}s")
+        self.ensure_healthy(require_ready=True)
+
+    def ensure_healthy(self, *, require_ready: bool = True) -> None:
+        """Raise when the supervised child is unavailable or exited."""
+        process = self._process
+        if process is None:
+            raise RuntimeError("SCOUT OOB service has not been started")
+        if self._failure is not None:
+            raise self._failure
+        if require_ready and not self._ready_event.is_set():
+            raise RuntimeError("SCOUT OOB daemon has not reported readiness")
         if not process.is_alive():
-            raise RuntimeError(f"SCOUT OOB daemon exited at readiness with code {process.exitcode}")
+            raise RuntimeError(f"SCOUT OOB daemon exited unexpectedly with code {process.exitcode}")
 
     @property
     def pid(self) -> int | None:
@@ -127,21 +175,46 @@ class OOBHangService:
         return self._process.exitcode if self._process is not None else None
 
     def close(self) -> None:
+        self._closing = True
         process = self._process
         self._process = None
-        if process is None:
-            return
-        if process.is_alive():
-            process.terminate()
-        process.join(timeout=5.0)
-        if process.is_alive():
-            process.kill()
-            process.join(timeout=2.0)
+        if process is not None:
+            if process.is_alive():
+                process.terminate()
+            process.join(timeout=5.0)
+            if process.is_alive():
+                process.kill()
+                process.join(timeout=2.0)
+            if self._monitor_thread is not None:
+                self._monitor_thread.join(timeout=2.0)
+                self._monitor_thread = None
         if self._report_queue is not None:
             self._report_queue.put(None)
         if self._report_thread is not None:
             self._report_thread.join(timeout=2.0)
             self._report_thread = None
+
+    def _supervise_child(self, process: multiprocessing.Process) -> None:
+        process.join()
+        if self._closing:
+            return
+        failure = RuntimeError(
+            f"SCOUT OOB daemon for rank {self._global_rank} exited unexpectedly "
+            f"with code {process.exitcode}"
+        )
+        self._failure = failure
+        report: SCOUTFaultReport = {
+            "failed_ranks": [self._global_rank],
+            "kind": "oob_daemon_failure",
+            "scope": "rank",
+            "sources": ["oob_daemon"],
+            "exit_code": process.exitcode,
+            "reason": str(failure),
+        }
+        if self._report_queue is not None:
+            self._report_queue.put(report)
+        else:
+            logger.critical("%s", failure)
 
     def _dispatch_reports(self) -> None:
         assert self._report_queue is not None
@@ -166,6 +239,8 @@ def _daemon_main(
     progress_event,
     ready_event,
     report_queue,
+    tracker_name: str,
+    tracker_token: bytes,
 ) -> None:
     _set_parent_death_signal()
     local_rank = peer_ranks.index(global_rank)
@@ -198,6 +273,8 @@ def _daemon_main(
             checkpoint_io_latency_threshold_s=config.checkpoint_io_latency_threshold_s,
             checkpoint_io_min_slowdown_ratio=config.checkpoint_io_min_slowdown_ratio,
             checkpoint_io_confirmation_rounds=config.checkpoint_io_confirmation_rounds,
+            tracker_name=tracker_name,
+            tracker_token=tracker_token,
         )
         _write_daemon_status(config, global_rank, "ready")
         ready_event.set()
@@ -304,6 +381,27 @@ def _group_port(peer_ranks: list[int]) -> int:
     base = int(os.environ.get("LM_SCOUT_OOB_PORT", int(os.environ.get("MASTER_PORT", 29500)) + 100))
     group_hash = sum((index + 1) * (rank + 1) for index, rank in enumerate(peer_ranks))
     return 1024 + ((base - 1024 + group_hash) % (65535 - 1024))
+
+
+def _tracker_channel_name(global_rank: int, peer_ranks: list[int]) -> str:
+    run_id = (
+        os.environ.get("TORCHELASTIC_RUN_ID")
+        or os.environ.get("LM_RUN_ID")
+        or os.environ.get("SLURM_JOB_ID")
+        or f"{os.environ.get('MASTER_ADDR', 'local')}:{os.environ.get('MASTER_PORT', 'none')}"
+    )
+    generation = os.environ.get("TORCHELASTIC_RESTART_COUNT", "0")
+    identity = "|".join(
+        (
+            run_id,
+            generation,
+            str(os.getpid()),
+            str(global_rank),
+            ",".join(str(rank) for rank in peer_ranks),
+        )
+    )
+    digest = hashlib.blake2s(identity.encode("utf-8"), digest_size=16).hexdigest()
+    return f"scout_op_{digest}"
 
 
 def _rendezvous_method(

--- a/lm_resiliency/detection/op_tracker.py
+++ b/lm_resiliency/detection/op_tracker.py
@@ -18,6 +18,7 @@ confirmed across ranks after a sustained stall.
 from __future__ import annotations
 
 import enum
+import os
 import struct
 import time
 from dataclasses import dataclass
@@ -28,9 +29,12 @@ from typing import Any
 # collective metadata fingerprint (int64), active diagnostic stage
 # (kind, key, sequence, start_ns), and most recently completed diagnostic stage
 # (kind, key, sequence, duration_ns).
-_SHM_FMT = "qd" + ("q" * 10)
-_SHM_SIZE = struct.calcsize(_SHM_FMT)
+_OWNER_FMT = "q16s"
+_OWNER_SIZE = struct.calcsize(_OWNER_FMT)
+_PROGRESS_FMT = "qd" + ("q" * 10)
+_SHM_SIZE = _OWNER_SIZE + struct.calcsize(_PROGRESS_FMT)
 _SHM_NAME_PREFIX = "scout_op_tracker_rank_"
+_DEFAULT_OWNER_TOKEN = bytes(16)
 _PROGRESS_SIGNAL_INTERVAL_NS = 500_000_000
 
 
@@ -71,8 +75,20 @@ class ProgressSnapshot:
     completed_stage_duration_ns: int
 
 
-def _shm_name(rank: int) -> str:
-    return f"{_SHM_NAME_PREFIX}{rank}"
+def _shm_name(rank: int, namespace: str | None = None) -> str:
+    return namespace or f"{_SHM_NAME_PREFIX}{rank}"
+
+
+def _pid_is_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
 
 
 def _diagnostic_stage(value: int) -> DiagnosticStage:
@@ -96,7 +112,14 @@ class OpTracker:
         rank: This process's global rank.
     """
 
-    def __init__(self, rank: int, progress_event: Any | None = None) -> None:
+    def __init__(
+        self,
+        rank: int,
+        progress_event: Any | None = None,
+        *,
+        shm_name: str | None = None,
+        owner_token: bytes | None = None,
+    ) -> None:
         self._rank = rank
         self._progress_event = progress_event
         self._last_progress_signal_ns = 0
@@ -112,24 +135,39 @@ class OpTracker:
         self._completed_stage_key: int = 0
         self._completed_stage_sequence: int = 0
         self._completed_stage_duration_ns: int = 0
-        self._shm_name = _shm_name(rank)
+        self._shm_name = _shm_name(rank, shm_name)
+        self._owner_token = _DEFAULT_OWNER_TOKEN if owner_token is None else owner_token
+        if len(self._owner_token) != 16:
+            raise ValueError("SCOUT op tracker owner token must contain exactly 16 bytes")
 
-        # Create or attach to existing shared memory
+        # Never attach to another live publisher. A dead owner may leave its
+        # segment behind after SIGKILL, in which case the exact channel name is
+        # safe to reclaim.
         try:
             self._shm = shared_memory.SharedMemory(name=self._shm_name, create=True, size=_SHM_SIZE)
         except FileExistsError:
+            existing = shared_memory.SharedMemory(name=self._shm_name, create=False)
+            try:
+                if existing.size < _OWNER_SIZE:
+                    raise FileExistsError(
+                        f"SCOUT op tracker channel {self._shm_name!r} has an unknown live owner"
+                    )
+                owner_pid, _ = struct.unpack_from(_OWNER_FMT, existing.buf, 0)
+                if _pid_is_alive(owner_pid):
+                    raise FileExistsError(
+                        f"SCOUT op tracker channel {self._shm_name!r} is owned by live "
+                        f"process {owner_pid}"
+                    )
+                existing.unlink()
+            finally:
+                existing.close()
             self._shm = shared_memory.SharedMemory(
-                name=self._shm_name, create=False, size=_SHM_SIZE
+                name=self._shm_name,
+                create=True,
+                size=_SHM_SIZE,
             )
-            if self._shm.size < _SHM_SIZE:
-                self._shm.close()
-                stale = shared_memory.SharedMemory(name=self._shm_name, create=False)
-                stale.unlink()
-                stale.close()
-                self._shm = shared_memory.SharedMemory(
-                    name=self._shm_name, create=True, size=_SHM_SIZE
-                )
 
+        struct.pack_into(_OWNER_FMT, self._shm.buf, 0, os.getpid(), self._owner_token)
         self._write(force_signal=True)
 
     def advance(self, metadata_fingerprint: int = 0, *, force_signal: bool = False) -> None:
@@ -202,9 +240,9 @@ class OpTracker:
 
     def _write(self, *, force_signal: bool = False) -> None:
         struct.pack_into(
-            _SHM_FMT,
+            _PROGRESS_FMT,
             self._shm.buf,
-            0,
+            _OWNER_SIZE,
             self._op_id,
             time.time(),
             self._step,
@@ -232,7 +270,13 @@ class OpTracker:
         """Release shared memory. Call during shutdown."""
         try:
             self._shm.close()
-            self._shm.unlink()
+            current = shared_memory.SharedMemory(name=self._shm_name, create=False)
+            try:
+                _, token = struct.unpack_from(_OWNER_FMT, current.buf, 0)
+                if token == self._owner_token:
+                    current.unlink()
+            finally:
+                current.close()
         except FileNotFoundError:
             pass
 
@@ -251,15 +295,36 @@ class OpTrackerReader:
         rank: The rank whose shared memory to read.
     """
 
-    def __init__(self, rank: int) -> None:
+    def __init__(
+        self,
+        rank: int,
+        *,
+        shm_name: str | None = None,
+        owner_token: bytes | None = None,
+    ) -> None:
         self._rank = rank
-        self._shm_name = _shm_name(rank)
+        self._shm_name = _shm_name(rank, shm_name)
+        self._owner_token = _DEFAULT_OWNER_TOKEN if owner_token is None else owner_token
+        if len(self._owner_token) != 16:
+            raise ValueError("SCOUT op tracker owner token must contain exactly 16 bytes")
         self._shm: shared_memory.SharedMemory | None = None
 
     def attach(self) -> bool:
         """Attach to the training process's shared memory. Returns False if not found."""
         try:
-            self._shm = shared_memory.SharedMemory(name=self._shm_name, create=False)
+            candidate = shared_memory.SharedMemory(name=self._shm_name, create=False)
+            if candidate.size < _SHM_SIZE:
+                candidate.close()
+                raise RuntimeError(
+                    f"SCOUT op tracker channel {self._shm_name!r} has an incompatible layout"
+                )
+            _, token = struct.unpack_from(_OWNER_FMT, candidate.buf, 0)
+            if token != self._owner_token:
+                candidate.close()
+                raise RuntimeError(
+                    f"SCOUT op tracker channel {self._shm_name!r} ownership token mismatch"
+                )
+            self._shm = candidate
             return True
         except FileNotFoundError:
             return False
@@ -296,7 +361,7 @@ class OpTrackerReader:
                 completed_stage_sequence=0,
                 completed_stage_duration_ns=0,
             )
-        values = struct.unpack_from(_SHM_FMT, self._shm.buf, 0)
+        values = struct.unpack_from(_PROGRESS_FMT, self._shm.buf, _OWNER_SIZE)
         return ProgressSnapshot(
             op_id=values[0],
             heartbeat=values[1],

--- a/lm_resiliency/detection/replay_harness.py
+++ b/lm_resiliency/detection/replay_harness.py
@@ -635,6 +635,7 @@ class ModelReplayHarness:
 
         Returns ReplayResult if detection ran this step, None otherwise.
         """
+        self._ensure_oob_healthy()
         self._step_count += 1
         self._snapshot_all_to_all_recipes()
         result = None
@@ -670,6 +671,7 @@ class ModelReplayHarness:
 
     def mark_step_boundary(self) -> None:
         """Publish an externally counted step without running scheduled replay."""
+        self._ensure_oob_healthy()
         if self._hang_instrumentation is not None:
             self._hang_instrumentation.step_boundary()
 
@@ -1299,8 +1301,22 @@ class ModelReplayHarness:
             self._layers,
             global_rank,
             progress_event=self._oob_service.progress_event,
+            tracker_name=self._oob_service.tracker_name,
+            tracker_token=self._oob_service.tracker_token,
         )
-        self._oob_service.start()
+        try:
+            self._oob_service.start()
+            self._oob_service.wait_until_ready()
+        except BaseException:
+            self._hang_instrumentation.close()
+            self._hang_instrumentation = None
+            self._oob_service.close()
+            self._oob_service = None
+            raise
+
+    def _ensure_oob_healthy(self) -> None:
+        if self._oob_service is not None:
+            self._oob_service.ensure_healthy()
 
     @property
     def last_result(self) -> ReplayResult | None:

--- a/lm_resiliency/detection/reports.py
+++ b/lm_resiliency/detection/reports.py
@@ -46,6 +46,8 @@ class SCOUTFaultReport(TypedDict, total=False):
     slow_groups: list[str]
     healthy_groups: list[str]
     confidence: float
+    exit_code: int | None
+    reason: str
 
 
 SCOUTFaultCallback = Callable[[SCOUTFaultReport], None]

--- a/tests/unit/test_oob_service.py
+++ b/tests/unit/test_oob_service.py
@@ -42,6 +42,46 @@ def test_readiness_wait_reports_early_child_exit():
         service.wait_until_ready(timeout_s=0.0)
 
 
+def test_health_check_reports_post_start_child_exit():
+    service = _unstarted_service()
+    service._ready_event.set()
+    service._process = Mock(is_alive=Mock(return_value=False), exitcode=23)
+
+    with pytest.raises(RuntimeError, match="exited unexpectedly with code 23"):
+        service.ensure_healthy()
+
+
+def test_supervisor_publishes_child_failure_to_callback_queue():
+    callback = Mock()
+    service = OOBHangService(
+        global_rank=3,
+        peer_ranks=[2, 3],
+        config=OOBHangConfig(),
+        report_callback=callback,
+    )
+    process = Mock(exitcode=9)
+
+    service._supervise_child(process)
+
+    report = service._report_queue.get(timeout=1.0)
+    assert report["kind"] == "oob_daemon_failure"
+    assert report["failed_ranks"] == [3]
+    assert report["exit_code"] == 9
+    service._report_queue.close()
+
+
+def test_tracker_channel_is_namespaced_by_run_generation_process_and_rank(monkeypatch):
+    monkeypatch.setenv("LM_RUN_ID", "job-a")
+    monkeypatch.setenv("TORCHELASTIC_RESTART_COUNT", "4")
+
+    rank_zero = OOBHangService(global_rank=0, peer_ranks=[0, 1], config=OOBHangConfig())
+    rank_one = OOBHangService(global_rank=1, peer_ranks=[0, 1], config=OOBHangConfig())
+    assert rank_zero.tracker_name != rank_one.tracker_name
+    assert rank_zero.tracker_name.startswith("scout_op_")
+    assert "job-a" not in rank_zero.tracker_name
+    assert rank_zero.tracker_token != rank_one.tracker_token
+
+
 def test_tcp_rendezvous_owns_a_store_instead_of_reusing_torchrun_agent_store():
     timeout = timedelta(seconds=10)
     store = object()

--- a/tests/unit/test_op_tracker.py
+++ b/tests/unit/test_op_tracker.py
@@ -91,6 +91,24 @@ class TestOpTracker(unittest.TestCase):
 
     def test_shm_name(self):
         self.assertEqual(_shm_name(99), "scout_op_tracker_rank_99")
+        self.assertEqual(_shm_name(99, "opaque-channel"), "opaque-channel")
+
+    def test_live_owner_collision_does_not_attach_or_unlink(self):
+        name = "scout_test_owner_collision"
+        owner = OpTracker(rank=102, shm_name=name, owner_token=b"a" * 16)
+        try:
+            with self.assertRaisesRegex(FileExistsError, "owned by live process"):
+                OpTracker(rank=102, shm_name=name, owner_token=b"b" * 16)
+
+            wrong_reader = OpTrackerReader(
+                rank=102,
+                shm_name=name,
+                owner_token=b"b" * 16,
+            )
+            with self.assertRaisesRegex(RuntimeError, "ownership token mismatch"):
+                wrong_reader.attach()
+        finally:
+            owner.close()
 
 
 class TestOpTrackerReader(unittest.TestCase):

--- a/tests/unit/test_replay_harness.py
+++ b/tests/unit/test_replay_harness.py
@@ -1017,18 +1017,46 @@ class TestHookRemoval:
 
             assert service_cls.call_args.kwargs["report_callback"] is oob_callback
             service_cls.return_value.start.assert_called_once()
+            service_cls.return_value.wait_until_ready.assert_called_once()
             instrumentation_cls.assert_called_once_with(
                 model,
                 model.layers,
                 1,
                 progress_event=service_cls.return_value.progress_event,
+                tracker_name=service_cls.return_value.tracker_name,
+                tracker_token=service_cls.return_value.tracker_token,
             )
             dataloader = harness.instrument_dataloader([1, 2])
             assert dataloader._scout_detection_interval == 7
+            harness.mark_step_boundary()
+            service_cls.return_value.ensure_healthy.assert_called_once()
             harness.remove_hooks()
 
         service_cls.return_value.close.assert_called_once()
         instrumentation_cls.return_value.close.assert_called_once()
+
+    def test_oob_startup_failure_cleans_up_partial_instrumentation(self):
+        model = LlamaLikeModel(num_layers=2, hidden_dim=32)
+
+        with (
+            patch.object(dist, "is_initialized", return_value=True),
+            patch.object(dist, "get_world_size", return_value=2),
+            patch.object(dist, "get_rank", return_value=0),
+            patch(
+                "lm_resiliency.detection.replay_harness.HangInstrumentation"
+            ) as instrumentation_cls,
+            patch("lm_resiliency.detection.replay_harness.OOBHangService") as service_cls,
+        ):
+            service_cls.return_value.wait_until_ready.side_effect = TimeoutError("not ready")
+            with pytest.raises(TimeoutError, match="not ready"):
+                ModelReplayHarness(
+                    model,
+                    config=ReplayHarnessConfig(check_interval=7),
+                    layers=model.layers,
+                )
+
+        instrumentation_cls.return_value.close.assert_called_once()
+        service_cls.return_value.close.assert_called_once()
 
     def test_remove_hooks(self):
         model = LlamaLikeModel(num_layers=4, hidden_dim=32)


### PR DESCRIPTION
## What changed

- replace rank-only shared-memory names with opaque run/restart/process/peer-group/rank-scoped channel names
- bind each channel to a 128-bit ownership token passed exactly to the training publisher and daemon reader
- refuse live-owner attachment/unlink, verify reader ownership, and reclaim a dead owner only for the exact requested channel
- wait for bounded child readiness during harness construction and clean up partial startup
- supervise unexpected child exit in a parent thread, emit an `oob_daemon_failure` manager report, and retain an actionable failure
- check daemon health at foreground step boundaries
- document the isolation and supervision contract

## Why

The previous channel name contained only the global rank, so concurrent jobs could attach to or unlink each other's progress segment. The harness also started the daemon without waiting for rendezvous and did not surface a later child exit, silently removing hang protection.

## Compatibility and impact

Existing constructor call shapes remain compatible through optional tracker name/token parameters. The internal shared-memory layout gains an ownership header and is intentionally isolated by a new opaque name. Harness construction now waits up to the existing OOB rendezvous timeout instead of returning before protection is ready.

## Validation

- `python -m pytest -q tests/unit/test_oob_service.py tests/unit/test_replay_harness.py tests/unit/test_orchestration_api.py` — 67 passed
- `ruff check` and `ruff format --check` on all changed Python files
- `git diff --check`

The local sandbox denies POSIX shared-memory creation, so the updated end-to-end `test_op_tracker.py` cases could not execute here; they are included for Linux CI. No GPU validation is required for the ownership/control-plane changes.

Closes #79.