### PR TITLE
[Feature][Torchrun] Prepare initial restart intent closure

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -600,12 +600,13 @@ current-head update, and an exact immutable-intent condition, but does not
 authenticate a closing lease or mutate the store. A frozen
 `PreparedInitialRestartIntentClosure` descriptor binds those records to a
 contiguous coordinator-lease authority slice beginning at the exact lease that
-opened the intent. It accepts same-lease renewal, nonoverlapping replacement,
-and delete/recreate transitions, while rejecting skipped mutations, expired
-renewals, overlapping leases, and recurrence of any generation or opening
-lease identity or fencing token after replacement. It bounds the future
-transaction to the final live lease but performs no store reads or mutations.
-A later preparer selects the slice from verified durable lease history. A frozen
+opened the intent. It accepts same-lease renewal and nonoverlapping in-place
+replacement while rejecting skipped mutations, expired renewals, overlapping
+leases, recurrence of any generation or opening lease identity or fencing
+token after replacement, and delete/recreate transitions that lack a durable
+deletion tombstone. It bounds the future transaction to the final live lease
+but performs no store reads or mutations. A later preparer selects the slice
+from verified durable lease history. A frozen
 `PreparedInitialRestartIntentOpen` descriptor binds the first intent record,
 current-intent head, exact generation revisions, coordinator fencing token,
 canonical run-scoped keys, and lease/intent commit window. It exposes immutable
@@ -644,7 +645,9 @@ the supplied closing lease to be the live durable tail, selects the contiguous
 authority slice beginning at the opening lease, and samples a monotonic commit
 lower bound after those reads. It returns
 `PreparedInitialRestartIntentClosure`; a separate executor owns the guarded
-store transaction and committed-result verification.
+store transaction and committed-result verification. Lease-key lifetime
+changes remain rejected until the store retains authoritative deletion
+evidence.
 
 A read-only `RestartIntentOpenStateReader` reconstructs the same
 `CommittedInitialRestartIntentOpen` contract after coordinator failover. It

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -638,6 +638,14 @@ verified generation history. Preparation obtains that history through one
 stable reader traversal rather than rereading the full predecessor chain for
 each generation.
 
+A non-mutating `RestartIntentClosurePreparer` reconstructs the current
+committed opening, double-collects verified coordinator-lease history, requires
+the supplied closing lease to be the live durable tail, selects the contiguous
+authority slice beginning at the opening lease, and samples a monotonic commit
+lower bound after those reads. It returns
+`PreparedInitialRestartIntentClosure`; a separate executor owns the guarded
+store transaction and committed-result verification.
+
 A read-only `RestartIntentOpenStateReader` reconstructs the same
 `CommittedInitialRestartIntentOpen` contract after coordinator failover. It
 stably reads the current-intent head and immutable intent, requires the

--- a/lm_resiliency/integrations/torchrun/_restart_intent_close.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_close.py
@@ -172,11 +172,10 @@ class PreparedInitialRestartIntentClosure:
                 raise ValueError("PreparedInitialRestartIntentClosure coordinator leases overlap")
             return
         if lifetime_delta == 1:
-            if mutation_delta != 2 or value_delta != 1:
-                raise ValueError(
-                    "PreparedInitialRestartIntentClosure recreated lease has invalid lineage"
-                )
-            return
+            raise ValueError(
+                "PreparedInitialRestartIntentClosure cannot authenticate a "
+                "delete/recreate lease transition without a durable deletion tombstone"
+            )
         raise ValueError(
             "PreparedInitialRestartIntentClosure lease chain omits one or more "
             "replacement authorities"

--- a/lm_resiliency/integrations/torchrun/_restart_intent_close_preparation.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_close_preparation.py
@@ -13,6 +13,10 @@ from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
     CoordinatorLeaseHistoryError,
     CoordinatorLeaseHistoryReader,
 )
+from lm_resiliency.integrations.torchrun._generation_reader import (
+    GenerationStateCorrupt,
+    GenerationStateError,
+)
 from lm_resiliency.integrations.torchrun._restart_intent_close import (
     PreparedInitialRestartIntentClosure,
 )
