### PR TITLE
[Feature][Torchrun] Read authenticated restart intent closure

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -690,10 +690,12 @@ canonical coordinator lease with the fencing token and lease digest carried by
 the immutable intent. Both opening entries require authoritative commit times,
 must follow the current generation, must bind its exact snapshot digest, and
 must name one exact authority in durable lease history whose grant, expiry, and
-fencing sequences bound the opening. Both pre-closure and closure reads
-double-collect verified generation and coordinator-lease histories around the
-persisted state so failover cannot combine old lease authority with a newer
-generation.
+fencing sequences bound the opening before the next lease mutation. The
+generation's own guard must resolve to one durable authority and satisfy the
+same causal lease bounds. Every suspected node must belong to that generation.
+Both pre-closure and closure reads double-collect verified generation and
+coordinator-lease histories around the persisted state so failover cannot
+combine old lease authority with a newer generation.
 
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -673,16 +673,15 @@ does not identify the intervening delete transaction, an authority followed by
 a delete-and-recreate lifetime cannot authenticate an earlier commit; that
 case remains rejected until the store provides a durable deletion tombstone.
 
-A read-only `InitialRestartIntentLifecycleReader` authenticates that first
-closure separately. It stably verifies the retained open-head predecessor,
-immutable intent, durable closed marker, immutable closure record, lifecycle
-head, referenced generation snapshot, and the opening and closing authorities
-from durable coordinator-lease history. The opening must commit while its
-generation is current, and the three closure values must share one later
-guarded transaction inside the closing lease window. Missing, rewritten,
-unlinked, noncanonical, or causally impossible state fails closed. The reader
-returns the exact verified records and store entries needed by the next
-lifecycle transition and performs no mutation.
+A read-only `InitialRestartIntentLifecycleReader` observes that first closure
+separately. It takes stable snapshots of the current-intent head, its retained
+open predecessor, immutable intent, immutable closure record, and lifecycle
+head; requires durable history for every observed key; obtains the referenced
+generation and verified coordinator-lease history through their existing
+readers; then constructs `PersistedInitialRestartIntentClosure` and
+`AuthenticatedInitialRestartIntentClosure`. Missing, rewritten, split,
+noncanonical, or contradictory state fails closed. Retryable dependency-read
+contention remains retryable, and the reader performs no mutation.
 
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -685,7 +685,11 @@ contention remains retryable, and the reader performs no mutation.
 Before the first closure, the same stable observation requires the current
 open head and its linked immutable intent to remain canonical create-once
 records from one guarded transaction; it also requires the lifecycle head and
-initial closure key to have no durable history.
+initial closure key to have no durable history. The guard must be the run's
+canonical coordinator lease with the fencing token and lease digest carried by
+the immutable intent. Closure reads double-collect verified generation and
+coordinator-lease histories around the persisted closure snapshot so failover
+cannot combine old lease authority with a newer generation.
 
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -682,6 +682,10 @@ readers; then constructs `PersistedInitialRestartIntentClosure` and
 `AuthenticatedInitialRestartIntentClosure`. Missing, rewritten, split,
 noncanonical, or contradictory state fails closed. Retryable dependency-read
 contention remains retryable, and the reader performs no mutation.
+Before the first closure, the same stable observation requires the current
+open head and its linked immutable intent to remain canonical create-once
+records from one guarded transaction; it also requires the lifecycle head and
+initial closure key to have no durable history.
 
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -667,11 +667,14 @@ closing authorities, requires them to occur in order, requires generation and
 intent opening to precede the immediate successor generation in both
 transaction and store time, and verifies that generation creation, intent
 opening, and closure each committed inside their authoritative lease windows
-and before the next durable lease mutation. Construction is fail closed and
-performs no control-store reads or mutations. Because retained value history
-does not identify the intervening delete transaction, an authority followed by
-a delete-and-recreate lifetime cannot authenticate an earlier commit; that
-case remains rejected until the store provides a durable deletion tombstone.
+and before the next durable lease mutation. When an immediate successor
+exists, its exact guard must also resolve to durable lease history and its
+generation commit must fall inside that authority's lease window. Construction
+is fail closed and performs no control-store reads or mutations. Because
+retained value history does not identify the intervening delete transaction,
+an authority followed by a delete-and-recreate lifetime cannot authenticate an
+earlier commit; that case remains rejected until the store provides a durable
+deletion tombstone.
 
 A read-only `InitialRestartIntentLifecycleReader` observes that first closure
 separately. It takes stable snapshots of the current-intent head, its retained

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -688,10 +688,12 @@ records from one guarded transaction; it also requires the lifecycle head and
 initial closure key to have no durable history. The guard must be the run's
 canonical coordinator lease with the fencing token and lease digest carried by
 the immutable intent. Both opening entries require authoritative commit times,
-must follow the current generation, and must bind its exact snapshot digest.
-Closure reads double-collect verified generation and coordinator-lease
-histories around the persisted closure snapshot so failover cannot combine old
-lease authority with a newer generation.
+must follow the current generation, must bind its exact snapshot digest, and
+must name one exact authority in durable lease history whose grant, expiry, and
+fencing sequences bound the opening. Both pre-closure and closure reads
+double-collect verified generation and coordinator-lease histories around the
+persisted state so failover cannot combine old lease authority with a newer
+generation.
 
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -673,6 +673,17 @@ does not identify the intervening delete transaction, an authority followed by
 a delete-and-recreate lifetime cannot authenticate an earlier commit; that
 case remains rejected until the store provides a durable deletion tombstone.
 
+A read-only `InitialRestartIntentLifecycleReader` authenticates that first
+closure separately. It stably verifies the retained open-head predecessor,
+immutable intent, durable closed marker, immutable closure record, lifecycle
+head, referenced generation snapshot, and the opening and closing authorities
+from durable coordinator-lease history. The opening must commit while its
+generation is current, and the three closure values must share one later
+guarded transaction inside the closing lease window. Missing, rewritten,
+unlinked, noncanonical, or causally impossible state fails closed. The reader
+returns the exact verified records and store entries needed by the next
+lifecycle transition and performs no mutation.
+
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be
 absent from the next assignment. Policy may additionally quarantine a removed

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -687,9 +687,11 @@ open head and its linked immutable intent to remain canonical create-once
 records from one guarded transaction; it also requires the lifecycle head and
 initial closure key to have no durable history. The guard must be the run's
 canonical coordinator lease with the fencing token and lease digest carried by
-the immutable intent. Closure reads double-collect verified generation and
-coordinator-lease histories around the persisted closure snapshot so failover
-cannot combine old lease authority with a newer generation.
+the immutable intent. Both opening entries require authoritative commit times,
+must follow the current generation, and must bind its exact snapshot digest.
+Closure reads double-collect verified generation and coordinator-lease
+histories around the persisted closure snapshot so failover cannot combine old
+lease authority with a newer generation.
 
 `suspected_node_ids` is the policy-approved replacement scope for the
 incident. Every listed node must belong to the committed generation and must be

--- a/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_auth.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_auth.py
@@ -143,6 +143,13 @@ class AuthenticatedInitialRestartIntentClosure:
             raise ValueError(
                 "AuthenticatedInitialRestartIntentClosure references the wrong generation"
             )
+        active_nodes = set(generation_record.assignment.slot_to_node_id.values())
+        unknown_nodes = sorted(set(intent.suspected_node_ids) - active_nodes)
+        if unknown_nodes:
+            raise ValueError(
+                "AuthenticatedInitialRestartIntentClosure suspects nodes outside its "
+                f"generation: {unknown_nodes!r}"
+            )
         successor = self.immediate_successor
         if successor is not None and (
             successor.record.assignment.run_id != intent.run_id

--- a/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_auth.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_auth.py
@@ -159,6 +159,14 @@ class AuthenticatedInitialRestartIntentClosure:
             raise ValueError(
                 "AuthenticatedInitialRestartIntentClosure immediate successor is invalid"
             )
+        if successor is not None:
+            successor_nodes = set(successor.record.assignment.slot_to_node_id.values())
+            retained_suspects = sorted(set(intent.suspected_node_ids) & successor_nodes)
+            if retained_suspects:
+                raise ValueError(
+                    "AuthenticatedInitialRestartIntentClosure immediate successor "
+                    f"retains suspected nodes: {retained_suspects!r}"
+                )
 
     def _generation_authority(self) -> CoordinatorLeaseAuthority:
         snapshot = self.generation_snapshot

--- a/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_auth.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_auth.py
@@ -35,6 +35,7 @@ class AuthenticatedInitialRestartIntentClosure:
     immediate_successor: StoredGenerationSnapshot | None
     lease_history: tuple[CoordinatorLeaseAuthority, ...]
     generation_authority: CoordinatorLeaseAuthority = field(init=False)
+    successor_authority: CoordinatorLeaseAuthority | None = field(init=False)
     opening_authority: CoordinatorLeaseAuthority = field(init=False)
     closing_authority: CoordinatorLeaseAuthority = field(init=False)
 
@@ -65,7 +66,18 @@ class AuthenticatedInitialRestartIntentClosure:
                 "tuple of CoordinatorLeaseAuthority values"
             )
         self._validate_generation()
-        generation_authority = self._generation_authority()
+        generation_authority = self._snapshot_authority(
+            self.generation_snapshot,
+            "generation",
+        )
+        successor_authority = (
+            None
+            if self.immediate_successor is None
+            else self._snapshot_authority(
+                self.immediate_successor,
+                "immediate successor",
+            )
+        )
         opening_authority = self._entry_authority(
             self.state.intent_entry,
             CoordinatorLeaseRecord(
@@ -95,12 +107,14 @@ class AuthenticatedInitialRestartIntentClosure:
             opening_authority,
             closing_authority,
         )
+        self._validate_successor_window(successor_authority)
         self._validate_causal_windows(
             generation_authority,
             opening_authority,
             closing_authority,
         )
         object.__setattr__(self, "generation_authority", generation_authority)
+        object.__setattr__(self, "successor_authority", successor_authority)
         object.__setattr__(self, "opening_authority", opening_authority)
         object.__setattr__(self, "closing_authority", closing_authority)
 
@@ -168,8 +182,11 @@ class AuthenticatedInitialRestartIntentClosure:
                     f"retains suspected nodes: {retained_suspects!r}"
                 )
 
