### PR TITLE
[Feature][GEMINI] Bind checkpoints to run and topology identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,12 @@ source .venv/bin/activate
 python -m pip install --upgrade pip
 python -m pip install -e .
 python examples/quickstart.py \
-  --checkpoint-dir /tmp/lm-resiliency-quickstart/checkpoints
+  --checkpoint-dir /tmp/lm-resiliency-quickstart/checkpoints \
+  --run-id my-quickstart
 ```
 
 The example trains a tiny causal LM through a complete forward, backward, and optimizer loop while GEMINI saves recovery state.
-Run it again with `--steps 6` to resume from the saved checkpoint.
+Run it again with the same `--run-id` and `--steps 6` to resume from the saved checkpoint.
 See [Examples](examples/README.md) for the recovery command and distributed production loops that exercise SCOUT.
 
 For integrations that do not need the repository examples, install the latest published package directly with `python -m pip install lm-resiliency`, adding `[torchtitan]`, `[megatron]`, `[deepspeed]`, or `[all]` as needed.

--- a/docs/api.md
+++ b/docs/api.md
@@ -259,6 +259,7 @@ resiliency = enable_resiliency(
     checkpoint=InMemoryCkptConfig(
         replication_jump=8,
         disk_folder="/local_nvme/gemini",
+        run_id="training-run-2026-08-15",
         verify_integrity=True,
     ),
     replay=ReplayHarnessConfig(

--- a/docs/gemini.md
+++ b/docs/gemini.md
@@ -80,6 +80,7 @@ config = InMemoryCkptConfig(
     replication_chunk_size=16 * 1024 * 1024,
     disk_flush_interval=100,
     disk_folder="./checkpoints",
+    run_id="training-run-2026-08-15",
     verify_integrity=False,
     skip_replication_if_hsdp=True,
     pin_memory=True,
@@ -93,11 +94,18 @@ config = InMemoryCkptConfig(
 | `replication_chunk_size` | Bytes per replication send |
 | `disk_flush_interval` | Node-local flush cadence; `0` disables periodic flush |
 | `disk_folder` | Node-local checkpoint directory |
+| `run_id` | Stable identity required to resume this run's node-local files |
 | `verify_integrity` | Store and verify CRC-32 for serialized shards |
 | `skip_replication_if_hsdp` | Use natural HSDP replicas instead of explicit peer transfer |
 | `pin_memory` | Allocate page-locked host buffers for asynchronous copies |
 
 The unified `enable_resiliency(..., interval=N)` call overrides the component interval.
+
+Set `run_id` to the same non-empty value on every rank and reuse it only for an
+intentional resume. When it is omitted, GEMINI uses `LM_RESILIENCY_RUN_ID` or
+torchrun's `TORCHELASTIC_RUN_ID`; without either launcher identity it coordinates
+a fresh ID for the current manager group. A newly constructed job therefore does
+not inherit files from an unrelated job that happened to reuse `disk_folder`.
 
 ## Checkpoint Validation
 
@@ -156,9 +164,21 @@ If newer status cannot be established, recovery selects the common verified step
 With `verify_integrity=True`, it stores a CRC-32 for each shard and treats a checksum failure as an unavailable shard.
 Checksums detect stored-byte corruption; they cannot prove that the source GPU state was numerically correct.
 
-Node-local files use checkpoint format version 2. Tensors are loaded through PyTorch's `weights_only=True` path, while reconstruction metadata is represented by a schema-constrained JSON document. The metadata schema supports the built-in containers and scalar types used by framework state, NumPy RNG values, and dense CPU tensors such as PyTorch RNG state. GEMINI validates the payload fields, metadata types, tensor count, shapes, dtypes, reconstruction paths, and optional CRC values before recovery can apply state. Unsupported caller-owned metadata fails the checkpoint write instead of falling back to unrestricted pickle deserialization.
+Node-local files use checkpoint format version 3. Files and status sidecars live
+under an opaque run/topology namespace. Every shard also records the exact run
+ID, topology fingerprint, owner rank, and step; the loader checks all four before
+recovery can apply state. The topology fingerprint covers world size, checkpoint
+group ranks, and the replication assignment, and all checkpoint ranks agree on
+the run/topology contract collectively during manager construction.
+
+Tensors are loaded through PyTorch's `weights_only=True` path, while reconstruction metadata is represented by a schema-constrained JSON document. The metadata schema supports the built-in containers and scalar types used by framework state, NumPy RNG values, and dense CPU tensors such as PyTorch RNG state. GEMINI validates the payload fields, metadata types, tensor count, shapes, dtypes, reconstruction paths, identity, and optional CRC values before recovery can apply state. Unsupported caller-owned metadata fails the checkpoint write instead of falling back to unrestricted pickle deserialization.
 
 The original `0.1.0` node-local format used unrestricted pickle metadata and is intentionally not loadable by newer versions. Complete an in-progress `0.1.0` recovery before upgrading, or use the framework-owned durable checkpoint as the upgrade boundary. Node-local GEMINI files remain a fast restart tier rather than a cross-version interchange format.
+
+Version 2 node-local files did not bind state to a run or topology and are not
+silently assigned to a version 3 run. Resume them with the release that wrote
+them and publish a framework-owned durable checkpoint, then upgrade and begin a
+version 3 run from that durable boundary.
 
 Safe deserialization prevents a replaced file from invoking arbitrary pickle globals, but it does not establish who produced the tensor values. Treat the checkpoint directory as training-state storage: restrict filesystem ownership and write permissions to the training job, avoid following untrusted symlinks or copying files from untrusted sources, and use framework-owned durable checkpoints when stronger provenance is required. CRC-32 detects accidental byte corruption only; an attacker able to replace a shard can also replace its checksum.
 
@@ -244,6 +264,6 @@ The table above remains historical evidence for its stated A100 workload and is 
 - `replication_jump` assumes a compatible rank placement and must be validated for the deployment.
 - Integrity checks detect corruption after capture, not corruption already present in source state.
 - Safe weights-only loading prevents arbitrary pickle execution but does not authenticate tensor values or their source.
-- Node-local checkpoint format version 2 does not load the unrestricted-pickle format written by `0.1.0`.
+- Node-local checkpoint format version 3 rejects legacy files without run/topology identity.
 - Signal-triggered flush requires a catchable signal and sufficient termination grace time.
 - Manager policy, relaunch, placement, and physical replacement remain external.

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,8 @@ The example executes the complete forward, backward, optimizer, and GEMINI check
 
 ```bash
 lm-resiliency-quickstart \
