### PR TITLE
[Feature][Torchrun] Decode persisted restart intent closure

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -651,6 +651,15 @@ absent. That signal does not authenticate the closure; the lifecycle reader
 must verify the linked closure records separately. The open-state reader
 performs no mutation.
 
+A frozen `PersistedInitialRestartIntentClosure` value decodes the first
+closure's immutable intent, retained open head, durable closed marker,
+immutable closure record, and lifecycle head from their authoritative store
+entries. It requires canonical bytes, one linked initial closure, immutable
+create-once records, exactly one current-head replacement, canonical
+coordinator-lease guard keys, shared opening and closure transactions, and
+causal transaction order. Generation and durable lease-history authentication
+remain the responsibility of the lifecycle reader that constructs this value.
+
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be
 absent from the next assignment. Policy may additionally quarantine a removed

--- a/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_state.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_state.py
@@ -195,6 +195,7 @@ class PersistedInitialRestartIntentClosure:
             self.closed_head_entry.mutation_sequence != 2
             or self.closed_head_entry.value_sequence != 2
             or self.closed_head_entry.lifetime_sequence != 1
+            or self.closed_head_entry.revision == self.open_head_entry.revision
         ):
             raise ValueError(
                 "PersistedInitialRestartIntentClosure.closed_head_entry does not "

--- a/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_state.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_state.py
@@ -1,0 +1,292 @@
+"""Canonical persisted state for the first restart-intent closure."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+from lm_resiliency.integrations.torchrun._control_store import ControlStoreEntry
+from lm_resiliency.integrations.torchrun._restart_intent_records import (
+    RestartIntentClosedHeadRecord,
+    RestartIntentHeadRecord,
+    RestartIntentLifecycleHeadRecord,
+    RestartIntentLifecycleRecord,
+    RestartIntentRecord,
+)
+
+_CONTROL_PREFIX = "lm_resiliency/torchrun/v1"
+
+
+@dataclass(frozen=True, slots=True)
+class PersistedInitialRestartIntentClosure:
+    """One canonical first closure reconstructed from persisted store entries."""
+
+    intent: RestartIntentRecord
+    open_head: RestartIntentHeadRecord
+    closed_head: RestartIntentClosedHeadRecord
+    lifecycle: RestartIntentLifecycleRecord
+    lifecycle_head: RestartIntentLifecycleHeadRecord
+    intent_entry: ControlStoreEntry
+    open_head_entry: ControlStoreEntry
+    closed_head_entry: ControlStoreEntry
+    lifecycle_entry: ControlStoreEntry
+    lifecycle_head_entry: ControlStoreEntry
+
+    def __post_init__(self) -> None:
+        record_types = (
+            ("intent", self.intent, RestartIntentRecord),
+            ("open_head", self.open_head, RestartIntentHeadRecord),
+            ("closed_head", self.closed_head, RestartIntentClosedHeadRecord),
+            ("lifecycle", self.lifecycle, RestartIntentLifecycleRecord),
+            (
+                "lifecycle_head",
+                self.lifecycle_head,
+                RestartIntentLifecycleHeadRecord,
+            ),
+        )
+        for path, value, expected_type in record_types:
+            if not isinstance(value, expected_type):
+                raise TypeError(
+                    f"PersistedInitialRestartIntentClosure.{path} must be {expected_type.__name__}"
+                )
+        entries = (
+            ("intent_entry", self.intent_entry),
+            ("open_head_entry", self.open_head_entry),
+            ("closed_head_entry", self.closed_head_entry),
+            ("lifecycle_entry", self.lifecycle_entry),
+            ("lifecycle_head_entry", self.lifecycle_head_entry),
+        )
+        for path, entry in entries:
+            if not isinstance(entry, ControlStoreEntry):
+                raise TypeError(
+                    f"PersistedInitialRestartIntentClosure.{path} must be ControlStoreEntry"
+                )
+        self._validate_records()
+        self._validate_entries()
+
+    @classmethod
+    def from_entries(
+        cls,
+        *,
+        run_id: str,
+        intent_entry: ControlStoreEntry,
+        open_head_entry: ControlStoreEntry,
+        closed_head_entry: ControlStoreEntry,
+        lifecycle_entry: ControlStoreEntry,
+        lifecycle_head_entry: ControlStoreEntry,
+    ) -> PersistedInitialRestartIntentClosure:
+        """Decode and validate one first-closure entry bundle."""
+
+        normalized_run_id = _nonempty_string(run_id, "run_id")
+        entries = {
+            "intent": intent_entry,
+            "open_head": open_head_entry,
+            "closed_head": closed_head_entry,
+            "lifecycle": lifecycle_entry,
+            "lifecycle_head": lifecycle_head_entry,
+        }
+        for path, entry in entries.items():
+            if not isinstance(entry, ControlStoreEntry):
+                raise TypeError(f"{path}_entry must be ControlStoreEntry")
+        try:
+            intent = RestartIntentRecord.from_json(intent_entry.value)
+            open_head = RestartIntentHeadRecord.from_json(open_head_entry.value)
+            closed_head = RestartIntentClosedHeadRecord.from_json(closed_head_entry.value)
+            lifecycle = RestartIntentLifecycleRecord.from_json(lifecycle_entry.value)
+            lifecycle_head = RestartIntentLifecycleHeadRecord.from_json(lifecycle_head_entry.value)
+        except (TypeError, ValueError) as error:
+            raise ValueError("persisted initial restart-intent closure is malformed") from error
+        decoded = cls(
+            intent=intent,
+            open_head=open_head,
+            closed_head=closed_head,
+            lifecycle=lifecycle,
+            lifecycle_head=lifecycle_head,
+            intent_entry=intent_entry,
+            open_head_entry=open_head_entry,
+            closed_head_entry=closed_head_entry,
+            lifecycle_entry=lifecycle_entry,
+            lifecycle_head_entry=lifecycle_head_entry,
+        )
+        if decoded.intent.intent.run_id != normalized_run_id:
+            raise ValueError("persisted initial restart-intent closure belongs to another run")
+        return decoded
+
+    @property
+    def opened_at_unix_ms(self) -> int:
+        committed_at_unix_ms = self.intent_entry.committed_at_unix_ms
+        if committed_at_unix_ms is None:
+            raise AssertionError("validated opening lost its commit time")
+        return committed_at_unix_ms
+
+    @property
+    def closed_at_unix_ms(self) -> int:
+        committed_at_unix_ms = self.closed_head_entry.committed_at_unix_ms
+        if committed_at_unix_ms is None:
+            raise AssertionError("validated closure lost its commit time")
+        return committed_at_unix_ms
+
+    @property
+    def opening_transaction_sequence(self) -> int:
+        return self.intent_entry.transaction_sequence
+
+    @property
+    def closing_transaction_sequence(self) -> int:
+        return self.closed_head_entry.transaction_sequence
+
+    def _validate_records(self) -> None:
+        if (
+            self.intent.intent.run_id != self.open_head.run_id
+            or self.intent.intent.generation != self.open_head.generation
+            or self.intent.intent.intent_id != self.open_head.intent_id
+            or self.intent.digest != self.open_head.intent_digest
+            or self.lifecycle.closed_intent != self.open_head
+            or self.lifecycle_head.run_id != self.open_head.run_id
+            or self.lifecycle_head.closure_index != 1
+            or self.lifecycle_head.generation != self.open_head.generation
+            or self.lifecycle_head.intent_id != self.open_head.intent_id
+            or self.lifecycle_head.lifecycle_digest != self.lifecycle.digest
+            or self.closed_head.run_id != self.lifecycle_head.run_id
+            or self.closed_head.closure_index != self.lifecycle_head.closure_index
+            or self.closed_head.generation != self.lifecycle_head.generation
+            or self.closed_head.intent_id != self.lifecycle_head.intent_id
+            or self.closed_head.lifecycle_head_digest != self.lifecycle_head.digest
+        ):
+            raise ValueError(
+                "PersistedInitialRestartIntentClosure records do not form one initial closure"
+            )
+
+    def _validate_entries(self) -> None:
+        record_entries = (
+            (self.intent, self.intent_entry, "intent_entry"),
+            (self.open_head, self.open_head_entry, "open_head_entry"),
+            (self.closed_head, self.closed_head_entry, "closed_head_entry"),
+            (self.lifecycle, self.lifecycle_entry, "lifecycle_entry"),
+            (
+                self.lifecycle_head,
+                self.lifecycle_head_entry,
+                "lifecycle_head_entry",
+            ),
+        )
+        for record, entry, path in record_entries:
+            if entry.value != record.to_json():
+                raise ValueError(
+                    f"PersistedInitialRestartIntentClosure.{path} is noncanonical "
+                    "or does not match its record"
+                )
+            if entry.committed_at_unix_ms is None:
+                raise ValueError(f"PersistedInitialRestartIntentClosure.{path} has no commit time")
+        for entry, path in (
+            (self.intent_entry, "intent_entry"),
+            (self.open_head_entry, "open_head_entry"),
+            (self.lifecycle_entry, "lifecycle_entry"),
+            (self.lifecycle_head_entry, "lifecycle_head_entry"),
+        ):
+            if (
+                entry.mutation_sequence != 1
+                or entry.value_sequence != 1
+                or entry.lifetime_sequence != 1
+            ):
+                raise ValueError(
+                    f"PersistedInitialRestartIntentClosure.{path} is not an "
+                    "immutable initial creation"
+                )
+        if (
+            self.closed_head_entry.mutation_sequence != 2
+            or self.closed_head_entry.value_sequence != 2
+            or self.closed_head_entry.lifetime_sequence != 1
+        ):
+            raise ValueError(
+                "PersistedInitialRestartIntentClosure.closed_head_entry does not "
+                "replace exactly one open head"
+            )
+        canonical_guard_key = _coordinator_lease_key(self.intent.intent.run_id)
+        opening_guard = _guard_provenance(self.intent_entry, canonical_guard_key)
+        if _guard_provenance(self.open_head_entry, canonical_guard_key) != opening_guard:
+            raise ValueError(
+                "PersistedInitialRestartIntentClosure opening entries do not share one guard"
+            )
+        if (
+            self.intent_entry.committed_at_unix_ms != self.open_head_entry.committed_at_unix_ms
+            or self.intent_entry.transaction_sequence != self.open_head_entry.transaction_sequence
+        ):
+            raise ValueError(
+                "PersistedInitialRestartIntentClosure opening entries do not share one transaction"
+            )
+        if (
+            self.intent.coordinator_fencing_token != self.intent_entry.guard_revision
+            or self.intent.coordinator_lease_digest != self.intent_entry.guard_value_digest
+        ):
+            raise ValueError(
+                "PersistedInitialRestartIntentClosure opening authority does not match its guard"
+            )
+        closure_entries = (
+            self.closed_head_entry,
+            self.lifecycle_entry,
+            self.lifecycle_head_entry,
+        )
+        closing_guard = _guard_provenance(
+            self.closed_head_entry,
+            canonical_guard_key,
+        )
+        if any(
+            _guard_provenance(entry, canonical_guard_key) != closing_guard
+            for entry in closure_entries[1:]
+        ):
+            raise ValueError(
+                "PersistedInitialRestartIntentClosure closure entries do not share one guard"
+            )
+        if any(
+            entry.committed_at_unix_ms != self.closed_head_entry.committed_at_unix_ms
+            or entry.transaction_sequence != self.closed_head_entry.transaction_sequence
+            for entry in closure_entries[1:]
+        ):
+            raise ValueError(
+                "PersistedInitialRestartIntentClosure closure entries do not share one transaction"
+            )
+        if (
+            self.lifecycle.coordinator_fencing_token != self.closed_head_entry.guard_revision
+            or self.lifecycle.coordinator_lease_digest != self.closed_head_entry.guard_value_digest
+        ):
+            raise ValueError(
+                "PersistedInitialRestartIntentClosure closing authority does not match its guard"
+            )
+        if (
+            self.closing_transaction_sequence <= self.opening_transaction_sequence
+            or self.closed_at_unix_ms < self.opened_at_unix_ms
+        ):
+            raise ValueError(
+                "PersistedInitialRestartIntentClosure closure does not follow its opening"
+            )
+
+
+def _guard_provenance(
+    entry: ControlStoreEntry,
+    expected_guard_key: str,
+) -> tuple[object, ...]:
+    provenance = (
+        entry.guard_key,
+        entry.guard_revision,
+        entry.guard_value_digest,
+        entry.guard_mutation_sequence,
+        entry.guard_value_sequence,
+        entry.guard_lifetime_sequence,
+        entry.guard_committed_at_unix_ms,
+    )
+    if entry.guard_key != expected_guard_key or any(value is None for value in provenance):
+        raise ValueError("PersistedInitialRestartIntentClosure entry has invalid guard provenance")
+    return provenance
+
+
+def _coordinator_lease_key(run_id: str) -> str:
+    run_digest = hashlib.sha256(run_id.encode("utf-8")).hexdigest()
+    return f"{_CONTROL_PREFIX}/runs/{run_digest}/coordinator-lease"
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+__all__ = ["PersistedInitialRestartIntentClosure"]

--- a/tests/unit/test_torchrun_restart_intent_lifecycle_state.py
+++ b/tests/unit/test_torchrun_restart_intent_lifecycle_state.py
@@ -283,6 +283,19 @@ def test_persisted_initial_closure_rejects_invalid_store_sequences(
         )
 
 
+def test_persisted_initial_closure_rejects_reused_head_revision():
+    state, _ = _state()
+
+    with pytest.raises(ValueError, match="replace exactly one"):
+        replace(
+            state,
+            closed_head_entry=replace(
+                state.closed_head_entry,
+                revision=state.open_head_entry.revision,
+            ),
+        )
+
+
 def test_persisted_initial_closure_rejects_noncanonical_guard_key():
     state, _ = _state()
 

--- a/tests/unit/test_torchrun_restart_intent_lifecycle_state.py
+++ b/tests/unit/test_torchrun_restart_intent_lifecycle_state.py
@@ -1,0 +1,400 @@
+"""Contract tests for canonical persisted initial-closure state."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import replace
+from typing import Any, cast
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseManager,
+)
+from lm_resiliency.integrations.torchrun._generation_state import GenerationStateManager
+from lm_resiliency.integrations.torchrun._protocol import (
+    RankAssignment,
+    RestartIntent,
+    SlotAssignment,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_close_records import (
+    InitialRestartIntentClosureRecords,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_lifecycle_state import (
+    PersistedInitialRestartIntentClosure,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open import (
+    RestartIntentOpenPreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
+    RestartIntentOpenExecutor,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_records import (
+    RestartIntentClosedHeadRecord,
+    RestartIntentLifecycleHeadRecord,
+    RestartIntentLifecycleRecord,
+)
+
+RUN_ID = "training-run"
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+    def set(self, now_unix_ms: int) -> None:
+        with self._lock:
+            self.now_unix_ms = now_unix_ms
+
+
+def _state() -> tuple[
+    PersistedInitialRestartIntentClosure,
+    InitialRestartIntentClosureRecords,
+]:
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    lease_manager = CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id="coordinator-a",
+        lease_duration_ms=100,
+        clock=clock,
+    )
+    generation_manager = GenerationStateManager(store, run_id=RUN_ID)
+    lease = lease_manager.acquire()
+    generation_manager.initialize(
+        lease,
+        RankAssignment.from_assignments(
+            run_id=RUN_ID,
+            generation=0,
+            assignments=(
+                SlotAssignment(0, "node-a", 0, 2),
+                SlotAssignment(1, "node-b", 2, 2),
+            ),
+            topology_digest="topology-v1",
+        ),
+    )
+    current = generation_manager.current()
+    assert current is not None
+    opened = RestartIntentOpenExecutor(store, run_id=RUN_ID).execute_initial_open(
+        RestartIntentOpenPreparer(
+            store,
+            run_id=RUN_ID,
+            clock=clock,
+        ).prepare_initial_open(
+            lease,
+            current,
+            RestartIntent(
+                intent_id="intent-a",
+                run_id=RUN_ID,
+                generation=0,
+                incident_ids=("incident-a",),
+                reason_code="attributed_sdc",
+                minimum_recovery_mode="recovery_verified",
+                suspected_node_ids=("node-b",),
+                prepare_deadline_unix_ms=1_200,
+            ),
+        )
+    )
+    lifecycle = RestartIntentLifecycleRecord(
+        closed_intent=opened.prepared.head,
+        coordinator_id=lease.record.coordinator_id,
+        lease_id=lease.record.lease_id,
+        coordinator_lease_duration_ms=lease.record.lease_duration_ms,
+        coordinator_fencing_token=lease.fencing_token,
+    )
+    lifecycle_head = RestartIntentLifecycleHeadRecord(
+        run_id=RUN_ID,
+        closure_index=1,
+        generation=0,
+        intent_id="intent-a",
+        lifecycle_digest=lifecycle.digest,
+    )
+    run_prefix = opened.prepared.intent_head_key.rsplit("/", 1)[0]
+    records = InitialRestartIntentClosureRecords(
+        opened=opened,
+        lifecycle=lifecycle,
+        lifecycle_head=lifecycle_head,
+        closed_head=RestartIntentClosedHeadRecord(
+            run_id=RUN_ID,
+            closure_index=1,
+            generation=0,
+            intent_id="intent-a",
+            lifecycle_head_digest=lifecycle_head.digest,
+        ),
+        intent_key=opened.prepared.intent_key,
+        intent_head_key=opened.prepared.intent_head_key,
+        closure_key=f"{run_prefix}/restart-intent-closures/1",
+        lifecycle_head_key=opened.prepared.lifecycle_head_key,
+    )
+    clock.set(1_010)
+    committed = store.compare_set_many_guarded(
+        records.writes,
+        guard_key=opened.prepared.coordinator_lease_key,
+        expected_guard_revision=lease.fencing_token,
+        not_before_unix_ms=1_010,
+        deadline_unix_ms=lease.expires_at_unix_ms,
+        conditions=records.conditions,
+    )
+    head_history = store.get_history(records.intent_head_key)
+    assert len(head_history) == 2
+    state = PersistedInitialRestartIntentClosure.from_entries(
+        run_id=RUN_ID,
+        intent_entry=opened.intent_entry,
+        open_head_entry=head_history[0],
+        closed_head_entry=committed[records.intent_head_key],
+        lifecycle_entry=committed[records.closure_key],
+        lifecycle_head_entry=committed[records.lifecycle_head_key],
+    )
+    return state, records
+
+
+def test_persisted_initial_closure_decodes_one_canonical_transaction():
+    state, records = _state()
+
+    assert state.intent == records.opened.prepared.record
+    assert state.open_head == records.opened.prepared.head
+    assert state.closed_head == records.closed_head
+    assert state.lifecycle == records.lifecycle
+    assert state.lifecycle_head == records.lifecycle_head
+    assert state.opened_at_unix_ms == records.opened.committed_at_unix_ms
+    assert state.closed_at_unix_ms == 1_010
+    assert state.closing_transaction_sequence > state.opening_transaction_sequence
+
+
+def test_persisted_initial_closure_is_immutable():
+    state, _ = _state()
+
+    with pytest.raises(AttributeError):
+        state.closed_head = state.closed_head
+
+
+def test_persisted_initial_closure_requires_entry_and_record_types():
+    state, _ = _state()
+
+    with pytest.raises(TypeError, match="ControlStoreEntry"):
+        replace(state, intent_entry={})
+    with pytest.raises(TypeError, match="RestartIntentRecord"):
+        replace(state, intent={})
+    with pytest.raises(TypeError, match="ControlStoreEntry"):
+        PersistedInitialRestartIntentClosure.from_entries(
+            run_id=RUN_ID,
+            intent_entry=cast(Any, {}),
+            open_head_entry=state.open_head_entry,
+            closed_head_entry=state.closed_head_entry,
+            lifecycle_entry=state.lifecycle_entry,
+            lifecycle_head_entry=state.lifecycle_head_entry,
+        )
+
+
+@pytest.mark.parametrize(
+    "entry_name",
+    [
+        "intent_entry",
+        "open_head_entry",
+        "closed_head_entry",
+        "lifecycle_entry",
+        "lifecycle_head_entry",
+    ],
+)
+def test_persisted_initial_closure_rejects_malformed_entry(entry_name):
+    state, _ = _state()
+
+    with pytest.raises(ValueError, match="malformed"):
+        PersistedInitialRestartIntentClosure.from_entries(
+            run_id=RUN_ID,
+            intent_entry=replace(state.intent_entry, value=b"{}")
+            if entry_name == "intent_entry"
+            else state.intent_entry,
+            open_head_entry=replace(state.open_head_entry, value=b"{}")
+            if entry_name == "open_head_entry"
+            else state.open_head_entry,
+            closed_head_entry=replace(state.closed_head_entry, value=b"{}")
+            if entry_name == "closed_head_entry"
+            else state.closed_head_entry,
+            lifecycle_entry=replace(state.lifecycle_entry, value=b"{}")
+            if entry_name == "lifecycle_entry"
+            else state.lifecycle_entry,
+            lifecycle_head_entry=replace(state.lifecycle_head_entry, value=b"{}")
+            if entry_name == "lifecycle_head_entry"
+            else state.lifecycle_head_entry,
+        )
+
+
+def test_persisted_initial_closure_rejects_unlinked_records():
+    state, _ = _state()
+    lifecycle = replace(
+        state.lifecycle,
+        closed_intent=replace(state.open_head, intent_id="intent-b"),
+    )
+
+    with pytest.raises(ValueError, match="do not form one"):
+        replace(
+            state,
+            lifecycle=lifecycle,
+            lifecycle_entry=replace(
+                state.lifecycle_entry,
+                value=lifecycle.to_json(),
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    ("entry_name", "changes", "message"),
+    [
+        (
+            "intent_entry",
+            {"mutation_sequence": 2},
+            "immutable initial creation",
+        ),
+        (
+            "lifecycle_head_entry",
+            {
+                "lifetime_sequence": 2,
+                "mutation_sequence": 3,
+                "value_sequence": 2,
+            },
+            "immutable initial creation",
+        ),
+        (
+            "closed_head_entry",
+            {"mutation_sequence": 3, "value_sequence": 3},
+            "replace exactly one",
+        ),
+    ],
+)
+def test_persisted_initial_closure_rejects_invalid_store_sequences(
+    entry_name,
+    changes,
+    message,
+):
+    state, _ = _state()
+
+    with pytest.raises(ValueError, match=message):
+        replace(
+            state,
+            **{entry_name: replace(getattr(state, entry_name), **changes)},
+        )
+
+
+def test_persisted_initial_closure_rejects_noncanonical_guard_key():
+    state, _ = _state()
+
+    with pytest.raises(ValueError, match="guard provenance"):
+        replace(
+            state,
+            lifecycle_entry=replace(
+                state.lifecycle_entry,
+                guard_key="other/coordinator-lease",
+            ),
+        )
+
+
+def test_persisted_initial_closure_rejects_split_open_transaction():
+    state, _ = _state()
+
+    with pytest.raises(ValueError, match="opening entries"):
+        replace(
+            state,
+            open_head_entry=replace(
+                state.open_head_entry,
+                transaction_sequence=state.open_head_entry.transaction_sequence + 1,
+            ),
+        )
+
+
+def test_persisted_initial_closure_rejects_split_close_transaction():
+    state, _ = _state()
+
+    with pytest.raises(ValueError, match="closure entries"):
+        replace(
+            state,
+            lifecycle_entry=replace(
+                state.lifecycle_entry,
+                transaction_sequence=state.lifecycle_entry.transaction_sequence + 1,
+            ),
+        )
+
+
+def test_persisted_initial_closure_rejects_authority_substitution():
+    state, _ = _state()
+
+    with pytest.raises(ValueError, match="opening authority"):
+        replace(
+            state,
+            intent_entry=replace(
+                state.intent_entry,
+                guard_revision=state.intent.coordinator_fencing_token + 1,
+            ),
+            open_head_entry=replace(
+                state.open_head_entry,
+                guard_revision=state.intent.coordinator_fencing_token + 1,
+            ),
+        )
+
+    with pytest.raises(ValueError, match="closing authority"):
+        replace(
+            state,
+            lifecycle_entry=replace(state.lifecycle_entry, guard_revision=2),
+            lifecycle_head_entry=replace(
+                state.lifecycle_head_entry,
+                guard_revision=2,
+            ),
+            closed_head_entry=replace(
+                state.closed_head_entry,
+                guard_revision=2,
+            ),
+        )
+
+
+def test_persisted_initial_closure_rejects_noncausal_close():
+    state, _ = _state()
+
+    with pytest.raises(ValueError, match="does not follow"):
+        replace(
+            state,
+            closed_head_entry=replace(
+                state.closed_head_entry,
+                transaction_sequence=state.opening_transaction_sequence,
+                committed_at_unix_ms=state.opened_at_unix_ms,
+            ),
+            lifecycle_entry=replace(
+                state.lifecycle_entry,
+                transaction_sequence=state.opening_transaction_sequence,
+                committed_at_unix_ms=state.opened_at_unix_ms,
+            ),
+            lifecycle_head_entry=replace(
+                state.lifecycle_head_entry,
+                transaction_sequence=state.opening_transaction_sequence,
+                committed_at_unix_ms=state.opened_at_unix_ms,
+            ),
+        )
+
+
+def test_persisted_initial_closure_is_run_scoped():
+    state, _ = _state()
+
+    with pytest.raises(ValueError, match="another run"):
+        PersistedInitialRestartIntentClosure.from_entries(
+            run_id="other-run",
+            intent_entry=state.intent_entry,
+            open_head_entry=state.open_head_entry,
+            closed_head_entry=state.closed_head_entry,
+            lifecycle_entry=state.lifecycle_entry,
+            lifecycle_head_entry=state.lifecycle_head_entry,
+        )
+    with pytest.raises(ValueError, match="non-empty"):
+        PersistedInitialRestartIntentClosure.from_entries(
+            run_id="",
+            intent_entry=state.intent_entry,
+            open_head_entry=state.open_head_entry,
+            closed_head_entry=state.closed_head_entry,
+            lifecycle_entry=state.lifecycle_entry,
+            lifecycle_head_entry=state.lifecycle_head_entry,
+        )


### PR DESCRIPTION
## Summary

- decode the immutable intent, retained open head, durable closed marker, immutable closure record, and lifecycle head for the first restart-intent closure
- require canonical record bytes, one linked initial closure, immutable create-once records, exactly one current-head replacement, and distinct open/closed revisions
- verify canonical coordinator-lease guard keys, shared opening and closure transactions, authority-to-guard identity, and causal transaction order

## Scope

This PR adds only the immutable persisted-closure value contract. It performs no store reads or mutations and does not authenticate generation or durable coordinator-lease history; the follow-up lifecycle reader will provide those checks.

## Validation

- `150` focused and adjacent torchrun tests pass
- `1717` CUDA-hidden CPU tests pass
- targeted Ruff and mypy pass
- `git diff --check` passes