-    def _generation_authority(self) -> CoordinatorLeaseAuthority:
-        snapshot = self.generation_snapshot
+    def _snapshot_authority(
+        self,
+        snapshot: StoredGenerationSnapshot,
+        label: str,
+    ) -> CoordinatorLeaseAuthority:
         record = CoordinatorLeaseRecord(
             run_id=snapshot.record.assignment.run_id,
             coordinator_id=snapshot.record.coordinator_id,
@@ -183,7 +200,7 @@ class AuthenticatedInitialRestartIntentClosure:
             mutation_sequence=snapshot.guard_mutation_sequence,
             value_sequence=snapshot.guard_value_sequence,
             lifetime_sequence=snapshot.guard_lifetime_sequence,
-            label="generation",
+            label=label,
         )
 
     def _entry_authority(
@@ -321,6 +338,32 @@ class AuthenticatedInitialRestartIntentClosure:
             raise ValueError(
                 "AuthenticatedInitialRestartIntentClosure closure is outside its "
                 "causal lease window"
+            )
+
+    def _validate_successor_window(
+        self,
+        authority: CoordinatorLeaseAuthority | None,
+    ) -> None:
+        successor = self.immediate_successor
+        if successor is None:
+            if authority is not None:
+                raise AssertionError("successor authority exists without a successor")
+            return
+        if authority is None:
+            raise AssertionError("successor exists without an authority")
+        if (
+            successor.transaction_sequence <= authority.transaction_sequence
+            or successor.committed_at_unix_ms < authority.lease.granted_at_unix_ms
+            or successor.committed_at_unix_ms >= authority.lease.expires_at_unix_ms
+            or not self._commit_precedes_next_authority(
+                authority,
+                transaction_sequence=successor.transaction_sequence,
+                committed_at_unix_ms=successor.committed_at_unix_ms,
+            )
+        ):
+            raise ValueError(
+                "AuthenticatedInitialRestartIntentClosure immediate successor is "
+                "outside its lease window"
             )
 
     def _commit_precedes_next_authority(

--- a/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_reader.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_reader.py
@@ -15,6 +15,7 @@ from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
     CoordinatorLeaseHistoryReader,
 )
 from lm_resiliency.integrations.torchrun._generation_reader import (
+    CurrentGeneration,
     GenerationStateCorrupt,
     GenerationStateReader,
     StoredGenerationSnapshot,
@@ -140,25 +141,7 @@ class InitialRestartIntentLifecycleReader:
             intent_key = self.intent_key(lifecycle_head.intent_id)
             closure_observation = self._observe(closure_key)
             intent_observation = self._observe(intent_key)
-            try:
-                lease_history = self._lease_history_reader.read()
-                generation_result = self._generation_reader.current_with_history()
-            except (
-                CoordinatorLeaseHistoryCorrupt,
-                GenerationStateCorrupt,
-            ) as error:
-                raise RestartIntentLifecycleReadCorrupt(
-                    "restart-intent lifecycle dependencies are corrupt"
-                ) from error
-            generation_snapshot = None
-            successor = None
-            if generation_result is not None:
-                _, generation_history = generation_result
-                if lifecycle_head.generation < len(generation_history):
-                    generation_snapshot = generation_history[lifecycle_head.generation]
-                    successor_index = lifecycle_head.generation + 1
-                    if successor_index < len(generation_history):
-                        successor = generation_history[successor_index]
+            lease_history, generation_result = self._read_dependencies()
             if not self._stable(
                 self._intent_head_key,
                 head_observation,
@@ -170,6 +153,21 @@ class InitialRestartIntentLifecycleReader:
                 intent_observation,
             ):
                 continue
+            confirmed_lease_history, confirmed_generation_result = self._read_dependencies()
+            if (
+                lease_history != confirmed_lease_history
+                or generation_result != confirmed_generation_result
+            ):
+                continue
+            generation_snapshot = None
+            successor = None
+            if generation_result is not None:
+                _, generation_history = generation_result
+                if lifecycle_head.generation < len(generation_history):
+                    generation_snapshot = generation_history[lifecycle_head.generation]
+                    successor_index = lifecycle_head.generation + 1
+                    if successor_index < len(generation_history):
+                        successor = generation_history[successor_index]
             return self._authenticate_closure(
                 head_observation,
                 lifecycle_observation,
@@ -268,6 +266,46 @@ class InitialRestartIntentLifecycleReader:
                 "current restart-intent head and immutable intent "
                 "do not share one guarded transaction"
             )
+        guard_provenance = (
+            intent_entry.guard_key,
+            intent_entry.guard_revision,
+            intent_entry.guard_value_digest,
+            intent_entry.guard_committed_at_unix_ms,
+            intent_entry.guard_mutation_sequence,
+            intent_entry.guard_value_sequence,
+            intent_entry.guard_lifetime_sequence,
+        )
+        if any(value is None for value in guard_provenance):
+            raise RestartIntentLifecycleReadCorrupt(
+                "immutable restart intent has incomplete coordinator lease provenance"
+            )
+        if (
+            intent_entry.guard_key != self._generation_reader.coordinator_lease_key
+            or intent_entry.guard_revision != intent.coordinator_fencing_token
+            or intent_entry.guard_value_digest != intent.coordinator_lease_digest
+        ):
+            raise RestartIntentLifecycleReadCorrupt(
+                "immutable restart intent has invalid coordinator lease provenance"
+            )
+
+    def _read_dependencies(
+        self,
+    ) -> tuple[
+        tuple[CoordinatorLeaseAuthority, ...],
+        tuple[CurrentGeneration, tuple[StoredGenerationSnapshot, ...]] | None,
+    ]:
+        try:
+            return (
+                self._lease_history_reader.read(),
+                self._generation_reader.current_with_history(),
+            )
+        except (
+            CoordinatorLeaseHistoryCorrupt,
+            GenerationStateCorrupt,
+        ) as error:
+            raise RestartIntentLifecycleReadCorrupt(
+                "restart-intent lifecycle dependencies are corrupt"
+            ) from error
 
     def _authenticate_closure(
         self,

--- a/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_reader.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_reader.py
@@ -336,6 +336,12 @@ class InitialRestartIntentLifecycleReader:
             raise RestartIntentLifecycleReadCorrupt(
                 "current generation does not match the open restart intent"
             )
+        active_nodes = set(snapshot.record.assignment.slot_to_node_id.values())
+        unknown_nodes = sorted(set(intent.intent.suspected_node_ids) - active_nodes)
+        if unknown_nodes:
+            raise RestartIntentLifecycleReadCorrupt(
+                f"open restart intent suspects nodes outside its generation: {unknown_nodes!r}"
+            )
         generation_authority = self._generation_authority(
             snapshot,
             lease_history,

--- a/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_reader.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_reader.py
@@ -1,0 +1,668 @@
+"""Fail-closed reads of the first committed restart-intent closure."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Protocol, Self, TypeVar
+
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStore,
+    ControlStoreEntry,
+)
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseRecord,
+)
+from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
+    CoordinatorLeaseAuthority,
+    CoordinatorLeaseHistoryCorrupt,
+    CoordinatorLeaseHistoryReader,
+)
+from lm_resiliency.integrations.torchrun._generation_reader import (
+    GenerationStateCorrupt,
+    GenerationStateReader,
+    StoredGenerationSnapshot,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_records import (
+    RestartIntentClosedHeadRecord,
+    RestartIntentHeadRecord,
+    RestartIntentLifecycleHeadRecord,
+    RestartIntentLifecycleRecord,
+    RestartIntentRecord,
+)
+
+_CONTROL_PREFIX = "lm_resiliency/torchrun/v1"
+_MAX_READ_ATTEMPTS = 8
+
+
+class RestartIntentLifecycleReadError(RuntimeError):
+    """Base error for persisted restart-intent lifecycle reads."""
+
+
+class RestartIntentLifecycleReadCorrupt(RestartIntentLifecycleReadError):
+    """Raised when persisted restart-intent lifecycle state is contradictory."""
+
+
+@dataclass(frozen=True, slots=True)
+class StoredInitialRestartIntentClosure:
+    """One verified first restart-intent closure and its authoritative entries."""
+
+    intent: RestartIntentRecord
+    open_head: RestartIntentHeadRecord
+    closed_head: RestartIntentClosedHeadRecord
+    lifecycle: RestartIntentLifecycleRecord
+    lifecycle_head: RestartIntentLifecycleHeadRecord
+    generation_snapshot: StoredGenerationSnapshot
+    opening_authority: CoordinatorLeaseAuthority
+    closing_authority: CoordinatorLeaseAuthority
+    intent_entry: ControlStoreEntry
+    open_head_entry: ControlStoreEntry
+    closed_head_entry: ControlStoreEntry
+    lifecycle_entry: ControlStoreEntry
+    lifecycle_head_entry: ControlStoreEntry
+
+    def __post_init__(self) -> None:
+        expected_types = (
+            ("intent", self.intent, RestartIntentRecord),
+            ("open_head", self.open_head, RestartIntentHeadRecord),
+            ("closed_head", self.closed_head, RestartIntentClosedHeadRecord),
+            ("lifecycle", self.lifecycle, RestartIntentLifecycleRecord),
+            (
+                "lifecycle_head",
+                self.lifecycle_head,
+                RestartIntentLifecycleHeadRecord,
+            ),
+            (
+                "generation_snapshot",
+                self.generation_snapshot,
+                StoredGenerationSnapshot,
+            ),
+            (
+                "opening_authority",
+                self.opening_authority,
+                CoordinatorLeaseAuthority,
+            ),
+            (
+                "closing_authority",
+                self.closing_authority,
+                CoordinatorLeaseAuthority,
+            ),
+        )
+        for path, value, expected_type in expected_types:
+            if not isinstance(value, expected_type):
+                raise TypeError(
+                    f"StoredInitialRestartIntentClosure.{path} must be {expected_type.__name__}"
+                )
+        for path in (
+            "intent_entry",
+            "open_head_entry",
+            "closed_head_entry",
+            "lifecycle_entry",
+            "lifecycle_head_entry",
+        ):
+            if not isinstance(getattr(self, path), ControlStoreEntry):
+                raise TypeError(
+                    f"StoredInitialRestartIntentClosure.{path} must be ControlStoreEntry"
+                )
+        if (
+            self.lifecycle.closed_intent != self.open_head
+            or self.lifecycle_head.lifecycle_digest != self.lifecycle.digest
+            or self.closed_head.lifecycle_head_digest != self.lifecycle_head.digest
+        ):
+            raise ValueError("StoredInitialRestartIntentClosure records do not form one closure")
+
+    @property
+    def closed_at_unix_ms(self) -> int:
+        committed_at_unix_ms = self.closed_head_entry.committed_at_unix_ms
+        if committed_at_unix_ms is None:
+            raise AssertionError("validated closure lost its commit time")
+        return committed_at_unix_ms
+
+    @property
+    def transaction_sequence(self) -> int:
+        return self.closed_head_entry.transaction_sequence
+
+
+@dataclass(frozen=True, slots=True)
+class _ObservedKey:
+    entry: ControlStoreEntry | None
+    history: tuple[ControlStoreEntry, ...]
+    has_history: bool
+
+
+class _CanonicalRecord(Protocol):
+    @classmethod
+    def from_json(cls, encoded: bytes) -> Self: ...
+
+    def to_json(self) -> bytes: ...
+
+
+_CanonicalRecordT = TypeVar("_CanonicalRecordT", bound=_CanonicalRecord)
+
+
+class InitialRestartIntentLifecycleReader:
+    """Read and verify the first committed restart-intent closure."""
+
+    def __init__(self, store: ControlStore, *, run_id: str) -> None:
+        self._store = store
+        self._run_id = _nonempty_string(run_id, "run_id")
+        run_digest = hashlib.sha256(self._run_id.encode("utf-8")).hexdigest()
+        self._run_prefix = f"{_CONTROL_PREFIX}/runs/{run_digest}"
+        self._intent_head_key = f"{self._run_prefix}/restart-intent-head"
+        self._lifecycle_head_key = f"{self._run_prefix}/restart-intent-lifecycle-head"
+        self._generation_reader = GenerationStateReader(store, run_id=self._run_id)
+        self._lease_history_reader = CoordinatorLeaseHistoryReader(
+            store,
+            run_id=self._run_id,
+        )
+
+    @property
+    def intent_head_key(self) -> str:
+        return self._intent_head_key
+
+    @property
+    def lifecycle_head_key(self) -> str:
+        return self._lifecycle_head_key
+
+    def intent_key(self, intent_id: str) -> str:
+        normalized_intent_id = _nonempty_string(intent_id, "intent_id")
+        intent_digest = hashlib.sha256(normalized_intent_id.encode("utf-8")).hexdigest()
+        return f"{self._run_prefix}/restart-intents/{intent_digest}"
+
+    def closure_key(self, closure_index: int) -> str:
+        normalized_index = _positive_integer(closure_index, "closure_index")
+        return f"{self._run_prefix}/restart-intent-closures/{normalized_index}"
+
+    def read(self) -> StoredInitialRestartIntentClosure | None:
+        """Return one stable verified closure, or ``None`` before closure."""
+
+        for _ in range(_MAX_READ_ATTEMPTS):
+            head_observation = self._observe(self._intent_head_key)
+            lifecycle_observation = self._observe(self._lifecycle_head_key)
+            if not self._stable(
+                self._intent_head_key,
+                head_observation,
+                self._lifecycle_head_key,
+                lifecycle_observation,
+            ):
+                continue
+            if lifecycle_observation.entry is None:
+                self._validate_absent_lifecycle(
+                    head_observation,
+                    lifecycle_observation,
+                )
+                return None
+            lifecycle_head = self._decode_lifecycle_head(lifecycle_observation)
+            if lifecycle_head.closure_index != 1:
+                raise RestartIntentLifecycleReadCorrupt(
+                    "initial restart-intent closure index is not one"
+                )
+            closure_key = self.closure_key(lifecycle_head.closure_index)
+            intent_key = self.intent_key(lifecycle_head.intent_id)
+            closure_observation = self._observe(closure_key)
+            intent_observation = self._observe(intent_key)
+            try:
+                lease_history = self._lease_history_reader.read()
+                generation_snapshot = self._generation_reader.get(lifecycle_head.generation)
+                successor = self._generation_reader.get(lifecycle_head.generation + 1)
+            except (
+                CoordinatorLeaseHistoryCorrupt,
+                GenerationStateCorrupt,
+            ) as error:
+                raise RestartIntentLifecycleReadCorrupt(
+                    "restart-intent lifecycle dependencies are corrupt"
+                ) from error
+            if not self._stable(
+                self._intent_head_key,
+                head_observation,
+                self._lifecycle_head_key,
+                lifecycle_observation,
+                closure_key,
+                closure_observation,
+                intent_key,
+                intent_observation,
+            ):
+                continue
+            return self._validate_closure(
+                head_observation,
+                lifecycle_observation,
+                closure_observation,
+                intent_observation,
+                lifecycle_head,
+                generation_snapshot,
+                successor,
+                lease_history,
+            )
+        raise RestartIntentLifecycleReadError(
+            "restart-intent lifecycle changed repeatedly during read"
+        )
+
+    def _validate_absent_lifecycle(
+        self,
+        head: _ObservedKey,
+        lifecycle: _ObservedKey,
+    ) -> None:
+        if lifecycle.has_history or lifecycle.history:
+            raise RestartIntentLifecycleReadCorrupt("restart-intent lifecycle head was deleted")
+        if head.entry is None:
+            if head.has_history or head.history:
+                raise RestartIntentLifecycleReadCorrupt("current restart-intent head was deleted")
+            return
+        if not head.has_history or not head.history:
+            raise RestartIntentLifecycleReadCorrupt(
+                "live restart-intent head has no durable history"
+            )
+        try:
+            RestartIntentHeadRecord.from_json(head.entry.value)
+        except (TypeError, ValueError) as open_error:
+            try:
+                RestartIntentClosedHeadRecord.from_json(head.entry.value)
+            except (TypeError, ValueError) as closed_error:
+                raise RestartIntentLifecycleReadCorrupt(
+                    "current restart-intent head is malformed"
+                ) from closed_error
+            raise RestartIntentLifecycleReadCorrupt(
+                "closed restart-intent head has no lifecycle state"
+            ) from open_error
+
+    def _validate_closure(
+        self,
+        head_observation: _ObservedKey,
+        lifecycle_observation: _ObservedKey,
+        closure_observation: _ObservedKey,
+        intent_observation: _ObservedKey,
+        lifecycle_head: RestartIntentLifecycleHeadRecord,
+        generation_snapshot: StoredGenerationSnapshot | None,
+        successor: StoredGenerationSnapshot | None,
+        lease_history: tuple[CoordinatorLeaseAuthority, ...],
+    ) -> StoredInitialRestartIntentClosure:
+        head_entry = _required_entry(head_observation, "current restart-intent head")
+        lifecycle_head_entry = _required_entry(
+            lifecycle_observation,
+            "restart-intent lifecycle head",
+        )
+        closure_entry = _required_entry(
+            closure_observation,
+            "immutable restart-intent closure",
+        )
+        intent_entry = _required_entry(
+            intent_observation,
+            "immutable restart intent",
+        )
+        if len(head_observation.history) != 2:
+            raise RestartIntentLifecycleReadCorrupt(
+                "current restart-intent head does not retain one open predecessor"
+            )
+        open_head_entry, retained_closed_entry = head_observation.history
+        if retained_closed_entry != head_entry:
+            raise RestartIntentLifecycleReadCorrupt(
+                "current restart-intent head is absent from its history"
+            )
+        _require_immutable_history(
+            lifecycle_observation,
+            "restart-intent lifecycle head",
+        )
+        _require_immutable_history(
+            closure_observation,
+            "immutable restart-intent closure",
+        )
+        _require_immutable_history(
+            intent_observation,
+            "immutable restart intent",
+        )
+        open_head = _decode_canonical(
+            open_head_entry,
+            RestartIntentHeadRecord,
+            "predecessor restart-intent head",
+        )
+        closed_head = _decode_canonical(
+            head_entry,
+            RestartIntentClosedHeadRecord,
+            "closed restart-intent head",
+        )
+        lifecycle = _decode_canonical(
+            closure_entry,
+            RestartIntentLifecycleRecord,
+            "immutable restart-intent closure",
+        )
+        intent = _decode_canonical(
+            intent_entry,
+            RestartIntentRecord,
+            "immutable restart intent",
+        )
+        if (
+            closed_head.run_id != self._run_id
+            or lifecycle_head.run_id != self._run_id
+            or lifecycle.closed_intent != open_head
+            or open_head.run_id != intent.intent.run_id
+            or open_head.generation != intent.intent.generation
+            or open_head.intent_id != intent.intent.intent_id
+            or open_head.intent_digest != intent.digest
+            or lifecycle_head.closure_index != closed_head.closure_index
+            or lifecycle_head.generation != closed_head.generation
+            or lifecycle_head.intent_id != closed_head.intent_id
+            or lifecycle_head.digest != closed_head.lifecycle_head_digest
+            or lifecycle_head.lifecycle_digest != lifecycle.digest
+        ):
+            raise RestartIntentLifecycleReadCorrupt(
+                "restart-intent closure records do not identify one intent"
+            )
+        if generation_snapshot is None:
+            raise RestartIntentLifecycleReadCorrupt(
+                "restart-intent closure references a missing generation"
+            )
+        if generation_snapshot.record.digest != intent.generation_snapshot_digest:
+            raise RestartIntentLifecycleReadCorrupt(
+                "restart-intent closure references the wrong generation snapshot"
+            )
+        self._validate_store_sequences(
+            intent_entry,
+            open_head_entry,
+            head_entry,
+            lifecycle_head_entry,
+            closure_entry,
+        )
+        opening_authority = self._authority(
+            intent_entry,
+            CoordinatorLeaseRecord(
+                run_id=self._run_id,
+                coordinator_id=intent.coordinator_id,
+                lease_id=intent.lease_id,
+                lease_duration_ms=intent.coordinator_lease_duration_ms,
+            ),
+            intent.coordinator_fencing_token,
+            intent.coordinator_lease_digest,
+            lease_history,
+            "opening",
+        )
+        closing_authority = self._authority(
+            head_entry,
+            CoordinatorLeaseRecord(
+                run_id=self._run_id,
+                coordinator_id=lifecycle.coordinator_id,
+                lease_id=lifecycle.lease_id,
+                lease_duration_ms=lifecycle.coordinator_lease_duration_ms,
+            ),
+            lifecycle.coordinator_fencing_token,
+            lifecycle.coordinator_lease_digest,
+            lease_history,
+            "closing",
+        )
+        self._validate_transactions(
+            intent,
+            intent_entry,
+            open_head_entry,
+            head_entry,
+            lifecycle_head_entry,
+            closure_entry,
+            generation_snapshot,
+            successor,
+            opening_authority,
+            closing_authority,
+        )
+        return StoredInitialRestartIntentClosure(
+            intent=intent,
+            open_head=open_head,
+            closed_head=closed_head,
+            lifecycle=lifecycle,
+            lifecycle_head=lifecycle_head,
+            generation_snapshot=generation_snapshot,
+            opening_authority=opening_authority,
+            closing_authority=closing_authority,
+            intent_entry=intent_entry,
+            open_head_entry=open_head_entry,
+            closed_head_entry=head_entry,
+            lifecycle_entry=closure_entry,
+            lifecycle_head_entry=lifecycle_head_entry,
+        )
+
+    def _decode_lifecycle_head(
+        self,
+        observation: _ObservedKey,
+    ) -> RestartIntentLifecycleHeadRecord:
+        entry = _required_entry(observation, "restart-intent lifecycle head")
+        _require_immutable_history(observation, "restart-intent lifecycle head")
+        lifecycle_head = _decode_canonical(
+            entry,
+            RestartIntentLifecycleHeadRecord,
+            "restart-intent lifecycle head",
+        )
+        if lifecycle_head.run_id != self._run_id:
+            raise RestartIntentLifecycleReadCorrupt(
+                "restart-intent lifecycle head belongs to another run"
+            )
+        return lifecycle_head
+
+    def _validate_store_sequences(
+        self,
+        intent_entry: ControlStoreEntry,
+        open_head_entry: ControlStoreEntry,
+        closed_head_entry: ControlStoreEntry,
+        lifecycle_head_entry: ControlStoreEntry,
+        closure_entry: ControlStoreEntry,
+    ) -> None:
+        for path, entry in (
+            ("immutable restart intent", intent_entry),
+            ("predecessor restart-intent head", open_head_entry),
+            ("restart-intent lifecycle head", lifecycle_head_entry),
+            ("immutable restart-intent closure", closure_entry),
+        ):
+            if (
+                entry.mutation_sequence != 1
+                or entry.value_sequence != 1
+                or entry.lifetime_sequence != 1
+            ):
+                raise RestartIntentLifecycleReadCorrupt(
+                    f"{path} is not an immutable initial creation"
+                )
+        if (
+            closed_head_entry.mutation_sequence != 2
+            or closed_head_entry.value_sequence != 2
+            or closed_head_entry.lifetime_sequence != 1
+        ):
+            raise RestartIntentLifecycleReadCorrupt(
+                "closed restart-intent head has invalid store sequences"
+            )
+
+    def _validate_transactions(
+        self,
+        intent: RestartIntentRecord,
+        intent_entry: ControlStoreEntry,
+        open_head_entry: ControlStoreEntry,
+        closed_head_entry: ControlStoreEntry,
+        lifecycle_head_entry: ControlStoreEntry,
+        closure_entry: ControlStoreEntry,
+        generation_snapshot: StoredGenerationSnapshot,
+        successor: StoredGenerationSnapshot | None,
+        opening_authority: CoordinatorLeaseAuthority,
+        closing_authority: CoordinatorLeaseAuthority,
+    ) -> None:
+        if (
+            intent_entry.committed_at_unix_ms is None
+            or open_head_entry.committed_at_unix_ms is None
+            or intent_entry.committed_at_unix_ms != open_head_entry.committed_at_unix_ms
+            or intent_entry.transaction_sequence != open_head_entry.transaction_sequence
+            or _guard_provenance(intent_entry) != _guard_provenance(open_head_entry)
+        ):
+            raise RestartIntentLifecycleReadCorrupt(
+                "restart-intent opening records do not share one transaction"
+            )
+        opened_at = intent_entry.committed_at_unix_ms
+        if (
+            intent_entry.transaction_sequence
+            <= max(
+                generation_snapshot.transaction_sequence,
+                opening_authority.transaction_sequence,
+            )
+            or opened_at < generation_snapshot.committed_at_unix_ms
+            or opened_at < opening_authority.lease.granted_at_unix_ms
+            or opened_at
+            >= min(
+                opening_authority.lease.expires_at_unix_ms,
+                intent.intent.prepare_deadline_unix_ms,
+            )
+            or (
+                successor is not None
+                and intent_entry.transaction_sequence >= successor.transaction_sequence
+            )
+        ):
+            raise RestartIntentLifecycleReadCorrupt(
+                "restart-intent opening is outside its causal window"
+            )
+        closure_entries = (
+            closed_head_entry,
+            lifecycle_head_entry,
+            closure_entry,
+        )
+        closed_at = closed_head_entry.committed_at_unix_ms
+        closure_transaction = closed_head_entry.transaction_sequence
+        closure_guard = _guard_provenance(closed_head_entry)
+        if closed_at is None or any(
+            entry.committed_at_unix_ms != closed_at
+            or entry.transaction_sequence != closure_transaction
+            or _guard_provenance(entry) != closure_guard
+            for entry in closure_entries[1:]
+        ):
+            raise RestartIntentLifecycleReadCorrupt(
+                "restart-intent closure records do not share one transaction"
+            )
+        if (
+            closure_transaction
+            <= max(
+                intent_entry.transaction_sequence,
+                closing_authority.transaction_sequence,
+            )
+            or closed_at < opened_at
+            or closed_at < closing_authority.lease.granted_at_unix_ms
+            or closed_at >= closing_authority.lease.expires_at_unix_ms
+        ):
+            raise RestartIntentLifecycleReadCorrupt(
+                "restart-intent closure is outside its causal lease window"
+            )
+
+    def _authority(
+        self,
+        entry: ControlStoreEntry,
+        record: CoordinatorLeaseRecord,
+        fencing_token: int,
+        lease_digest: str,
+        history: tuple[CoordinatorLeaseAuthority, ...],
+        label: str,
+    ) -> CoordinatorLeaseAuthority:
+        provenance = _guard_provenance(entry)
+        (
+            guard_key,
+            guard_revision,
+            guard_value_digest,
+            guard_mutation_sequence,
+            guard_value_sequence,
+            guard_lifetime_sequence,
+            guard_committed_at_unix_ms,
+        ) = provenance
+        if (
+            guard_key != self._generation_reader.coordinator_lease_key
+            or guard_revision != fencing_token
+            or guard_value_digest != lease_digest
+        ):
+            raise RestartIntentLifecycleReadCorrupt(
+                f"restart-intent {label} has invalid lease provenance"
+            )
+        matches = tuple(
+            authority
+            for authority in history
+            if (
+                authority.lease.record == record
+                and authority.lease.fencing_token == guard_revision
+                and authority.lease.granted_at_unix_ms == guard_committed_at_unix_ms
+                and authority.mutation_sequence == guard_mutation_sequence
+                and authority.value_sequence == guard_value_sequence
+                and authority.lifetime_sequence == guard_lifetime_sequence
+            )
+        )
+        if len(matches) != 1:
+            raise RestartIntentLifecycleReadCorrupt(
+                f"restart-intent {label} authority is absent from lease history"
+            )
+        return matches[0]
+
+    def _observe(self, key: str) -> _ObservedKey:
+        return _ObservedKey(
+            entry=self._store.get(key),
+            history=self._store.get_history(key),
+            has_history=self._store.has_history(key),
+        )
+
+    def _stable(self, *items: object) -> bool:
+        for index in range(0, len(items), 2):
+            key = items[index]
+            observation = items[index + 1]
+            if not isinstance(key, str) or not isinstance(observation, _ObservedKey):
+                raise AssertionError("invalid lifecycle stability input")
+            if self._observe(key) != observation:
+                return False
+        return True
+
+
+def _required_entry(observation: _ObservedKey, path: str) -> ControlStoreEntry:
+    if observation.entry is None:
+        raise RestartIntentLifecycleReadCorrupt(f"{path} is missing")
+    if not observation.has_history or not observation.history:
+        raise RestartIntentLifecycleReadCorrupt(f"{path} has no durable history")
+    return observation.entry
+
+
+def _require_immutable_history(observation: _ObservedKey, path: str) -> None:
+    entry = _required_entry(observation, path)
+    if observation.history != (entry,):
+        raise RestartIntentLifecycleReadCorrupt(f"{path} is not an immutable retained value")
+
+
+def _decode_canonical(
+    entry: ControlStoreEntry,
+    record_type: type[_CanonicalRecordT],
+    path: str,
+) -> _CanonicalRecordT:
+    try:
+        record = record_type.from_json(entry.value)
+    except (TypeError, ValueError) as error:
+        raise RestartIntentLifecycleReadCorrupt(f"{path} is malformed") from error
+    if entry.value != record.to_json():
+        raise RestartIntentLifecycleReadCorrupt(f"{path} is noncanonical")
+    return record
+
+
+def _guard_provenance(entry: ControlStoreEntry) -> tuple[object, ...]:
+    provenance = (
+        entry.guard_key,
+        entry.guard_revision,
+        entry.guard_value_digest,
+        entry.guard_mutation_sequence,
+        entry.guard_value_sequence,
+        entry.guard_lifetime_sequence,
+        entry.guard_committed_at_unix_ms,
+    )
+    if any(value is None for value in provenance):
+        raise RestartIntentLifecycleReadCorrupt(
+            "restart-intent lifecycle has incomplete guard provenance"
+        )
+    return provenance
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+def _positive_integer(value: object, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{path} must be a positive integer")
+    return value
+
+
+__all__ = [
+    "InitialRestartIntentLifecycleReader",
+    "RestartIntentLifecycleReadCorrupt",
+    "RestartIntentLifecycleReadError",
+    "StoredInitialRestartIntentClosure",
+]

--- a/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_reader.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_reader.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass
-from typing import Protocol, Self, TypeVar
 
 from lm_resiliency.integrations.torchrun._control_store import (
     ControlStore,
@@ -22,6 +21,9 @@ from lm_resiliency.integrations.torchrun._generation_reader import (
     GenerationStateCorrupt,
     GenerationStateReader,
     StoredGenerationSnapshot,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_lifecycle_state import (
+    PersistedInitialRestartIntentClosure,
 )
 from lm_resiliency.integrations.torchrun._restart_intent_records import (
     RestartIntentClosedHeadRecord,
@@ -45,82 +47,62 @@ class RestartIntentLifecycleReadCorrupt(RestartIntentLifecycleReadError):
 
 @dataclass(frozen=True, slots=True)
 class StoredInitialRestartIntentClosure:
-    """One verified first restart-intent closure and its authoritative entries."""
+    """One closure authenticated against generation and lease history."""
 
-    intent: RestartIntentRecord
-    open_head: RestartIntentHeadRecord
-    closed_head: RestartIntentClosedHeadRecord
-    lifecycle: RestartIntentLifecycleRecord
-    lifecycle_head: RestartIntentLifecycleHeadRecord
+    state: PersistedInitialRestartIntentClosure
     generation_snapshot: StoredGenerationSnapshot
     opening_authority: CoordinatorLeaseAuthority
     closing_authority: CoordinatorLeaseAuthority
-    intent_entry: ControlStoreEntry
-    open_head_entry: ControlStoreEntry
-    closed_head_entry: ControlStoreEntry
-    lifecycle_entry: ControlStoreEntry
-    lifecycle_head_entry: ControlStoreEntry
 
     def __post_init__(self) -> None:
-        expected_types = (
-            ("intent", self.intent, RestartIntentRecord),
-            ("open_head", self.open_head, RestartIntentHeadRecord),
-            ("closed_head", self.closed_head, RestartIntentClosedHeadRecord),
-            ("lifecycle", self.lifecycle, RestartIntentLifecycleRecord),
-            (
-                "lifecycle_head",
-                self.lifecycle_head,
-                RestartIntentLifecycleHeadRecord,
-            ),
-            (
-                "generation_snapshot",
-                self.generation_snapshot,
-                StoredGenerationSnapshot,
-            ),
-            (
-                "opening_authority",
-                self.opening_authority,
-                CoordinatorLeaseAuthority,
-            ),
-            (
-                "closing_authority",
-                self.closing_authority,
-                CoordinatorLeaseAuthority,
-            ),
-        )
-        for path, value, expected_type in expected_types:
-            if not isinstance(value, expected_type):
-                raise TypeError(
-                    f"StoredInitialRestartIntentClosure.{path} must be {expected_type.__name__}"
-                )
-        for path in (
-            "intent_entry",
-            "open_head_entry",
-            "closed_head_entry",
-            "lifecycle_entry",
-            "lifecycle_head_entry",
-        ):
-            if not isinstance(getattr(self, path), ControlStoreEntry):
-                raise TypeError(
-                    f"StoredInitialRestartIntentClosure.{path} must be ControlStoreEntry"
-                )
-        if (
-            self.lifecycle.closed_intent != self.open_head
-            or self.lifecycle_head.lifecycle_digest != self.lifecycle.digest
-            or self.closed_head.lifecycle_head_digest != self.lifecycle_head.digest
-        ):
-            raise ValueError("StoredInitialRestartIntentClosure records do not form one closure")
+        if not isinstance(self.state, PersistedInitialRestartIntentClosure):
+            raise TypeError(
+                "StoredInitialRestartIntentClosure.state must be "
+                "PersistedInitialRestartIntentClosure"
+            )
+        if not isinstance(self.generation_snapshot, StoredGenerationSnapshot):
+            raise TypeError(
+                "StoredInitialRestartIntentClosure.generation_snapshot must be "
+                "StoredGenerationSnapshot"
+            )
+        if not isinstance(self.opening_authority, CoordinatorLeaseAuthority):
+            raise TypeError(
+                "StoredInitialRestartIntentClosure.opening_authority must be "
+                "CoordinatorLeaseAuthority"
+            )
+        if not isinstance(self.closing_authority, CoordinatorLeaseAuthority):
+            raise TypeError(
+                "StoredInitialRestartIntentClosure.closing_authority must be "
+                "CoordinatorLeaseAuthority"
+            )
+
+    @property
+    def intent(self) -> RestartIntentRecord:
+        return self.state.intent
+
+    @property
+    def open_head(self) -> RestartIntentHeadRecord:
+        return self.state.open_head
+
+    @property
+    def closed_head(self) -> RestartIntentClosedHeadRecord:
+        return self.state.closed_head
+
+    @property
+    def lifecycle(self) -> RestartIntentLifecycleRecord:
+        return self.state.lifecycle
+
+    @property
+    def lifecycle_head(self) -> RestartIntentLifecycleHeadRecord:
+        return self.state.lifecycle_head
 
     @property
     def closed_at_unix_ms(self) -> int:
-        committed_at_unix_ms = self.closed_head_entry.committed_at_unix_ms
-        if committed_at_unix_ms is None:
-            raise AssertionError("validated closure lost its commit time")
-        return committed_at_unix_ms
+        return self.state.closed_at_unix_ms
 
     @property
     def transaction_sequence(self) -> int:
-        return self.closed_head_entry.transaction_sequence
+        return self.state.closing_transaction_sequence
 
 
 @dataclass(frozen=True, slots=True)
@@ -128,16 +110,6 @@ class _ObservedKey:
     entry: ControlStoreEntry | None
     history: tuple[ControlStoreEntry, ...]
     has_history: bool
-
-
-class _CanonicalRecord(Protocol):
-    @classmethod
-    def from_json(cls, encoded: bytes) -> Self: ...
-
-    def to_json(self) -> bytes: ...
-
-
-_CanonicalRecordT = TypeVar("_CanonicalRecordT", bound=_CanonicalRecord)
 
 
 class InitialRestartIntentLifecycleReader:
@@ -193,10 +165,6 @@ class InitialRestartIntentLifecycleReader:
                 )
                 return None
             lifecycle_head = self._decode_lifecycle_head(lifecycle_observation)
-            if lifecycle_head.closure_index != 1:
-                raise RestartIntentLifecycleReadCorrupt(
-                    "initial restart-intent closure index is not one"
-                )
             closure_key = self.closure_key(lifecycle_head.closure_index)
             intent_key = self.intent_key(lifecycle_head.intent_id)
             closure_observation = self._observe(closure_key)
@@ -228,7 +196,6 @@ class InitialRestartIntentLifecycleReader:
                 lifecycle_observation,
                 closure_observation,
                 intent_observation,
-                lifecycle_head,
                 generation_snapshot,
                 successor,
                 lease_history,
@@ -253,7 +220,7 @@ class InitialRestartIntentLifecycleReader:
                 "live restart-intent head has no durable history"
             )
         try:
-            RestartIntentHeadRecord.from_json(head.entry.value)
+            open_head = RestartIntentHeadRecord.from_json(head.entry.value)
         except (TypeError, ValueError) as open_error:
             try:
                 RestartIntentClosedHeadRecord.from_json(head.entry.value)
@@ -264,6 +231,10 @@ class InitialRestartIntentLifecycleReader:
             raise RestartIntentLifecycleReadCorrupt(
                 "closed restart-intent head has no lifecycle state"
             ) from open_error
+        if open_head.run_id != self._run_id or head.entry.value != open_head.to_json():
+            raise RestartIntentLifecycleReadCorrupt(
+                "current restart-intent head is noncanonical or belongs to another run"
+            )
 
     def _validate_closure(
         self,
@@ -271,21 +242,20 @@ class InitialRestartIntentLifecycleReader:
         lifecycle_observation: _ObservedKey,
         closure_observation: _ObservedKey,
         intent_observation: _ObservedKey,
-        lifecycle_head: RestartIntentLifecycleHeadRecord,
         generation_snapshot: StoredGenerationSnapshot | None,
         successor: StoredGenerationSnapshot | None,
         lease_history: tuple[CoordinatorLeaseAuthority, ...],
     ) -> StoredInitialRestartIntentClosure:
         head_entry = _required_entry(head_observation, "current restart-intent head")
-        lifecycle_head_entry = _required_entry(
+        lifecycle_head_entry = _immutable_entry(
             lifecycle_observation,
             "restart-intent lifecycle head",
         )
-        closure_entry = _required_entry(
+        closure_entry = _immutable_entry(
             closure_observation,
             "immutable restart-intent closure",
         )
-        intent_entry = _required_entry(
+        intent_entry = _immutable_entry(
             intent_observation,
             "immutable restart intent",
         )
@@ -298,249 +268,153 @@ class InitialRestartIntentLifecycleReader:
             raise RestartIntentLifecycleReadCorrupt(
                 "current restart-intent head is absent from its history"
             )
-        _require_immutable_history(
-            lifecycle_observation,
-            "restart-intent lifecycle head",
-        )
-        _require_immutable_history(
-            closure_observation,
-            "immutable restart-intent closure",
-        )
-        _require_immutable_history(
-            intent_observation,
-            "immutable restart intent",
-        )
-        open_head = _decode_canonical(
-            open_head_entry,
-            RestartIntentHeadRecord,
-            "predecessor restart-intent head",
-        )
-        closed_head = _decode_canonical(
-            head_entry,
-            RestartIntentClosedHeadRecord,
-            "closed restart-intent head",
-        )
-        lifecycle = _decode_canonical(
-            closure_entry,
-            RestartIntentLifecycleRecord,
-            "immutable restart-intent closure",
-        )
-        intent = _decode_canonical(
-            intent_entry,
-            RestartIntentRecord,
-            "immutable restart intent",
-        )
-        if (
-            closed_head.run_id != self._run_id
-            or lifecycle_head.run_id != self._run_id
-            or lifecycle.closed_intent != open_head
-            or open_head.run_id != intent.intent.run_id
-            or open_head.generation != intent.intent.generation
-            or open_head.intent_id != intent.intent.intent_id
-            or open_head.intent_digest != intent.digest
-            or lifecycle_head.closure_index != closed_head.closure_index
-            or lifecycle_head.generation != closed_head.generation
-            or lifecycle_head.intent_id != closed_head.intent_id
-            or lifecycle_head.digest != closed_head.lifecycle_head_digest
-            or lifecycle_head.lifecycle_digest != lifecycle.digest
-        ):
-            raise RestartIntentLifecycleReadCorrupt(
-                "restart-intent closure records do not identify one intent"
+        try:
+            state = PersistedInitialRestartIntentClosure.from_entries(
+                run_id=self._run_id,
+                intent_entry=intent_entry,
+                open_head_entry=open_head_entry,
+                closed_head_entry=head_entry,
+                lifecycle_entry=closure_entry,
+                lifecycle_head_entry=lifecycle_head_entry,
             )
+        except (TypeError, ValueError) as error:
+            raise RestartIntentLifecycleReadCorrupt(
+                "persisted restart-intent closure is contradictory"
+            ) from error
         if generation_snapshot is None:
             raise RestartIntentLifecycleReadCorrupt(
                 "restart-intent closure references a missing generation"
             )
-        if generation_snapshot.record.digest != intent.generation_snapshot_digest:
+        if generation_snapshot.record.digest != state.intent.generation_snapshot_digest:
             raise RestartIntentLifecycleReadCorrupt(
                 "restart-intent closure references the wrong generation snapshot"
             )
-        self._validate_store_sequences(
-            intent_entry,
-            open_head_entry,
-            head_entry,
-            lifecycle_head_entry,
-            closure_entry,
+        generation_authority = self._generation_authority(
+            generation_snapshot,
+            lease_history,
         )
-        opening_authority = self._authority(
-            intent_entry,
+        opening_authority = self._entry_authority(
+            state.intent_entry,
             CoordinatorLeaseRecord(
                 run_id=self._run_id,
-                coordinator_id=intent.coordinator_id,
-                lease_id=intent.lease_id,
-                lease_duration_ms=intent.coordinator_lease_duration_ms,
+                coordinator_id=state.intent.coordinator_id,
+                lease_id=state.intent.lease_id,
+                lease_duration_ms=state.intent.coordinator_lease_duration_ms,
             ),
-            intent.coordinator_fencing_token,
-            intent.coordinator_lease_digest,
+            state.intent.coordinator_fencing_token,
+            state.intent.coordinator_lease_digest,
             lease_history,
             "opening",
         )
-        closing_authority = self._authority(
-            head_entry,
+        closing_authority = self._entry_authority(
+            state.closed_head_entry,
             CoordinatorLeaseRecord(
                 run_id=self._run_id,
-                coordinator_id=lifecycle.coordinator_id,
-                lease_id=lifecycle.lease_id,
-                lease_duration_ms=lifecycle.coordinator_lease_duration_ms,
+                coordinator_id=state.lifecycle.coordinator_id,
+                lease_id=state.lifecycle.lease_id,
+                lease_duration_ms=state.lifecycle.coordinator_lease_duration_ms,
             ),
-            lifecycle.coordinator_fencing_token,
-            lifecycle.coordinator_lease_digest,
+            state.lifecycle.coordinator_fencing_token,
+            state.lifecycle.coordinator_lease_digest,
             lease_history,
             "closing",
         )
-        self._validate_transactions(
-            intent,
-            intent_entry,
-            open_head_entry,
-            head_entry,
-            lifecycle_head_entry,
-            closure_entry,
-            generation_snapshot,
-            successor,
-            opening_authority,
-            closing_authority,
-        )
+        generation_index = lease_history.index(generation_authority)
+        opening_index = lease_history.index(opening_authority)
+        closing_index = lease_history.index(closing_authority)
+        if generation_index > opening_index or opening_index > closing_index:
+            raise RestartIntentLifecycleReadCorrupt(
+                "restart-intent lifecycle lease authorities are out of order"
+            )
+        if (
+            state.opening_transaction_sequence
+            <= max(
+                generation_snapshot.transaction_sequence,
+                opening_authority.transaction_sequence,
+            )
+            or state.opened_at_unix_ms < generation_snapshot.committed_at_unix_ms
+            or state.opened_at_unix_ms < opening_authority.lease.granted_at_unix_ms
+            or state.opened_at_unix_ms
+            >= min(
+                opening_authority.lease.expires_at_unix_ms,
+                state.intent.intent.prepare_deadline_unix_ms,
+            )
+            or (
+                successor is not None
+                and state.opening_transaction_sequence >= successor.transaction_sequence
+            )
+        ):
+            raise RestartIntentLifecycleReadCorrupt(
+                "restart-intent opening is outside its causal window"
+            )
+        if (
+            state.closing_transaction_sequence
+            <= max(
+                state.opening_transaction_sequence,
+                closing_authority.transaction_sequence,
+            )
+            or state.closed_at_unix_ms < closing_authority.lease.granted_at_unix_ms
+            or state.closed_at_unix_ms >= closing_authority.lease.expires_at_unix_ms
+        ):
+            raise RestartIntentLifecycleReadCorrupt(
+                "restart-intent closure is outside its causal lease window"
+            )
         return StoredInitialRestartIntentClosure(
-            intent=intent,
-            open_head=open_head,
-            closed_head=closed_head,
-            lifecycle=lifecycle,
-            lifecycle_head=lifecycle_head,
+            state=state,
             generation_snapshot=generation_snapshot,
             opening_authority=opening_authority,
             closing_authority=closing_authority,
-            intent_entry=intent_entry,
-            open_head_entry=open_head_entry,
-            closed_head_entry=head_entry,
-            lifecycle_entry=closure_entry,
-            lifecycle_head_entry=lifecycle_head_entry,
         )
 
     def _decode_lifecycle_head(
         self,
         observation: _ObservedKey,
     ) -> RestartIntentLifecycleHeadRecord:
-        entry = _required_entry(observation, "restart-intent lifecycle head")
-        _require_immutable_history(observation, "restart-intent lifecycle head")
-        lifecycle_head = _decode_canonical(
-            entry,
-            RestartIntentLifecycleHeadRecord,
-            "restart-intent lifecycle head",
-        )
-        if lifecycle_head.run_id != self._run_id:
+        entry = _immutable_entry(observation, "restart-intent lifecycle head")
+        try:
+            lifecycle_head = RestartIntentLifecycleHeadRecord.from_json(entry.value)
+        except (TypeError, ValueError) as error:
             raise RestartIntentLifecycleReadCorrupt(
-                "restart-intent lifecycle head belongs to another run"
+                "restart-intent lifecycle head is malformed"
+            ) from error
+        if lifecycle_head.run_id != self._run_id or entry.value != lifecycle_head.to_json():
+            raise RestartIntentLifecycleReadCorrupt(
+                "restart-intent lifecycle head is noncanonical or belongs to another run"
             )
         return lifecycle_head
 
-    def _validate_store_sequences(
+    def _generation_authority(
         self,
-        intent_entry: ControlStoreEntry,
-        open_head_entry: ControlStoreEntry,
-        closed_head_entry: ControlStoreEntry,
-        lifecycle_head_entry: ControlStoreEntry,
-        closure_entry: ControlStoreEntry,
-    ) -> None:
-        for path, entry in (
-            ("immutable restart intent", intent_entry),
-            ("predecessor restart-intent head", open_head_entry),
-            ("restart-intent lifecycle head", lifecycle_head_entry),
-            ("immutable restart-intent closure", closure_entry),
-        ):
-            if (
-                entry.mutation_sequence != 1
-                or entry.value_sequence != 1
-                or entry.lifetime_sequence != 1
-            ):
-                raise RestartIntentLifecycleReadCorrupt(
-                    f"{path} is not an immutable initial creation"
-                )
-        if (
-            closed_head_entry.mutation_sequence != 2
-            or closed_head_entry.value_sequence != 2
-            or closed_head_entry.lifetime_sequence != 1
-        ):
-            raise RestartIntentLifecycleReadCorrupt(
-                "closed restart-intent head has invalid store sequences"
-            )
-
-    def _validate_transactions(
-        self,
-        intent: RestartIntentRecord,
-        intent_entry: ControlStoreEntry,
-        open_head_entry: ControlStoreEntry,
-        closed_head_entry: ControlStoreEntry,
-        lifecycle_head_entry: ControlStoreEntry,
-        closure_entry: ControlStoreEntry,
-        generation_snapshot: StoredGenerationSnapshot,
-        successor: StoredGenerationSnapshot | None,
-        opening_authority: CoordinatorLeaseAuthority,
-        closing_authority: CoordinatorLeaseAuthority,
-    ) -> None:
-        if (
-            intent_entry.committed_at_unix_ms is None
-            or open_head_entry.committed_at_unix_ms is None
-            or intent_entry.committed_at_unix_ms != open_head_entry.committed_at_unix_ms
-            or intent_entry.transaction_sequence != open_head_entry.transaction_sequence
-            or _guard_provenance(intent_entry) != _guard_provenance(open_head_entry)
-        ):
-            raise RestartIntentLifecycleReadCorrupt(
-                "restart-intent opening records do not share one transaction"
-            )
-        opened_at = intent_entry.committed_at_unix_ms
-        if (
-            intent_entry.transaction_sequence
-            <= max(
-                generation_snapshot.transaction_sequence,
-                opening_authority.transaction_sequence,
-            )
-            or opened_at < generation_snapshot.committed_at_unix_ms
-            or opened_at < opening_authority.lease.granted_at_unix_ms
-            or opened_at
-            >= min(
-                opening_authority.lease.expires_at_unix_ms,
-                intent.intent.prepare_deadline_unix_ms,
-            )
-            or (
-                successor is not None
-                and intent_entry.transaction_sequence >= successor.transaction_sequence
-            )
-        ):
-            raise RestartIntentLifecycleReadCorrupt(
-                "restart-intent opening is outside its causal window"
-            )
-        closure_entries = (
-            closed_head_entry,
-            lifecycle_head_entry,
-            closure_entry,
+        snapshot: StoredGenerationSnapshot,
+        history: tuple[CoordinatorLeaseAuthority, ...],
+    ) -> CoordinatorLeaseAuthority:
+        record = CoordinatorLeaseRecord(
+            run_id=self._run_id,
+            coordinator_id=snapshot.record.coordinator_id,
+            lease_id=snapshot.record.lease_id,
+            lease_duration_ms=snapshot.record.coordinator_lease_duration_ms,
         )
-        closed_at = closed_head_entry.committed_at_unix_ms
-        closure_transaction = closed_head_entry.transaction_sequence
-        closure_guard = _guard_provenance(closed_head_entry)
-        if closed_at is None or any(
-            entry.committed_at_unix_ms != closed_at
-            or entry.transaction_sequence != closure_transaction
-            or _guard_provenance(entry) != closure_guard
-            for entry in closure_entries[1:]
-        ):
-            raise RestartIntentLifecycleReadCorrupt(
-                "restart-intent closure records do not share one transaction"
-            )
+        authority = _unique_authority(
+            history,
+            record=record,
+            fencing_token=snapshot.record.coordinator_fencing_token,
+            granted_at_unix_ms=snapshot.guard_committed_at_unix_ms,
+            mutation_sequence=snapshot.guard_mutation_sequence,
+            value_sequence=snapshot.guard_value_sequence,
+            lifetime_sequence=snapshot.guard_lifetime_sequence,
+            label="generation",
+        )
         if (
-            closure_transaction
-            <= max(
-                intent_entry.transaction_sequence,
-                closing_authority.transaction_sequence,
-            )
-            or closed_at < opened_at
-            or closed_at < closing_authority.lease.granted_at_unix_ms
-            or closed_at >= closing_authority.lease.expires_at_unix_ms
+            snapshot.transaction_sequence <= authority.transaction_sequence
+            or snapshot.committed_at_unix_ms < authority.lease.granted_at_unix_ms
+            or snapshot.committed_at_unix_ms >= authority.lease.expires_at_unix_ms
         ):
             raise RestartIntentLifecycleReadCorrupt(
-                "restart-intent closure is outside its causal lease window"
+                "restart-intent generation is outside its causal lease window"
             )
+        return authority
 
-    def _authority(
+    def _entry_authority(
         self,
         entry: ControlStoreEntry,
         record: CoordinatorLeaseRecord,
@@ -549,41 +423,34 @@ class InitialRestartIntentLifecycleReader:
         history: tuple[CoordinatorLeaseAuthority, ...],
         label: str,
     ) -> CoordinatorLeaseAuthority:
-        provenance = _guard_provenance(entry)
-        (
-            guard_key,
-            guard_revision,
-            guard_value_digest,
-            guard_mutation_sequence,
-            guard_value_sequence,
-            guard_lifetime_sequence,
-            guard_committed_at_unix_ms,
-        ) = provenance
+        provenance = (
+            entry.guard_key,
+            entry.guard_revision,
+            entry.guard_value_digest,
+            entry.guard_mutation_sequence,
+            entry.guard_value_sequence,
+            entry.guard_lifetime_sequence,
+            entry.guard_committed_at_unix_ms,
+        )
         if (
-            guard_key != self._generation_reader.coordinator_lease_key
-            or guard_revision != fencing_token
-            or guard_value_digest != lease_digest
+            entry.guard_key != self._generation_reader.coordinator_lease_key
+            or entry.guard_revision != fencing_token
+            or entry.guard_value_digest != lease_digest
+            or any(value is None for value in provenance)
         ):
             raise RestartIntentLifecycleReadCorrupt(
                 f"restart-intent {label} has invalid lease provenance"
             )
-        matches = tuple(
-            authority
-            for authority in history
-            if (
-                authority.lease.record == record
-                and authority.lease.fencing_token == guard_revision
-                and authority.lease.granted_at_unix_ms == guard_committed_at_unix_ms
-                and authority.mutation_sequence == guard_mutation_sequence
-                and authority.value_sequence == guard_value_sequence
-                and authority.lifetime_sequence == guard_lifetime_sequence
-            )
+        return _unique_authority(
+            history,
+            record=record,
+            fencing_token=fencing_token,
+            granted_at_unix_ms=entry.guard_committed_at_unix_ms,
+            mutation_sequence=entry.guard_mutation_sequence,
+            value_sequence=entry.guard_value_sequence,
+            lifetime_sequence=entry.guard_lifetime_sequence,
+            label=label,
         )
-        if len(matches) != 1:
-            raise RestartIntentLifecycleReadCorrupt(
-                f"restart-intent {label} authority is absent from lease history"
-            )
-        return matches[0]
 
     def _observe(self, key: str) -> _ObservedKey:
         return _ObservedKey(
@@ -611,41 +478,41 @@ def _required_entry(observation: _ObservedKey, path: str) -> ControlStoreEntry:
     return observation.entry
 
 
-def _require_immutable_history(observation: _ObservedKey, path: str) -> None:
+def _immutable_entry(observation: _ObservedKey, path: str) -> ControlStoreEntry:
     entry = _required_entry(observation, path)
     if observation.history != (entry,):
         raise RestartIntentLifecycleReadCorrupt(f"{path} is not an immutable retained value")
+    return entry
 
 
-def _decode_canonical(
-    entry: ControlStoreEntry,
-    record_type: type[_CanonicalRecordT],
-    path: str,
-) -> _CanonicalRecordT:
-    try:
-        record = record_type.from_json(entry.value)
-    except (TypeError, ValueError) as error:
-        raise RestartIntentLifecycleReadCorrupt(f"{path} is malformed") from error
-    if entry.value != record.to_json():
-        raise RestartIntentLifecycleReadCorrupt(f"{path} is noncanonical")
-    return record
-
-
-def _guard_provenance(entry: ControlStoreEntry) -> tuple[object, ...]:
-    provenance = (
-        entry.guard_key,
-        entry.guard_revision,
-        entry.guard_value_digest,
-        entry.guard_mutation_sequence,
-        entry.guard_value_sequence,
-        entry.guard_lifetime_sequence,
-        entry.guard_committed_at_unix_ms,
-    )
-    if any(value is None for value in provenance):
-        raise RestartIntentLifecycleReadCorrupt(
-            "restart-intent lifecycle has incomplete guard provenance"
+def _unique_authority(
+    history: tuple[CoordinatorLeaseAuthority, ...],
+    *,
+    record: CoordinatorLeaseRecord,
+    fencing_token: int,
+    granted_at_unix_ms: object,
+    mutation_sequence: object,
+    value_sequence: object,
+    lifetime_sequence: object,
+    label: str,
+) -> CoordinatorLeaseAuthority:
+    matches = tuple(
+        authority
+        for authority in history
+        if (
+            authority.lease.record == record
+            and authority.lease.fencing_token == fencing_token
+            and authority.lease.granted_at_unix_ms == granted_at_unix_ms
+            and authority.mutation_sequence == mutation_sequence
+            and authority.value_sequence == value_sequence
+            and authority.lifetime_sequence == lifetime_sequence
         )
-    return provenance
+    )
+    if len(matches) != 1:
+        raise RestartIntentLifecycleReadCorrupt(
+            f"restart-intent {label} authority is absent from lease history"
+        )
+    return matches[0]
 
 
 def _nonempty_string(value: object, path: str) -> str:

--- a/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_reader.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_reader.py
@@ -155,6 +155,7 @@ class InitialRestartIntentLifecycleReader:
                     intent_observation,
                     generation_result,
                     opening_authority,
+                    lease_history,
                 )
                 return None
             lifecycle_head = self._decode_lifecycle_head(lifecycle_observation)
@@ -320,6 +321,7 @@ class InitialRestartIntentLifecycleReader:
         intent_observation: _ObservedKey,
         generation_result: (tuple[CurrentGeneration, tuple[StoredGenerationSnapshot, ...]] | None),
         opening_authority: CoordinatorLeaseAuthority,
+        lease_history: tuple[CoordinatorLeaseAuthority, ...],
     ) -> None:
         if generation_result is None:
             raise RestartIntentLifecycleReadCorrupt(
@@ -333,6 +335,28 @@ class InitialRestartIntentLifecycleReader:
         ):
             raise RestartIntentLifecycleReadCorrupt(
                 "current generation does not match the open restart intent"
+            )
+        generation_authority = self._generation_authority(
+            snapshot,
+            lease_history,
+        )
+        if lease_history.index(generation_authority) > lease_history.index(opening_authority):
+            raise RestartIntentLifecycleReadCorrupt(
+                "open restart-intent lease predates its generation authority"
+            )
+        if (
+            snapshot.transaction_sequence <= generation_authority.transaction_sequence
+            or snapshot.committed_at_unix_ms < generation_authority.lease.granted_at_unix_ms
+            or snapshot.committed_at_unix_ms >= generation_authority.lease.expires_at_unix_ms
+            or not _commit_precedes_next_authority(
+                lease_history,
+                generation_authority,
+                transaction_sequence=snapshot.transaction_sequence,
+                committed_at_unix_ms=snapshot.committed_at_unix_ms,
+            )
+        ):
+            raise RestartIntentLifecycleReadCorrupt(
+                "current generation is outside its coordinator lease window"
             )
         intent_entry = _required_entry(intent_observation, "immutable restart intent")
         committed_at_unix_ms = intent_entry.committed_at_unix_ms
@@ -354,10 +378,45 @@ class InitialRestartIntentLifecycleReader:
                 opening_authority.lease.expires_at_unix_ms,
                 intent.intent.prepare_deadline_unix_ms,
             )
+            or not _commit_precedes_next_authority(
+                lease_history,
+                opening_authority,
+                transaction_sequence=intent_entry.transaction_sequence,
+                committed_at_unix_ms=committed_at_unix_ms,
+            )
         ):
             raise RestartIntentLifecycleReadCorrupt(
                 "open restart intent is outside its generation, lease, or deadline window"
             )
+
+    def _generation_authority(
+        self,
+        snapshot: StoredGenerationSnapshot,
+        lease_history: tuple[CoordinatorLeaseAuthority, ...],
+    ) -> CoordinatorLeaseAuthority:
+        record = CoordinatorLeaseRecord(
+            run_id=snapshot.record.assignment.run_id,
+            coordinator_id=snapshot.record.coordinator_id,
+            lease_id=snapshot.record.lease_id,
+            lease_duration_ms=snapshot.record.coordinator_lease_duration_ms,
+        )
+        matches = tuple(
+            authority
+            for authority in lease_history
+            if (
+                authority.lease.record == record
+                and authority.lease.fencing_token == snapshot.record.coordinator_fencing_token
+                and authority.lease.granted_at_unix_ms == snapshot.guard_committed_at_unix_ms
+                and authority.mutation_sequence == snapshot.guard_mutation_sequence
+                and authority.value_sequence == snapshot.guard_value_sequence
+                and authority.lifetime_sequence == snapshot.guard_lifetime_sequence
+            )
+        )
+        if len(matches) != 1:
+            raise RestartIntentLifecycleReadCorrupt(
+                "generation coordinator lease is absent from durable lease history"
+            )
+        return matches[0]
 
     def _opening_authority(
         self,
@@ -549,6 +608,25 @@ def _transaction_provenance(entry: ControlStoreEntry) -> tuple[object, ...]:
         entry.guard_mutation_sequence,
         entry.guard_value_sequence,
         entry.guard_lifetime_sequence,
+    )
+
+
+def _commit_precedes_next_authority(
+    lease_history: tuple[CoordinatorLeaseAuthority, ...],
+    authority: CoordinatorLeaseAuthority,
+    *,
+    transaction_sequence: int,
+    committed_at_unix_ms: int,
+) -> bool:
+    authority_index = lease_history.index(authority)
+    if authority_index + 1 == len(lease_history):
+        return True
+    successor = lease_history[authority_index + 1]
+    if successor.lifetime_sequence != authority.lifetime_sequence:
+        return False
+    return (
+        transaction_sequence < successor.transaction_sequence
+        and committed_at_unix_ms <= successor.lease.granted_at_unix_ms
     )
 
 

--- a/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_reader.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_reader.py
@@ -9,6 +9,9 @@ from lm_resiliency.integrations.torchrun._control_store import (
     ControlStore,
     ControlStoreEntry,
 )
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseRecord,
+)
 from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
     CoordinatorLeaseAuthority,
     CoordinatorLeaseHistoryCorrupt,
@@ -119,7 +122,7 @@ class InitialRestartIntentLifecycleReader:
                     return None
                 intent_key = self.intent_key(open_head.intent_id)
                 intent_observation = self._observe(intent_key)
-                generation_result = self._read_generation()
+                lease_history, generation_result = self._read_dependencies()
                 if not self._stable(
                     self._intent_head_key,
                     head_observation,
@@ -131,18 +134,27 @@ class InitialRestartIntentLifecycleReader:
                     intent_observation,
                 ):
                     continue
-                confirmed_generation_result = self._read_generation()
-                if generation_result != confirmed_generation_result:
+                confirmed_lease_history, confirmed_generation_result = self._read_dependencies()
+                if (
+                    lease_history != confirmed_lease_history
+                    or generation_result != confirmed_generation_result
+                ):
                     continue
                 intent = self._validate_open_intent(
                     open_head,
                     head_observation,
                     intent_observation,
                 )
+                opening_authority = self._opening_authority(
+                    intent,
+                    intent_observation,
+                    lease_history,
+                )
                 self._validate_open_generation(
                     intent,
                     intent_observation,
                     generation_result,
+                    opening_authority,
                 )
                 return None
             lifecycle_head = self._decode_lifecycle_head(lifecycle_observation)
@@ -307,6 +319,7 @@ class InitialRestartIntentLifecycleReader:
         intent: RestartIntentRecord,
         intent_observation: _ObservedKey,
         generation_result: (tuple[CurrentGeneration, tuple[StoredGenerationSnapshot, ...]] | None),
+        opening_authority: CoordinatorLeaseAuthority,
     ) -> None:
         if generation_result is None:
             raise RestartIntentLifecycleReadCorrupt(
@@ -326,12 +339,74 @@ class InitialRestartIntentLifecycleReader:
         if committed_at_unix_ms is None:
             raise AssertionError("validated restart intent lost its commit time")
         if (
-            intent_entry.transaction_sequence <= snapshot.transaction_sequence
-            or committed_at_unix_ms < snapshot.committed_at_unix_ms
+            intent_entry.transaction_sequence
+            <= max(
+                snapshot.transaction_sequence,
+                opening_authority.transaction_sequence,
+            )
+            or committed_at_unix_ms
+            < max(
+                snapshot.committed_at_unix_ms,
+                opening_authority.lease.granted_at_unix_ms,
+            )
+            or committed_at_unix_ms
+            >= min(
+                opening_authority.lease.expires_at_unix_ms,
+                intent.intent.prepare_deadline_unix_ms,
+            )
         ):
             raise RestartIntentLifecycleReadCorrupt(
-                "open restart intent does not follow its current generation"
+                "open restart intent is outside its generation, lease, or deadline window"
             )
+
+    def _opening_authority(
+        self,
+        intent: RestartIntentRecord,
+        intent_observation: _ObservedKey,
+        lease_history: tuple[CoordinatorLeaseAuthority, ...],
+    ) -> CoordinatorLeaseAuthority:
+        intent_entry = _required_entry(intent_observation, "immutable restart intent")
+        provenance = (
+            intent_entry.guard_revision,
+            intent_entry.guard_committed_at_unix_ms,
+            intent_entry.guard_mutation_sequence,
+            intent_entry.guard_value_sequence,
+            intent_entry.guard_lifetime_sequence,
+        )
+        if any(value is None for value in provenance):
+            raise RestartIntentLifecycleReadCorrupt(
+                "immutable restart intent has incomplete coordinator lease provenance"
+            )
+        (
+            guard_revision,
+            guard_committed_at_unix_ms,
+            guard_mutation_sequence,
+            guard_value_sequence,
+            guard_lifetime_sequence,
+        ) = provenance
+        lease_record = CoordinatorLeaseRecord(
+            run_id=intent.intent.run_id,
+            coordinator_id=intent.coordinator_id,
+            lease_id=intent.lease_id,
+            lease_duration_ms=intent.coordinator_lease_duration_ms,
+        )
+        matches = tuple(
+            authority
+            for authority in lease_history
+            if (
+                authority.lease.record == lease_record
+                and authority.lease.fencing_token == guard_revision
+                and authority.lease.granted_at_unix_ms == guard_committed_at_unix_ms
+                and authority.mutation_sequence == guard_mutation_sequence
+                and authority.value_sequence == guard_value_sequence
+                and authority.lifetime_sequence == guard_lifetime_sequence
+            )
+        )
+        if len(matches) != 1:
+            raise RestartIntentLifecycleReadCorrupt(
+                "opening coordinator lease is absent from durable lease history"
+            )
+        return matches[0]
 
     def _read_dependencies(
         self,

--- a/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_reader.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_reader.py
@@ -119,6 +119,7 @@ class InitialRestartIntentLifecycleReader:
                     return None
                 intent_key = self.intent_key(open_head.intent_id)
                 intent_observation = self._observe(intent_key)
+                generation_result = self._read_generation()
                 if not self._stable(
                     self._intent_head_key,
                     head_observation,
@@ -130,10 +131,18 @@ class InitialRestartIntentLifecycleReader:
                     intent_observation,
                 ):
                     continue
-                self._validate_open_intent(
+                confirmed_generation_result = self._read_generation()
+                if generation_result != confirmed_generation_result:
+                    continue
+                intent = self._validate_open_intent(
                     open_head,
                     head_observation,
                     intent_observation,
+                )
+                self._validate_open_generation(
+                    intent,
+                    intent_observation,
+                    generation_result,
                 )
                 return None
             lifecycle_head = self._decode_lifecycle_head(lifecycle_observation)
@@ -233,7 +242,7 @@ class InitialRestartIntentLifecycleReader:
         head: RestartIntentHeadRecord,
         head_observation: _ObservedKey,
         intent_observation: _ObservedKey,
-    ) -> None:
+    ) -> RestartIntentRecord:
         head_entry = _required_entry(head_observation, "current restart-intent head")
         intent_entry = _immutable_entry(intent_observation, "immutable restart intent")
         if (
@@ -261,6 +270,10 @@ class InitialRestartIntentLifecycleReader:
             raise RestartIntentLifecycleReadCorrupt(
                 "current restart-intent head does not identify its immutable record"
             )
+        if head_entry.committed_at_unix_ms is None or intent_entry.committed_at_unix_ms is None:
+            raise RestartIntentLifecycleReadCorrupt(
+                "current restart-intent opening has no authoritative commit time"
+            )
         if _transaction_provenance(head_entry) != _transaction_provenance(intent_entry):
             raise RestartIntentLifecycleReadCorrupt(
                 "current restart-intent head and immutable intent "
@@ -287,6 +300,38 @@ class InitialRestartIntentLifecycleReader:
             raise RestartIntentLifecycleReadCorrupt(
                 "immutable restart intent has invalid coordinator lease provenance"
             )
+        return intent
+
+    def _validate_open_generation(
+        self,
+        intent: RestartIntentRecord,
+        intent_observation: _ObservedKey,
+        generation_result: (tuple[CurrentGeneration, tuple[StoredGenerationSnapshot, ...]] | None),
+    ) -> None:
+        if generation_result is None:
+            raise RestartIntentLifecycleReadCorrupt(
+                "open restart intent exists without committed generation state"
+            )
+        current, _ = generation_result
+        snapshot = current.snapshot
+        if (
+            snapshot.record.assignment.generation != intent.intent.generation
+            or snapshot.record.digest != intent.generation_snapshot_digest
+        ):
+            raise RestartIntentLifecycleReadCorrupt(
+                "current generation does not match the open restart intent"
+            )
+        intent_entry = _required_entry(intent_observation, "immutable restart intent")
+        committed_at_unix_ms = intent_entry.committed_at_unix_ms
+        if committed_at_unix_ms is None:
+            raise AssertionError("validated restart intent lost its commit time")
+        if (
+            intent_entry.transaction_sequence <= snapshot.transaction_sequence
+            or committed_at_unix_ms < snapshot.committed_at_unix_ms
+        ):
+            raise RestartIntentLifecycleReadCorrupt(
+                "open restart intent does not follow its current generation"
+            )
 
     def _read_dependencies(
         self,
@@ -295,14 +340,19 @@ class InitialRestartIntentLifecycleReader:
         tuple[CurrentGeneration, tuple[StoredGenerationSnapshot, ...]] | None,
     ]:
         try:
-            return (
-                self._lease_history_reader.read(),
-                self._generation_reader.current_with_history(),
-            )
-        except (
-            CoordinatorLeaseHistoryCorrupt,
-            GenerationStateCorrupt,
-        ) as error:
+            lease_history = self._lease_history_reader.read()
+        except CoordinatorLeaseHistoryCorrupt as error:
+            raise RestartIntentLifecycleReadCorrupt(
+                "restart-intent lifecycle dependencies are corrupt"
+            ) from error
+        return lease_history, self._read_generation()
+
+    def _read_generation(
+        self,
+    ) -> tuple[CurrentGeneration, tuple[StoredGenerationSnapshot, ...]] | None:
+        try:
+            return self._generation_reader.current_with_history()
+        except GenerationStateCorrupt as error:
             raise RestartIntentLifecycleReadCorrupt(
                 "restart-intent lifecycle dependencies are corrupt"
             ) from error

--- a/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_reader.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_reader.py
@@ -9,9 +9,6 @@ from lm_resiliency.integrations.torchrun._control_store import (
     ControlStore,
     ControlStoreEntry,
 )
-from lm_resiliency.integrations.torchrun._coordinator_lease import (
-    CoordinatorLeaseRecord,
-)
 from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
     CoordinatorLeaseAuthority,
     CoordinatorLeaseHistoryCorrupt,
@@ -22,6 +19,9 @@ from lm_resiliency.integrations.torchrun._generation_reader import (
     GenerationStateReader,
     StoredGenerationSnapshot,
 )
+from lm_resiliency.integrations.torchrun._restart_intent_lifecycle_auth import (
+    AuthenticatedInitialRestartIntentClosure,
+)
 from lm_resiliency.integrations.torchrun._restart_intent_lifecycle_state import (
     PersistedInitialRestartIntentClosure,
 )
@@ -29,8 +29,6 @@ from lm_resiliency.integrations.torchrun._restart_intent_records import (
     RestartIntentClosedHeadRecord,
     RestartIntentHeadRecord,
     RestartIntentLifecycleHeadRecord,
-    RestartIntentLifecycleRecord,
-    RestartIntentRecord,
 )
 
 _CONTROL_PREFIX = "lm_resiliency/torchrun/v1"
@@ -43,66 +41,6 @@ class RestartIntentLifecycleReadError(RuntimeError):
 
 class RestartIntentLifecycleReadCorrupt(RestartIntentLifecycleReadError):
     """Raised when persisted restart-intent lifecycle state is contradictory."""
-
-
-@dataclass(frozen=True, slots=True)
-class StoredInitialRestartIntentClosure:
-    """One closure authenticated against generation and lease history."""
-
-    state: PersistedInitialRestartIntentClosure
-    generation_snapshot: StoredGenerationSnapshot
-    opening_authority: CoordinatorLeaseAuthority
-    closing_authority: CoordinatorLeaseAuthority
-
-    def __post_init__(self) -> None:
-        if not isinstance(self.state, PersistedInitialRestartIntentClosure):
-            raise TypeError(
-                "StoredInitialRestartIntentClosure.state must be "
-                "PersistedInitialRestartIntentClosure"
-            )
-        if not isinstance(self.generation_snapshot, StoredGenerationSnapshot):
-            raise TypeError(
-                "StoredInitialRestartIntentClosure.generation_snapshot must be "
-                "StoredGenerationSnapshot"
-            )
-        if not isinstance(self.opening_authority, CoordinatorLeaseAuthority):
-            raise TypeError(
-                "StoredInitialRestartIntentClosure.opening_authority must be "
-                "CoordinatorLeaseAuthority"
-            )
-        if not isinstance(self.closing_authority, CoordinatorLeaseAuthority):
-            raise TypeError(
-                "StoredInitialRestartIntentClosure.closing_authority must be "
-                "CoordinatorLeaseAuthority"
-            )
-
-    @property
-    def intent(self) -> RestartIntentRecord:
-        return self.state.intent
-
-    @property
-    def open_head(self) -> RestartIntentHeadRecord:
-        return self.state.open_head
-
-    @property
-    def closed_head(self) -> RestartIntentClosedHeadRecord:
-        return self.state.closed_head
-
-    @property
-    def lifecycle(self) -> RestartIntentLifecycleRecord:
-        return self.state.lifecycle
-
-    @property
-    def lifecycle_head(self) -> RestartIntentLifecycleHeadRecord:
-        return self.state.lifecycle_head
-
-    @property
-    def closed_at_unix_ms(self) -> int:
-        return self.state.closed_at_unix_ms
-
-    @property
-    def transaction_sequence(self) -> int:
-        return self.state.closing_transaction_sequence
 
 
 @dataclass(frozen=True, slots=True)
@@ -145,8 +83,8 @@ class InitialRestartIntentLifecycleReader:
         normalized_index = _positive_integer(closure_index, "closure_index")
         return f"{self._run_prefix}/restart-intent-closures/{normalized_index}"
 
-    def read(self) -> StoredInitialRestartIntentClosure | None:
-        """Return one stable verified closure, or ``None`` before closure."""
+    def read(self) -> AuthenticatedInitialRestartIntentClosure | None:
+        """Return one stable authenticated closure, or ``None`` before closure."""
 
         for _ in range(_MAX_READ_ATTEMPTS):
             head_observation = self._observe(self._intent_head_key)
@@ -171,8 +109,7 @@ class InitialRestartIntentLifecycleReader:
             intent_observation = self._observe(intent_key)
             try:
                 lease_history = self._lease_history_reader.read()
-                generation_snapshot = self._generation_reader.get(lifecycle_head.generation)
-                successor = self._generation_reader.get(lifecycle_head.generation + 1)
+                generation_result = self._generation_reader.current_with_history()
             except (
                 CoordinatorLeaseHistoryCorrupt,
                 GenerationStateCorrupt,
@@ -180,6 +117,15 @@ class InitialRestartIntentLifecycleReader:
                 raise RestartIntentLifecycleReadCorrupt(
                     "restart-intent lifecycle dependencies are corrupt"
                 ) from error
+            generation_snapshot = None
+            successor = None
+            if generation_result is not None:
+                _, generation_history = generation_result
+                if lifecycle_head.generation < len(generation_history):
+                    generation_snapshot = generation_history[lifecycle_head.generation]
+                    successor_index = lifecycle_head.generation + 1
+                    if successor_index < len(generation_history):
+                        successor = generation_history[successor_index]
             if not self._stable(
                 self._intent_head_key,
                 head_observation,
@@ -191,7 +137,7 @@ class InitialRestartIntentLifecycleReader:
                 intent_observation,
             ):
                 continue
-            return self._validate_closure(
+            return self._authenticate_closure(
                 head_observation,
                 lifecycle_observation,
                 closure_observation,
@@ -236,7 +182,7 @@ class InitialRestartIntentLifecycleReader:
                 "current restart-intent head is noncanonical or belongs to another run"
             )
 
-    def _validate_closure(
+    def _authenticate_closure(
         self,
         head_observation: _ObservedKey,
         lifecycle_observation: _ObservedKey,
@@ -245,7 +191,7 @@ class InitialRestartIntentLifecycleReader:
         generation_snapshot: StoredGenerationSnapshot | None,
         successor: StoredGenerationSnapshot | None,
         lease_history: tuple[CoordinatorLeaseAuthority, ...],
-    ) -> StoredInitialRestartIntentClosure:
+    ) -> AuthenticatedInitialRestartIntentClosure:
         head_entry = _required_entry(head_observation, "current restart-intent head")
         lifecycle_head_entry = _immutable_entry(
             lifecycle_observation,
@@ -268,6 +214,10 @@ class InitialRestartIntentLifecycleReader:
             raise RestartIntentLifecycleReadCorrupt(
                 "current restart-intent head is absent from its history"
             )
+        if generation_snapshot is None:
+            raise RestartIntentLifecycleReadCorrupt(
+                "restart-intent closure references a missing generation"
+            )
         try:
             state = PersistedInitialRestartIntentClosure.from_entries(
                 run_id=self._run_id,
@@ -277,94 +227,16 @@ class InitialRestartIntentLifecycleReader:
                 lifecycle_entry=closure_entry,
                 lifecycle_head_entry=lifecycle_head_entry,
             )
+            return AuthenticatedInitialRestartIntentClosure(
+                state=state,
+                generation_snapshot=generation_snapshot,
+                immediate_successor=successor,
+                lease_history=lease_history,
+            )
         except (TypeError, ValueError) as error:
             raise RestartIntentLifecycleReadCorrupt(
                 "persisted restart-intent closure is contradictory"
             ) from error
-        if generation_snapshot is None:
-            raise RestartIntentLifecycleReadCorrupt(
-                "restart-intent closure references a missing generation"
-            )
-        if generation_snapshot.record.digest != state.intent.generation_snapshot_digest:
-            raise RestartIntentLifecycleReadCorrupt(
-                "restart-intent closure references the wrong generation snapshot"
-            )
-        generation_authority = self._generation_authority(
-            generation_snapshot,
-            lease_history,
-        )
-        opening_authority = self._entry_authority(
-            state.intent_entry,
-            CoordinatorLeaseRecord(
-                run_id=self._run_id,
-                coordinator_id=state.intent.coordinator_id,
-                lease_id=state.intent.lease_id,
-                lease_duration_ms=state.intent.coordinator_lease_duration_ms,
-            ),
-            state.intent.coordinator_fencing_token,
-            state.intent.coordinator_lease_digest,
-            lease_history,
-            "opening",
-        )
-        closing_authority = self._entry_authority(
-            state.closed_head_entry,
-            CoordinatorLeaseRecord(
-                run_id=self._run_id,
-                coordinator_id=state.lifecycle.coordinator_id,
-                lease_id=state.lifecycle.lease_id,
-                lease_duration_ms=state.lifecycle.coordinator_lease_duration_ms,
-            ),
-            state.lifecycle.coordinator_fencing_token,
-            state.lifecycle.coordinator_lease_digest,
-            lease_history,
-            "closing",
-        )
-        generation_index = lease_history.index(generation_authority)
-        opening_index = lease_history.index(opening_authority)
-        closing_index = lease_history.index(closing_authority)
-        if generation_index > opening_index or opening_index > closing_index:
-            raise RestartIntentLifecycleReadCorrupt(
-                "restart-intent lifecycle lease authorities are out of order"
-            )
-        if (
-            state.opening_transaction_sequence
-            <= max(
-                generation_snapshot.transaction_sequence,
-                opening_authority.transaction_sequence,
-            )
-            or state.opened_at_unix_ms < generation_snapshot.committed_at_unix_ms
-            or state.opened_at_unix_ms < opening_authority.lease.granted_at_unix_ms
-            or state.opened_at_unix_ms
-            >= min(
-                opening_authority.lease.expires_at_unix_ms,
-                state.intent.intent.prepare_deadline_unix_ms,
-            )
-            or (
-                successor is not None
-                and state.opening_transaction_sequence >= successor.transaction_sequence
-            )
-        ):
-            raise RestartIntentLifecycleReadCorrupt(
-                "restart-intent opening is outside its causal window"
-            )
-        if (
-            state.closing_transaction_sequence
-            <= max(
-                state.opening_transaction_sequence,
-                closing_authority.transaction_sequence,
-            )
-            or state.closed_at_unix_ms < closing_authority.lease.granted_at_unix_ms
-            or state.closed_at_unix_ms >= closing_authority.lease.expires_at_unix_ms
-        ):
-            raise RestartIntentLifecycleReadCorrupt(
-                "restart-intent closure is outside its causal lease window"
-            )
-        return StoredInitialRestartIntentClosure(
-            state=state,
-            generation_snapshot=generation_snapshot,
-            opening_authority=opening_authority,
-            closing_authority=closing_authority,
-        )
 
     def _decode_lifecycle_head(
         self,
@@ -382,75 +254,6 @@ class InitialRestartIntentLifecycleReader:
                 "restart-intent lifecycle head is noncanonical or belongs to another run"
             )
         return lifecycle_head
-
-    def _generation_authority(
-        self,
-        snapshot: StoredGenerationSnapshot,
-        history: tuple[CoordinatorLeaseAuthority, ...],
-    ) -> CoordinatorLeaseAuthority:
-        record = CoordinatorLeaseRecord(
-            run_id=self._run_id,
-            coordinator_id=snapshot.record.coordinator_id,
-            lease_id=snapshot.record.lease_id,
-            lease_duration_ms=snapshot.record.coordinator_lease_duration_ms,
-        )
-        authority = _unique_authority(
-            history,
-            record=record,
-            fencing_token=snapshot.record.coordinator_fencing_token,
-            granted_at_unix_ms=snapshot.guard_committed_at_unix_ms,
-            mutation_sequence=snapshot.guard_mutation_sequence,
-            value_sequence=snapshot.guard_value_sequence,
-            lifetime_sequence=snapshot.guard_lifetime_sequence,
-            label="generation",
-        )
-        if (
-            snapshot.transaction_sequence <= authority.transaction_sequence
-            or snapshot.committed_at_unix_ms < authority.lease.granted_at_unix_ms
-            or snapshot.committed_at_unix_ms >= authority.lease.expires_at_unix_ms
-        ):
-            raise RestartIntentLifecycleReadCorrupt(
-                "restart-intent generation is outside its causal lease window"
-            )
-        return authority
-
-    def _entry_authority(
-        self,
-        entry: ControlStoreEntry,
-        record: CoordinatorLeaseRecord,
-        fencing_token: int,
-        lease_digest: str,
-        history: tuple[CoordinatorLeaseAuthority, ...],
-        label: str,
-    ) -> CoordinatorLeaseAuthority:
-        provenance = (
-            entry.guard_key,
-            entry.guard_revision,
-            entry.guard_value_digest,
-            entry.guard_mutation_sequence,
-            entry.guard_value_sequence,
-            entry.guard_lifetime_sequence,
-            entry.guard_committed_at_unix_ms,
-        )
-        if (
-            entry.guard_key != self._generation_reader.coordinator_lease_key
-            or entry.guard_revision != fencing_token
-            or entry.guard_value_digest != lease_digest
-            or any(value is None for value in provenance)
-        ):
-            raise RestartIntentLifecycleReadCorrupt(
-                f"restart-intent {label} has invalid lease provenance"
-            )
-        return _unique_authority(
-            history,
-            record=record,
-            fencing_token=fencing_token,
-            granted_at_unix_ms=entry.guard_committed_at_unix_ms,
-            mutation_sequence=entry.guard_mutation_sequence,
-            value_sequence=entry.guard_value_sequence,
-            lifetime_sequence=entry.guard_lifetime_sequence,
-            label=label,
-        )
 
     def _observe(self, key: str) -> _ObservedKey:
         return _ObservedKey(
@@ -485,36 +288,6 @@ def _immutable_entry(observation: _ObservedKey, path: str) -> ControlStoreEntry:
     return entry
 
 
-def _unique_authority(
-    history: tuple[CoordinatorLeaseAuthority, ...],
-    *,
-    record: CoordinatorLeaseRecord,
-    fencing_token: int,
-    granted_at_unix_ms: object,
-    mutation_sequence: object,
-    value_sequence: object,
-    lifetime_sequence: object,
-    label: str,
-) -> CoordinatorLeaseAuthority:
-    matches = tuple(
-        authority
-        for authority in history
-        if (
-            authority.lease.record == record
-            and authority.lease.fencing_token == fencing_token
-            and authority.lease.granted_at_unix_ms == granted_at_unix_ms
-            and authority.mutation_sequence == mutation_sequence
-            and authority.value_sequence == value_sequence
-            and authority.lifetime_sequence == lifetime_sequence
-        )
-    )
-    if len(matches) != 1:
-        raise RestartIntentLifecycleReadCorrupt(
-            f"restart-intent {label} authority is absent from lease history"
-        )
-    return matches[0]
-
-
 def _nonempty_string(value: object, path: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"{path} must be a non-empty string")
@@ -531,5 +304,4 @@ __all__ = [
     "InitialRestartIntentLifecycleReader",
     "RestartIntentLifecycleReadCorrupt",
     "RestartIntentLifecycleReadError",
-    "StoredInitialRestartIntentClosure",
 ]

--- a/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_reader.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_reader.py
@@ -60,6 +60,7 @@ class InitialRestartIntentLifecycleReader:
         self._run_prefix = f"{_CONTROL_PREFIX}/runs/{run_digest}"
         self._intent_head_key = f"{self._run_prefix}/restart-intent-head"
         self._lifecycle_head_key = f"{self._run_prefix}/restart-intent-lifecycle-head"
+        self._initial_closure_key = f"{self._run_prefix}/restart-intent-closures/1"
         self._generation_reader = GenerationStateReader(store, run_id=self._run_id)
         self._lease_history_reader = CoordinatorLeaseHistoryReader(
             store,
@@ -97,9 +98,20 @@ class InitialRestartIntentLifecycleReader:
             ):
                 continue
             if lifecycle_observation.entry is None:
+                closure_observation = self._observe(self._initial_closure_key)
+                if not self._stable(
+                    self._intent_head_key,
+                    head_observation,
+                    self._lifecycle_head_key,
+                    lifecycle_observation,
+                    self._initial_closure_key,
+                    closure_observation,
+                ):
+                    continue
                 self._validate_absent_lifecycle(
                     head_observation,
                     lifecycle_observation,
+                    closure_observation,
                 )
                 return None
             lifecycle_head = self._decode_lifecycle_head(lifecycle_observation)
@@ -154,9 +166,14 @@ class InitialRestartIntentLifecycleReader:
         self,
         head: _ObservedKey,
         lifecycle: _ObservedKey,
+        closure: _ObservedKey,
     ) -> None:
         if lifecycle.has_history or lifecycle.history:
             raise RestartIntentLifecycleReadCorrupt("restart-intent lifecycle head was deleted")
+        if closure.entry is not None or closure.has_history or closure.history:
+            raise RestartIntentLifecycleReadCorrupt(
+                "restart-intent closure exists without a lifecycle head"
+            )
         if head.entry is None:
             if head.has_history or head.history:
                 raise RestartIntentLifecycleReadCorrupt("current restart-intent head was deleted")
@@ -177,6 +194,15 @@ class InitialRestartIntentLifecycleReader:
             raise RestartIntentLifecycleReadCorrupt(
                 "closed restart-intent head has no lifecycle state"
             ) from open_error
+        if (
+            head.history != (head.entry,)
+            or head.entry.mutation_sequence != 1
+            or head.entry.value_sequence != 1
+            or head.entry.lifetime_sequence != 1
+        ):
+            raise RestartIntentLifecycleReadCorrupt(
+                "live restart-intent head is not an immutable initial creation"
+            )
         if open_head.run_id != self._run_id or head.entry.value != open_head.to_json():
             raise RestartIntentLifecycleReadCorrupt(
                 "current restart-intent head is noncanonical or belongs to another run"

--- a/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_reader.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_lifecycle_reader.py
@@ -29,6 +29,7 @@ from lm_resiliency.integrations.torchrun._restart_intent_records import (
     RestartIntentClosedHeadRecord,
     RestartIntentHeadRecord,
     RestartIntentLifecycleHeadRecord,
+    RestartIntentRecord,
 )
 
 _CONTROL_PREFIX = "lm_resiliency/torchrun/v1"
@@ -108,10 +109,30 @@ class InitialRestartIntentLifecycleReader:
                     closure_observation,
                 ):
                     continue
-                self._validate_absent_lifecycle(
+                open_head = self._validate_absent_lifecycle(
                     head_observation,
                     lifecycle_observation,
                     closure_observation,
+                )
+                if open_head is None:
+                    return None
+                intent_key = self.intent_key(open_head.intent_id)
+                intent_observation = self._observe(intent_key)
+                if not self._stable(
+                    self._intent_head_key,
+                    head_observation,
+                    self._lifecycle_head_key,
+                    lifecycle_observation,
+                    self._initial_closure_key,
+                    closure_observation,
+                    intent_key,
+                    intent_observation,
+                ):
+                    continue
+                self._validate_open_intent(
+                    open_head,
+                    head_observation,
+                    intent_observation,
                 )
                 return None
             lifecycle_head = self._decode_lifecycle_head(lifecycle_observation)
@@ -167,7 +188,7 @@ class InitialRestartIntentLifecycleReader:
         head: _ObservedKey,
         lifecycle: _ObservedKey,
         closure: _ObservedKey,
-    ) -> None:
+    ) -> RestartIntentHeadRecord | None:
         if lifecycle.has_history or lifecycle.history:
             raise RestartIntentLifecycleReadCorrupt("restart-intent lifecycle head was deleted")
         if closure.entry is not None or closure.has_history or closure.history:
@@ -177,7 +198,7 @@ class InitialRestartIntentLifecycleReader:
         if head.entry is None:
             if head.has_history or head.history:
                 raise RestartIntentLifecycleReadCorrupt("current restart-intent head was deleted")
-            return
+            return None
         if not head.has_history or not head.history:
             raise RestartIntentLifecycleReadCorrupt(
                 "live restart-intent head has no durable history"
@@ -206,6 +227,46 @@ class InitialRestartIntentLifecycleReader:
         if open_head.run_id != self._run_id or head.entry.value != open_head.to_json():
             raise RestartIntentLifecycleReadCorrupt(
                 "current restart-intent head is noncanonical or belongs to another run"
+            )
+        return open_head
+
+    def _validate_open_intent(
+        self,
+        head: RestartIntentHeadRecord,
+        head_observation: _ObservedKey,
+        intent_observation: _ObservedKey,
+    ) -> None:
+        head_entry = _required_entry(head_observation, "current restart-intent head")
+        intent_entry = _immutable_entry(intent_observation, "immutable restart intent")
+        if (
+            intent_entry.mutation_sequence != 1
+            or intent_entry.value_sequence != 1
+            or intent_entry.lifetime_sequence != 1
+        ):
+            raise RestartIntentLifecycleReadCorrupt(
+                "immutable restart intent is not an initial creation"
+            )
+        try:
+            intent = RestartIntentRecord.from_json(intent_entry.value)
+        except (TypeError, ValueError) as error:
+            raise RestartIntentLifecycleReadCorrupt(
+                "immutable restart intent is malformed"
+            ) from error
+        if intent_entry.value != intent.to_json():
+            raise RestartIntentLifecycleReadCorrupt("immutable restart intent is noncanonical")
+        if (
+            intent.intent.run_id != self._run_id
+            or head.generation != intent.intent.generation
+            or head.intent_id != intent.intent.intent_id
+            or head.intent_digest != intent.digest
+        ):
+            raise RestartIntentLifecycleReadCorrupt(
+                "current restart-intent head does not identify its immutable record"
+            )
+        if _transaction_provenance(head_entry) != _transaction_provenance(intent_entry):
+            raise RestartIntentLifecycleReadCorrupt(
+                "current restart-intent head and immutable intent "
+                "do not share one guarded transaction"
             )
 
     def _authenticate_closure(
@@ -312,6 +373,20 @@ def _immutable_entry(observation: _ObservedKey, path: str) -> ControlStoreEntry:
     if observation.history != (entry,):
         raise RestartIntentLifecycleReadCorrupt(f"{path} is not an immutable retained value")
     return entry
+
+
+def _transaction_provenance(entry: ControlStoreEntry) -> tuple[object, ...]:
+    return (
+        entry.committed_at_unix_ms,
+        entry.transaction_sequence,
+        entry.guard_key,
+        entry.guard_revision,
+        entry.guard_value_digest,
+        entry.guard_committed_at_unix_ms,
+        entry.guard_mutation_sequence,
+        entry.guard_value_sequence,
+        entry.guard_lifetime_sequence,
+    )
 
 
 def _nonempty_string(value: object, path: str) -> str:

--- a/tests/unit/test_torchrun_restart_intent_lifecycle_auth.py
+++ b/tests/unit/test_torchrun_restart_intent_lifecycle_auth.py
@@ -289,6 +289,31 @@ def test_authenticated_closure_accepts_immediate_generation_successor():
         )
 
 
+def test_authenticated_closure_rejects_successor_that_retains_suspect():
+    fixture = _fixture()
+    current = fixture.generation_manager.current()
+    assert current is not None
+    fixture.clock.set(1_020)
+    fixture.generation_manager.commit_successor(
+        fixture.opening_lease,
+        current,
+        _assignment(generation=1),
+    )
+    successor = GenerationStateReader(fixture.store, run_id=RUN_ID).get(1)
+    assert successor is not None
+
+    with pytest.raises(ValueError, match="successor retains suspected nodes"):
+        AuthenticatedInitialRestartIntentClosure(
+            state=fixture.state,
+            generation_snapshot=fixture.generation,
+            immediate_successor=successor,
+            lease_history=CoordinatorLeaseHistoryReader(
+                fixture.store,
+                run_id=RUN_ID,
+            ).read(),
+        )
+
+
 def test_authenticated_closure_rejects_wrong_generation_or_successor():
     fixture = _fixture()
 

--- a/tests/unit/test_torchrun_restart_intent_lifecycle_auth.py
+++ b/tests/unit/test_torchrun_restart_intent_lifecycle_auth.py
@@ -260,6 +260,7 @@ def test_authenticated_closure_accepts_immediate_generation_successor():
     )
 
     assert authenticated.immediate_successor == successor
+    assert authenticated.successor_authority == authenticated.generation_authority
 
     with pytest.raises(ValueError, match="opening is outside"):
         AuthenticatedInitialRestartIntentClosure(
@@ -274,7 +275,7 @@ def test_authenticated_closure_accepts_immediate_generation_successor():
                 run_id=RUN_ID,
             ).read(),
         )
-    with pytest.raises(ValueError, match="opening is outside"):
+    with pytest.raises(ValueError, match="successor is outside"):
         AuthenticatedInitialRestartIntentClosure(
             state=fixture.state,
             generation_snapshot=fixture.generation,
@@ -286,6 +287,45 @@ def test_authenticated_closure_accepts_immediate_generation_successor():
                 fixture.store,
                 run_id=RUN_ID,
             ).read(),
+        )
+
+
+def test_authenticated_closure_authenticates_successor_lease_authority():
+    fixture = _fixture()
+    current = fixture.generation_manager.current()
+    assert current is not None
+    fixture.clock.set(1_020)
+    fixture.generation_manager.commit_successor(
+        fixture.opening_lease,
+        current,
+        _assignment(generation=1, node_id="node-c"),
+    )
+    successor = GenerationStateReader(fixture.store, run_id=RUN_ID).get(1)
+    assert successor is not None
+    lease_history = CoordinatorLeaseHistoryReader(
+        fixture.store,
+        run_id=RUN_ID,
+    ).read()
+
+    with pytest.raises(ValueError, match="successor authority is absent"):
+        AuthenticatedInitialRestartIntentClosure(
+            state=fixture.state,
+            generation_snapshot=fixture.generation,
+            immediate_successor=replace(
+                successor,
+                guard_mutation_sequence=successor.guard_mutation_sequence + 1,
+            ),
+            lease_history=lease_history,
+        )
+    with pytest.raises(ValueError, match="successor is outside its lease window"):
+        AuthenticatedInitialRestartIntentClosure(
+            state=fixture.state,
+            generation_snapshot=fixture.generation,
+            immediate_successor=replace(
+                successor,
+                transaction_sequence=lease_history[0].transaction_sequence,
+            ),
+            lease_history=lease_history,
         )
 
 

--- a/tests/unit/test_torchrun_restart_intent_lifecycle_auth.py
+++ b/tests/unit/test_torchrun_restart_intent_lifecycle_auth.py
@@ -316,6 +316,60 @@ def test_authenticated_closure_rejects_wrong_generation_or_successor():
         )
 
 
+def test_authenticated_closure_rejects_suspects_outside_generation():
+    fixture = _fixture()
+    intent = replace(
+        fixture.state.intent.intent,
+        suspected_node_ids=("node-z",),
+    )
+    record = replace(fixture.state.intent, intent=intent)
+    open_head = replace(fixture.state.open_head, intent_digest=record.digest)
+    lifecycle = replace(fixture.state.lifecycle, closed_intent=open_head)
+    lifecycle_head = replace(
+        fixture.state.lifecycle_head,
+        lifecycle_digest=lifecycle.digest,
+    )
+    closed_head = replace(
+        fixture.state.closed_head,
+        lifecycle_head_digest=lifecycle_head.digest,
+    )
+    state = PersistedInitialRestartIntentClosure(
+        intent=record,
+        open_head=open_head,
+        closed_head=closed_head,
+        lifecycle=lifecycle,
+        lifecycle_head=lifecycle_head,
+        intent_entry=replace(
+            fixture.state.intent_entry,
+            value=record.to_json(),
+        ),
+        open_head_entry=replace(
+            fixture.state.open_head_entry,
+            value=open_head.to_json(),
+        ),
+        closed_head_entry=replace(
+            fixture.state.closed_head_entry,
+            value=closed_head.to_json(),
+        ),
+        lifecycle_entry=replace(
+            fixture.state.lifecycle_entry,
+            value=lifecycle.to_json(),
+        ),
+        lifecycle_head_entry=replace(
+            fixture.state.lifecycle_head_entry,
+            value=lifecycle_head.to_json(),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="suspects nodes outside"):
+        AuthenticatedInitialRestartIntentClosure(
+            state=state,
+            generation_snapshot=fixture.generation,
+            immediate_successor=None,
+            lease_history=fixture.lease_history,
+        )
+
+
 def test_authenticated_closure_requires_exact_ordered_authorities():
     fixture = _fixture(closing_mode="replacement")
 

--- a/tests/unit/test_torchrun_restart_intent_lifecycle_reader.py
+++ b/tests/unit/test_torchrun_restart_intent_lifecycle_reader.py
@@ -333,6 +333,40 @@ def test_lifecycle_reader_rejects_open_authority_absent_from_lease_history():
         reader.read()
 
 
+def test_lifecycle_reader_bounds_open_commit_by_next_lease_mutation():
+    clock, store, lease_manager, _, lease, opened, reader = _open_state()
+    clock.set(1_010)
+    lease_manager.renew(lease)
+    next_authority = reader._lease_history_reader.read()[-1]
+    changes = {
+        "committed_at_unix_ms": next_authority.lease.granted_at_unix_ms,
+        "transaction_sequence": next_authority.transaction_sequence,
+    }
+    _replace_entry(store, opened.prepared.intent_head_key, **changes)
+    _replace_entry(store, opened.prepared.intent_key, **changes)
+
+    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="lease.*window"):
+        reader.read()
+
+
+def test_lifecycle_reader_authenticates_generation_lease_history():
+    _, store, _, generation_manager, _, _, reader = _open_state()
+    snapshot_key = generation_manager.snapshot_key(0)
+    snapshot_entry = store.get(snapshot_key)
+    head_entry = store.get(generation_manager.head_key)
+    assert snapshot_entry is not None
+    assert head_entry is not None
+    assert snapshot_entry.guard_mutation_sequence is not None
+    changes = {
+        "guard_mutation_sequence": snapshot_entry.guard_mutation_sequence + 1,
+    }
+    _replace_entry(store, snapshot_key, **changes)
+    _replace_entry(store, generation_manager.head_key, **changes)
+
+    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="generation coordinator lease"):
+        reader.read()
+
+
 def test_lifecycle_reader_rejects_open_entries_without_commit_times():
     _, store, _, _, _, opened, reader = _open_state()
     _replace_entry(

--- a/tests/unit/test_torchrun_restart_intent_lifecycle_reader.py
+++ b/tests/unit/test_torchrun_restart_intent_lifecycle_reader.py
@@ -38,6 +38,7 @@ from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
 )
 from lm_resiliency.integrations.torchrun._restart_intent_records import (
     RestartIntentClosedHeadRecord,
+    RestartIntentHeadRecord,
     RestartIntentLifecycleHeadRecord,
     RestartIntentLifecycleRecord,
 )
@@ -314,6 +315,50 @@ def test_lifecycle_reader_rejects_invalid_open_guard_provenance(
     _replace_entry(store, opened.prepared.intent_key, **changes)
 
     with pytest.raises(RestartIntentLifecycleReadCorrupt, match="lease provenance"):
+        reader.read()
+
+
+def test_lifecycle_reader_rejects_open_entries_without_commit_times():
+    _, store, _, _, _, opened, reader = _open_state()
+    _replace_entry(
+        store,
+        opened.prepared.intent_head_key,
+        committed_at_unix_ms=None,
+    )
+    _replace_entry(
+        store,
+        opened.prepared.intent_key,
+        committed_at_unix_ms=None,
+    )
+
+    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="commit time"):
+        reader.read()
+
+
+def test_lifecycle_reader_rejects_invalid_open_generation_binding():
+    _, store, _, _, _, opened, reader = _open_state()
+    record = replace(
+        opened.prepared.record,
+        generation_snapshot_digest="0" * 64,
+    )
+    head = RestartIntentHeadRecord(
+        run_id=RUN_ID,
+        generation=record.intent.generation,
+        intent_id=record.intent.intent_id,
+        intent_digest=record.digest,
+    )
+    _replace_entry(
+        store,
+        opened.prepared.intent_head_key,
+        value=head.to_json(),
+    )
+    _replace_entry(
+        store,
+        opened.prepared.intent_key,
+        value=record.to_json(),
+    )
+
+    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="generation"):
         reader.read()
 
 

--- a/tests/unit/test_torchrun_restart_intent_lifecycle_reader.py
+++ b/tests/unit/test_torchrun_restart_intent_lifecycle_reader.py
@@ -7,10 +7,7 @@ from dataclasses import replace
 
 import pytest
 
-from lm_resiliency.integrations.torchrun._control_store import (
-    ControlStoreWrite,
-    InMemoryControlStore,
-)
+from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
 from lm_resiliency.integrations.torchrun._coordinator_lease import (
     CoordinatorLeaseManager,
     HeldCoordinatorLease,
@@ -303,48 +300,12 @@ def test_lifecycle_reader_retries_atomic_closure_during_read(monkeypatch):
     assert observed.lifecycle == records.lifecycle
 
 
-@pytest.mark.parametrize(
-    ("key_role", "change", "message"),
-    [
-        ("intent", {"value": b"invalid"}, "intent is malformed"),
-        ("closure", {"value": b"invalid"}, "closure is malformed"),
-        ("lifecycle", {"value": b"invalid"}, "head is malformed"),
-        ("closed", {"value": b"invalid"}, "head is malformed"),
-    ],
-)
-def test_lifecycle_reader_rejects_malformed_records(
-    key_role,
-    change,
-    message,
-):
+def test_lifecycle_reader_translates_invalid_persisted_closure():
     clock, store, _, _, lease, opened, reader = _open_state()
     records = _commit_closure(clock, store, opened, lease)
-    keys = {
-        "intent": records.intent_key,
-        "closure": records.closure_key,
-        "lifecycle": records.lifecycle_head_key,
-        "closed": records.intent_head_key,
-    }
-    _replace_entry(store, keys[key_role], **change)
+    _replace_entry(store, records.closure_key, value=b"invalid")
 
-    with pytest.raises(RestartIntentLifecycleReadCorrupt, match=message):
-        reader.read()
-
-
-def test_lifecycle_reader_rejects_unlinked_closure_records():
-    clock, store, _, _, lease, opened, reader = _open_state()
-    records = _commit_closure(clock, store, opened, lease)
-    substituted = replace(
-        records.lifecycle_head,
-        lifecycle_digest="0" * 64,
-    )
-    _replace_entry(
-        store,
-        records.lifecycle_head_key,
-        value=substituted.to_json(),
-    )
-
-    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="one intent"):
+    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="contradictory"):
         reader.read()
 
 
@@ -374,96 +335,6 @@ def test_lifecycle_reader_rejects_missing_or_rewritten_records():
         reader.read()
 
 
-def test_lifecycle_reader_rejects_noncanonical_closing_lease_provenance():
-    clock, store, _, _, lease, opened, reader = _open_state()
-    records = _commit_closure(clock, store, opened, lease)
-    for key in (
-        records.intent_head_key,
-        records.lifecycle_head_key,
-        records.closure_key,
-    ):
-        _replace_entry(store, key, guard_key="other/coordinator-lease")
-
-    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="lease provenance"):
-        reader.read()
-
-
-def test_lifecycle_reader_rejects_closure_of_another_predecessor():
-    clock, store, _, _, lease, opened, reader = _open_state()
-    records = _commit_closure(clock, store, opened, lease)
-    other_head = replace(opened.prepared.head, intent_id="intent-b")
-    other_closure = replace(records.lifecycle, closed_intent=other_head)
-    other_lifecycle_head = replace(
-        records.lifecycle_head,
-        lifecycle_digest=other_closure.digest,
-    )
-    substitutions = {
-        records.intent_head_key: replace(
-            records.closed_head,
-            lifecycle_head_digest=other_lifecycle_head.digest,
-        ).to_json(),
-        records.lifecycle_head_key: other_lifecycle_head.to_json(),
-        records.closure_key: other_closure.to_json(),
-    }
-    for key, value in substitutions.items():
-        _replace_entry(store, key, value=value)
-
-    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="one intent"):
-        reader.read()
-
-
-def test_lifecycle_reader_rejects_skipped_initial_index():
-    clock, store, _, _, lease, opened, reader = _open_state()
-    lifecycle = RestartIntentLifecycleRecord(
-        closed_intent=opened.prepared.head,
-        coordinator_id=lease.record.coordinator_id,
-        lease_id=lease.record.lease_id,
-        coordinator_lease_duration_ms=lease.record.lease_duration_ms,
-        coordinator_fencing_token=lease.fencing_token,
-    )
-    lifecycle_head = RestartIntentLifecycleHeadRecord(
-        run_id=RUN_ID,
-        closure_index=2,
-        generation=0,
-        intent_id="intent-a",
-        lifecycle_digest=lifecycle.digest,
-    )
-    closed_head = RestartIntentClosedHeadRecord(
-        run_id=RUN_ID,
-        closure_index=2,
-        generation=0,
-        intent_id="intent-a",
-        lifecycle_head_digest=lifecycle_head.digest,
-    )
-    clock.set(1_010)
-    store.compare_set_many_guarded(
-        {
-            opened.prepared.intent_head_key: ControlStoreWrite(
-                expected_revision=opened.head_entry.revision,
-                value=closed_head.to_json(),
-            ),
-            opened.prepared.lifecycle_head_key: ControlStoreWrite(
-                expected_revision=None,
-                value=lifecycle_head.to_json(),
-                require_never_created=True,
-            ),
-            reader.closure_key(2): ControlStoreWrite(
-                expected_revision=None,
-                value=lifecycle.to_json(),
-                require_never_created=True,
-            ),
-        },
-        guard_key=opened.prepared.coordinator_lease_key,
-        expected_guard_revision=lease.fencing_token,
-        not_before_unix_ms=1_010,
-        deadline_unix_ms=lease.expires_at_unix_ms,
-        conditions={opened.prepared.intent_key: opened.intent_entry.revision},
-    )
-
-    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="index"):
-        reader.read()
-
-
 def test_lifecycle_reader_rejects_closure_outside_causal_window():
     clock, store, _, _, lease, opened, reader = _open_state()
     records = _commit_closure(clock, store, opened, lease)
@@ -475,7 +346,7 @@ def test_lifecycle_reader_rejects_closure_outside_causal_window():
         _replace_entry(
             store,
             key,
-            transaction_sequence=opened.transaction_sequence,
+            committed_at_unix_ms=lease.expires_at_unix_ms,
         )
 
     with pytest.raises(RestartIntentLifecycleReadCorrupt, match="causal lease window"):

--- a/tests/unit/test_torchrun_restart_intent_lifecycle_reader.py
+++ b/tests/unit/test_torchrun_restart_intent_lifecycle_reader.py
@@ -1,0 +1,516 @@
+"""Contract tests for persisted initial restart-intent closure reads."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import replace
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStoreWrite,
+    InMemoryControlStore,
+)
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseManager,
+    HeldCoordinatorLease,
+)
+from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
+    CoordinatorLeaseHistoryError,
+)
+from lm_resiliency.integrations.torchrun._generation_reader import GenerationStateError
+from lm_resiliency.integrations.torchrun._generation_state import GenerationStateManager
+from lm_resiliency.integrations.torchrun._protocol import (
+    RankAssignment,
+    RestartIntent,
+    SlotAssignment,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_close_records import (
+    InitialRestartIntentClosureRecords,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_lifecycle_reader import (
+    InitialRestartIntentLifecycleReader,
+    RestartIntentLifecycleReadCorrupt,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open import (
+    RestartIntentOpenPreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
+    CommittedInitialRestartIntentOpen,
+    RestartIntentOpenExecutor,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_records import (
+    RestartIntentClosedHeadRecord,
+    RestartIntentLifecycleHeadRecord,
+    RestartIntentLifecycleRecord,
+)
+
+RUN_ID = "training-run"
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+    def set(self, now_unix_ms: int) -> None:
+        with self._lock:
+            self.now_unix_ms = now_unix_ms
+
+
+def _manager(
+    store: InMemoryControlStore,
+    clock: ManualClock,
+    coordinator_id: str,
+) -> CoordinatorLeaseManager:
+    return CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id=coordinator_id,
+        lease_duration_ms=100,
+        clock=clock,
+    )
+
+
+def _assignment(
+    generation: int = 0,
+    *,
+    node_id: str = "node-b",
+) -> RankAssignment:
+    return RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=generation,
+        assignments=(
+            SlotAssignment(0, "node-a", 0, 2),
+            SlotAssignment(1, node_id, 2, 2),
+        ),
+        topology_digest="topology-v1",
+    )
+
+
+def _intent() -> RestartIntent:
+    return RestartIntent(
+        intent_id="intent-a",
+        run_id=RUN_ID,
+        generation=0,
+        incident_ids=("incident-a",),
+        reason_code="attributed_sdc",
+        minimum_recovery_mode="recovery_verified",
+        suspected_node_ids=("node-b",),
+        prepare_deadline_unix_ms=1_200,
+    )
+
+
+def _open_state() -> tuple[
+    ManualClock,
+    InMemoryControlStore,
+    CoordinatorLeaseManager,
+    GenerationStateManager,
+    HeldCoordinatorLease,
+    CommittedInitialRestartIntentOpen,
+    InitialRestartIntentLifecycleReader,
+]:
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    lease_manager = _manager(store, clock, "coordinator-a")
+    generation_manager = GenerationStateManager(store, run_id=RUN_ID)
+    lease = lease_manager.acquire()
+    generation_manager.initialize(lease, _assignment())
+    current = generation_manager.current()
+    assert current is not None
+    prepared = RestartIntentOpenPreparer(
+        store,
+        run_id=RUN_ID,
+        clock=clock,
+    ).prepare_initial_open(lease, current, _intent())
+    opened = RestartIntentOpenExecutor(
+        store,
+        run_id=RUN_ID,
+    ).execute_initial_open(prepared)
+    return (
+        clock,
+        store,
+        lease_manager,
+        generation_manager,
+        lease,
+        opened,
+        InitialRestartIntentLifecycleReader(store, run_id=RUN_ID),
+    )
+
+
+def _records(
+    opened: CommittedInitialRestartIntentOpen,
+    lease: HeldCoordinatorLease,
+    *,
+    closure_index: int = 1,
+) -> InitialRestartIntentClosureRecords:
+    lifecycle = RestartIntentLifecycleRecord(
+        closed_intent=opened.prepared.head,
+        coordinator_id=lease.record.coordinator_id,
+        lease_id=lease.record.lease_id,
+        coordinator_lease_duration_ms=lease.record.lease_duration_ms,
+        coordinator_fencing_token=lease.fencing_token,
+    )
+    lifecycle_head = RestartIntentLifecycleHeadRecord(
+        run_id=RUN_ID,
+        closure_index=closure_index,
+        generation=opened.prepared.record.intent.generation,
+        intent_id=opened.prepared.record.intent.intent_id,
+        lifecycle_digest=lifecycle.digest,
+    )
+    run_prefix = opened.prepared.intent_head_key.rsplit("/", 1)[0]
+    return InitialRestartIntentClosureRecords(
+        opened=opened,
+        lifecycle=lifecycle,
+        lifecycle_head=lifecycle_head,
+        closed_head=RestartIntentClosedHeadRecord(
+            run_id=RUN_ID,
+            closure_index=closure_index,
+            generation=lifecycle_head.generation,
+            intent_id=lifecycle_head.intent_id,
+            lifecycle_head_digest=lifecycle_head.digest,
+        ),
+        intent_key=opened.prepared.intent_key,
+        intent_head_key=opened.prepared.intent_head_key,
+        closure_key=f"{run_prefix}/restart-intent-closures/{closure_index}",
+        lifecycle_head_key=opened.prepared.lifecycle_head_key,
+    )
+
+
+def _commit_closure(
+    clock: ManualClock,
+    store: InMemoryControlStore,
+    opened: CommittedInitialRestartIntentOpen,
+    lease: HeldCoordinatorLease,
+) -> InitialRestartIntentClosureRecords:
+    records = _records(opened, lease)
+    clock.set(max(clock.now_unix_ms, lease.granted_at_unix_ms, 1_010))
+    store.compare_set_many_guarded(
+        records.writes,
+        guard_key=opened.prepared.coordinator_lease_key,
+        expected_guard_revision=lease.fencing_token,
+        not_before_unix_ms=clock.now_unix_ms,
+        deadline_unix_ms=lease.expires_at_unix_ms,
+        conditions=records.conditions,
+    )
+    return records
+
+
+def _replace_entry(
+    store: InMemoryControlStore,
+    key: str,
+    **changes,
+) -> None:
+    updated = replace(store._entries[key], **changes)
+    store._entries[key] = updated
+    store._histories[key][-1] = updated
+
+
+def test_lifecycle_reader_returns_none_before_closure():
+    store = InMemoryControlStore(clock=ManualClock())
+    reader = InitialRestartIntentLifecycleReader(store, run_id=RUN_ID)
+
+    assert reader.read() is None
+
+    _, _, _, _, _, _, open_reader = _open_state()
+    assert open_reader.read() is None
+
+
+def test_lifecycle_reader_reconstructs_verified_closure():
+    clock, store, _, _, lease, opened, reader = _open_state()
+    records = _commit_closure(clock, store, opened, lease)
+
+    observed = reader.read()
+
+    assert observed is not None
+    assert observed.intent == opened.prepared.record
+    assert observed.open_head == opened.prepared.head
+    assert observed.closed_head == records.closed_head
+    assert observed.lifecycle == records.lifecycle
+    assert observed.lifecycle_head == records.lifecycle_head
+    assert observed.opening_authority.lease == opened.prepared.lease
+    assert observed.closing_authority.lease == lease
+    assert observed.closed_at_unix_ms == clock.now_unix_ms
+
+
+def test_lifecycle_reader_accepts_renewed_or_replaced_closing_lease():
+    clock, store, lease_manager, _, lease, opened, reader = _open_state()
+    clock.set(1_010)
+    renewed = lease_manager.renew(lease)
+    _commit_closure(clock, store, opened, renewed)
+
+    observed = reader.read()
+    assert observed is not None
+    assert observed.closing_authority.lease == renewed
+
+    clock, store, _, _, lease, opened, reader = _open_state()
+    clock.set(lease.expires_at_unix_ms)
+    replacement = _manager(store, clock, "coordinator-b").acquire()
+    _commit_closure(clock, store, opened, replacement)
+
+    observed = reader.read()
+    assert observed is not None
+    assert observed.closing_authority.lease == replacement
+
+
+def test_lifecycle_reader_accepts_closure_after_generation_advance():
+    clock, store, _, generation_manager, lease, opened, reader = _open_state()
+    _commit_closure(clock, store, opened, lease)
+    current = generation_manager.current()
+    assert current is not None
+    clock.set(1_020)
+    generation_manager.commit_successor(
+        lease,
+        current,
+        _assignment(generation=1, node_id="node-c"),
+    )
+
+    observed = reader.read()
+
+    assert observed is not None
+    assert observed.generation_snapshot.record.assignment.generation == 0
+
+
+def test_lifecycle_reader_retries_atomic_closure_during_read(monkeypatch):
+    clock, store, _, _, lease, opened, reader = _open_state()
+    records = _records(opened, lease)
+    original_get = store.get
+    triggered = False
+
+    def racing_get(key: str):
+        nonlocal triggered
+        if key == reader.lifecycle_head_key and not triggered:
+            triggered = True
+            clock.set(1_010)
+            store.compare_set_many_guarded(
+                records.writes,
+                guard_key=opened.prepared.coordinator_lease_key,
+                expected_guard_revision=lease.fencing_token,
+                not_before_unix_ms=1_010,
+                deadline_unix_ms=lease.expires_at_unix_ms,
+                conditions=records.conditions,
+            )
+        return original_get(key)
+
+    monkeypatch.setattr(store, "get", racing_get)
+
+    observed = reader.read()
+    assert observed is not None
+    assert observed.lifecycle == records.lifecycle
+
+
+@pytest.mark.parametrize(
+    ("key_role", "change", "message"),
+    [
+        ("intent", {"value": b"invalid"}, "intent is malformed"),
+        ("closure", {"value": b"invalid"}, "closure is malformed"),
+        ("lifecycle", {"value": b"invalid"}, "head is malformed"),
+        ("closed", {"value": b"invalid"}, "head is malformed"),
+    ],
+)
+def test_lifecycle_reader_rejects_malformed_records(
+    key_role,
+    change,
+    message,
+):
+    clock, store, _, _, lease, opened, reader = _open_state()
+    records = _commit_closure(clock, store, opened, lease)
+    keys = {
+        "intent": records.intent_key,
+        "closure": records.closure_key,
+        "lifecycle": records.lifecycle_head_key,
+        "closed": records.intent_head_key,
+    }
+    _replace_entry(store, keys[key_role], **change)
+
+    with pytest.raises(RestartIntentLifecycleReadCorrupt, match=message):
+        reader.read()
+
+
+def test_lifecycle_reader_rejects_unlinked_closure_records():
+    clock, store, _, _, lease, opened, reader = _open_state()
+    records = _commit_closure(clock, store, opened, lease)
+    substituted = replace(
+        records.lifecycle_head,
+        lifecycle_digest="0" * 64,
+    )
+    _replace_entry(
+        store,
+        records.lifecycle_head_key,
+        value=substituted.to_json(),
+    )
+
+    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="one intent"):
+        reader.read()
+
+
+def test_lifecycle_reader_rejects_missing_or_rewritten_records():
+    clock, store, _, _, lease, opened, reader = _open_state()
+    records = _commit_closure(clock, store, opened, lease)
+    closure_entry = store.get(records.closure_key)
+    assert closure_entry is not None
+    store.compare_delete(
+        records.closure_key,
+        expected_revision=closure_entry.revision,
+    )
+
+    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="closure is missing"):
+        reader.read()
+
+    clock, store, _, _, lease, opened, reader = _open_state()
+    records = _commit_closure(clock, store, opened, lease)
+    lifecycle_entry = store.get(records.lifecycle_head_key)
+    assert lifecycle_entry is not None
+    store.compare_set(
+        records.lifecycle_head_key,
+        expected_revision=lifecycle_entry.revision,
+        value=records.lifecycle_head.to_json(),
+    )
+    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="immutable"):
+        reader.read()
+
+
+def test_lifecycle_reader_rejects_noncanonical_closing_lease_provenance():
+    clock, store, _, _, lease, opened, reader = _open_state()
+    records = _commit_closure(clock, store, opened, lease)
+    for key in (
+        records.intent_head_key,
+        records.lifecycle_head_key,
+        records.closure_key,
+    ):
+        _replace_entry(store, key, guard_key="other/coordinator-lease")
+
+    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="lease provenance"):
+        reader.read()
+
+
+def test_lifecycle_reader_rejects_closure_of_another_predecessor():
+    clock, store, _, _, lease, opened, reader = _open_state()
+    records = _commit_closure(clock, store, opened, lease)
+    other_head = replace(opened.prepared.head, intent_id="intent-b")
+    other_closure = replace(records.lifecycle, closed_intent=other_head)
+    other_lifecycle_head = replace(
+        records.lifecycle_head,
+        lifecycle_digest=other_closure.digest,
+    )
+    substitutions = {
+        records.intent_head_key: replace(
+            records.closed_head,
+            lifecycle_head_digest=other_lifecycle_head.digest,
+        ).to_json(),
+        records.lifecycle_head_key: other_lifecycle_head.to_json(),
+        records.closure_key: other_closure.to_json(),
+    }
+    for key, value in substitutions.items():
+        _replace_entry(store, key, value=value)
+
+    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="one intent"):
+        reader.read()
+
+
+def test_lifecycle_reader_rejects_skipped_initial_index():
+    clock, store, _, _, lease, opened, reader = _open_state()
+    lifecycle = RestartIntentLifecycleRecord(
+        closed_intent=opened.prepared.head,
+        coordinator_id=lease.record.coordinator_id,
+        lease_id=lease.record.lease_id,
+        coordinator_lease_duration_ms=lease.record.lease_duration_ms,
+        coordinator_fencing_token=lease.fencing_token,
+    )
+    lifecycle_head = RestartIntentLifecycleHeadRecord(
+        run_id=RUN_ID,
+        closure_index=2,
+        generation=0,
+        intent_id="intent-a",
+        lifecycle_digest=lifecycle.digest,
+    )
+    closed_head = RestartIntentClosedHeadRecord(
+        run_id=RUN_ID,
+        closure_index=2,
+        generation=0,
+        intent_id="intent-a",
+        lifecycle_head_digest=lifecycle_head.digest,
+    )
+    clock.set(1_010)
+    store.compare_set_many_guarded(
+        {
+            opened.prepared.intent_head_key: ControlStoreWrite(
+                expected_revision=opened.head_entry.revision,
+                value=closed_head.to_json(),
+            ),
+            opened.prepared.lifecycle_head_key: ControlStoreWrite(
+                expected_revision=None,
+                value=lifecycle_head.to_json(),
+                require_never_created=True,
+            ),
+            reader.closure_key(2): ControlStoreWrite(
+                expected_revision=None,
+                value=lifecycle.to_json(),
+                require_never_created=True,
+            ),
+        },
+        guard_key=opened.prepared.coordinator_lease_key,
+        expected_guard_revision=lease.fencing_token,
+        not_before_unix_ms=1_010,
+        deadline_unix_ms=lease.expires_at_unix_ms,
+        conditions={opened.prepared.intent_key: opened.intent_entry.revision},
+    )
+
+    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="index"):
+        reader.read()
+
+
+def test_lifecycle_reader_rejects_closure_outside_causal_window():
+    clock, store, _, _, lease, opened, reader = _open_state()
+    records = _commit_closure(clock, store, opened, lease)
+    for key in (
+        records.intent_head_key,
+        records.lifecycle_head_key,
+        records.closure_key,
+    ):
+        _replace_entry(
+            store,
+            key,
+            transaction_sequence=opened.transaction_sequence,
+        )
+
+    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="causal lease window"):
+        reader.read()
+
+
+@pytest.mark.parametrize(
+    "dependency_error",
+    [
+        CoordinatorLeaseHistoryError("lease history changed"),
+        GenerationStateError("generation changed"),
+    ],
+)
+def test_lifecycle_reader_preserves_retryable_dependency_errors(
+    dependency_error: RuntimeError,
+    monkeypatch,
+):
+    clock, store, _, _, lease, opened, reader = _open_state()
+    _commit_closure(clock, store, opened, lease)
+
+    def fail(*args):
+        raise dependency_error
+
+    if isinstance(dependency_error, CoordinatorLeaseHistoryError):
+        monkeypatch.setattr(reader._lease_history_reader, "read", fail)
+    else:
+        monkeypatch.setattr(reader._generation_reader, "get", fail)
+
+    with pytest.raises(type(dependency_error), match="changed"):
+        reader.read()
+
+
+def test_lifecycle_reader_is_run_scoped():
+    _, store, _, _, _, _, _ = _open_state()
+
+    assert InitialRestartIntentLifecycleReader(store, run_id="other-run").read() is None
+    with pytest.raises(ValueError, match="non-empty"):
+        InitialRestartIntentLifecycleReader(store, run_id="")

