### PR TITLE
[Feature][Torchrun] Authenticate persisted restart intent closure

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -668,7 +668,10 @@ intent opening to precede the immediate successor generation in both
 transaction and store time, and verifies that generation creation, intent
 opening, and closure each committed inside their authoritative lease windows
 and before the next durable lease mutation. Construction is fail closed and
-performs no control-store reads or mutations.
+performs no control-store reads or mutations. Because retained value history
+does not identify the intervening delete transaction, an authority followed by
+a delete-and-recreate lifetime cannot authenticate an earlier commit; that
+case remains rejected until the store provides a durable deletion tombstone.
 
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -664,10 +664,11 @@ A frozen `AuthenticatedInitialRestartIntentClosure` value binds that decoded
 closure to the referenced immutable generation and verified durable
 coordinator-lease history. It resolves the exact generation, opening, and
 closing authorities, requires them to occur in order, requires generation and
-intent opening to precede the immediate successor generation, and verifies
-that generation creation, intent opening, and closure each committed inside
-their authoritative lease windows. Construction is fail closed and performs
-no control-store reads or mutations.
+intent opening to precede the immediate successor generation in both
+transaction and store time, and verifies that generation creation, intent
+opening, and closure each committed inside their authoritative lease windows
+and before the next durable lease mutation. Construction is fail closed and
+performs no control-store reads or mutations.
 
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -660,6 +660,15 @@ coordinator-lease guard keys, shared opening and closure transactions, and
 causal transaction order. Generation and durable lease-history authentication
 remain the responsibility of the lifecycle reader that constructs this value.
 
+A frozen `AuthenticatedInitialRestartIntentClosure` value binds that decoded
+closure to the referenced immutable generation and verified durable
+coordinator-lease history. It resolves the exact generation, opening, and
+closing authorities, requires them to occur in order, requires generation and
+intent opening to precede the immediate successor generation, and verifies
+that generation creation, intent opening, and closure each committed inside
+their authoritative lease windows. Construction is fail closed and performs
+no control-store reads or mutations.
+
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be
 absent from the next assignment. Policy may additionally quarantine a removed

--- a/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_auth.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_auth.py
@@ -319,6 +319,8 @@ class AuthenticatedInitialRestartIntentClosure:
         if authority_index + 1 == len(self.lease_history):
             return True
         successor = self.lease_history[authority_index + 1]
