### PR TITLE
[Bugfix][GEMINI] Bound and key checkpoint transfers

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -569,6 +569,9 @@ if step >= 0 and destination is not None:
 `copy_checkpoint_to` copies flushed local and peer shards.
 Import `make_transfer` from `lm_resiliency.manager_api` when endpoint-addressed manager transfer is required.
 The `"torch_dist"` and `"nixl"` backends share the `CheckpointTransfer` contract.
+Every transfer is keyed, bounded by `timeout_s`, and validates endpoint, tensor layout, byte count, and per-chunk checksums before applying received buffers.
+`TorchDistTransfer` uses a dedicated Gloo pair group even when the training world uses NCCL; both endpoints create the same pair in coordinated order, or the manager may pass an already-created dedicated Gloo `process_group`.
+NIXL is one-sided while the torch-distributed backend requires both endpoints to participate, so `make_transfer("nixl", ...)` fails if NIXL is unavailable unless the manager explicitly sets `allow_backend_fallback=True` after arranging the two-sided protocol.
 
 Launcher retry, placement, replacement, and quarantine policy remain outside this repository.
 

--- a/docs/gemini.md
+++ b/docs/gemini.md
@@ -50,6 +50,8 @@ Validate this assumption when rank placement is not contiguous by node.
 The built-in replication path uses a dedicated Gloo process group.
 It is validated for correctness over TCP and is not a line-rate RDMA implementation.
 Production deployments can use manager-driven Torch Distributed or NIXL transfer APIs for replacement workflows, but automatic checkpoint replication currently uses Gloo.
+Manager-driven transfers bind a key to endpoint and tensor metadata, verify per-chunk checksums, and use bounded waits.
+The torch-distributed backend communicates on a dedicated Gloo group and requires both endpoints; fallback from one-sided NIXL is therefore explicit rather than automatic.
 
 `replication_chunk_size` limits the largest in-flight transfer unit.
 Choose it from measured training communication slack rather than assuming a fixed network rate:

--- a/lm_resiliency/checkpointing/transfer.py
+++ b/lm_resiliency/checkpointing/transfer.py
@@ -23,13 +23,118 @@ result plugs straight into GEMINI's unflatten/load path.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
+import socket
+import threading
+import time
 from abc import ABC, abstractmethod
+from datetime import timedelta
 from typing import Any, Protocol
 
 import torch
 
+from lm_resiliency.checkpointing.disk import shard_checksums
+
 logger = logging.getLogger(__name__)