--- a/tests/unit/test_torchrun_restart_intent_lifecycle_reader.py
+++ b/tests/unit/test_torchrun_restart_intent_lifecycle_reader.py
@@ -230,6 +230,31 @@ def test_lifecycle_reader_rejects_closed_head_without_lifecycle():
         reader.read()
 
 
+def test_lifecycle_reader_rejects_rewritten_open_head_without_lifecycle():
+    _, store, _, _, _, opened, reader = _open_state()
+    store.compare_set(
+        opened.prepared.intent_head_key,
+        expected_revision=opened.head_entry.revision,
+        value=opened.prepared.head.to_json(),
+    )
+
+    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="initial creation"):
+        reader.read()
+
+
+def test_lifecycle_reader_rejects_orphaned_closure_without_lifecycle_head():
+    _, store, _, _, lease, opened, reader = _open_state()
+    records = _records(opened, lease)
+    store.compare_set(
+        records.closure_key,
+        expected_revision=None,
+        value=records.lifecycle.to_json(),
+    )
+
+    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="without a lifecycle"):
+        reader.read()
+
+
 def test_lifecycle_reader_reconstructs_verified_closure():
     clock, store, _, _, lease, opened, reader = _open_state()
     records = _commit_closure(clock, store, opened, lease)

--- a/tests/unit/test_torchrun_restart_intent_lifecycle_reader.py
+++ b/tests/unit/test_torchrun_restart_intent_lifecycle_reader.py
@@ -318,6 +318,21 @@ def test_lifecycle_reader_rejects_invalid_open_guard_provenance(
         reader.read()
 
 
+def test_lifecycle_reader_rejects_open_authority_absent_from_lease_history():
+    _, store, _, _, _, opened, reader = _open_state()
+    intent_entry = store.get(opened.prepared.intent_key)
+    assert intent_entry is not None
+    assert intent_entry.guard_mutation_sequence is not None
+    changes = {
+        "guard_mutation_sequence": intent_entry.guard_mutation_sequence + 1,
+    }
+    _replace_entry(store, opened.prepared.intent_head_key, **changes)
+    _replace_entry(store, opened.prepared.intent_key, **changes)
+
+    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="durable lease history"):
+        reader.read()
+
+
 def test_lifecycle_reader_rejects_open_entries_without_commit_times():
     _, store, _, _, _, opened, reader = _open_state()
     _replace_entry(

--- a/tests/unit/test_torchrun_restart_intent_lifecycle_reader.py
+++ b/tests/unit/test_torchrun_restart_intent_lifecycle_reader.py
@@ -296,6 +296,27 @@ def test_lifecycle_reader_rejects_split_open_transaction_without_lifecycle():
         reader.read()
 
 
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    [
+        ("guard_key", "other-guard"),
+        ("guard_revision", 10_000),
+        ("guard_value_digest", "0" * 64),
+    ],
+)
+def test_lifecycle_reader_rejects_invalid_open_guard_provenance(
+    field: str,
+    replacement: object,
+):
+    _, store, _, _, _, opened, reader = _open_state()
+    changes = {field: replacement}
+    _replace_entry(store, opened.prepared.intent_head_key, **changes)
+    _replace_entry(store, opened.prepared.intent_key, **changes)
+
+    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="lease provenance"):
+        reader.read()
+
+
 def test_lifecycle_reader_reconstructs_verified_closure():
     clock, store, _, _, lease, opened, reader = _open_state()
     records = _commit_closure(clock, store, opened, lease)