+        if successor.lifetime_sequence != authority.lifetime_sequence:
+            return False
         return (
             transaction_sequence < successor.transaction_sequence
             and committed_at_unix_ms <= successor.lease.granted_at_unix_ms

--- a/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_auth.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_auth.py
@@ -1,0 +1,294 @@
+"""Pure authentication of one persisted initial restart-intent closure."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from lm_resiliency.integrations.torchrun._control_store import ControlStoreEntry
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseRecord,
+)
+from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
+    CoordinatorLeaseAuthority,
+)
+from lm_resiliency.integrations.torchrun._generation_reader import (
+    StoredGenerationSnapshot,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_lifecycle_state import (
+    PersistedInitialRestartIntentClosure,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_records import (
+    RestartIntentClosedHeadRecord,
+    RestartIntentHeadRecord,
+    RestartIntentLifecycleHeadRecord,
+    RestartIntentLifecycleRecord,
+    RestartIntentRecord,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class AuthenticatedInitialRestartIntentClosure:
+    """One persisted closure bound to generation and lease history."""
+
+    state: PersistedInitialRestartIntentClosure
+    generation_snapshot: StoredGenerationSnapshot
+    immediate_successor: StoredGenerationSnapshot | None
+    lease_history: tuple[CoordinatorLeaseAuthority, ...]
+    generation_authority: CoordinatorLeaseAuthority = field(init=False)
+    opening_authority: CoordinatorLeaseAuthority = field(init=False)
+    closing_authority: CoordinatorLeaseAuthority = field(init=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.state, PersistedInitialRestartIntentClosure):
+            raise TypeError(
+                "AuthenticatedInitialRestartIntentClosure.state must be "
+                "PersistedInitialRestartIntentClosure"
+            )
+        if not isinstance(self.generation_snapshot, StoredGenerationSnapshot):
+            raise TypeError(
+                "AuthenticatedInitialRestartIntentClosure.generation_snapshot must "
+                "be StoredGenerationSnapshot"
+            )
+        if self.immediate_successor is not None and not isinstance(
+            self.immediate_successor,
+            StoredGenerationSnapshot,
+        ):
+            raise TypeError(
+                "AuthenticatedInitialRestartIntentClosure.immediate_successor must "
+                "be StoredGenerationSnapshot or None"
+            )
+        if not isinstance(self.lease_history, tuple) or any(
+            not isinstance(authority, CoordinatorLeaseAuthority) for authority in self.lease_history
+        ):
+            raise TypeError(
+                "AuthenticatedInitialRestartIntentClosure.lease_history must be a "
+                "tuple of CoordinatorLeaseAuthority values"
+            )
+        self._validate_generation()
+        generation_authority = self._generation_authority()
+        opening_authority = self._entry_authority(
+            self.state.intent_entry,
+            CoordinatorLeaseRecord(
+                run_id=self.state.intent.intent.run_id,
+                coordinator_id=self.state.intent.coordinator_id,
+                lease_id=self.state.intent.lease_id,
+                lease_duration_ms=self.state.intent.coordinator_lease_duration_ms,
+            ),
+            self.state.intent.coordinator_fencing_token,
+            self.state.intent.coordinator_lease_digest,
+            "opening",
+        )
+        closing_authority = self._entry_authority(
+            self.state.closed_head_entry,
+            CoordinatorLeaseRecord(
+                run_id=self.state.intent.intent.run_id,
+                coordinator_id=self.state.lifecycle.coordinator_id,
+                lease_id=self.state.lifecycle.lease_id,
+                lease_duration_ms=self.state.lifecycle.coordinator_lease_duration_ms,
+            ),
+            self.state.lifecycle.coordinator_fencing_token,
+            self.state.lifecycle.coordinator_lease_digest,
+            "closing",
+        )
+        self._validate_authority_order(
+            generation_authority,
+            opening_authority,
+            closing_authority,
+        )
+        self._validate_causal_windows(
+            generation_authority,
+            opening_authority,
+            closing_authority,
+        )
+        object.__setattr__(self, "generation_authority", generation_authority)
+        object.__setattr__(self, "opening_authority", opening_authority)
+        object.__setattr__(self, "closing_authority", closing_authority)
+
+    @property
+    def intent(self) -> RestartIntentRecord:
+        return self.state.intent
+
+    @property
+    def open_head(self) -> RestartIntentHeadRecord:
+        return self.state.open_head
+
+    @property
+    def closed_head(self) -> RestartIntentClosedHeadRecord:
+        return self.state.closed_head
+
+    @property
+    def lifecycle(self) -> RestartIntentLifecycleRecord:
+        return self.state.lifecycle
+
+    @property
+    def lifecycle_head(self) -> RestartIntentLifecycleHeadRecord:
+        return self.state.lifecycle_head
+
+    @property
+    def closed_at_unix_ms(self) -> int:
+        return self.state.closed_at_unix_ms
+
+    @property
+    def transaction_sequence(self) -> int:
+        return self.state.closing_transaction_sequence
+
+    def _validate_generation(self) -> None:
+        intent = self.state.intent.intent
+        generation_record = self.generation_snapshot.record
+        if (
+            generation_record.assignment.run_id != intent.run_id
+            or generation_record.assignment.generation != intent.generation
+            or generation_record.digest != self.state.intent.generation_snapshot_digest
+        ):
+            raise ValueError(
+                "AuthenticatedInitialRestartIntentClosure references the wrong generation"
+            )
+        successor = self.immediate_successor
+        if successor is not None and (
+            successor.record.assignment.run_id != intent.run_id
+            or successor.record.assignment.generation != intent.generation + 1
+            or successor.record.previous_snapshot_digest != generation_record.digest
+        ):
+            raise ValueError(
+                "AuthenticatedInitialRestartIntentClosure immediate successor is invalid"
+            )
+
+    def _generation_authority(self) -> CoordinatorLeaseAuthority:
+        snapshot = self.generation_snapshot
+        record = CoordinatorLeaseRecord(
+            run_id=snapshot.record.assignment.run_id,
+            coordinator_id=snapshot.record.coordinator_id,
+            lease_id=snapshot.record.lease_id,
+            lease_duration_ms=snapshot.record.coordinator_lease_duration_ms,
+        )
+        return self._unique_authority(
+            record=record,
+            fencing_token=snapshot.record.coordinator_fencing_token,
+            granted_at_unix_ms=snapshot.guard_committed_at_unix_ms,
+            mutation_sequence=snapshot.guard_mutation_sequence,
+            value_sequence=snapshot.guard_value_sequence,
+            lifetime_sequence=snapshot.guard_lifetime_sequence,
+            label="generation",
+        )
+
+    def _entry_authority(
+        self,
+        entry: ControlStoreEntry,
+        record: CoordinatorLeaseRecord,
+        fencing_token: int,
+        lease_digest: str,
+        label: str,
+    ) -> CoordinatorLeaseAuthority:
+        if (
+            entry.guard_revision != fencing_token
+            or entry.guard_value_digest != lease_digest
+            or entry.guard_committed_at_unix_ms is None
+            or entry.guard_mutation_sequence is None
+            or entry.guard_value_sequence is None
+            or entry.guard_lifetime_sequence is None
+        ):
+            raise ValueError(
+                f"AuthenticatedInitialRestartIntentClosure {label} lease provenance is incomplete"
+            )
+        return self._unique_authority(
+            record=record,
+            fencing_token=fencing_token,
+            granted_at_unix_ms=entry.guard_committed_at_unix_ms,
+            mutation_sequence=entry.guard_mutation_sequence,
+            value_sequence=entry.guard_value_sequence,
+            lifetime_sequence=entry.guard_lifetime_sequence,
+            label=label,
+        )
+
+    def _unique_authority(
+        self,
+        *,
+        record: CoordinatorLeaseRecord,
+        fencing_token: int,
+        granted_at_unix_ms: int,
+        mutation_sequence: int,
+        value_sequence: int,
+        lifetime_sequence: int,
+        label: str,
+    ) -> CoordinatorLeaseAuthority:
+        matches = tuple(
+            authority
+            for authority in self.lease_history
+            if (
+                authority.lease.record == record
+                and authority.lease.fencing_token == fencing_token
+                and authority.lease.granted_at_unix_ms == granted_at_unix_ms
+                and authority.mutation_sequence == mutation_sequence
+                and authority.value_sequence == value_sequence
+                and authority.lifetime_sequence == lifetime_sequence
+            )
+        )
+        if len(matches) != 1:
+            raise ValueError(
+                f"AuthenticatedInitialRestartIntentClosure {label} authority is "
+                "absent from lease history"
+            )
+        return matches[0]
+
+    def _validate_authority_order(
+        self,
+        generation: CoordinatorLeaseAuthority,
+        opening: CoordinatorLeaseAuthority,
+        closing: CoordinatorLeaseAuthority,
+    ) -> None:
+        generation_index = self.lease_history.index(generation)
+        opening_index = self.lease_history.index(opening)
+        closing_index = self.lease_history.index(closing)
+        if generation_index > opening_index or opening_index > closing_index:
+            raise ValueError(
+                "AuthenticatedInitialRestartIntentClosure lease authorities are out of order"
+            )
+
+    def _validate_causal_windows(
+        self,
+        generation: CoordinatorLeaseAuthority,
+        opening: CoordinatorLeaseAuthority,
+        closing: CoordinatorLeaseAuthority,
+    ) -> None:
+        snapshot = self.generation_snapshot
+        state = self.state
+        if (
+            snapshot.transaction_sequence <= generation.transaction_sequence
+            or snapshot.committed_at_unix_ms < generation.lease.granted_at_unix_ms
+            or snapshot.committed_at_unix_ms >= generation.lease.expires_at_unix_ms
+        ):
+            raise ValueError(
+                "AuthenticatedInitialRestartIntentClosure generation is outside its lease window"
+            )
+        if (
+            state.opening_transaction_sequence
+            <= max(snapshot.transaction_sequence, opening.transaction_sequence)
+            or state.opened_at_unix_ms < snapshot.committed_at_unix_ms
+            or state.opened_at_unix_ms < opening.lease.granted_at_unix_ms
+            or state.opened_at_unix_ms
+            >= min(
+                opening.lease.expires_at_unix_ms,
+                state.intent.intent.prepare_deadline_unix_ms,
+            )
+            or (
+                self.immediate_successor is not None
+                and state.opening_transaction_sequence
+                >= self.immediate_successor.transaction_sequence
+            )
+        ):
+            raise ValueError(
+                "AuthenticatedInitialRestartIntentClosure opening is outside its causal window"
+            )
+        if (
+            state.closing_transaction_sequence
+            <= max(state.opening_transaction_sequence, closing.transaction_sequence)
+            or state.closed_at_unix_ms < closing.lease.granted_at_unix_ms
+            or state.closed_at_unix_ms >= closing.lease.expires_at_unix_ms
+        ):
+            raise ValueError(
+                "AuthenticatedInitialRestartIntentClosure closure is outside its "
+                "causal lease window"
+            )
+
+
+__all__ = ["AuthenticatedInitialRestartIntentClosure"]

--- a/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_auth.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_auth.py
@@ -256,6 +256,11 @@ class AuthenticatedInitialRestartIntentClosure:
             snapshot.transaction_sequence <= generation.transaction_sequence
             or snapshot.committed_at_unix_ms < generation.lease.granted_at_unix_ms
             or snapshot.committed_at_unix_ms >= generation.lease.expires_at_unix_ms
+            or not self._commit_precedes_next_authority(
+                generation,
+                transaction_sequence=snapshot.transaction_sequence,
+                committed_at_unix_ms=snapshot.committed_at_unix_ms,
+            )
         ):
             raise ValueError(
                 "AuthenticatedInitialRestartIntentClosure generation is outside its lease window"
@@ -272,8 +277,16 @@ class AuthenticatedInitialRestartIntentClosure:
             )
             or (
                 self.immediate_successor is not None
-                and state.opening_transaction_sequence
-                >= self.immediate_successor.transaction_sequence
+                and (
+                    state.opening_transaction_sequence
+                    >= self.immediate_successor.transaction_sequence
+                    or state.opened_at_unix_ms > self.immediate_successor.committed_at_unix_ms
+                )
+            )
+            or not self._commit_precedes_next_authority(
+                opening,
+                transaction_sequence=state.opening_transaction_sequence,
+                committed_at_unix_ms=state.opened_at_unix_ms,
             )
         ):
             raise ValueError(
@@ -284,11 +297,32 @@ class AuthenticatedInitialRestartIntentClosure:
             <= max(state.opening_transaction_sequence, closing.transaction_sequence)
             or state.closed_at_unix_ms < closing.lease.granted_at_unix_ms
             or state.closed_at_unix_ms >= closing.lease.expires_at_unix_ms
+            or not self._commit_precedes_next_authority(
+                closing,
+                transaction_sequence=state.closing_transaction_sequence,
+                committed_at_unix_ms=state.closed_at_unix_ms,
+            )
         ):
             raise ValueError(
                 "AuthenticatedInitialRestartIntentClosure closure is outside its "
                 "causal lease window"
             )
+
+    def _commit_precedes_next_authority(
+        self,
+        authority: CoordinatorLeaseAuthority,
+        *,
+        transaction_sequence: int,
+        committed_at_unix_ms: int,
+    ) -> bool:
+        authority_index = self.lease_history.index(authority)
+        if authority_index + 1 == len(self.lease_history):
+            return True
+        successor = self.lease_history[authority_index + 1]
+        return (
+            transaction_sequence < successor.transaction_sequence
+            and committed_at_unix_ms <= successor.lease.granted_at_unix_ms
+        )
 
 
 __all__ = ["AuthenticatedInitialRestartIntentClosure"]

--- a/tests/unit/test_torchrun_restart_intent_lifecycle_auth.py
+++ b/tests/unit/test_torchrun_restart_intent_lifecycle_auth.py
@@ -1,0 +1,413 @@
+"""Contract tests for persisted restart-intent closure authentication."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, replace
+from typing import Any, cast
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseManager,
+    HeldCoordinatorLease,
+)
+from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
+    CoordinatorLeaseAuthority,
+    CoordinatorLeaseHistoryReader,
+)
+from lm_resiliency.integrations.torchrun._generation_reader import (
+    GenerationStateReader,
+    StoredGenerationSnapshot,
+)
+from lm_resiliency.integrations.torchrun._generation_state import GenerationStateManager
+from lm_resiliency.integrations.torchrun._protocol import (
+    RankAssignment,
+    RestartIntent,
+    SlotAssignment,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_close_records import (
+    InitialRestartIntentClosureRecords,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_lifecycle_auth import (
+    AuthenticatedInitialRestartIntentClosure,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_lifecycle_state import (
+    PersistedInitialRestartIntentClosure,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open import (
+    RestartIntentOpenPreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
+    RestartIntentOpenExecutor,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_records import (
+    RestartIntentClosedHeadRecord,
+    RestartIntentLifecycleHeadRecord,
+    RestartIntentLifecycleRecord,
+)
+
+RUN_ID = "training-run"
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+    def set(self, now_unix_ms: int) -> None:
+        with self._lock:
+            self.now_unix_ms = now_unix_ms
+
+
+@dataclass(frozen=True, slots=True)
+class ClosureFixture:
+    clock: ManualClock
+    store: InMemoryControlStore
+    generation_manager: GenerationStateManager
+    lease_manager: CoordinatorLeaseManager
+    opening_lease: HeldCoordinatorLease
+    state: PersistedInitialRestartIntentClosure
+    generation: StoredGenerationSnapshot
+    successor: StoredGenerationSnapshot | None
+    lease_history: tuple[CoordinatorLeaseAuthority, ...]
+
+
+def _manager(
+    store: InMemoryControlStore,
+    clock: ManualClock,
+    coordinator_id: str,
+) -> CoordinatorLeaseManager:
+    return CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id=coordinator_id,
+        lease_duration_ms=100,
+        clock=clock,
+    )
+
+
+def _assignment(generation: int = 0, *, node_id: str = "node-b") -> RankAssignment:
+    return RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=generation,
+        assignments=(
+            SlotAssignment(0, "node-a", 0, 2),
+            SlotAssignment(1, node_id, 2, 2),
+        ),
+        topology_digest="topology-v1",
+    )
+
+
+def _fixture(*, closing_mode: str = "opening") -> ClosureFixture:
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    lease_manager = _manager(store, clock, "coordinator-a")
+    generation_manager = GenerationStateManager(store, run_id=RUN_ID)
+    opening_lease = lease_manager.acquire()
+    generation_manager.initialize(opening_lease, _assignment())
+    current = generation_manager.current()
+    assert current is not None
+    intent = RestartIntent(
+        intent_id="intent-a",
+        run_id=RUN_ID,
+        generation=0,
+        incident_ids=("incident-a",),
+        reason_code="attributed_sdc",
+        minimum_recovery_mode="recovery_verified",
+        suspected_node_ids=("node-b",),
+        prepare_deadline_unix_ms=1_200,
+    )
+    prepared = RestartIntentOpenPreparer(
+        store,
+        run_id=RUN_ID,
+        clock=clock,
+    ).prepare_initial_open(opening_lease, current, intent)
+    opened = RestartIntentOpenExecutor(
+        store,
+        run_id=RUN_ID,
+    ).execute_initial_open(prepared)
+    closing_lease = opening_lease
+    if closing_mode == "renewed":
+        clock.set(1_010)
+        closing_lease = lease_manager.renew(opening_lease)
+    elif closing_mode == "replacement":
+        clock.set(opening_lease.expires_at_unix_ms)
+        closing_lease = _manager(store, clock, "coordinator-b").acquire()
+    elif closing_mode != "opening":
+        raise AssertionError(f"unsupported closing mode: {closing_mode}")
+    lifecycle = RestartIntentLifecycleRecord(
+        closed_intent=prepared.head,
+        coordinator_id=closing_lease.record.coordinator_id,
+        lease_id=closing_lease.record.lease_id,
+        coordinator_lease_duration_ms=closing_lease.record.lease_duration_ms,
+        coordinator_fencing_token=closing_lease.fencing_token,
+    )
+    lifecycle_head = RestartIntentLifecycleHeadRecord(
+        run_id=RUN_ID,
+        closure_index=1,
+        generation=0,
+        intent_id=intent.intent_id,
+        lifecycle_digest=lifecycle.digest,
+    )
+    run_prefix = prepared.intent_head_key.rsplit("/", 1)[0]
+    records = InitialRestartIntentClosureRecords(
+        opened=opened,
+        lifecycle=lifecycle,
+        lifecycle_head=lifecycle_head,
+        closed_head=RestartIntentClosedHeadRecord(
+            run_id=RUN_ID,
+            closure_index=1,
+            generation=0,
+            intent_id=intent.intent_id,
+            lifecycle_head_digest=lifecycle_head.digest,
+        ),
+        intent_key=prepared.intent_key,
+        intent_head_key=prepared.intent_head_key,
+        closure_key=f"{run_prefix}/restart-intent-closures/1",
+        lifecycle_head_key=prepared.lifecycle_head_key,
+    )
+    clock.set(max(clock.now_unix_ms, closing_lease.granted_at_unix_ms, 1_010))
+    committed = store.compare_set_many_guarded(
+        records.writes,
+        guard_key=prepared.coordinator_lease_key,
+        expected_guard_revision=closing_lease.fencing_token,
+        not_before_unix_ms=clock.now_unix_ms,
+        deadline_unix_ms=closing_lease.expires_at_unix_ms,
+        conditions=records.conditions,
+    )
+    head_history = store.get_history(records.intent_head_key)
+    assert len(head_history) == 2
+    state = PersistedInitialRestartIntentClosure.from_entries(
+        run_id=RUN_ID,
+        intent_entry=opened.intent_entry,
+        open_head_entry=head_history[0],
+        closed_head_entry=committed[records.intent_head_key],
+        lifecycle_entry=committed[records.closure_key],
+        lifecycle_head_entry=committed[records.lifecycle_head_key],
+    )
+    generation_reader = GenerationStateReader(store, run_id=RUN_ID)
+    generation = generation_reader.get(0)
+    assert generation is not None
+    return ClosureFixture(
+        clock=clock,
+        store=store,
+        generation_manager=generation_manager,
+        lease_manager=lease_manager,
+        opening_lease=opening_lease,
+        state=state,
+        generation=generation,
+        successor=generation_reader.get(1),
+        lease_history=CoordinatorLeaseHistoryReader(store, run_id=RUN_ID).read(),
+    )
+
+
+def _authenticate(
+    fixture: ClosureFixture,
+) -> AuthenticatedInitialRestartIntentClosure:
+    return AuthenticatedInitialRestartIntentClosure(
+        state=fixture.state,
+        generation_snapshot=fixture.generation,
+        immediate_successor=fixture.successor,
+        lease_history=fixture.lease_history,
+    )
+
+
+@pytest.mark.parametrize("closing_mode", ["opening", "renewed", "replacement"])
+def test_authenticated_closure_resolves_exact_authorities(closing_mode: str):
+    fixture = _fixture(closing_mode=closing_mode)
+
+    authenticated = _authenticate(fixture)
+
+    assert authenticated.intent == fixture.state.intent
+    assert authenticated.open_head == fixture.state.open_head
+    assert authenticated.closed_head == fixture.state.closed_head
+    assert authenticated.lifecycle == fixture.state.lifecycle
+    assert authenticated.lifecycle_head == fixture.state.lifecycle_head
+    assert authenticated.generation_authority == fixture.lease_history[0]
+    assert authenticated.opening_authority == fixture.lease_history[0]
+    assert authenticated.closing_authority == fixture.lease_history[-1]
+    assert authenticated.closed_at_unix_ms == fixture.state.closed_at_unix_ms
+    assert authenticated.transaction_sequence == fixture.state.closing_transaction_sequence
+
+
+def test_authenticated_closure_accepts_immediate_generation_successor():
+    fixture = _fixture()
+    current = fixture.generation_manager.current()
+    assert current is not None
+    fixture.clock.set(1_020)
+    fixture.generation_manager.commit_successor(
+        fixture.opening_lease,
+        current,
+        _assignment(generation=1, node_id="node-c"),
+    )
+    successor = GenerationStateReader(fixture.store, run_id=RUN_ID).get(1)
+    assert successor is not None
+
+    authenticated = AuthenticatedInitialRestartIntentClosure(
+        state=fixture.state,
+        generation_snapshot=fixture.generation,
+        immediate_successor=successor,
+        lease_history=CoordinatorLeaseHistoryReader(
+            fixture.store,
+            run_id=RUN_ID,
+        ).read(),
+    )
+
+    assert authenticated.immediate_successor == successor
+
+    with pytest.raises(ValueError, match="opening is outside"):
+        AuthenticatedInitialRestartIntentClosure(
+            state=fixture.state,
+            generation_snapshot=fixture.generation,
+            immediate_successor=replace(
+                successor,
+                transaction_sequence=fixture.state.opening_transaction_sequence,
+            ),
+            lease_history=CoordinatorLeaseHistoryReader(
+                fixture.store,
+                run_id=RUN_ID,
+            ).read(),
+        )
+
+
+def test_authenticated_closure_rejects_wrong_generation_or_successor():
+    fixture = _fixture()
+
+    with pytest.raises(ValueError, match="wrong generation"):
+        AuthenticatedInitialRestartIntentClosure(
+            state=fixture.state,
+            generation_snapshot=replace(
+                fixture.generation,
+                record=replace(
+                    fixture.generation.record,
+                    assignment=_assignment(generation=1, node_id="node-c"),
+                    previous_snapshot_digest="0" * 64,
+                ),
+            ),
+            immediate_successor=None,
+            lease_history=fixture.lease_history,
+        )
+
+    with pytest.raises(ValueError, match="immediate successor"):
+        AuthenticatedInitialRestartIntentClosure(
+            state=fixture.state,
+            generation_snapshot=fixture.generation,
+            immediate_successor=fixture.generation,
+            lease_history=fixture.lease_history,
+        )
+
+
+def test_authenticated_closure_requires_exact_ordered_authorities():
+    fixture = _fixture(closing_mode="replacement")
+
+    with pytest.raises(ValueError, match="generation authority is absent"):
+        AuthenticatedInitialRestartIntentClosure(
+            state=fixture.state,
+            generation_snapshot=fixture.generation,
+            immediate_successor=None,
+            lease_history=(),
+        )
+
+    with pytest.raises(ValueError, match="out of order"):
+        AuthenticatedInitialRestartIntentClosure(
+            state=fixture.state,
+            generation_snapshot=fixture.generation,
+            immediate_successor=None,
+            lease_history=tuple(reversed(fixture.lease_history)),
+        )
+
+
+def test_authenticated_closure_rejects_generation_outside_lease_window():
+    fixture = _fixture()
+    authority = fixture.lease_history[0]
+
+    with pytest.raises(ValueError, match="generation is outside"):
+        AuthenticatedInitialRestartIntentClosure(
+            state=fixture.state,
+            generation_snapshot=replace(
+                fixture.generation,
+                transaction_sequence=authority.transaction_sequence,
+            ),
+            immediate_successor=None,
+            lease_history=fixture.lease_history,
+        )
+
+
+def test_authenticated_closure_rejects_opening_outside_causal_window():
+    fixture = _fixture()
+    transaction_sequence = fixture.generation.transaction_sequence
+    state = replace(
+        fixture.state,
+        intent_entry=replace(
+            fixture.state.intent_entry,
+            transaction_sequence=transaction_sequence,
+        ),
+        open_head_entry=replace(
+            fixture.state.open_head_entry,
+            transaction_sequence=transaction_sequence,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="opening is outside"):
+        AuthenticatedInitialRestartIntentClosure(
+            state=state,
+            generation_snapshot=fixture.generation,
+            immediate_successor=None,
+            lease_history=fixture.lease_history,
+        )
+
+
+def test_authenticated_closure_rejects_closure_outside_lease_window():
+    fixture = _fixture()
+    expiry = fixture.lease_history[-1].lease.expires_at_unix_ms
+    state = replace(
+        fixture.state,
+        closed_head_entry=replace(
+            fixture.state.closed_head_entry,
+            committed_at_unix_ms=expiry,
+        ),
+        lifecycle_entry=replace(
+            fixture.state.lifecycle_entry,
+            committed_at_unix_ms=expiry,
+        ),
+        lifecycle_head_entry=replace(
+            fixture.state.lifecycle_head_entry,
+            committed_at_unix_ms=expiry,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="closure is outside"):
+        AuthenticatedInitialRestartIntentClosure(
+            state=state,
+            generation_snapshot=fixture.generation,
+            immediate_successor=None,
+            lease_history=fixture.lease_history,
+        )
+
+
+def test_authenticated_closure_is_immutable_and_strictly_typed():
+    fixture = _fixture()
+    authenticated = _authenticate(fixture)
+
+    with pytest.raises(AttributeError):
+        authenticated.closing_authority = authenticated.opening_authority
+    with pytest.raises(TypeError, match="state"):
+        AuthenticatedInitialRestartIntentClosure(
+            state=cast(Any, {}),
+            generation_snapshot=fixture.generation,
+            immediate_successor=None,
+            lease_history=fixture.lease_history,
+        )
+    with pytest.raises(TypeError, match="lease_history"):
+        AuthenticatedInitialRestartIntentClosure(
+            state=fixture.state,
+            generation_snapshot=fixture.generation,
+            immediate_successor=None,
+            lease_history=cast(Any, []),
+        )

--- a/tests/unit/test_torchrun_restart_intent_lifecycle_auth.py
+++ b/tests/unit/test_torchrun_restart_intent_lifecycle_auth.py
@@ -417,6 +417,25 @@ def test_authenticated_closure_bounds_old_authority_by_next_mutation():
         )
 
 
+def test_authenticated_closure_rejects_unorderable_delete_recreate_history():
+    fixture = _fixture()
+    fixture.clock.set(1_020)
+    fixture.lease_manager.release(fixture.opening_lease)
+    _manager(fixture.store, fixture.clock, "coordinator-b").acquire()
+    lease_history = CoordinatorLeaseHistoryReader(
+        fixture.store,
+        run_id=RUN_ID,
+    ).read()
+
+    with pytest.raises(ValueError, match="generation is outside"):
+        AuthenticatedInitialRestartIntentClosure(
+            state=fixture.state,
+            generation_snapshot=fixture.generation,
+            immediate_successor=None,
+            lease_history=lease_history,
+        )
+
+
 def test_authenticated_closure_rejects_opening_outside_causal_window():
     fixture = _fixture()
     transaction_sequence = fixture.generation.transaction_sequence

--- a/tests/unit/test_torchrun_restart_intent_lifecycle_auth.py
+++ b/tests/unit/test_torchrun_restart_intent_lifecycle_auth.py
@@ -274,6 +274,19 @@ def test_authenticated_closure_accepts_immediate_generation_successor():
                 run_id=RUN_ID,
             ).read(),
         )
+    with pytest.raises(ValueError, match="opening is outside"):
+        AuthenticatedInitialRestartIntentClosure(
+            state=fixture.state,
+            generation_snapshot=fixture.generation,
+            immediate_successor=replace(
+                successor,
+                committed_at_unix_ms=fixture.state.opened_at_unix_ms - 1,
+            ),
+            lease_history=CoordinatorLeaseHistoryReader(
+                fixture.store,
+                run_id=RUN_ID,
+            ).read(),
+        )
 
 
 def test_authenticated_closure_rejects_wrong_generation_or_successor():
@@ -336,6 +349,71 @@ def test_authenticated_closure_rejects_generation_outside_lease_window():
             ),
             immediate_successor=None,
             lease_history=fixture.lease_history,
+        )
+
+
+def test_authenticated_closure_bounds_old_authority_by_next_mutation():
+    fixture = _fixture(closing_mode="renewed")
+    next_authority = fixture.lease_history[1]
+
+    with pytest.raises(ValueError, match="generation is outside"):
+        AuthenticatedInitialRestartIntentClosure(
+            state=fixture.state,
+            generation_snapshot=replace(
+                fixture.generation,
+                transaction_sequence=next_authority.transaction_sequence,
+            ),
+            immediate_successor=None,
+            lease_history=fixture.lease_history,
+        )
+
+    state = replace(
+        fixture.state,
+        intent_entry=replace(
+            fixture.state.intent_entry,
+            transaction_sequence=next_authority.transaction_sequence,
+        ),
+        open_head_entry=replace(
+            fixture.state.open_head_entry,
+            transaction_sequence=next_authority.transaction_sequence,
+        ),
+    )
+    with pytest.raises(ValueError, match="opening is outside"):
+        AuthenticatedInitialRestartIntentClosure(
+            state=state,
+            generation_snapshot=fixture.generation,
+            immediate_successor=None,
+            lease_history=fixture.lease_history,
+        )
+
+    fixture = _fixture()
+    fixture.clock.set(1_020)
+    fixture.lease_manager.renew(fixture.opening_lease)
+    lease_history = CoordinatorLeaseHistoryReader(
+        fixture.store,
+        run_id=RUN_ID,
+    ).read()
+    state = replace(
+        fixture.state,
+        closed_head_entry=replace(
+            fixture.state.closed_head_entry,
+            transaction_sequence=lease_history[-1].transaction_sequence,
+        ),
+        lifecycle_entry=replace(
+            fixture.state.lifecycle_entry,
+            transaction_sequence=lease_history[-1].transaction_sequence,
+        ),
+        lifecycle_head_entry=replace(
+            fixture.state.lifecycle_head_entry,
+            transaction_sequence=lease_history[-1].transaction_sequence,
+        ),
+    )
+    with pytest.raises(ValueError, match="closure is outside"):
+        AuthenticatedInitialRestartIntentClosure(
+            state=state,
+            generation_snapshot=fixture.generation,
+            immediate_successor=None,
+            lease_history=lease_history,
         )
 
 


### PR DESCRIPTION
## Summary
- add a frozen value that binds a decoded initial restart-intent closure to its immutable generation
- resolve exact generation, opening, and closing coordinator lease authorities from verified durable history
- fail closed on wrong generations, missing or reordered authority, stale-generation openings, commits outside authoritative lease windows, commits attributed after the next lease mutation, successor timestamp inversions, and unorderable delete/recreate lifetimes

## Scope
This PR is non-mutating and performs no control-store reads. The stable lifecycle reader that supplies decoded state and verified histories remains a separate follow-up. Delete/recreate histories remain conservatively unsupported until durable deletion transaction metadata exists.

## Validation
- `130` focused torchrun lifecycle/generation/lease tests
- `1751` full CPU tests with CUDA hidden
- Ruff format/check
- targeted mypy
- `git diff --check`