### PR TITLE
[Feature][Torchrun] Execute initial restart intent closure

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -649,6 +649,14 @@ store transaction and committed-result verification. Lease-key lifetime
 changes remain rejected until the store retains authoritative deletion
 evidence.
 
+`RestartIntentClosureExecutor` submits that prepared transaction and returns a
+frozen `CommittedInitialRestartIntentClosure` only after verifying the exact
+three-key result, immutable closure/lifecycle creation, one in-place
+current-head replacement, shared transaction identity, closing-lease
+provenance, prepared time window, and causal order after both opening and lease
+authority. Store revision, history, deadline, and clock failures are translated
+into closure-specific fail-closed errors.
+
 A read-only `RestartIntentOpenStateReader` reconstructs the same
 `CommittedInitialRestartIntentOpen` contract after coordinator failover. It
 stably reads the current-intent head and immutable intent, requires the

--- a/lm_resiliency/integrations/torchrun/_restart_intent_close_execution.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_close_execution.py
@@ -1,0 +1,247 @@
+"""Guarded execution of prepared initial restart-intent closures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStore,
+    ControlStoreClockError,
+    ControlStoreConflict,
+    ControlStoreDeadlineExceeded,
+    ControlStoreEntry,
+    ControlStoreHistoryConflict,
+    ControlStoreTooEarly,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_close import (
+    PreparedInitialRestartIntentClosure,
+)
+
+
+class RestartIntentClosureExecutionError(RuntimeError):
+    """Base error for committing a prepared restart-intent closure."""
+
+
+class RestartIntentClosureExecutionConflict(RestartIntentClosureExecutionError):
+    """Raised when opening or lifecycle state changes before commit."""
+
+
+class RestartIntentClosureExecutionLeaseLost(RestartIntentClosureExecutionError):
+    """Raised when the closing coordinator lease changes or expires."""
+
+
+class RestartIntentClosureExecutionClockError(RestartIntentClosureExecutionError):
+    """Raised when authoritative store time contradicts preparation."""
+
+
+class RestartIntentClosureExecutionCorrupt(RestartIntentClosureExecutionError):
+    """Raised when the transaction returns contradictory committed state."""
+
+
+@dataclass(frozen=True, slots=True)
+class CommittedInitialRestartIntentClosure:
+    """Verified committed entries for one initial restart-intent closure."""
+
+    prepared: PreparedInitialRestartIntentClosure
+    closed_head_entry: ControlStoreEntry
+    lifecycle_entry: ControlStoreEntry
+    lifecycle_head_entry: ControlStoreEntry
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.prepared, PreparedInitialRestartIntentClosure):
+            raise TypeError(
+                "CommittedInitialRestartIntentClosure.prepared must be "
+                "PreparedInitialRestartIntentClosure"
+            )
+        entries = (
+            ("closed_head_entry", self.closed_head_entry),
+            ("lifecycle_entry", self.lifecycle_entry),
+            ("lifecycle_head_entry", self.lifecycle_head_entry),
+        )
+        for path, entry in entries:
+            if not isinstance(entry, ControlStoreEntry):
+                raise TypeError(
+                    f"CommittedInitialRestartIntentClosure.{path} must be ControlStoreEntry"
+                )
+        records = self.prepared.records
+        expected_values = {
+            "closed_head_entry": records.closed_head.to_json(),
+            "lifecycle_entry": records.lifecycle.to_json(),
+            "lifecycle_head_entry": records.lifecycle_head.to_json(),
+        }
+        for path, entry in entries:
+            if entry.value != expected_values[path]:
+                raise ValueError(
+                    f"CommittedInitialRestartIntentClosure.{path} does not match its preparation"
+                )
+            self._validate_guard(path, entry)
+        self._validate_entry_lineage()
+        self._validate_transaction()
+
+    def _validate_guard(self, path: str, entry: ControlStoreEntry) -> None:
+        authority = self.prepared.lease_authority
+        if (
+            entry.guard_key != self.prepared.coordinator_lease_key
+            or entry.guard_revision != self.prepared.expected_guard_revision
+            or entry.guard_value_digest != self.prepared.records.lifecycle.coordinator_lease_digest
+            or entry.guard_committed_at_unix_ms != authority.lease.granted_at_unix_ms
+            or entry.guard_mutation_sequence != authority.mutation_sequence
+            or entry.guard_value_sequence != authority.value_sequence
+            or entry.guard_lifetime_sequence != authority.lifetime_sequence
+        ):
+            raise ValueError(
+                f"CommittedInitialRestartIntentClosure.{path} has invalid lease provenance"
+            )
+        if entry.committed_at_unix_ms is None:
+            raise ValueError(
+                f"CommittedInitialRestartIntentClosure.{path} has no authoritative commit time"
+            )
+
+    def _validate_entry_lineage(self) -> None:
+        opened_head = self.prepared.records.opened.head_entry
+        closed_head = self.closed_head_entry
+        if (
+            closed_head.revision == opened_head.revision
+            or closed_head.mutation_sequence != opened_head.mutation_sequence + 1
+            or closed_head.value_sequence != opened_head.value_sequence + 1
+            or closed_head.lifetime_sequence != opened_head.lifetime_sequence
+        ):
+            raise ValueError(
+                "CommittedInitialRestartIntentClosure closed head is not one in-place update"
+            )
+        for path, entry in (
+            ("lifecycle_entry", self.lifecycle_entry),
+            ("lifecycle_head_entry", self.lifecycle_head_entry),
+        ):
+            if (
+                entry.mutation_sequence != 1
+                or entry.value_sequence != 1
+                or entry.lifetime_sequence != 1
+            ):
+                raise ValueError(
+                    f"CommittedInitialRestartIntentClosure.{path} is not an immutable creation"
+                )
+
+    def _validate_transaction(self) -> None:
+        entries = (
+            self.closed_head_entry,
+            self.lifecycle_entry,
+            self.lifecycle_head_entry,
+        )
+        commit_times = {entry.committed_at_unix_ms for entry in entries}
+        transaction_sequences = {entry.transaction_sequence for entry in entries}
+        if len(commit_times) != 1 or None in commit_times or len(transaction_sequences) != 1:
+            raise ValueError(
+                "CommittedInitialRestartIntentClosure entries do not share one transaction"
+            )
+        committed_at_unix_ms = self.closed_head_entry.committed_at_unix_ms
+        if committed_at_unix_ms is None:
+            raise AssertionError("validated closure lost its commit time")
+        if (
+            committed_at_unix_ms < self.prepared.not_before_unix_ms
+            or committed_at_unix_ms >= self.prepared.deadline_unix_ms
+        ):
+            raise ValueError(
+                "CommittedInitialRestartIntentClosure commit is outside its prepared window"
+            )
+        if self.closed_head_entry.transaction_sequence <= max(
+            self.prepared.records.opened.transaction_sequence,
+            self.prepared.coordinator_lease_transaction_sequence,
+        ):
+            raise ValueError(
+                "CommittedInitialRestartIntentClosure does not follow its opening and lease"
+            )
+
+    @property
+    def committed_at_unix_ms(self) -> int:
+        committed_at_unix_ms = self.closed_head_entry.committed_at_unix_ms
+        if committed_at_unix_ms is None:
+            raise AssertionError("validated closure lost its commit time")
+        return committed_at_unix_ms
+
+    @property
+    def transaction_sequence(self) -> int:
+        return self.closed_head_entry.transaction_sequence
+
+
+class RestartIntentClosureExecutor:
+    """Commit and verify one prepared initial restart-intent closure."""
+
+    def __init__(self, store: ControlStore, *, run_id: str) -> None:
+        self._store = store
+        self._run_id = _nonempty_string(run_id, "run_id")
+
+    def execute_initial_closure(
+        self,
+        prepared: PreparedInitialRestartIntentClosure,
+    ) -> CommittedInitialRestartIntentClosure:
+        if not isinstance(prepared, PreparedInitialRestartIntentClosure):
+            raise TypeError("prepared must be PreparedInitialRestartIntentClosure")
+        if prepared.records.opened.prepared.record.intent.run_id != self._run_id:
+            raise ValueError("prepared restart-intent closure belongs to another run")
+        try:
+            committed = self._store.compare_set_many_guarded(
+                prepared.writes,
+                guard_key=prepared.coordinator_lease_key,
+                expected_guard_revision=prepared.expected_guard_revision,
+                not_before_unix_ms=prepared.not_before_unix_ms,
+                deadline_unix_ms=prepared.deadline_unix_ms,
+                conditions=prepared.conditions,
+            )
+        except ControlStoreConflict as error:
+            if error.key == prepared.coordinator_lease_key:
+                raise RestartIntentClosureExecutionLeaseLost(
+                    "coordinator lease changed before restart-intent closure"
+                ) from error
+            raise RestartIntentClosureExecutionConflict(
+                f"restart-intent closure state changed at {error.key!r}"
+            ) from error
+        except ControlStoreHistoryConflict as error:
+            raise RestartIntentClosureExecutionConflict(
+                f"restart-intent closure key {error.key!r} has prior history"
+            ) from error
+        except ControlStoreDeadlineExceeded as error:
+            raise RestartIntentClosureExecutionLeaseLost(
+                "coordinator lease expired before restart-intent closure"
+            ) from error
+        except (ControlStoreTooEarly, ControlStoreClockError) as error:
+            raise RestartIntentClosureExecutionClockError(
+                "control-store time contradicts restart-intent closure preparation"
+            ) from error
+        expected_keys = {
+            prepared.records.intent_head_key,
+            prepared.records.closure_key,
+            prepared.records.lifecycle_head_key,
+        }
+        if set(committed) != expected_keys:
+            raise RestartIntentClosureExecutionCorrupt(
+                "restart-intent closure returned an unexpected committed key set"
+            )
+        try:
+            return CommittedInitialRestartIntentClosure(
+                prepared=prepared,
+                closed_head_entry=committed[prepared.records.intent_head_key],
+                lifecycle_entry=committed[prepared.records.closure_key],
+                lifecycle_head_entry=committed[prepared.records.lifecycle_head_key],
+            )
+        except (TypeError, ValueError) as error:
+            raise RestartIntentClosureExecutionCorrupt(
+                "restart-intent closure returned contradictory committed state"
+            ) from error
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+__all__ = [
+    "CommittedInitialRestartIntentClosure",
+    "RestartIntentClosureExecutionClockError",
+    "RestartIntentClosureExecutionConflict",
+    "RestartIntentClosureExecutionCorrupt",
+    "RestartIntentClosureExecutionError",
+    "RestartIntentClosureExecutionLeaseLost",
+    "RestartIntentClosureExecutor",
+]

--- a/tests/unit/test_torchrun_restart_intent_close_execution.py
+++ b/tests/unit/test_torchrun_restart_intent_close_execution.py
@@ -1,0 +1,270 @@
+"""Contract tests for guarded restart-intent closure execution."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Collection, Mapping
+from dataclasses import replace
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStoreEntry,
+    ControlStoreWrite,
+    InMemoryControlStore,
+)
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseManager,
+)
+from lm_resiliency.integrations.torchrun._generation_state import GenerationStateManager
+from lm_resiliency.integrations.torchrun._protocol import (
+    RankAssignment,
+    RestartIntent,
+    SlotAssignment,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_close_execution import (
+    RestartIntentClosureExecutionClockError,
+    RestartIntentClosureExecutionConflict,
+    RestartIntentClosureExecutionCorrupt,
+    RestartIntentClosureExecutionLeaseLost,
+    RestartIntentClosureExecutor,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_close_preparation import (
+    RestartIntentClosurePreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_lifecycle_reader import (
+    InitialRestartIntentLifecycleReader,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open import (
+    RestartIntentOpenPreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
+    RestartIntentOpenExecutor,
+)
+
+RUN_ID = "training-run"
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+    def set(self, now_unix_ms: int) -> None:
+        with self._lock:
+            self.now_unix_ms = now_unix_ms
+
+
+class TamperedClosureResultStore(InMemoryControlStore):
+    def __init__(self, *, clock: ManualClock, tamper: str) -> None:
+        super().__init__(clock=clock)
+        self._tamper = tamper
+
+    def compare_set_many_guarded(
+        self,
+        writes: Mapping[str, ControlStoreWrite],
+        *,
+        guard_key: str,
+        expected_guard_revision: int,
+        not_before_unix_ms: int,
+        deadline_unix_ms: int,
+        conditions: Mapping[str, int | None] | None = None,
+        never_created_conditions: Collection[str] | None = None,
+    ) -> Mapping[str, ControlStoreEntry]:
+        committed = dict(
+            super().compare_set_many_guarded(
+                writes,
+                guard_key=guard_key,
+                expected_guard_revision=expected_guard_revision,
+                not_before_unix_ms=not_before_unix_ms,
+                deadline_unix_ms=deadline_unix_ms,
+                conditions=conditions,
+                never_created_conditions=never_created_conditions,
+            )
+        )
+        if not any(key.endswith("/restart-intent-lifecycle-head") for key in committed):
+            return committed
+        head_key = next(key for key in committed if key.endswith("/restart-intent-head"))
+        closure_key = next(key for key in committed if "/restart-intent-closures/" in key)
+        lifecycle_key = next(
+            key for key in committed if key.endswith("/restart-intent-lifecycle-head")
+        )
+        if self._tamper == "missing_lifecycle":
+            return {head_key: committed[head_key], closure_key: committed[closure_key]}
+        if self._tamper == "value":
+            committed[closure_key] = replace(committed[closure_key], value=b"{}")
+        elif self._tamper == "transaction":
+            committed[lifecycle_key] = replace(
+                committed[lifecycle_key],
+                transaction_sequence=committed[lifecycle_key].transaction_sequence + 1,
+            )
+        elif self._tamper == "guard":
+            committed[head_key] = replace(
+                committed[head_key],
+                guard_value_digest="0" * 64,
+            )
+        elif self._tamper == "head_lineage":
+            committed[head_key] = replace(
+                committed[head_key],
+                mutation_sequence=committed[head_key].mutation_sequence + 1,
+            )
+        elif self._tamper == "time":
+            committed_at = committed[lifecycle_key].committed_at_unix_ms
+            assert committed_at is not None
+            committed[lifecycle_key] = replace(
+                committed[lifecycle_key],
+                committed_at_unix_ms=committed_at + 1,
+            )
+        elif self._tamper == "order":
+            for key in committed:
+                committed[key] = replace(committed[key], transaction_sequence=3)
+        else:
+            raise AssertionError(f"unsupported tamper {self._tamper!r}")
+        return committed
+
+
+def _assignment() -> RankAssignment:
+    return RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=0,
+        assignments=(
+            SlotAssignment(0, "node-a", 0, 2),
+            SlotAssignment(1, "node-b", 2, 2),
+        ),
+        topology_digest="topology-v1",
+    )
+
+
+def _state(*, tamper: str | None = None, preparation_clock: ManualClock | None = None):
+    store_clock = ManualClock()
+    store = (
+        InMemoryControlStore(clock=store_clock)
+        if tamper is None
+        else TamperedClosureResultStore(clock=store_clock, tamper=tamper)
+    )
+    lease_manager = CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id="coordinator-a",
+        lease_duration_ms=100,
+        clock=store_clock,
+    )
+    lease = lease_manager.acquire()
+    generation_manager = GenerationStateManager(store, run_id=RUN_ID)
+    current = generation_manager.initialize(lease, _assignment())
+    intent = RestartIntent(
+        intent_id="intent-a",
+        run_id=RUN_ID,
+        generation=0,
+        incident_ids=("incident-a",),
+        reason_code="attributed_sdc",
+        minimum_recovery_mode="recovery_verified",
+        suspected_node_ids=("node-b",),
+        prepare_deadline_unix_ms=1_200,
+    )
+    RestartIntentOpenExecutor(store, run_id=RUN_ID).execute_initial_open(
+        RestartIntentOpenPreparer(
+            store,
+            run_id=RUN_ID,
+            clock=store_clock,
+        ).prepare_initial_open(lease, current, intent)
+    )
+    prepared = RestartIntentClosurePreparer(
+        store,
+        run_id=RUN_ID,
+        clock=preparation_clock or store_clock,
+    ).prepare_initial_closure(lease)
+    return store_clock, store, lease_manager, lease, prepared
+
+
+def test_execute_initial_closure_commits_and_verifies_all_records():
+    _, store, _, _, prepared = _state()
+
+    committed = RestartIntentClosureExecutor(
+        store,
+        run_id=RUN_ID,
+    ).execute_initial_closure(prepared)
+
+    assert committed.prepared == prepared
+    assert committed.closed_head_entry == store.get(prepared.records.intent_head_key)
+    assert committed.lifecycle_entry == store.get(prepared.records.closure_key)
+    assert committed.lifecycle_head_entry == store.get(prepared.records.lifecycle_head_key)
+    assert committed.committed_at_unix_ms == 1_000
+    assert committed.transaction_sequence > prepared.records.opened.transaction_sequence
+    assert InitialRestartIntentLifecycleReader(store, run_id=RUN_ID).read() is not None
+
+
+def test_execute_initial_closure_rejects_changed_state_or_duplicate_execution():
+    _, store, _, _, prepared = _state()
+    intent_entry = store.get(prepared.records.intent_key)
+    assert intent_entry is not None
+    store.compare_set(
+        prepared.records.intent_key,
+        expected_revision=intent_entry.revision,
+        value=intent_entry.value,
+    )
+    executor = RestartIntentClosureExecutor(store, run_id=RUN_ID)
+
+    with pytest.raises(RestartIntentClosureExecutionConflict, match="state changed"):
+        executor.execute_initial_closure(prepared)
+
+    _, store, _, _, prepared = _state()
+    executor = RestartIntentClosureExecutor(store, run_id=RUN_ID)
+    executor.execute_initial_closure(prepared)
+    with pytest.raises(RestartIntentClosureExecutionConflict):
+        executor.execute_initial_closure(prepared)
+
+
+def test_execute_initial_closure_rejects_stale_or_expired_lease():
+    clock, store, lease_manager, lease, prepared = _state()
+    clock.set(1_010)
+    lease_manager.renew(lease)
+    executor = RestartIntentClosureExecutor(store, run_id=RUN_ID)
+
+    with pytest.raises(RestartIntentClosureExecutionLeaseLost, match="changed"):
+        executor.execute_initial_closure(prepared)
+
+    clock, store, _, lease, prepared = _state()
+    clock.set(lease.expires_at_unix_ms)
+    with pytest.raises(RestartIntentClosureExecutionLeaseLost, match="expired"):
+        RestartIntentClosureExecutor(
+            store,
+            run_id=RUN_ID,
+        ).execute_initial_closure(prepared)
+
+
+def test_execute_initial_closure_rejects_store_time_before_preparation():
+    preparation_clock = ManualClock(1_010)
+    _, store, _, _, prepared = _state(preparation_clock=preparation_clock)
+
+    with pytest.raises(RestartIntentClosureExecutionClockError, match="contradicts"):
+        RestartIntentClosureExecutor(
+            store,
+            run_id=RUN_ID,
+        ).execute_initial_closure(prepared)
+
+
+@pytest.mark.parametrize(
+    "tamper",
+    [
+        "missing_lifecycle",
+        "value",
+        "transaction",
+        "guard",
+        "head_lineage",
+        "time",
+        "order",
+    ],
+)
+def test_execute_initial_closure_rejects_tampered_results(tamper: str):
+    _, store, _, _, prepared = _state(tamper=tamper)
+
+    with pytest.raises(RestartIntentClosureExecutionCorrupt):
+        RestartIntentClosureExecutor(
+            store,
+            run_id=RUN_ID,
+        ).execute_initial_closure(prepared)


### PR DESCRIPTION
## Summary

- execute one already prepared initial restart-intent closure under the exact coordinator lease guard
- translate revision, history, deadline, and store-clock failures into closure-specific errors
- verify the exact three-key result, immutable records, current-head replacement lineage, shared transaction, lease provenance, time window, and causal order
- keep restart-plan publication and worker runtime behavior out of this PR

## Compatibility

This is an internal torchrun integration module and adds no public package export or runtime activation.

## Validation

- focused closure execution/preparation/lifecycle tests (55 passed)
- `CUDA_VISIBLE_DEVICES="" .venv/bin/python -m pytest -q` (1,808 passed)
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `/home/ubuntu/anaconda3/bin/mypy lm_resiliency/integrations/torchrun/_restart_intent_close_execution.py`
- `git diff --check`