@@ -349,6 +370,39 @@ def test_lifecycle_reader_accepts_closure_after_generation_advance():
 
     assert observed is not None
     assert observed.generation_snapshot.record.assignment.generation == 0
+
+
+def test_lifecycle_reader_rejects_mixed_lease_and_generation_histories(
+    monkeypatch,
+):
+    clock, store, lease_manager, generation_manager, lease, opened, reader = _open_state()
+    _commit_closure(clock, store, opened, lease)
+    original_current_with_history = reader._generation_reader.current_with_history
+    triggered = False
+
+    def racing_current_with_history():
+        nonlocal triggered
+        if not triggered:
+            triggered = True
+            current = generation_manager.current()
+            assert current is not None
+            lease_manager.release(lease)
+            replacement = _manager(store, clock, "coordinator-b").acquire()
+            generation_manager.commit_successor(
+                replacement,
+                current,
+                _assignment(generation=1, node_id="node-c"),
+            )
+        return original_current_with_history()
+
+    monkeypatch.setattr(
+        reader._generation_reader,
+        "current_with_history",
+        racing_current_with_history,
+    )
+
+    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="contradictory"):
+        reader.read()
 
 
 def test_lifecycle_reader_retries_atomic_closure_during_read(monkeypatch):

--- a/tests/unit/test_torchrun_restart_intent_lifecycle_reader.py
+++ b/tests/unit/test_torchrun_restart_intent_lifecycle_reader.py
@@ -411,6 +411,29 @@ def test_lifecycle_reader_rejects_invalid_open_generation_binding():
         reader.read()
 
 