@@ -156,6 +160,14 @@ class RestartIntentClosurePreparer:
         except RestartIntentOpenStateError as error:
             raise RestartIntentClosurePreparationConflict(
                 "restart-intent opening changed repeatedly during preparation"
+            ) from error
+        except (CoordinatorLeaseHistoryCorrupt, GenerationStateCorrupt) as error:
+            raise RestartIntentClosurePreparationCorrupt(
+                "restart-intent opening dependencies are corrupt"
+            ) from error
+        except (CoordinatorLeaseHistoryError, GenerationStateError) as error:
+            raise RestartIntentClosurePreparationConflict(
+                "restart-intent opening dependencies changed repeatedly during preparation"
             ) from error
 
     def _read_lease_history(self) -> tuple[CoordinatorLeaseAuthority, ...]:

--- a/lm_resiliency/integrations/torchrun/_restart_intent_close_preparation.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_close_preparation.py
@@ -1,0 +1,262 @@
+"""Authenticated preparation of the first restart-intent closure."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+
+from lm_resiliency.integrations.torchrun._control_store import ControlStore
+from lm_resiliency.integrations.torchrun._coordinator_lease import HeldCoordinatorLease
+from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
+    CoordinatorLeaseAuthority,
+    CoordinatorLeaseHistoryCorrupt,
+    CoordinatorLeaseHistoryError,
+    CoordinatorLeaseHistoryReader,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_close import (
+    PreparedInitialRestartIntentClosure,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_close_records import (
+    InitialRestartIntentClosureRecords,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
+    CommittedInitialRestartIntentOpen,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_reader import (
+    RestartIntentOpenStateClosed,
+    RestartIntentOpenStateCorrupt,
+    RestartIntentOpenStateError,
+    RestartIntentOpenStateReader,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_records import (
+    RestartIntentClosedHeadRecord,
+    RestartIntentLifecycleHeadRecord,
+    RestartIntentLifecycleRecord,
+)
+
+_MAX_READ_ATTEMPTS = 8
+
+
+class RestartIntentClosurePreparationError(RuntimeError):
+    """Base error for preparing the first restart-intent closure."""
+
+
+class RestartIntentClosurePreparationConflict(RestartIntentClosurePreparationError):
+    """Raised when the current restart-intent state changes or is not open."""
+
+
+class RestartIntentClosurePreparationLeaseLost(RestartIntentClosurePreparationError):
+    """Raised when the supplied closing lease is stale or expired."""
+
+
+class RestartIntentClosurePreparationCorrupt(RestartIntentClosurePreparationError):
+    """Raised when persisted opening or lease history is contradictory."""
+
+
+class RestartIntentClosurePreparationClockError(RestartIntentClosurePreparationError):
+    """Raised when the coordinator preparation clock moves backward."""
+
+
+class RestartIntentClosurePreparer:
+    """Read and authenticate inputs for the first closure transaction."""
+
+    def __init__(
+        self,
+        store: ControlStore,
+        *,
+        run_id: str,
+        clock: Callable[[], int],
+    ) -> None:
+        self._run_id = _nonempty_string(run_id, "run_id")
+        if not callable(clock):
+            raise TypeError("clock must be callable")
+        self._clock = clock
+        self._clock_lock = threading.Lock()
+        self._last_now_unix_ms = 0
+        self._open_reader = RestartIntentOpenStateReader(store, run_id=self._run_id)
+        self._lease_history_reader = CoordinatorLeaseHistoryReader(
+            store,
+            run_id=self._run_id,
+        )
+
+    def prepare_initial_closure(
+        self,
+        lease: HeldCoordinatorLease,
+    ) -> PreparedInitialRestartIntentClosure:
+        """Return authenticated, non-mutating inputs for the first closure."""
+
+        self._validate_lease_type(lease)
+        opened, lease_history = self._read_stable_inputs()
+        if opened is None:
+            raise RestartIntentClosurePreparationConflict("no current restart intent is open")
+        if not lease_history or lease_history[-1].lease != lease:
+            raise RestartIntentClosurePreparationLeaseLost(
+                "closing coordinator lease is not the live durable authority"
+            )
+        opening_authority = _opening_authority(opened)
+        try:
+            opening_index = lease_history.index(opening_authority)
+        except ValueError as error:
+            raise RestartIntentClosurePreparationCorrupt(
+                "opening coordinator lease is absent from durable lease history"
+            ) from error
+        now_unix_ms = self._now_unix_ms()
+        if now_unix_ms < lease.granted_at_unix_ms:
+            raise RestartIntentClosurePreparationClockError(
+                "closure preparation clock precedes the authoritative lease grant"
+            )
+        not_before_unix_ms = max(
+            opened.committed_at_unix_ms,
+            lease.granted_at_unix_ms,
+            now_unix_ms,
+        )
+        if not_before_unix_ms >= lease.expires_at_unix_ms:
+            raise RestartIntentClosurePreparationLeaseLost(
+                "closing coordinator lease expired before closure preparation"
+            )
+        records = _closure_records(opened, lease)
+        try:
+            return PreparedInitialRestartIntentClosure(
+                records=records,
+                lease_authority_chain=lease_history[opening_index:],
+                not_before_unix_ms=not_before_unix_ms,
+                deadline_unix_ms=lease.expires_at_unix_ms,
+            )
+        except ValueError as error:
+            raise RestartIntentClosurePreparationCorrupt(
+                "persisted lease history cannot authorize restart-intent closure"
+            ) from error
+
+    def _read_stable_inputs(
+        self,
+    ) -> tuple[
+        CommittedInitialRestartIntentOpen | None,
+        tuple[CoordinatorLeaseAuthority, ...],
+    ]:
+        for _ in range(_MAX_READ_ATTEMPTS):
+            opened = self._read_open()
+            lease_history = self._read_lease_history()
+            if opened == self._read_open() and lease_history == self._read_lease_history():
+                return opened, lease_history
+        raise RestartIntentClosurePreparationConflict(
+            "restart-intent closure inputs changed repeatedly during preparation"
+        )
+
+    def _read_open(self) -> CommittedInitialRestartIntentOpen | None:
+        try:
+            return self._open_reader.read()
+        except RestartIntentOpenStateClosed as error:
+            raise RestartIntentClosurePreparationConflict(
+                "restart intent is already closed"
+            ) from error
+        except RestartIntentOpenStateCorrupt as error:
+            raise RestartIntentClosurePreparationCorrupt(
+                "persisted restart-intent opening is corrupt"
+            ) from error
+        except RestartIntentOpenStateError as error:
+            raise RestartIntentClosurePreparationConflict(
+                "restart-intent opening changed repeatedly during preparation"
+            ) from error
+
+    def _read_lease_history(self) -> tuple[CoordinatorLeaseAuthority, ...]:
+        try:
+            return self._lease_history_reader.read()
+        except CoordinatorLeaseHistoryCorrupt as error:
+            raise RestartIntentClosurePreparationCorrupt(
+                "coordinator lease history is corrupt"
+            ) from error
+        except CoordinatorLeaseHistoryError as error:
+            raise RestartIntentClosurePreparationConflict(
+                "coordinator lease history changed repeatedly during preparation"
+            ) from error
+
+    def _validate_lease_type(self, lease: HeldCoordinatorLease) -> None:
+        if not isinstance(lease, HeldCoordinatorLease):
+            raise TypeError("lease must be HeldCoordinatorLease")
+        if lease.record.run_id != self._run_id:
+            raise ValueError("coordinator lease belongs to another run")
+
+    def _now_unix_ms(self) -> int:
+        with self._clock_lock:
+            now_unix_ms = _positive_integer(
+                self._clock(),
+                "restart-intent closure preparation clock",
+            )
+            if now_unix_ms < self._last_now_unix_ms:
+                raise RestartIntentClosurePreparationClockError(
+                    "restart-intent closure preparation clock moved backward"
+                )
+            self._last_now_unix_ms = now_unix_ms
+            return now_unix_ms
+
+
+def _opening_authority(
+    opened: CommittedInitialRestartIntentOpen,
+) -> CoordinatorLeaseAuthority:
+    prepared = opened.prepared
+    return CoordinatorLeaseAuthority(
+        lease=prepared.lease,
+        transaction_sequence=prepared.coordinator_lease_transaction_sequence,
+        mutation_sequence=prepared.coordinator_lease_mutation_sequence,
+        value_sequence=prepared.coordinator_lease_value_sequence,
+        lifetime_sequence=prepared.coordinator_lease_lifetime_sequence,
+    )
+
+
+def _closure_records(
+    opened: CommittedInitialRestartIntentOpen,
+    lease: HeldCoordinatorLease,
+) -> InitialRestartIntentClosureRecords:
+    lifecycle = RestartIntentLifecycleRecord(
+        closed_intent=opened.prepared.head,
+        coordinator_id=lease.record.coordinator_id,
+        lease_id=lease.record.lease_id,
+        coordinator_lease_duration_ms=lease.record.lease_duration_ms,
+        coordinator_fencing_token=lease.fencing_token,
+    )
+    lifecycle_head = RestartIntentLifecycleHeadRecord(
+        run_id=opened.prepared.record.intent.run_id,
+        closure_index=1,
+        generation=opened.prepared.record.intent.generation,
+        intent_id=opened.prepared.record.intent.intent_id,
+        lifecycle_digest=lifecycle.digest,
+    )
+    run_prefix = opened.prepared.intent_head_key.rsplit("/", 1)[0]
+    return InitialRestartIntentClosureRecords(
+        opened=opened,
+        lifecycle=lifecycle,
+        lifecycle_head=lifecycle_head,
+        closed_head=RestartIntentClosedHeadRecord(
+            run_id=lifecycle_head.run_id,
+            closure_index=lifecycle_head.closure_index,
+            generation=lifecycle_head.generation,
+            intent_id=lifecycle_head.intent_id,
+            lifecycle_head_digest=lifecycle_head.digest,
+        ),
+        intent_key=opened.prepared.intent_key,
+        intent_head_key=opened.prepared.intent_head_key,
+        closure_key=f"{run_prefix}/restart-intent-closures/1",
+        lifecycle_head_key=opened.prepared.lifecycle_head_key,
+    )
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+def _positive_integer(value: object, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{path} must be a positive integer")
+    return value
+
+
+__all__ = [
+    "RestartIntentClosurePreparationClockError",
+    "RestartIntentClosurePreparationConflict",
+    "RestartIntentClosurePreparationCorrupt",
+    "RestartIntentClosurePreparationError",
+    "RestartIntentClosurePreparationLeaseLost",
+    "RestartIntentClosurePreparer",
+]

--- a/tests/unit/test_torchrun_restart_intent_close.py
+++ b/tests/unit/test_torchrun_restart_intent_close.py
@@ -271,19 +271,15 @@ def test_prepared_initial_closure_accepts_renewal_and_multiple_replacements():
     assert len(prepared.lease_authority_chain) == 4
 
 
-def test_prepared_initial_closure_accepts_delete_and_recreate():
+def test_prepared_initial_closure_rejects_delete_and_recreate():
     clock, store, opened, lease = _open_state()
     clock.set(1_010)
     _manager(store, clock, "coordinator-a").release(lease)
-    replacement = _manager(store, clock, "coordinator-b").acquire()
+    _manager(store, clock, "coordinator-b").acquire()
+    history = CoordinatorLeaseHistoryReader(store, run_id=RUN_ID).read()
 
-    prepared = _prepared(
-        opened,
-        CoordinatorLeaseHistoryReader(store, run_id=RUN_ID).read(),
-    )
-
-    assert prepared.lease == replacement
-    assert prepared.coordinator_lease_lifetime_sequence == 2
+    with pytest.raises(ValueError, match="delete/recreate"):
+        _prepared(opened, history)
 
 
 def test_prepared_initial_closure_rejects_expired_renewal_and_overlap():

--- a/tests/unit/test_torchrun_restart_intent_close_preparation.py
+++ b/tests/unit/test_torchrun_restart_intent_close_preparation.py
@@ -173,6 +173,20 @@ def test_closure_preparer_accepts_renewed_and_replacement_leases():
     assert len(replacement_prepared.lease_authority_chain) == 3
 
 
+def test_closure_preparer_rejects_delete_and_recreate_lease_history():
+    clock, store, lease_manager, lease, _ = _open_state()
+    clock.set(1_010)
+    lease_manager.release(lease)
+    replacement = _manager(store, clock, "coordinator-b").acquire()
+
+    with pytest.raises(RestartIntentClosurePreparationCorrupt, match="cannot authorize"):
+        RestartIntentClosurePreparer(
+            store,
+            run_id=RUN_ID,
+            clock=clock,
+        ).prepare_initial_closure(replacement)
+
+
 def test_closure_preparer_rejects_missing_or_closed_intent():
     clock = ManualClock()
     store = InMemoryControlStore(clock=clock)

--- a/tests/unit/test_torchrun_restart_intent_close_preparation.py
+++ b/tests/unit/test_torchrun_restart_intent_close_preparation.py
@@ -1,0 +1,262 @@
+"""Contract tests for restart-intent closure preparation."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseManager,
+    HeldCoordinatorLease,
+)
+from lm_resiliency.integrations.torchrun._generation_state import GenerationStateManager
+from lm_resiliency.integrations.torchrun._protocol import (
+    RankAssignment,
+    RestartIntent,
+    SlotAssignment,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_close_preparation import (
+    RestartIntentClosurePreparationClockError,
+    RestartIntentClosurePreparationConflict,
+    RestartIntentClosurePreparationCorrupt,
+    RestartIntentClosurePreparationLeaseLost,
+    RestartIntentClosurePreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open import (
+    RestartIntentOpenPreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
+    CommittedInitialRestartIntentOpen,
+    RestartIntentOpenExecutor,
+)
+
+RUN_ID = "training-run"
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+    def set(self, now_unix_ms: int) -> None:
+        with self._lock:
+            self.now_unix_ms = now_unix_ms
+
+
+def _manager(
+    store: InMemoryControlStore,
+    clock: ManualClock,
+    coordinator_id: str,
+    *,
+    run_id: str = RUN_ID,
+) -> CoordinatorLeaseManager:
+    return CoordinatorLeaseManager(
+        store,
+        run_id=run_id,
+        coordinator_id=coordinator_id,
+        lease_duration_ms=100,
+        clock=clock,
+    )
+
+
+def _assignment() -> RankAssignment:
+    return RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=0,
+        assignments=(
+            SlotAssignment(0, "node-a", 0, 2),
+            SlotAssignment(1, "node-b", 2, 2),
+        ),
+        topology_digest="topology-v1",
+    )
+
+
+def _open_state() -> tuple[
+    ManualClock,
+    InMemoryControlStore,
+    CoordinatorLeaseManager,
+    HeldCoordinatorLease,
+    CommittedInitialRestartIntentOpen,
+]:
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    lease_manager = _manager(store, clock, "coordinator-a")
+    lease = lease_manager.acquire()
+    generation_manager = GenerationStateManager(store, run_id=RUN_ID)
+    current = generation_manager.initialize(lease, _assignment())
+    intent = RestartIntent(
+        intent_id="intent-a",
+        run_id=RUN_ID,
+        generation=0,
+        incident_ids=("incident-a",),
+        reason_code="attributed_sdc",
+        minimum_recovery_mode="recovery_verified",
+        suspected_node_ids=("node-b",),
+        prepare_deadline_unix_ms=1_200,
+    )
+    opened = RestartIntentOpenExecutor(store, run_id=RUN_ID).execute_initial_open(
+        RestartIntentOpenPreparer(
+            store,
+            run_id=RUN_ID,
+            clock=clock,
+        ).prepare_initial_open(lease, current, intent)
+    )
+    return clock, store, lease_manager, lease, opened
+
+
+def test_closure_preparer_returns_nonmutating_opening_authority_inputs():
+    clock, store, _, lease, opened = _open_state()
+    histories_before = {
+        key: store.get_history(key)
+        for key in (
+            opened.prepared.intent_key,
+            opened.prepared.intent_head_key,
+            opened.prepared.lifecycle_head_key,
+        )
+    }
+
+    prepared = RestartIntentClosurePreparer(
+        store,
+        run_id=RUN_ID,
+        clock=clock,
+    ).prepare_initial_closure(lease)
+
+    assert prepared.records.opened == opened
+    assert prepared.lease == lease
+    assert prepared.not_before_unix_ms == clock.now_unix_ms
+    assert prepared.deadline_unix_ms == lease.expires_at_unix_ms
+    assert len(prepared.lease_authority_chain) == 1
+    assert {key: store.get_history(key) for key in histories_before} == histories_before
+
+
+def test_closure_preparer_accepts_renewed_and_replacement_leases():
+    clock, store, lease_manager, lease, _ = _open_state()
+    clock.set(1_010)
+    renewed = lease_manager.renew(lease)
+
+    renewed_prepared = RestartIntentClosurePreparer(
+        store,
+        run_id=RUN_ID,
+        clock=clock,
+    ).prepare_initial_closure(renewed)
+
+    assert renewed_prepared.lease == renewed
+    assert len(renewed_prepared.lease_authority_chain) == 2
+
+    clock.set(renewed.expires_at_unix_ms)
+    replacement = _manager(store, clock, "coordinator-b").acquire()
+    replacement_prepared = RestartIntentClosurePreparer(
+        store,
+        run_id=RUN_ID,
+        clock=clock,
+    ).prepare_initial_closure(replacement)
+
+    assert replacement_prepared.lease == replacement
+    assert len(replacement_prepared.lease_authority_chain) == 3
+
+
+def test_closure_preparer_rejects_missing_or_closed_intent():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    lease = _manager(store, clock, "coordinator-a").acquire()
+    preparer = RestartIntentClosurePreparer(
+        store,
+        run_id=RUN_ID,
+        clock=clock,
+    )
+
+    with pytest.raises(RestartIntentClosurePreparationConflict, match="no current"):
+        preparer.prepare_initial_closure(lease)
+
+    clock, store, _, lease, _ = _open_state()
+    preparer = RestartIntentClosurePreparer(
+        store,
+        run_id=RUN_ID,
+        clock=clock,
+    )
+    prepared = preparer.prepare_initial_closure(lease)
+    store.compare_set_many_guarded(
+        prepared.writes,
+        guard_key=prepared.coordinator_lease_key,
+        expected_guard_revision=prepared.expected_guard_revision,
+        not_before_unix_ms=prepared.not_before_unix_ms,
+        deadline_unix_ms=prepared.deadline_unix_ms,
+        conditions=prepared.conditions,
+    )
+
+    with pytest.raises(RestartIntentClosurePreparationConflict, match="already closed"):
+        preparer.prepare_initial_closure(lease)
+
+
+def test_closure_preparer_rejects_stale_foreign_or_expired_lease():
+    clock, store, lease_manager, lease, _ = _open_state()
+    clock.set(1_010)
+    lease_manager.renew(lease)
+    preparer = RestartIntentClosurePreparer(
+        store,
+        run_id=RUN_ID,
+        clock=clock,
+    )
+
+    with pytest.raises(RestartIntentClosurePreparationLeaseLost, match="live durable"):
+        preparer.prepare_initial_closure(lease)
+    foreign = _manager(
+        InMemoryControlStore(clock=clock),
+        clock,
+        "coordinator-x",
+        run_id="other-run",
+    ).acquire()
+    with pytest.raises(ValueError, match="another run"):
+        preparer.prepare_initial_closure(foreign)
+
+    clock, store, _, lease, _ = _open_state()
+    clock.set(lease.expires_at_unix_ms)
+    with pytest.raises(RestartIntentClosurePreparationLeaseLost, match="expired"):
+        RestartIntentClosurePreparer(
+            store,
+            run_id=RUN_ID,
+            clock=clock,
+        ).prepare_initial_closure(lease)
+
+
+def test_closure_preparer_rejects_invalid_or_regressing_clock():
+    store_clock, store, _, lease, _ = _open_state()
+    preparation_clock = ManualClock(lease.granted_at_unix_ms - 1)
+    preparer = RestartIntentClosurePreparer(
+        store,
+        run_id=RUN_ID,
+        clock=preparation_clock,
+    )
+
+    with pytest.raises(RestartIntentClosurePreparationClockError, match="precedes"):
+        preparer.prepare_initial_closure(lease)
+
+    preparation_clock.set(store_clock.now_unix_ms + 10)
+    preparer.prepare_initial_closure(lease)
+    preparation_clock.set(store_clock.now_unix_ms + 5)
+    with pytest.raises(RestartIntentClosurePreparationClockError, match="moved backward"):
+        preparer.prepare_initial_closure(lease)
+
+
+def test_closure_preparer_translates_corrupt_opening():
+    clock, store, _, lease, opened = _open_state()
+    intent_entry = store.get(opened.prepared.intent_key)
+    assert intent_entry is not None
+    store.compare_set(
+        opened.prepared.intent_key,
+        expected_revision=intent_entry.revision,
+        value=b"{}",
+    )
+
+    with pytest.raises(RestartIntentClosurePreparationCorrupt, match="opening is corrupt"):
+        RestartIntentClosurePreparer(
+            store,
+            run_id=RUN_ID,
+            clock=clock,
+        ).prepare_initial_closure(lease)

--- a/tests/unit/test_torchrun_restart_intent_close_preparation.py
+++ b/tests/unit/test_torchrun_restart_intent_close_preparation.py
@@ -11,6 +11,10 @@ from lm_resiliency.integrations.torchrun._coordinator_lease import (
     CoordinatorLeaseManager,
     HeldCoordinatorLease,
 )
+from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
+    CoordinatorLeaseHistoryError,
+)
+from lm_resiliency.integrations.torchrun._generation_reader import GenerationStateError
 from lm_resiliency.integrations.torchrun._generation_state import GenerationStateManager
 from lm_resiliency.integrations.torchrun._protocol import (
     RankAssignment,
@@ -47,6 +51,14 @@ class ManualClock:
     def set(self, now_unix_ms: int) -> None:
         with self._lock:
             self.now_unix_ms = now_unix_ms
+
+
+class FailingOpenReader:
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+
+    def read(self):
+        raise self._error
 
 
 def _manager(
@@ -260,3 +272,26 @@ def test_closure_preparer_translates_corrupt_opening():
             run_id=RUN_ID,
             clock=clock,
         ).prepare_initial_closure(lease)
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        GenerationStateError("generation changed repeatedly"),
+        CoordinatorLeaseHistoryError("lease history changed repeatedly"),
+    ],
+)
+def test_closure_preparer_translates_dependency_contention(error: Exception):
+    clock, store, _, lease, _ = _open_state()
+    preparer = RestartIntentClosurePreparer(
+        store,
+        run_id=RUN_ID,
+        clock=clock,
+    )
+    preparer._open_reader = FailingOpenReader(error)
+
+    with pytest.raises(
+        RestartIntentClosurePreparationConflict,
+        match="dependencies changed repeatedly",
+    ):
+        preparer.prepare_initial_closure(lease)


### PR DESCRIPTION
## Summary

- reconstruct and authenticate the current committed restart-intent opening
- double-collect verified coordinator lease history and require the supplied closing lease to be its live tail
- select the contiguous authority slice from opening through closing and build the existing immutable closure descriptor
- keep closure preparation non-mutating; guarded execution and committed-result verification remain a separate component

## Compatibility

This is an internal torchrun integration module and adds no public package export or runtime activation.

## Validation

- `CUDA_VISIBLE_DEVICES="" .venv/bin/python -m pytest -q tests/unit/test_torchrun_restart_intent_close_preparation.py tests/unit/test_torchrun_restart_intent_close.py tests/unit/test_torchrun_restart_intent_close_records.py tests/unit/test_torchrun_restart_intent_open_reader.py tests/unit/test_torchrun_coordinator_lease_history.py` (69 passed)
- `CUDA_VISIBLE_DEVICES="" .venv/bin/python -m pytest -q` (1,797 passed)
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `/home/ubuntu/anaconda3/bin/mypy lm_resiliency/integrations/torchrun/_restart_intent_close_preparation.py`
- `git diff --check`