+
+_TRANSFER_PROTOCOL_VERSION = 1
+_TERMINAL_FAILURE_STATES = {"FAILED", "ERROR", "CANCELLED", "CANCELED", "ABORTED"}
+
+
+def _tensor_manifest(tensors: list[torch.Tensor]) -> list[dict[str, object]]:
+    return [
+        {
+            "shape": list(tensor.shape),
+            "dtype": str(tensor.dtype),
+            "numel": tensor.numel(),
+            "bytes": tensor.numel() * tensor.element_size(),
+        }
+        for tensor in tensors
+    ]
+
+
+def _payload_manifest(
+    tensors: list[torch.Tensor],
+    *,
+    key: str,
+    source_rank: int,
+    destination_rank: int,
+    destination_host: str,
+) -> dict[str, object]:
+    cpu_tensors = [tensor.detach().cpu().contiguous() for tensor in tensors]
+    return {
+        "protocol_version": _TRANSFER_PROTOCOL_VERSION,
+        "key": key,
+        "source_rank": source_rank,
+        "destination_rank": destination_rank,
+        "source_host": socket.gethostname(),
+        "destination_host": destination_host,
+        "tensors": _tensor_manifest(cpu_tensors),
+        "checksums": shard_checksums(cpu_tensors),
+    }
+
+
+def _validate_manifest(
+    manifest: object,
+    buffers: list[torch.Tensor],
+    *,
+    key: str,
+    source_rank: int,
+    destination_rank: int,
+    peer_host: str,
+) -> None:
+    if not isinstance(manifest, dict):
+        raise RuntimeError("checkpoint transfer manifest must be a mapping")
+    expected_fields = {
+        "protocol_version",
+        "key",
+        "source_rank",
+        "destination_rank",
+        "source_host",
+        "destination_host",
+        "tensors",
+        "checksums",
+    }
+    if set(manifest) != expected_fields:
+        raise RuntimeError("checkpoint transfer manifest has unexpected or missing fields")
+    if manifest["protocol_version"] != _TRANSFER_PROTOCOL_VERSION:
+        raise RuntimeError("checkpoint transfer protocol version mismatch")
+    if manifest["key"] != key:
+        raise RuntimeError("checkpoint transfer key mismatch")
+    if manifest["source_rank"] != source_rank or manifest["destination_rank"] != destination_rank:
+        raise RuntimeError("checkpoint transfer endpoint mismatch")
+    if peer_host and manifest["source_host"] != peer_host:
+        raise RuntimeError(
+            f"checkpoint transfer source host mismatch: expected {peer_host!r}, "
+            f"got {manifest['source_host']!r}"
+        )
+    local_host = socket.gethostname()
+    if manifest["destination_host"] and manifest["destination_host"] != local_host:
+        raise RuntimeError(
+            f"checkpoint transfer destination host mismatch: expected {local_host!r}, "
+            f"got {manifest['destination_host']!r}"
+        )
+    if manifest["tensors"] != _tensor_manifest(buffers):
+        raise RuntimeError("checkpoint transfer tensor shape, dtype, or byte-count mismatch")
+    checksums = manifest["checksums"]
+    if not isinstance(checksums, list) or any(type(value) is not int for value in checksums):
+        raise RuntimeError("checkpoint transfer checksum manifest is invalid")
+
+
+def _transfer_tag(key: str) -> int:
+    digest = hashlib.blake2s(key.encode("utf-8"), digest_size=4).digest()
+    return int.from_bytes(digest, "big") % ((1 << 30) - 8)
+
+
+def _validate_request(key: str, *, rank: int, peer_rank: int, peer_host: str) -> None:
+    if not key:
+        raise ValueError("checkpoint transfer key must be non-empty")
+    if rank == peer_rank:
+        raise ValueError("checkpoint transfer peer must differ from the local rank")
+    if not peer_host:
+        raise ValueError("checkpoint transfer peer_host must be non-empty")
 
 
 class TransferMetadataStore(Protocol):
@@ -91,9 +196,26 @@ class NixlCheckpointTransfer(CheckpointTransfer):
         agent_name: str,
         metadata_store: TransferMetadataStore,
         chunk_size: int = 64 * 1024 * 1024,
+        *,
+        rank: int = -1,
+        timeout_s: float = 120.0,
+        poll_interval_s: float = 0.001,
     ) -> None:
+        if timeout_s <= 0:
+            raise ValueError("checkpoint transfer timeout must be positive")
+        if poll_interval_s <= 0:
+            raise ValueError("NIXL poll interval must be positive")
+        if rank < 0:
+            import torch.distributed as dist
+
+            if not dist.is_initialized():
+                raise ValueError("NIXL checkpoint transfer requires the local rank")
+            rank = dist.get_rank()
         self._control = metadata_store
         self._chunk_size = chunk_size
+        self._rank = rank
+        self._timeout_s = timeout_s
+        self._poll_interval_s = poll_interval_s
         self._served: dict[str, list[torch.Tensor]] = {}
         try:
             from nixl._api import nixl_agent, nixl_agent_config  # type: ignore
@@ -104,12 +226,24 @@ class NixlCheckpointTransfer(CheckpointTransfer):
             raise RuntimeError(f"NIXL unavailable: {e}") from e
 
     def serve(self, tensors: list[torch.Tensor], key: str, peer_rank: int, peer_host: str) -> None:
+        _validate_request(key, rank=self._rank, peer_rank=peer_rank, peer_host=peer_host)
+        old_reg = self._reg.pop(key, None)
+        if old_reg is not None:
+            self._agent.deregister_memory(old_reg)
         reg = self._agent.register_memory(tensors)
         self._reg[key] = reg
         self._served[key] = tensors
         self._control.put_transfer_meta(
             key,
             {
+                "transport": "nixl",
+                "manifest": _payload_manifest(
+                    tensors,
+                    key=key,
+                    source_rank=self._rank,
+                    destination_rank=peer_rank,
+                    destination_host=peer_host,
+                ),
                 "agent_meta": self._agent.get_agent_metadata(),
                 "descs": self._agent.get_serialized_descs(reg),
             },
@@ -117,23 +251,61 @@ class NixlCheckpointTransfer(CheckpointTransfer):
         logger.info(f"NIXL serve: published {len(tensors)} tensors under {key}")
 
     def fetch(self, buffers: list[torch.Tensor], key: str, peer_rank: int, peer_host: str) -> None:
-        meta = self._control.get_transfer_meta(key, wait=True)
+        _validate_request(key, rank=self._rank, peer_rank=peer_rank, peer_host=peer_host)
+        meta = self._control.get_transfer_meta(key, wait=True, timeout_s=self._timeout_s)
+        if meta.get("transport") != "nixl":
+            raise RuntimeError("checkpoint transfer metadata backend mismatch")
+        manifest = meta.get("manifest")
+        _validate_manifest(
+            manifest,
+            buffers,
+            key=key,
+            source_rank=peer_rank,
+            destination_rank=self._rank,
+            peer_host=peer_host,
+        )
         peer_agent = self._agent.add_remote_agent(meta["agent_meta"])
         remote_descs = self._agent.deserialize_descs(meta["descs"])
         local_reg = self._agent.register_memory(buffers)
-        local_descs = self._agent.get_xfer_descs(local_reg)
-        xfer = self._agent.initialize_xfer(
-            "READ", local_descs, remote_descs, peer_agent, key.encode()
-        )
-        self._agent.transfer(xfer)
-        while self._agent.check_xfer_state(xfer) != "DONE":
-            pass
+        try:
+            local_descs = self._agent.get_xfer_descs(local_reg)
+            xfer = self._agent.initialize_xfer(
+                "READ", local_descs, remote_descs, peer_agent, key.encode()
+            )
+            self._agent.transfer(xfer)
+            deadline = time.monotonic() + self._timeout_s
+            while True:
+                raw_state = self._agent.check_xfer_state(xfer)
+                state = str(raw_state).upper().rsplit(".", 1)[-1]
+                if state == "DONE":
+                    break
+                if state in _TERMINAL_FAILURE_STATES:
+                    raise RuntimeError(f"NIXL checkpoint transfer {key!r} failed: {raw_state}")
+                if time.monotonic() >= deadline:
+                    cancel = getattr(self._agent, "cancel_xfer", None)
+                    if callable(cancel):
+                        cancel(xfer)
+                    raise TimeoutError(
+                        f"NIXL checkpoint transfer {key!r} exceeded {self._timeout_s:.1f}s"
+                    )
+                time.sleep(self._poll_interval_s)
+            expected = manifest["checksums"]
+            actual = shard_checksums([buffer.detach().cpu().contiguous() for buffer in buffers])
+            if actual != expected:
+                raise RuntimeError(f"NIXL checkpoint transfer {key!r} failed checksum")
+        finally:
+            self._agent.deregister_memory(local_reg)
+            remove_remote = getattr(self._agent, "remove_remote_agent", None)
+            if callable(remove_remote):
+                remove_remote(peer_agent)
         logger.info(f"NIXL fetch: pulled {len(buffers)} tensors for {key}")
 
     def close(self) -> None:
         try:
             for key, reg in getattr(self, "_reg", {}).items():
                 self._agent.deregister_memory(reg)
+            self._reg.clear()
+            self._served.clear()
         except Exception:  # pragma: no cover
             pass
 
@@ -147,31 +319,228 @@ class TorchDistTransfer(CheckpointTransfer):
     ChunkedGlooBackend so a partial NIC is not overwhelmed.
     """
 
-    def __init__(self, rank: int, chunk_size: int = 64 * 1024 * 1024) -> None:
+    def __init__(
+        self,
+        rank: int,
+        chunk_size: int = 64 * 1024 * 1024,
+        *,
+        timeout_s: float = 120.0,
+        process_group: object | None = None,
+    ) -> None:
         import torch.distributed as dist
 
         if not dist.is_initialized():
             raise RuntimeError("torch.distributed must be initialized for TorchDistTransfer")
+        if chunk_size <= 0:
+            raise ValueError("checkpoint transfer chunk_size must be positive")
+        if timeout_s <= 0:
+            raise ValueError("checkpoint transfer timeout must be positive")
         self._dist = dist
+        actual_rank = dist.get_rank()
+        if rank != actual_rank:
+            raise ValueError(
+                f"TorchDistTransfer rank {rank} does not match distributed rank {actual_rank}"
+            )
         self._rank = rank
         self._chunk_size = chunk_size
+        self._timeout_s = timeout_s
+        self._wait_timeout = timedelta(seconds=timeout_s)
+        self._provided_group = process_group
+        self._groups: dict[int, object] = {}
+        self._group_lock = threading.Lock()
+        if process_group is not None and str(dist.get_backend(process_group)).lower() != "gloo":
+            raise ValueError("TorchDistTransfer requires a dedicated Gloo process group")
+
+    def _group_for_peer(self, peer_rank: int) -> object:
+        if self._provided_group is not None:
+            return self._provided_group
+        with self._group_lock:
+            group = self._groups.get(peer_rank)
+            if group is None:
+                group = self._dist.new_group(
+                    ranks=sorted((self._rank, peer_rank)),
+                    backend="gloo",
+                    timeout=self._wait_timeout,
+                    use_local_synchronization=True,
+                )
+                self._groups[peer_rank] = group
+            return group
+
+    def _wait(self, work: object, *, operation: str) -> None:
+        try:
+            completed = work.wait(timeout=self._wait_timeout)
+        except Exception as error:
+            raise TimeoutError(
+                f"checkpoint transfer {operation} exceeded {self._timeout_s:.1f}s"
+            ) from error
+        if completed is False:
+            raise TimeoutError(f"checkpoint transfer {operation} exceeded {self._timeout_s:.1f}s")
+
+    def _send(
+        self,
+        tensor: torch.Tensor,
+        *,
+        peer_rank: int,
+        group: object,
+        tag: int,
+        operation: str,
+    ) -> None:
+        work = self._dist.isend(tensor, dst=peer_rank, group=group, tag=tag)
+        self._wait(work, operation=operation)
+
+    def _recv(
+        self,
+        tensor: torch.Tensor,
+        *,
+        peer_rank: int,
+        group: object,
+        tag: int,
+        operation: str,
+    ) -> None:
+        work = self._dist.irecv(tensor, src=peer_rank, group=group, tag=tag)
+        self._wait(work, operation=operation)
 
     def serve(self, tensors: list[torch.Tensor], key: str, peer_rank: int, peer_host: str) -> None:
-        for t in tensors:
-            flat = t.contiguous().view(-1)
+        _validate_request(key, rank=self._rank, peer_rank=peer_rank, peer_host=peer_host)
+        cpu_tensors = [tensor.detach().cpu().contiguous() for tensor in tensors]
+        manifest = _payload_manifest(
+            cpu_tensors,
+            key=key,
+            source_rank=self._rank,
+            destination_rank=peer_rank,
+            destination_host=peer_host,
+        )
+        encoded = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        tag = _transfer_tag(key)
+        group = self._group_for_peer(peer_rank)
+        self._send(
+            torch.tensor([len(encoded)], dtype=torch.int64),
+            peer_rank=peer_rank,
+            group=group,
+            tag=tag,
+            operation=f"{key!r} manifest length send",
+        )
+        self._send(
+            torch.tensor(list(encoded), dtype=torch.uint8),
+            peer_rank=peer_rank,
+            group=group,
+            tag=tag + 1,
+            operation=f"{key!r} manifest send",
+        )
+        accepted = torch.zeros(1, dtype=torch.int32)
+        self._recv(
+            accepted,
+            peer_rank=peer_rank,
+            group=group,
+            tag=tag + 2,
+            operation=f"{key!r} preflight acknowledgement",
+        )
+        if accepted.item() != 1:
+            raise RuntimeError(f"checkpoint transfer {key!r} was rejected by the destination")
+        for tensor in cpu_tensors:
+            flat = tensor.view(-1)
             elems = max(1, self._chunk_size // flat.element_size())
             for off in range(0, flat.numel(), elems):
-                self._dist.send(flat[off : off + elems], dst=peer_rank)
+                self._send(
+                    flat[off : off + elems],
+                    peer_rank=peer_rank,
+                    group=group,
+                    tag=tag + 3,
+                    operation=f"{key!r} payload send",
+                )
+        verified = torch.zeros(1, dtype=torch.int32)
+        self._recv(
+            verified,
+            peer_rank=peer_rank,
+            group=group,
+            tag=tag + 4,
+            operation=f"{key!r} checksum acknowledgement",
+        )
+        if verified.item() != 1:
+            raise RuntimeError(f"checkpoint transfer {key!r} failed destination checksum")
 
     def fetch(self, buffers: list[torch.Tensor], key: str, peer_rank: int, peer_host: str) -> None:
-        for b in buffers:
-            flat = b.contiguous().view(-1)
+        _validate_request(key, rank=self._rank, peer_rank=peer_rank, peer_host=peer_host)
+        tag = _transfer_tag(key)
+        group = self._group_for_peer(peer_rank)
+        encoded_size = torch.zeros(1, dtype=torch.int64)
+        self._recv(
+            encoded_size,
+            peer_rank=peer_rank,
+            group=group,
+            tag=tag,
+            operation=f"{key!r} manifest length receive",
+        )
+        size = int(encoded_size.item())
+        if size <= 0 or size > 64 * 1024 * 1024:
+            raise RuntimeError(f"checkpoint transfer {key!r} manifest size is invalid")
+        encoded = torch.empty(size, dtype=torch.uint8)
+        self._recv(
+            encoded,
+            peer_rank=peer_rank,
+            group=group,
+            tag=tag + 1,
+            operation=f"{key!r} manifest receive",
+        )
+        try:
+            manifest = json.loads(bytes(encoded.tolist()))
+            _validate_manifest(
+                manifest,
+                buffers,
+                key=key,
+                source_rank=peer_rank,
+                destination_rank=self._rank,
+                peer_host=peer_host,
+            )
+        except Exception:
+            self._send(
+                torch.zeros(1, dtype=torch.int32),
+                peer_rank=peer_rank,
+                group=group,
+                tag=tag + 2,
+                operation=f"{key!r} preflight rejection",
+            )
+            raise
+        self._send(
+            torch.ones(1, dtype=torch.int32),
+            peer_rank=peer_rank,
+            group=group,
+            tag=tag + 2,
+            operation=f"{key!r} preflight acknowledgement",
+        )
+        cpu_buffers = [
+            torch.empty(buffer.shape, dtype=buffer.dtype, device="cpu") for buffer in buffers
+        ]
+        for buffer in cpu_buffers:
+            flat = buffer.view(-1)
             elems = max(1, self._chunk_size // flat.element_size())
             for off in range(0, flat.numel(), elems):
-                self._dist.recv(flat[off : off + elems], src=peer_rank)
+                self._recv(
+                    flat[off : off + elems],
+                    peer_rank=peer_rank,
+                    group=group,
+                    tag=tag + 3,
+                    operation=f"{key!r} payload receive",
+                )
+        expected = manifest["checksums"]
+        actual = shard_checksums(cpu_buffers)
+        verified = actual == expected
+        self._send(
+            torch.tensor([int(verified)], dtype=torch.int32),
+            peer_rank=peer_rank,
+            group=group,
+            tag=tag + 4,
+            operation=f"{key!r} checksum acknowledgement",
+        )
+        if not verified:
+            raise RuntimeError(f"checkpoint transfer {key!r} failed checksum")
+        for destination, source in zip(buffers, cpu_buffers):
+            destination.copy_(source.to(destination.device))
 
     def close(self) -> None:
-        pass
+        for group in self._groups.values():
+            self._dist.destroy_process_group(group)
+        self._groups.clear()
 
 
 def make_transfer(
@@ -182,11 +551,16 @@ def make_transfer(
     metadata_store: TransferMetadataStore | None = None,
     control: TransferMetadataStore | None = None,
     chunk_size: int = 64 * 1024 * 1024,
+    timeout_s: float = 120.0,
+    process_group: object | None = None,
+    allow_backend_fallback: bool = False,
 ) -> CheckpointTransfer:
-    """Construct the requested transfer backend, falling back to torch_dist.
+    """Construct the requested transfer backend.
 
-    "nixl" is preferred for production (RDMA/GPUDirect, one-sided). If the nixl
-    package is unavailable we log and fall back to the always-present Gloo path.
+    ``nixl`` is preferred for production (RDMA/GPUDirect, one-sided). Backend
+    fallback is disabled by default because torch_dist requires synchronous
+    participation from both endpoints. Set ``allow_backend_fallback=True`` only
+    when the caller has arranged that two-sided protocol explicitly.
     ``control`` is a backward-compatible alias for ``metadata_store``.
     """
     if backend not in {"nixl", "torch_dist"}:
@@ -200,7 +574,26 @@ def make_transfer(
         if metadata_store is None:
             raise ValueError("the nixl backend requires a metadata_store")
         try:
-            return NixlCheckpointTransfer(agent_name, metadata_store, chunk_size)
+            return NixlCheckpointTransfer(
+                agent_name,
+                metadata_store,
+                chunk_size,
+                rank=rank,
+                timeout_s=timeout_s,
+            )
         except Exception as e:
-            logger.warning(f"NIXL backend unavailable ({e}); falling back to torch_dist")
-    return TorchDistTransfer(rank, chunk_size)
+            if not allow_backend_fallback:
+                raise RuntimeError(
+                    "NIXL backend unavailable and two-sided fallback was not enabled"
+                ) from e
+            logger.warning(
+                "NIXL backend unavailable (%s); using explicitly enabled two-sided "
+                "torch_dist fallback",
+                e,
+            )
+    return TorchDistTransfer(
+        rank,
+        chunk_size,
+        timeout_s=timeout_s,
+        process_group=process_group,
+    )

--- a/tests/integration/core/test_checkpoint_transfer.py
+++ b/tests/integration/core/test_checkpoint_transfer.py
@@ -1,0 +1,103 @@
+"""Two-rank keyed TorchDistTransfer validation.
+
+Run:
+    torchrun --nproc-per-node=2 tests/integration/core/test_checkpoint_transfer.py
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+from unittest.mock import patch
+
+import torch
+import torch.distributed as dist
+
+from lm_resiliency.checkpointing.transfer import TorchDistTransfer
+
+
+def _run_threads(functions) -> list[BaseException]:
+    errors: list[BaseException] = []
+
+    def run(function) -> None:
+        try:
+            function()
+        except BaseException as error:  # noqa: BLE001 - surfaced after every thread joins
+            errors.append(error)
+
+    threads = [threading.Thread(target=run, args=(function,)) for function in functions]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10.0)
+    if any(thread.is_alive() for thread in threads):
+        errors.append(TimeoutError("checkpoint transfer thread did not finish"))
+    return errors
+
+
+def main() -> None:
+    dist.init_process_group("gloo")
+    rank = dist.get_rank()
+    peer = 1 - rank
+    host = socket.gethostname()
+    transfer = TorchDistTransfer(rank, chunk_size=8, timeout_s=5.0)
+
+    if rank == 0:
+        tensors = [torch.arange(8, dtype=torch.float32), torch.arange(5, dtype=torch.int64)]
+        errors = _run_threads(
+            [
+                lambda: transfer.serve([tensors[0]], "owner/step-7", peer, host),
+                lambda: transfer.serve([tensors[1]], "peer/step-7", peer, host),
+            ]
+        )
+    else:
+        first = torch.empty(8, dtype=torch.float32)
+        second = torch.empty(5, dtype=torch.int64)
+        errors = _run_threads(
+            [
+                lambda: transfer.fetch([first], "owner/step-7", peer, host),
+                lambda: transfer.fetch([second], "peer/step-7", peer, host),
+            ]
+        )
+        if not errors:
+            assert torch.equal(first, torch.arange(8, dtype=torch.float32))
+            assert torch.equal(second, torch.arange(5, dtype=torch.int64))
+
+    ok = torch.tensor([int(not errors)], dtype=torch.int32)
+    dist.all_reduce(ok, op=dist.ReduceOp.MIN)
+    assert ok.item() == 1, errors
+
+    mismatch_rejected = False
+    try:
+        if rank == 0:
+            transfer.serve([torch.ones(4)], "shape-mismatch", peer, host)
+        else:
+            transfer.fetch([torch.empty(3)], "shape-mismatch", peer, host)
+    except RuntimeError:
+        mismatch_rejected = True
+    rejected = torch.tensor([int(mismatch_rejected)], dtype=torch.int32)
+    dist.all_reduce(rejected, op=dist.ReduceOp.MIN)
+    assert rejected.item() == 1
+
+    checksum_rejected = False
+    try:
+        if rank == 0:
+            with patch(
+                "lm_resiliency.checkpointing.transfer.shard_checksums",
+                return_value=[0],
+            ):
+                transfer.serve([torch.ones(4)], "checksum-mismatch", peer, host)
+        else:
+            transfer.fetch([torch.empty(4)], "checksum-mismatch", peer, host)
+    except RuntimeError:
+        checksum_rejected = True
+    rejected = torch.tensor([int(checksum_rejected)], dtype=torch.int32)
+    dist.all_reduce(rejected, op=dist.ReduceOp.MIN)
+    assert rejected.item() == 1
+
+    transfer.close()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_checkpoint_transfer.py
+++ b/tests/unit/test_checkpoint_transfer.py
@@ -1,0 +1,124 @@
+"""Checkpoint transfer contract and timeout tests."""
+
+from __future__ import annotations
+
+import socket
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from lm_resiliency.checkpointing.transfer import (
+    NixlCheckpointTransfer,
+    TorchDistTransfer,
+    _payload_manifest,
+    _transfer_tag,
+    _validate_manifest,
+)
+
+
+def test_manifest_binds_key_endpoints_host_and_tensor_layout():
+    tensor = torch.ones(4, dtype=torch.float32)
+    manifest = _payload_manifest(
+        [tensor.unsqueeze(0)],
+        key="step-7",
+        source_rank=3,
+        destination_rank=9,
+        destination_host=socket.gethostname(),
+    )
+
+    _validate_manifest(
+        manifest,
+        [tensor.unsqueeze(0)],
+        key="step-7",
+        source_rank=3,
+        destination_rank=9,
+        peer_host=socket.gethostname(),
+    )
+    with pytest.raises(RuntimeError, match="key mismatch"):
+        _validate_manifest(
+            manifest,
+            [tensor.unsqueeze(0)],
+            key="step-8",
+            source_rank=3,
+            destination_rank=9,
+            peer_host=socket.gethostname(),
+        )
+    with pytest.raises(RuntimeError, match="tensor shape"):
+        _validate_manifest(
+            manifest,
+            [torch.ones(3)],
+            key="step-7",
+            source_rank=3,
+            destination_rank=9,
+            peer_host=socket.gethostname(),
+        )
+
+
+def test_transfer_tags_are_stable_and_keyed():
+    assert _transfer_tag("owner/step-7") == _transfer_tag("owner/step-7")
+    assert _transfer_tag("owner/step-7") != _transfer_tag("peer/step-7")
+
+
+def _nixl_transfer(state: str) -> tuple[NixlCheckpointTransfer, MagicMock]:
+    buffer = torch.zeros(4)
+    manifest = _payload_manifest(
+        [buffer],
+        key="step-7",
+        source_rank=1,
+        destination_rank=0,
+        destination_host=socket.gethostname(),
+    )
+    control = MagicMock()
+    control.get_transfer_meta.return_value = {
+        "transport": "nixl",
+        "manifest": manifest,
+        "agent_meta": "agent",
+        "descs": "descs",
+    }
+    agent = MagicMock()
+    agent.check_xfer_state.return_value = state
+    transfer = object.__new__(NixlCheckpointTransfer)
+    transfer._control = control
+    transfer._agent = agent
+    transfer._rank = 0
+    transfer._timeout_s = 1.0
+    transfer._poll_interval_s = 0.001
+    return transfer, agent
+
+
+def test_nixl_terminal_failure_is_not_polled_forever():
+    transfer, agent = _nixl_transfer("FAILED")
+
+    with pytest.raises(RuntimeError, match="failed"):
+        transfer.fetch([torch.zeros(4)], "step-7", peer_rank=1, peer_host=socket.gethostname())
+
+    agent.deregister_memory.assert_called_once()
+
+
+def test_nixl_timeout_cancels_transfer():
+    transfer, agent = _nixl_transfer("PENDING")
+
+    with (
+        patch(
+            "lm_resiliency.checkpointing.transfer.time.monotonic",
+            side_effect=[10.0, 11.1],
+        ),
+        pytest.raises(TimeoutError, match="exceeded"),
+    ):
+        transfer.fetch([torch.zeros(4)], "step-7", peer_rank=1, peer_host=socket.gethostname())
+
+    agent.cancel_xfer.assert_called_once()
+    agent.deregister_memory.assert_called_once()
+
+
+def test_torch_dist_wait_has_a_bounded_failure():
+    transfer = object.__new__(TorchDistTransfer)
+    transfer._timeout_s = 2.0
+    transfer._wait_timeout = timedelta(seconds=2.0)
+    work = MagicMock()
+    work.wait.return_value = False
+
+    with pytest.raises(TimeoutError, match="exceeded 2.0s"):
+        transfer._wait(work, operation="manifest")

--- a/tests/unit/test_orchestration_api.py
+++ b/tests/unit/test_orchestration_api.py
@@ -328,7 +328,38 @@ def test_transfer_factory_validates_public_contract():
         transfer = make_transfer("torch_dist", rank=3, chunk_size=1024)
 
     assert transfer is transfer_cls.return_value
-    transfer_cls.assert_called_once_with(3, 1024)
+    transfer_cls.assert_called_once_with(
+        3,
+        1024,
+        timeout_s=120.0,
+        process_group=None,
+    )
+
+
+def test_nixl_fallback_requires_explicit_two_sided_opt_in():
+    store = MagicMock()
+    with patch(
+        "lm_resiliency.checkpointing.transfer.NixlCheckpointTransfer",
+        side_effect=RuntimeError("missing nixl"),
+    ):
+        with pytest.raises(RuntimeError, match="fallback was not enabled"):
+            make_transfer("nixl", rank=0, metadata_store=store)
+
+    with (
+        patch(
+            "lm_resiliency.checkpointing.transfer.NixlCheckpointTransfer",
+            side_effect=RuntimeError("missing nixl"),
+        ),
+        patch("lm_resiliency.checkpointing.transfer.TorchDistTransfer") as transfer_cls,
+    ):
+        transfer = make_transfer(
+            "nixl",
+            rank=0,
+            metadata_store=store,
+            allow_backend_fallback=True,
+        )
+
+    assert transfer is transfer_cls.return_value
 
 
 def test_checkpoint_only_handle_has_no_platform_dependency(tmp_path):


### PR DESCRIPTION
## What changed

- give each transfer key a stable tag range and a versioned manifest
- bind manifests to source/destination rank, canonical host, tensor shape/dtype/numel/bytes, and per-chunk CRCs
- use lazily created dedicated Gloo pair groups, including when the training world is NCCL
- add bounded nonblocking sends/receives plus preflight and final checksum acknowledgements
- receive into CPU staging buffers and apply them only after integrity succeeds
- add NIXL metadata contracts, metadata/poll deadlines, terminal failure handling, cancellation, checksum validation, and registration cleanup
- make NIXL-to-torch_dist fallback opt-in because it changes one-sided to two-sided semantics
- document the manager-facing contract
- add real two-rank concurrent-key, layout-mismatch, and checksum-mismatch coverage

## Why

The previous torch backend used untagged blocking operations on the default group, ignored the key and host, and had no contract or integrity handshake. NIXL polled forever and the factory could silently replace a one-sided protocol with a two-sided one. These paths could cross-wire concurrent transfers, fail on NCCL worlds with CPU buffers, or hang recovery indefinitely.

## Compatibility and impact

The public `serve`/`fetch` methods are unchanged. `make_transfer` gains optional timeout, dedicated group, and explicit fallback controls. The intentional behavior change is that NIXL unavailability now raises unless `allow_backend_fallback=True`.

## Validation

- `python -m pytest -q tests/unit/test_checkpoint_transfer.py tests/unit/test_orchestration_api.py tests/unit/test_unified_api.py` — 47 passed
- `PYTHONPATH=. MASTER_ADDR=127.0.0.1 MASTER_PORT=29689 torchrun --nnodes=1 --nproc-per-node=2 --master-addr=127.0.0.1 --master-port=29689 tests/integration/core/test_checkpoint_transfer.py` — passed
- `ruff check`, `ruff format --check`, and `git diff --check`

NIXL hardware and NCCL-world/Gloo-pair validation remain outstanding; NIXL failure/timeout state handling is covered with deterministic agent doubles.

Closes #81.