+def test_lifecycle_reader_rejects_open_suspects_outside_generation():
+    _, store, _, _, _, opened, reader = _open_state()
+    intent = replace(
+        opened.prepared.record.intent,
+        suspected_node_ids=("node-z",),
+    )
+    record = replace(opened.prepared.record, intent=intent)
+    head = replace(opened.prepared.head, intent_digest=record.digest)
+    _replace_entry(
+        store,
+        opened.prepared.intent_head_key,
+        value=head.to_json(),
+    )
+    _replace_entry(
+        store,
+        opened.prepared.intent_key,
+        value=record.to_json(),
+    )
+
+    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="suspects nodes outside"):
+        reader.read()
+
+
 def test_lifecycle_reader_reconstructs_verified_closure():
     clock, store, _, _, lease, opened, reader = _open_state()
     records = _commit_closure(clock, store, opened, lease)

--- a/tests/unit/test_torchrun_restart_intent_lifecycle_reader.py
+++ b/tests/unit/test_torchrun_restart_intent_lifecycle_reader.py
@@ -255,6 +255,47 @@ def test_lifecycle_reader_rejects_orphaned_closure_without_lifecycle_head():
         reader.read()
 
 
+def test_lifecycle_reader_rejects_missing_open_intent_without_lifecycle():
+    _, store, _, _, _, opened, reader = _open_state()
+    intent_entry = store.get(opened.prepared.intent_key)
+    assert intent_entry is not None
+    store.compare_delete(
+        opened.prepared.intent_key,
+        expected_revision=intent_entry.revision,
+    )
+
+    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="intent is missing"):
+        reader.read()
+
+
+def test_lifecycle_reader_rejects_rewritten_open_intent_without_lifecycle():
+    _, store, _, _, _, opened, reader = _open_state()
+    intent_entry = store.get(opened.prepared.intent_key)
+    assert intent_entry is not None
+    store.compare_set(
+        opened.prepared.intent_key,
+        expected_revision=intent_entry.revision,
+        value=opened.prepared.record.to_json(),
+    )
+
+    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="immutable retained"):
+        reader.read()
+
+
+def test_lifecycle_reader_rejects_split_open_transaction_without_lifecycle():
+    _, store, _, _, _, opened, reader = _open_state()
+    intent_entry = store.get(opened.prepared.intent_key)
+    assert intent_entry is not None
+    _replace_entry(
+        store,
+        opened.prepared.intent_key,
+        transaction_sequence=intent_entry.transaction_sequence + 1,
+    )
+
+    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="guarded transaction"):
+        reader.read()
+
+
 def test_lifecycle_reader_reconstructs_verified_closure():
     clock, store, _, _, lease, opened, reader = _open_state()
     records = _commit_closure(clock, store, opened, lease)