-  --checkpoint-dir /tmp/lm-resiliency-quickstart/checkpoints
+  --checkpoint-dir /tmp/lm-resiliency-quickstart/checkpoints \
+  --run-id my-quickstart
 ```
 
 Run it again with a larger step target to resume from the saved GEMINI checkpoint:
@@ -15,7 +16,8 @@ Run it again with a larger step target to resume from the saved GEMINI checkpoin
 ```bash
 lm-resiliency-quickstart \
   --steps 6 \
-  --checkpoint-dir /tmp/lm-resiliency-quickstart/checkpoints
+  --checkpoint-dir /tmp/lm-resiliency-quickstart/checkpoints \
+  --run-id my-quickstart
 ```
 
 The installed command and library come from the same wheel.

--- a/lm_resiliency/checkpointing/_disk_format.py
+++ b/lm_resiliency/checkpointing/_disk_format.py
@@ -13,7 +13,7 @@ import torch
 from lm_resiliency.checkpointing.state_dict import FlatStateDictMetadata, TensorEntry
 
 FORMAT_NAME = "lm-resiliency.gemini.node-local"
-FORMAT_VERSION = 2
+FORMAT_VERSION = 3
 
 _METADATA_SCHEMA_VERSION = 1
 _MAX_METADATA_BYTES = 64 * 1024 * 1024
@@ -135,18 +135,35 @@ def decode_metadata(encoded: object) -> FlatStateDictMetadata:
 
 def validate_payload(
     payload: object,
-) -> tuple[FlatStateDictMetadata, list[torch.Tensor], list[int] | None]:
+) -> tuple[FlatStateDictMetadata, list[torch.Tensor], list[int] | None, dict[str, object]]:
     """Validate the weights-only payload before recovery can apply its contents."""
     _require_mapping(payload, "checkpoint payload")
     _require_exact_keys(
         payload,
-        {"format", "version", "metadata_json", "tensors", "checksums"},
+        {"format", "version", "identity", "metadata_json", "tensors", "checksums"},
         "checkpoint payload",
     )
     if payload["format"] != FORMAT_NAME:
         raise CheckpointFormatError("unrecognized or legacy checkpoint format")
     if payload["version"] != FORMAT_VERSION:
         raise CheckpointFormatError(f"unsupported checkpoint format version {payload['version']!r}")
+
+    identity = payload["identity"]
+    _require_mapping(identity, "checkpoint identity")
+    _require_exact_keys(
+        identity,
+        {"run_id", "topology_id", "owner_rank", "step"},
+        "checkpoint identity",
+    )
+    if not isinstance(identity["run_id"], str) or not identity["run_id"].strip():
+        raise CheckpointFormatError("checkpoint identity run_id must be a non-empty string")
+    if not isinstance(identity["topology_id"], str) or not identity["topology_id"].strip():
+        raise CheckpointFormatError("checkpoint identity topology_id must be a non-empty string")
+    for field in ("owner_rank", "step"):
+        if type(identity[field]) is not int or identity[field] < 0:
+            raise CheckpointFormatError(
+                f"checkpoint identity {field} must be a non-negative integer"
+            )
 
     metadata = decode_metadata(payload["metadata_json"])
     tensors = payload["tensors"]
@@ -178,7 +195,7 @@ def validate_payload(
             raise CheckpointFormatError(
                 "checkpoint checksums must be null or a list of unsigned CRC-32 values"
             )
-    return metadata, tensors, checksums
+    return metadata, tensors, checksums, dict(identity)
 
 
 def _encode_value(value: Any, *, depth: int) -> dict[str, Any]:

--- a/lm_resiliency/checkpointing/config.py
+++ b/lm_resiliency/checkpointing/config.py
@@ -24,6 +24,10 @@ class InMemoryCkptConfig:
             for a same-node restart. GEMINI is single-tier by design: durable /
             global checkpointing is the pre-training framework's responsibility,
             reached via the caller's load_fallback when GEMINI has nothing to load.
+        run_id: Stable identity of the training run allowed to recover node-local
+            checkpoints. Reuse the same non-empty value for an intentional resume.
+            When omitted, GEMINI uses the launcher's stable run id when available,
+            otherwise creates and coordinates a fresh id for this manager group.
         verify_integrity: If True, store a per-shard CRC-32 on every disk write and
             verify it on load. Guards at-rest / in-flight byte corruption (DRAM
             rot, transfer flips, NVMe errors) — the failure mode layer replay
@@ -38,6 +42,7 @@ class InMemoryCkptConfig:
     replication_chunk_size: int = 16 * 1024 * 1024  # 16 MiB
     disk_flush_interval: int = 100
     disk_folder: str = "./checkpoints"
+    run_id: str | None = None
     verify_integrity: bool = False
     skip_replication_if_hsdp: bool = True
     pin_memory: bool = True

--- a/lm_resiliency/checkpointing/disk.py
+++ b/lm_resiliency/checkpointing/disk.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 _STEP_DIR_PATTERN = re.compile(r"step-(\d+)")
 _STATUS_FILE = "GEMINI_CHECKPOINT_STATUS"
-_STATUS_SCHEMA_VERSION = 1
+_STATUS_SCHEMA_VERSION = 2
 
 # Chunk + thread the CRC so it stays sub-second on multi-GB shards. zlib.crc32
 # releases the GIL, so per-chunk tasks scale near-linearly with worker count
@@ -43,6 +43,10 @@ class ChecksumMismatch(Exception):
     """Raised when a loaded shard fails its stored checksum."""
 
 
+class CheckpointIdentityMismatch(ValueError):
+    """Raised when trust metadata belongs to another run or topology."""
+
+
 @dataclass(frozen=True, slots=True)
 class CheckpointStatus:
     """Persisted GEMINI candidate, recovery pointer, and restart policy."""
@@ -51,19 +55,33 @@ class CheckpointStatus:
     recovery_verified_step: int = -1
     recovery_mode: str = "latest"
 
-    def to_dict(self) -> dict[str, int | str]:
+    def to_dict(
+        self, *, run_id: str | None = None, topology_id: str | None = None
+    ) -> dict[str, int | str | None]:
         return {
             "schema_version": _STATUS_SCHEMA_VERSION,
+            "run_id": run_id,
+            "topology_id": topology_id,
             "candidate_step": self.candidate_step,
             "recovery_verified_step": self.recovery_verified_step,
             "recovery_mode": self.recovery_mode,
         }
 
     @classmethod
-    def from_dict(cls, value: dict[str, object]) -> CheckpointStatus:
+    def from_dict(
+        cls,
+        value: dict[str, object],
+        *,
+        run_id: str | None = None,
+        topology_id: str | None = None,
+    ) -> CheckpointStatus:
         if value.get("schema_version") != _STATUS_SCHEMA_VERSION:
             raise ValueError(
                 f"unsupported GEMINI checkpoint status schema {value.get('schema_version')!r}"
+            )
+        if value.get("run_id") != run_id or value.get("topology_id") != topology_id:
+            raise CheckpointIdentityMismatch(
+                "GEMINI checkpoint status belongs to another run or topology"
             )
         return cls(
             candidate_step=int(value.get("candidate_step", -1)),
@@ -76,15 +94,24 @@ class CheckpointStatusStore:
     """Atomically persist one rank's checkpoint trust metadata.
 
     Rank-scoped files avoid read-modify-write races when multiple local workers
-    share a node-local checkpoint directory. The unscoped filename remains a
-    read-only fallback for checkpoints written by older releases.
+    share a node-local checkpoint directory. An identity-mismatched sidecar is
+    ignored and cannot constrain or promote the current run.
     """
 
-    def __init__(self, folder: str | Path, rank: int | None = None) -> None:
+    def __init__(
+        self,
+        folder: str | Path,
+        rank: int | None = None,
+        *,
+        run_id: str | None = None,
+        topology_id: str | None = None,
+    ) -> None:
         self._folder = Path(folder)
         self._rank = rank
         self._path = self._folder / self.filename(rank)
         self._legacy_path = self._folder / _STATUS_FILE
+        self._run_id = run_id
+        self._topology_id = topology_id
 
     @staticmethod
     def filename(rank: int | None) -> str:
@@ -98,19 +125,23 @@ class CheckpointStatusStore:
 
     def read(self) -> CheckpointStatus:
         if self._path.exists():
-            return self._read_path(self._path)
+            status = self._read_eligible_path(self._path)
+            if status is not None:
+                return status
         if self._rank is not None:
             peer_status = self._read_peer_fallback()
             if peer_status != CheckpointStatus():
                 return peer_status
         if self._legacy_path.exists():
-            return self._read_path(self._legacy_path)
+            status = self._read_eligible_path(self._legacy_path)
+            if status is not None:
+                return status
         return CheckpointStatus()
 
     def write(self, status: CheckpointStatus) -> None:
         self._folder.mkdir(parents=True, exist_ok=True)
         encoded = json.dumps(
-            status.to_dict(),
+            status.to_dict(run_id=self._run_id, topology_id=self._topology_id),
             sort_keys=True,
             separators=(",", ":"),
         ).encode("utf-8")
@@ -136,17 +167,26 @@ class CheckpointStatusStore:
             except FileNotFoundError:
                 pass
 
-    @staticmethod
-    def _read_path(path: Path) -> CheckpointStatus:
+    def _read_path(self, path: Path) -> CheckpointStatus:
         with path.open("r", encoding="utf-8") as handle:
-            return CheckpointStatus.from_dict(json.load(handle))
+            return CheckpointStatus.from_dict(
+                json.load(handle), run_id=self._run_id, topology_id=self._topology_id
+            )
+
+    def _read_eligible_path(self, path: Path) -> CheckpointStatus | None:
+        try:
+            return self._read_path(path)
+        except CheckpointIdentityMismatch:
+            logger.warning("Ignoring checkpoint status from another run or topology: %s", path)
+            return None
 
     def _read_peer_fallback(self) -> CheckpointStatus:
         """Use surviving rank sidecars only as a conservative verified pointer."""
         statuses = [
-            self._read_path(path)
+            status
             for path in sorted(self._folder.glob(f"{_STATUS_FILE}.rank-*"))
             if path != self._path
+            if (status := self._read_eligible_path(path)) is not None
         ]
         if not statuses:
             return CheckpointStatus()
@@ -197,7 +237,9 @@ def shard_checksums(
 class DiskSerializer:
     """Handles async checkpoint flush to disk and loading from disk.
 
-    Checkpoints are stored as: {folder}/step-{step}/rank-{rank}.pt
+    Checkpoints are stored as: {folder}/step-{step}/rank-{rank}.pt. Managers
+    provide run and topology identities and place this folder in an isolated
+    namespace; the identity is also authenticated by the payload schema.
     Each file contains a versioned, weights-only payload for that rank. Tensor
     reconstruction metadata is encoded with a schema-constrained JSON codec so
     loading never needs to allow arbitrary pickle globals.
@@ -209,13 +251,41 @@ class DiskSerializer:
             load (raising ChecksumMismatch on a corrupt shard).
     """
 
-    def __init__(self, folder: str, rank: int = 0, integrity: bool = False) -> None:
+    def __init__(
+        self,
+        folder: str,
+        rank: int = 0,
+        integrity: bool = False,
+        *,
+        run_id: str = "standalone",
+        topology_id: str = "standalone",
+        namespace: bool = False,
+    ) -> None:
         self._folder = Path(folder)
+        self._run_id = self._validate_identity(run_id, "run_id")
+        self._topology_id = self._validate_identity(topology_id, "topology_id")
+        if namespace:
+            self._folder = self.namespace_folder(self._folder, self._run_id, self._topology_id)
         self._rank = rank
         self._integrity = integrity
         self._write_thread: threading.Thread | None = None
         self._write_error: BaseException | None = None
         self._latest_flushed_step: int = -1
+
+    @staticmethod
+    def _validate_identity(value: str, field: str) -> str:
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"{field} must be a non-empty string")
+        return value
+
+    @staticmethod
+    def namespace_folder(folder: str | Path, run_id: str, topology_id: str) -> Path:
+        """Return an opaque, path-safe namespace for one run and topology."""
+        import hashlib
+
+        run_digest = hashlib.sha256(run_id.encode("utf-8")).hexdigest()[:24]
+        topology_digest = hashlib.sha256(topology_id.encode("utf-8")).hexdigest()[:24]
+        return Path(folder) / "runs" / run_digest / topology_digest
 
     @property
     def latest_flushed_step(self) -> int:
@@ -241,7 +311,18 @@ class DiskSerializer:
                 step_dir = self._folder / f"step-{step}"
                 step_dir.mkdir(parents=True, exist_ok=True)
                 save_path = step_dir / f"rank-{self._rank}.pt"
-                torch.save(_checkpoint_payload(metadata, tensors_copy, checksums), save_path)
+                torch.save(
+                    _checkpoint_payload(
+                        metadata,
+                        tensors_copy,
+                        checksums,
+                        run_id=self._run_id,
+                        topology_id=self._topology_id,
+                        owner_rank=self._rank,
+                        step=step,
+                    ),
+                    save_path,
+                )
                 self._latest_flushed_step = step
                 logger.info(f"Flushed checkpoint step {step} to {save_path}")
             except BaseException as e:
@@ -283,7 +364,18 @@ class DiskSerializer:
         save_path = step_dir / f"rank-{target_rank}.pt"
         tensors_copy = [t.clone() for t in tensors]
         checksums = shard_checksums(tensors_copy) if self._integrity else None
-        torch.save(_checkpoint_payload(metadata, tensors_copy, checksums), save_path)
+        torch.save(
+            _checkpoint_payload(
+                metadata,
+                tensors_copy,
+                checksums,
+                run_id=self._run_id,
+                topology_id=self._topology_id,
+                owner_rank=target_rank,
+                step=step,
+            ),
+            save_path,
+        )
         self._latest_flushed_step = max(self._latest_flushed_step, step)
         logger.info(f"Flushed checkpoint step {step} (rank {target_rank}) to {save_path}")
         return save_path
@@ -305,7 +397,17 @@ class DiskSerializer:
                 f"{load_path}: unsafe, malformed, or legacy checkpoint; "
                 f"only format version {FORMAT_VERSION} is supported"
             ) from error
-        metadata, tensors, stored = validate_payload(payload)
+        metadata, tensors, stored, identity = validate_payload(payload)
+        expected_identity = {
+            "run_id": self._run_id,
+            "topology_id": self._topology_id,
+            "owner_rank": target_rank,
+            "step": step,
+        }
+        if identity != expected_identity:
+            raise CheckpointFormatError(
+                f"{load_path}: checkpoint identity mismatch; expected {expected_identity!r}"
+            )
         for index, tensor in enumerate(tensors):
             if type(tensor) is not torch.Tensor:
                 raise CheckpointFormatError(
@@ -394,12 +496,23 @@ def _checkpoint_payload(
     metadata: FlatStateDictMetadata,
     tensors: list[torch.Tensor],
     checksums: list[int] | None,
+    *,
+    run_id: str,
+    topology_id: str,
+    owner_rank: int,
+    step: int,
 ) -> dict[str, object]:
     """Build the only payload shape accepted by the safe loader."""
     _validate_metadata_runtime_types(metadata.non_tensor_data)
     return {
         "format": FORMAT_NAME,
         "version": FORMAT_VERSION,
+        "identity": {
+            "run_id": run_id,
+            "topology_id": topology_id,
+            "owner_rank": owner_rank,
+            "step": step,
+        },
         "metadata_json": encode_metadata(metadata),
         "tensors": tensors,
         "checksums": checksums,

--- a/lm_resiliency/checkpointing/manager.py
+++ b/lm_resiliency/checkpointing/manager.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 
 import atexit
 import enum
+import hashlib
+import json
 import logging
+import os
 import pickle
 import shutil
 import signal
 import threading
+import uuid
 from pathlib import Path
 from typing import Any, Callable
 
@@ -144,10 +148,10 @@ class InMemoryCheckpointManager:
         self._replication_source: Any | None = None
 
         # Peer replication
+        jump = config.replication_jump
+        if jump < 0:
+            jump = torch.cuda.device_count() if torch.cuda.is_available() else 1
         if not self._skip_replication and self._world_size > 1:
-            jump = config.replication_jump
-            if jump < 0:
-                jump = torch.cuda.device_count() if torch.cuda.is_available() else 1
             backend = ChunkedGlooBackend(
                 replication_jump=jump,
                 chunk_size=config.replication_chunk_size,
@@ -158,14 +162,32 @@ class InMemoryCheckpointManager:
         else:
             self._replicator = PeerReplicator(None, enabled=False)
 
+        self._run_id = self._resolve_checkpoint_run_id(config.run_id)
+        self.config.run_id = self._run_id
+        topology = self._checkpoint_topology(jump)
+        self._require_exact_checkpoint_contract(self._run_id, topology)
+        self._topology_id = hashlib.sha256(
+            json.dumps(topology, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+
         # Node-local (fast) tier. GEMINI is deliberately single-tier: durable /
         # global checkpointing is the pre-training framework's job (reached via the
         # caller's load_fallback when GEMINI has nothing to load — e.g. a fresh
         # allocation whose node-local tier is empty).
         self._disk = DiskSerializer(
-            folder=config.disk_folder, rank=self._rank, integrity=config.verify_integrity
+            folder=config.disk_folder,
+            rank=self._rank,
+            integrity=config.verify_integrity,
+            run_id=self._run_id,
+            topology_id=self._topology_id,
+            namespace=True,
         )
-        self._checkpoint_status = CheckpointStatusStore(config.disk_folder, rank=self._rank)
+        self._checkpoint_status = CheckpointStatusStore(
+            self._disk._folder,
+            rank=self._rank,
+            run_id=self._run_id,
+            topology_id=self._topology_id,
+        )
         self._save_count = 0
         self._restart_dest_fn: Callable[[], str | Path | None] | None = None
 
@@ -174,6 +196,76 @@ class InMemoryCheckpointManager:
         signal.signal(signal.SIGTERM, self._sigterm_handler)
         signal.signal(signal.SIGINT, self._sigterm_handler)
         self._exit_flush_registered = False
+
+    def _resolve_checkpoint_run_id(self, configured: str | None) -> str:
+        """Resolve one stable run id, coordinating a fresh id when necessary."""
+        if configured is not None:
+            if not isinstance(configured, str) or not configured.strip():
+                raise ValueError("checkpoint run_id must be a non-empty string")
+            return configured
+
+        value = os.environ.get("LM_RESILIENCY_RUN_ID")
+        if value and value.strip():
+            return value
+        value = os.environ.get("TORCHELASTIC_RUN_ID")
+        if value and value.strip() and value.strip().lower() != "none":
+            return value
+
+        source = 0
+        if dist.is_initialized() and self._process_group is not None:
+            source = dist.get_process_group_ranks(self._process_group)[0]
+        value = uuid.uuid4().hex if self._rank == source else ""
+        if dist.is_initialized() and dist.get_world_size(self._process_group) > 1:
+            values = [value]
+            dist.broadcast_object_list(values, src=source, group=self._process_group)
+            value = values[0]
+        return value
+
+    def _checkpoint_topology(self, replication_jump: int) -> dict[str, object]:
+        group_ranks = list(range(self._world_size))
+        if dist.is_initialized() and self._process_group is not None:
+            group_ranks = list(dist.get_process_group_ranks(self._process_group))
+        peer_map: dict[str, int] = {}
+        if not self._skip_replication and self._world_size > 1:
+            segment_size = replication_jump * 2
+            for rank in group_ranks:
+                segment_start = (rank // segment_size) * segment_size
+                offset = rank - segment_start
+                peer_map[str(rank)] = (
+                    rank + replication_jump
+                    if offset < replication_jump
+                    else rank - replication_jump
+                )
+        return {
+            "world_size": self._world_size,
+            "checkpoint_group_ranks": group_ranks,
+            "replication_jump": replication_jump if peer_map else None,
+            "replication_peers": peer_map,
+        }
+
+    def _require_exact_checkpoint_contract(self, run_id: str, topology: dict[str, object]) -> None:
+        """Fail before disk eligibility if checkpoint ranks disagree on identity."""
+        if not dist.is_initialized() or dist.get_world_size(self._process_group) == 1:
+            return
+        encoded = json.dumps(
+            {"run_id": run_id, "topology": topology},
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        digest = int.from_bytes(hashlib.sha256(encoded).digest()[:8], "big") & ((1 << 63) - 1)
+        device = torch.device("cpu")
+        if str(dist.get_backend(self._process_group)).lower() == "nccl":
+            if not torch.cuda.is_available():
+                raise RuntimeError("NCCL checkpoint identity agreement requires a CUDA device")
+            device = torch.device("cuda", torch.cuda.current_device())
+        lower = torch.tensor([digest], dtype=torch.int64, device=device)
+        upper = lower.clone()
+        dist.all_reduce(lower, op=dist.ReduceOp.MIN, group=self._process_group)
+        dist.all_reduce(upper, op=dist.ReduceOp.MAX, group=self._process_group)
+        if lower.item() != upper.item():
+            raise RuntimeError(
+                "checkpoint ranks disagree on run_id or topology; node-local recovery is unsafe"
+            )
 
     def _should_skip_replication(self, par_info: Any | None) -> bool:
         if not self.config.skip_replication_if_hsdp:
@@ -730,7 +822,7 @@ class InMemoryCheckpointManager:
         source = self._disk._folder
         if not source.exists():
             return -1
-        destination = Path(destination)
+        destination = DiskSerializer.namespace_folder(destination, self._run_id, self._topology_id)
         ranks = {self._rank}
         peer_rank = self._replicator.peer_rank
         if peer_rank >= 0:
@@ -752,7 +844,12 @@ class InMemoryCheckpointManager:
                 latest = max(latest, step)
         status = self.checkpoint_status
         for rank in ranks:
-            CheckpointStatusStore(destination, rank=rank).write(status)
+            CheckpointStatusStore(
+                destination,
+                rank=rank,
+                run_id=self._run_id,
+                topology_id=self._topology_id,
+            ).write(status)
         return latest
 
     def _flush_slots(self, disk: DiskSerializer) -> int:

--- a/lm_resiliency/quickstart.py
+++ b/lm_resiliency/quickstart.py
@@ -70,6 +70,11 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         default=Path("/tmp/lm-resiliency-quickstart/checkpoints"),
     )
+    parser.add_argument(
+        "--run-id",
+        default="lm-resiliency-quickstart",
+        help="stable identity to reuse only when intentionally resuming this example",
+    )
     return parser.parse_args()
 
 
@@ -92,6 +97,7 @@ def main() -> None:
         checkpoint=InMemoryCkptConfig(
             disk_flush_interval=1,
             disk_folder=str(args.checkpoint_dir),
+            run_id=args.run_id,
             pin_memory=False,
             verify_integrity=True,
         ),

--- a/tests/unit/test_checkpoint_recovery.py
+++ b/tests/unit/test_checkpoint_recovery.py
@@ -51,6 +51,44 @@ def test_flush_for_restart_own_shard_round_trip(tmp_path):
     reloaded_manager.close()
 
 
+def test_fresh_run_cannot_discover_stale_node_local_checkpoint(tmp_path):
+    first = InMemoryCheckpointManager(
+        InMemoryCkptConfig(
+            disk_flush_interval=0,
+            disk_folder=str(tmp_path),
+            run_id="run-a",
+        )
+    )
+    first.save({"w": torch.full((2,), 7.0)}, step=7)
+    first.maybe_wait()
+    first.flush_for_restart()
+    first.close()
+
+    fresh = InMemoryCheckpointManager(
+        InMemoryCkptConfig(
+            disk_flush_interval=0,
+            disk_folder=str(tmp_path),
+            run_id="run-b",
+        )
+    )
+    assert fresh.find_latest() == -1
+    assert fresh.load() is None
+    fresh.close()
+
+    resumed = InMemoryCheckpointManager(
+        InMemoryCkptConfig(
+            disk_flush_interval=0,
+            disk_folder=str(tmp_path),
+            run_id="run-a",
+        )
+    )
+    recovered = resumed.load()
+    assert recovered is not None
+    assert recovered[1] == 7
+    assert torch.equal(recovered[0]["w"], torch.full((2,), 7.0))
+    resumed.close()
+
+
 def test_flush_for_restart_disarms_exit_flush_until_next_save(tmp_path):
     config = InMemoryCkptConfig(
         enable=True,
@@ -125,7 +163,7 @@ def test_gemini_load_returns_none_on_corruption(tmp_path):
     assert manager.load() is not None
     manager.close()
 
-    rank_file = next(tmp_path.glob("step-*/rank-0.pt"))
+    rank_file = next(tmp_path.glob("runs/*/*/step-*/rank-0.pt"))
     raw = torch.load(rank_file, weights_only=True)
     raw["tensors"][0][0] += 9.0
     torch.save(raw, rank_file)
@@ -149,7 +187,13 @@ def test_disk_safe_format_round_trips_schema_constrained_metadata(tmp_path):
     path = serializer.save_sync(metadata, tensors, step=6)
     raw = torch.load(path, weights_only=True)
     assert raw["format"] == "lm-resiliency.gemini.node-local"
-    assert raw["version"] == 2
+    assert raw["version"] == 3
+    assert raw["identity"] == {
+        "run_id": "standalone",
+        "topology_id": "standalone",
+        "owner_rank": 0,
+        "step": 6,
+    }
     assert isinstance(raw["metadata_json"], str)
 
     loaded_metadata, loaded_tensors = serializer.load(6)
@@ -159,6 +203,22 @@ def test_disk_safe_format_round_trips_schema_constrained_metadata(tmp_path):
     assert np.array_equal(restored["numpy_rng"], state["numpy_rng"])
     assert restored["types"] == state["types"]
     assert restored["bytes"] == state["bytes"]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (("run_id", "other-run"), ("topology_id", "other-topology"), ("owner_rank", 1), ("step", 7)),
+)
+def test_disk_load_rejects_checkpoint_identity_mismatch(tmp_path, field, value):
+    metadata, tensors = flatten({"w": torch.ones(2)})
+    serializer = DiskSerializer(str(tmp_path), rank=0, run_id="run-a", topology_id="topology-a")
+    path = serializer.save_sync(metadata, tensors, step=6)
+    raw = torch.load(path, weights_only=True)
+    raw["identity"][field] = value
+    torch.save(raw, path)
+
+    with pytest.raises(CheckpointFormatError, match="identity mismatch"):
+        serializer.load(6)
 
 
 def test_disk_safe_format_round_trips_tensor_valued_extra(tmp_path):
@@ -364,6 +424,7 @@ def test_restart_destination_mirrors_flushed_checkpoint(tmp_path):
             disk_flush_interval=0,
             disk_folder=str(mirror),
             verify_integrity=True,
+            run_id=config.run_id,
         )
     )
     result = recovered.load()
@@ -384,6 +445,7 @@ def test_extra_state_round_trips_through_gemini(tmp_path):
         interval=1,
         disk_flush_interval=0,
         disk_folder=str(tmp_path),
+        run_id="extra-state-test",
     )
 
     state = enable_resiliency(

--- a/tests/unit/test_checkpoint_safe_recovery.py
+++ b/tests/unit/test_checkpoint_safe_recovery.py
@@ -16,6 +16,7 @@ import torch.multiprocessing as mp
 
 from lm_resiliency.checkpointing._disk_format import CheckpointFormatError
 from lm_resiliency.checkpointing.buffer import SlotState
+from lm_resiliency.checkpointing.config import InMemoryCkptConfig
 from lm_resiliency.checkpointing.disk import DiskSerializer
 from lm_resiliency.checkpointing.manager import InMemoryCheckpointManager
 from lm_resiliency.checkpointing.state_dict import FlatStateDictMetadata, flatten
@@ -161,6 +162,39 @@ def _gloo_recovery_worker(
         dist.destroy_process_group()
 
 
+def _gloo_identity_worker(
+    rank: int,
+    world_size: int,
+    rendezvous: str,
+    checkpoint_dir: str,
+    result_dir: str,
+) -> None:
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{rendezvous}",
+        rank=rank,
+        world_size=world_size,
+        timeout=dt.timedelta(seconds=30),
+    )
+    try:
+        rejected = False
+        try:
+            InMemoryCheckpointManager(
+                InMemoryCkptConfig(
+                    disk_folder=checkpoint_dir,
+                    run_id=f"different-run-{rank}",
+                ),
+                parallelism_info=SimpleNamespace(has_natural_replicas=True),
+            )
+        except RuntimeError as error:
+            rejected = "disagree on run_id or topology" in str(error)
+        Path(result_dir, f"identity-rank-{rank}.json").write_text(
+            json.dumps({"rejected": rejected})
+        )
+    finally:
+        dist.destroy_process_group()
+
+
 @pytest.mark.skipif(not dist.is_gloo_available(), reason="PyTorch Gloo backend is unavailable")
 def test_cpu_gloo_recovery_consensus(tmp_path):
     world_size = 2
@@ -183,3 +217,25 @@ def test_cpu_gloo_recovery_consensus(tmp_path):
         {"memory_step": -1, "disk_rejected": True},
         {"memory_step": -1, "disk_rejected": True},
     ]
+
+
+@pytest.mark.skipif(not dist.is_gloo_available(), reason="PyTorch Gloo backend is unavailable")
+def test_cpu_gloo_requires_exact_run_identity_agreement(tmp_path):
+    world_size = 2
+    rendezvous = tmp_path / "identity-rendezvous"
+    checkpoint_dir = tmp_path / "identity-checkpoints"
+    result_dir = tmp_path / "identity-results"
+    result_dir.mkdir()
+
+    mp.spawn(
+        _gloo_identity_worker,
+        args=(world_size, str(rendezvous), str(checkpoint_dir), str(result_dir)),
+        nprocs=world_size,
+        join=True,
+    )
+
+    results = [
+        json.loads((result_dir / f"identity-rank-{rank}.json").read_text())
+        for rank in range(world_size)
+    ]
+    assert results == [{"rejected": True}, {"rejected": True}]

--- a/tests/unit/test_gemini_checkpoint.py
+++ b/tests/unit/test_gemini_checkpoint.py
@@ -52,6 +52,20 @@ def test_checkpoint_status_store_is_rank_scoped(tmp_dir):
     assert rank_one.path.name == "GEMINI_CHECKPOINT_STATUS.rank-1"
 
 
+def test_checkpoint_status_rejects_another_run_or_topology(tmp_dir):
+    writer = CheckpointStatusStore(tmp_dir, rank=0, run_id="run-a", topology_id="topology-a")
+    writer.write(CheckpointStatus(candidate_step=10))
+
+    assert (
+        CheckpointStatusStore(tmp_dir, rank=0, run_id="run-b", topology_id="topology-a").read()
+        == CheckpointStatus()
+    )
+    assert (
+        CheckpointStatusStore(tmp_dir, rank=0, run_id="run-a", topology_id="topology-b").read()
+        == CheckpointStatus()
+    )
+
+
 def test_rank_scoped_status_store_reads_legacy_status(tmp_dir):
     legacy = CheckpointStatusStore(tmp_dir)
     status = CheckpointStatus(candidate_step=10, recovery_verified_step=5)
@@ -287,8 +301,20 @@ def test_copy_to_writes_status_for_local_and_peer_shards(mock_dist, tmp_dir):
     with tempfile.TemporaryDirectory() as destination:
         mgr.copy_to(destination)
 
-        assert CheckpointStatusStore(destination, rank=0).read() == status
-        assert CheckpointStatusStore(destination, rank=7).read() == status
+        namespaced = mgr._disk.namespace_folder(destination, mgr._run_id, mgr._topology_id)
+
+        assert (
+            CheckpointStatusStore(
+                namespaced, rank=0, run_id=mgr._run_id, topology_id=mgr._topology_id
+            ).read()
+            == status
+        )
+        assert (
+            CheckpointStatusStore(
+                namespaced, rank=7, run_id=mgr._run_id, topology_id=mgr._topology_id
+            ).read()
+            == status
+        )
 
     mgr.close()
 


### PR DESCRIPTION
## Summary

- add an explicit GEMINI `run_id` resume contract, with launcher-derived or collectively generated fresh identities when omitted
- namespace node-local shards and trust sidecars by opaque run/topology digests
- bump the node-local format to v3 and validate run ID, topology fingerprint, owner rank, and step on every load
- require exact run/topology agreement across checkpoint ranks before node-local recovery becomes eligible
- preserve identity when mirroring own and peer shards, ignore mismatched status sidecars, and document the explicit v2 migration boundary
- add a stable `--run-id` to the quickstart resume workflow

Closes #77

## Testing

- `python -m pytest tests/unit/test_quickstart_example.py tests/unit/test_checkpoint_certification.py tests/unit/test_checkpoint_recovery.py tests/unit/test_checkpoint_safe_recovery.py tests/unit/test_durable_checkpoint.py tests/unit/test_gemini_checkpoint.py -q` — 87 passed
- `python -m pytest tests/unit -q --ignore=tests/unit/test_hang_detector.py --ignore=tests/unit/test_hang_instrumentation.py --ignore=tests/unit/test_op_tracker.py --ignore=tests/unit/test_stage_instrumentation.py` — 1657 passed
- focused tests include a real two-rank Gloo disagreement check
- `ruff check`, `ruff format --check`, and `git diff --check` passed

The four omitted files require POSIX shared-memory creation, which this sandbox rejects with `PermissionError`.