--- a/tests/unit/test_torchrun_restart_intent_lifecycle_reader.py
+++ b/tests/unit/test_torchrun_restart_intent_lifecycle_reader.py
@@ -217,6 +217,19 @@ def test_lifecycle_reader_returns_none_before_closure():
     assert open_reader.read() is None
 
 
+def test_lifecycle_reader_rejects_closed_head_without_lifecycle():
+    _, store, _, _, lease, opened, reader = _open_state()
+    records = _records(opened, lease)
+    store.compare_set(
+        records.intent_head_key,
+        expected_revision=opened.head_entry.revision,
+        value=records.closed_head.to_json(),
+    )
+
+    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="no lifecycle"):
+        reader.read()
+
+
 def test_lifecycle_reader_reconstructs_verified_closure():
     clock, store, _, _, lease, opened, reader = _open_state()
     records = _commit_closure(clock, store, opened, lease)
@@ -349,7 +362,7 @@ def test_lifecycle_reader_rejects_closure_outside_causal_window():
             committed_at_unix_ms=lease.expires_at_unix_ms,
         )
 
-    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="causal lease window"):
+    with pytest.raises(RestartIntentLifecycleReadCorrupt, match="contradictory"):
         reader.read()
 
 
@@ -373,7 +386,7 @@ def test_lifecycle_reader_preserves_retryable_dependency_errors(
     if isinstance(dependency_error, CoordinatorLeaseHistoryError):
         monkeypatch.setattr(reader._lease_history_reader, "read", fail)
     else:
-        monkeypatch.setattr(reader._generation_reader, "get", fail)
+        monkeypatch.setattr(reader._generation_reader, "current_with_history", fail)
 
     with pytest.raises(type(dependency_error), match="changed"):
         reader.read()


### PR DESCRIPTION
## Summary
- add a read-only lifecycle reader that stabilizes the current intent head, retained predecessor, immutable intent, closure record, and lifecycle head
- require durable history for every persisted key and reject split, missing, rewritten, or noncanonical lifecycle state
- return no closure only when the current open head and linked immutable intent are canonical create-once records from one guarded transaction and the initial closure key has never existed
- read generation history once, preserve retryable dependency contention, and delegate all causal validation to `PersistedInitialRestartIntentClosure` and `AuthenticatedInitialRestartIntentClosure`

## Scope
This PR performs no control-store mutations. Closure preparation and execution remain separate follow-up components.

## Validation
- `145` focused torchrun lifecycle/generation/lease tests
- `1785` full CPU tests with CUDA hidden
- Ruff format/check
- targeted mypy
- `git diff --check`