### PR TITLE
[Feature][Torchrun] Add authenticated restart acknowledgement receipt

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -928,6 +928,16 @@ not authentication. For latest recovery, the acknowledgement's canonical
 inventory digest must match the exact event used by the manifest; event-ID
 reuse cannot substitute different copies after preparation.
 
+The durable receipt envelope stores the worker acknowledgement together with
+the exact immutable restart-intent record, the authenticated agent-registration
+lifetime, its registration fencing token and authoritative grant time, and the
+coordinator-recorded receipt time. The envelope rejects a sender identity that
+does not match the acknowledgement, a receipt outside the authenticated
+registration lifetime, or a receipt after the intent deadline. The record is
+not self-authenticating: the acknowledgement persistence layer must still
+verify the registration and intent against authoritative control-store state
+before committing it.
+
 For a crashed or unreachable node, no preparation is assumed.
 
 ## API: lm-resiliency to the Framework

--- a/lm_resiliency/integrations/torchrun/_restart_ack_records.py
+++ b/lm_resiliency/integrations/torchrun/_restart_ack_records.py
@@ -1,0 +1,282 @@
+"""Strict persisted restart-acknowledgement receipt records."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import ClassVar, TypeVar
+
+from lm_resiliency.integrations.torchrun._agent_registration_records import (
+    AgentRegistrationRecord,
+    HeldAgentRegistration,
+)
+from lm_resiliency.integrations.torchrun._protocol import (
+    AgentIdentity,
+    ProtocolValidationError,
+    RestartAck,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_records import (
+    RestartIntentRecord,
+)
+
+_T = TypeVar("_T")
+
+
+@dataclass(frozen=True, slots=True)
+class RestartAckReceiptRecord:
+    """One worker acknowledgement and its authenticated receipt provenance."""
+
+    SCHEMA_VERSION: ClassVar[int] = 1
+
+    acknowledgement: RestartAck
+    intent_record: RestartIntentRecord
+    agent_registration: AgentRegistrationRecord
+    registration_fencing_token: int
+    registration_granted_at_unix_ms: int
+    received_at_unix_ms: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.acknowledgement, RestartAck):
+            raise TypeError("RestartAckReceiptRecord.acknowledgement must be RestartAck")
+        if not isinstance(self.intent_record, RestartIntentRecord):
+            raise TypeError("RestartAckReceiptRecord.intent_record must be RestartIntentRecord")
+        if not isinstance(self.agent_registration, AgentRegistrationRecord):
+            raise TypeError(
+                "RestartAckReceiptRecord.agent_registration must be AgentRegistrationRecord"
+            )
+        _positive_integer(
+            self.registration_fencing_token,
+            "RestartAckReceiptRecord.registration_fencing_token",
+        )
+        _positive_integer(
+            self.registration_granted_at_unix_ms,
+            "RestartAckReceiptRecord.registration_granted_at_unix_ms",
+        )
+        _positive_integer(
+            self.received_at_unix_ms,
+            "RestartAckReceiptRecord.received_at_unix_ms",
+        )
+        intent = self.intent_record.intent
+        acknowledgement = self.acknowledgement
+        if (
+            acknowledgement.intent_id != intent.intent_id
+            or acknowledgement.run_id != intent.run_id
+            or acknowledgement.generation != intent.generation
+        ):
+            raise ValueError(
+                "RestartAckReceiptRecord acknowledgement does not identify its restart intent"
+            )
+        identity = self.agent_registration.agent_identity
+        if (
+            acknowledgement.run_id != identity.run_id
+            or acknowledgement.node_id != identity.node_id
+            or acknowledgement.agent_id != identity.agent_id
+        ):
+            raise ValueError(
+                "RestartAckReceiptRecord acknowledgement does not match its authenticated "
+                "agent registration"
+            )
+        if self.received_at_unix_ms < self.registration_granted_at_unix_ms:
+            raise ValueError(
+                "RestartAckReceiptRecord receipt precedes its agent registration grant"
+            )
+        if self.received_at_unix_ms >= self.registration_expires_at_unix_ms:
+            raise ValueError(
+                "RestartAckReceiptRecord receipt is outside its agent registration lifetime"
+            )
+        if self.received_at_unix_ms > intent.prepare_deadline_unix_ms:
+            raise ValueError("RestartAckReceiptRecord receipt is after the restart intent deadline")
+
+    @property
+    def digest(self) -> str:
+        return hashlib.sha256(self.to_json()).hexdigest()
+
+    @property
+    def authenticated_registration(self) -> HeldAgentRegistration:
+        return HeldAgentRegistration(
+            record=self.agent_registration,
+            fencing_token=self.registration_fencing_token,
+            granted_at_unix_ms=self.registration_granted_at_unix_ms,
+        )
+
+    @property
+    def registration_expires_at_unix_ms(self) -> int:
+        return self.registration_granted_at_unix_ms + self.agent_registration.lease_duration_ms
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "acknowledgement": self.acknowledgement.to_dict(),
+            "intent_record": self.intent_record.to_dict(),
+            "agent_registration": self.agent_registration.to_dict(),
+            "registration_fencing_token": self.registration_fencing_token,
+            "registration_granted_at_unix_ms": self.registration_granted_at_unix_ms,
+            "received_at_unix_ms": self.received_at_unix_ms,
+        }
+
+    def to_json(self) -> bytes:
+        return _canonical_json(self.to_dict())
+
+    @classmethod
+    def from_json(cls, encoded: bytes) -> RestartAckReceiptRecord:
+        value = _json_object(encoded, cls.__name__)
+        _fields(
+            value,
+            path=cls.__name__,
+            required={
+                "schema_version",
+                "acknowledgement",
+                "intent_record",
+                "agent_registration",
+                "registration_fencing_token",
+                "registration_granted_at_unix_ms",
+                "received_at_unix_ms",
+            },
+        )
+        _schema_version(
+            value["schema_version"],
+            cls.__name__,
+            expected=cls.SCHEMA_VERSION,
+        )
+        acknowledgement_value = _mapping(
+            value["acknowledgement"],
+            "RestartAckReceiptRecord.acknowledgement",
+        )
+        _schema_version(
+            acknowledgement_value.get("schema_version"),
+            "RestartAckReceiptRecord.acknowledgement",
+            expected=RestartAck.SCHEMA_VERSION,
+        )
+        try:
+            acknowledgement = RestartAck.from_dict(acknowledgement_value)
+        except ProtocolValidationError as error:
+            raise ValueError("RestartAckReceiptRecord.acknowledgement is invalid") from error
+        intent_record = _decode_nested_record(
+            value["intent_record"],
+            path="RestartAckReceiptRecord.intent_record",
+            decoder=RestartIntentRecord.from_json,
+        )
+        registration_value = _mapping(
+            value["agent_registration"],
+            "RestartAckReceiptRecord.agent_registration",
+        )
+        identity_value = _mapping(
+            registration_value.get("agent_identity"),
+            "RestartAckReceiptRecord.agent_registration.agent_identity",
+        )
+        _schema_version(
+            identity_value.get("schema_version"),
+            "RestartAckReceiptRecord.agent_registration.agent_identity",
+            expected=AgentIdentity.SCHEMA_VERSION,
+        )
+        agent_registration = _decode_nested_record(
+            registration_value,
+            path="RestartAckReceiptRecord.agent_registration",
+            decoder=AgentRegistrationRecord.from_json,
+        )
+        return cls(
+            acknowledgement=acknowledgement,
+            intent_record=intent_record,
+            agent_registration=agent_registration,
+            registration_fencing_token=_positive_integer(
+                value["registration_fencing_token"],
+                "RestartAckReceiptRecord.registration_fencing_token",
+            ),
+            registration_granted_at_unix_ms=_positive_integer(
+                value["registration_granted_at_unix_ms"],
+                "RestartAckReceiptRecord.registration_granted_at_unix_ms",
+            ),
+            received_at_unix_ms=_positive_integer(
+                value["received_at_unix_ms"],
+                "RestartAckReceiptRecord.received_at_unix_ms",
+            ),
+        )
+
+
+def _decode_nested_record(
+    value: object,
+    *,
+    path: str,
+    decoder: Callable[[bytes], _T],
+) -> _T:
+    mapping = _mapping(value, path)
+    try:
+        return decoder(_canonical_json(mapping))
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{path} is invalid") from error
+
+
+def _canonical_json(value: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _json_object(encoded: bytes, path: str) -> Mapping[str, object]:
+    if not isinstance(encoded, bytes):
+        raise ValueError(f"{path}: expected encoded bytes")
+    try:
+        value = json.loads(
+            encoded,
+            object_pairs_hook=_reject_duplicate_object_fields,
+        )
+    except _DuplicateRestartAckField as error:
+        raise ValueError(f"{path}: {error}") from error
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{path}: invalid JSON") from error
+    return _mapping(value, path)
+
+
+def _mapping(value: object, path: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping) or not all(isinstance(key, str) for key in value):
+        raise ValueError(f"{path}: expected a JSON object")
+    return value
+
+
+def _fields(
+    value: Mapping[str, object],
+    *,
+    path: str,
+    required: set[str],
+) -> None:
+    missing = required - set(value)
+    unknown = set(value) - required
+    if missing:
+        raise ValueError(f"{path}: missing fields {sorted(missing)!r}")
+    if unknown:
+        raise ValueError(f"{path}: unknown fields {sorted(unknown)!r}")
+
+
+def _schema_version(value: object, path: str, *, expected: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value != expected:
+        raise ValueError(f"{path}.schema_version: unsupported value {value!r}")
+    return value
+
+
+def _positive_integer(value: object, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{path} must be a positive integer")
+    return value
+
+
+class _DuplicateRestartAckField(ValueError):
+    pass
+
+
+def _reject_duplicate_object_fields(
+    pairs: list[tuple[str, object]],
+) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            raise _DuplicateRestartAckField(f"duplicate field {key!r}")
+        value[key] = item
+    return value
+
+
+__all__ = ["RestartAckReceiptRecord"]

--- a/tests/unit/test_torchrun_restart_ack_records.py
+++ b/tests/unit/test_torchrun_restart_ack_records.py
@@ -1,0 +1,342 @@
+"""Contract tests for persisted torchrun restart acknowledgement receipts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import replace
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._agent_registration_records import (
+    AgentRegistrationRecord,
+)
+from lm_resiliency.integrations.torchrun._protocol import (
+    AgentIdentity,
+    RestartAck,
+    RestartIntent,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_records import (
+    RestartAckReceiptRecord,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_records import (
+    RestartIntentRecord,
+)
+
+
+def _intent() -> RestartIntent:
+    return RestartIntent(
+        intent_id="intent-a",
+        run_id="training-run",
+        generation=4,
+        incident_ids=("incident-a",),
+        reason_code="attributed_sdc",
+        minimum_recovery_mode="recovery_verified",
+        suspected_node_ids=("node-b",),
+        prepare_deadline_unix_ms=50_000,
+    )
+
+
+def _intent_record() -> RestartIntentRecord:
+    return RestartIntentRecord(
+        intent=_intent(),
+        generation_snapshot_digest="a" * 64,
+        coordinator_id="coordinator-a",
+        lease_id="lease-a",
+        coordinator_lease_duration_ms=30_000,
+        coordinator_fencing_token=7,
+    )
+
+
+def _registration() -> AgentRegistrationRecord:
+    return AgentRegistrationRecord(
+        agent_identity=AgentIdentity(
+            run_id="training-run",
+            node_id="node-a",
+            agent_id="agent-a",
+            hostname="host-a",
+            local_world_size=2,
+            resource_ids=("gpu-a0", "gpu-a1"),
+            environment_digest="environment-v1",
+        ),
+        registration_id="registration-a",
+        lease_duration_ms=30_000,
+    )
+
+
+def _acknowledgement() -> RestartAck:
+    return RestartAck(
+        intent_id="intent-a",
+        run_id="training-run",
+        node_id="node-a",
+        agent_id="agent-a",
+        generation=4,
+        flushed_step=40,
+        inventory_event_digests={"inventory-a": "b" * 64},
+        transferred_owner_ranks=(0, 1),
+        transferred_peer_ranks=(2, 3),
+        success=True,
+        reason="prepared",
+    )
+
+
+def _record(
+    *,
+    acknowledgement: RestartAck | None = None,
+    intent_record: RestartIntentRecord | None = None,
+    agent_registration: AgentRegistrationRecord | None = None,
+    registration_fencing_token: int = 9,
+    registration_granted_at_unix_ms: int = 1_000,
+    received_at_unix_ms: int = 20_000,
+) -> RestartAckReceiptRecord:
+    return RestartAckReceiptRecord(
+        acknowledgement=acknowledgement or _acknowledgement(),
+        intent_record=intent_record or _intent_record(),
+        agent_registration=agent_registration or _registration(),
+        registration_fencing_token=registration_fencing_token,
+        registration_granted_at_unix_ms=registration_granted_at_unix_ms,
+        received_at_unix_ms=received_at_unix_ms,
+    )
+
+
+def test_restart_ack_receipt_round_trips_canonical_json():
+    record = _record()
+
+    encoded = record.to_json()
+    decoded = RestartAckReceiptRecord.from_json(encoded)
+
+    assert decoded == record
+    assert encoded == json.dumps(
+        record.to_dict(),
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    assert record.digest == hashlib.sha256(encoded).hexdigest()
+
+
+def test_restart_ack_receipt_reconstructs_authenticated_registration():
+    record = _record()
+
+    authenticated = record.authenticated_registration
+
+    assert authenticated.record == record.agent_registration
+    assert authenticated.fencing_token == record.registration_fencing_token
+    assert authenticated.granted_at_unix_ms == record.registration_granted_at_unix_ms
+    assert authenticated.expires_at_unix_ms == record.registration_expires_at_unix_ms
+
+
+def test_restart_ack_receipt_is_immutable():
+    record = _record()
+
+    with pytest.raises(AttributeError):
+        record.received_at_unix_ms = 20_001
+    with pytest.raises(AttributeError):
+        record.acknowledgement.inventory_event_digests = {}
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("intent_id", "intent-b", "restart intent"),
+        ("run_id", "other-run", "restart intent"),
+        ("generation", 5, "restart intent"),
+    ],
+)
+def test_restart_ack_receipt_requires_matching_intent(field, value, message):
+    acknowledgement = replace(_acknowledgement(), **{field: value})
+
+    with pytest.raises(ValueError, match=message):
+        _record(acknowledgement=acknowledgement)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("run_id", "other-run"),
+        ("node_id", "node-b"),
+        ("agent_id", "agent-b"),
+    ],
+)
+def test_restart_ack_receipt_requires_matching_authenticated_identity(field, value):
+    identity = replace(_registration().agent_identity, **{field: value})
+    registration = replace(_registration(), agent_identity=identity)
+
+    with pytest.raises(ValueError, match="authenticated agent registration"):
+        _record(agent_registration=registration)
+
+
+def test_restart_ack_receipt_accepts_registration_grant_boundary():
+    record = _record(received_at_unix_ms=1_000)
+
+    assert record.received_at_unix_ms == record.registration_granted_at_unix_ms
+
+
+def test_restart_ack_receipt_accepts_intent_deadline_boundary():
+    record = _record(
+        registration_granted_at_unix_ms=25_000,
+        received_at_unix_ms=50_000,
+    )
+
+    assert record.received_at_unix_ms == record.intent_record.intent.prepare_deadline_unix_ms
+
+
+@pytest.mark.parametrize(
+    ("received_at_unix_ms", "message"),
+    [
+        (999, "precedes"),
+        (31_000, "registration lifetime"),
+        (31_001, "registration lifetime"),
+    ],
+)
+def test_restart_ack_receipt_rejects_receipt_outside_registration_lifetime(
+    received_at_unix_ms,
+    message,
+):
+    with pytest.raises(ValueError, match=message):
+        _record(received_at_unix_ms=received_at_unix_ms)
+
+
+def test_restart_ack_receipt_rejects_receipt_after_intent_deadline():
+    with pytest.raises(ValueError, match="intent deadline"):
+        _record(
+            registration_granted_at_unix_ms=25_000,
+            received_at_unix_ms=50_001,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("acknowledgement", {}, "RestartAck"),
+        ("intent_record", {}, "RestartIntentRecord"),
+        ("agent_registration", {}, "AgentRegistrationRecord"),
+    ],
+)
+def test_restart_ack_receipt_requires_record_types(field, value, message):
+    kwargs = {
+        "acknowledgement": _acknowledgement(),
+        "intent_record": _intent_record(),
+        "agent_registration": _registration(),
+    }
+    kwargs[field] = value
+
+    with pytest.raises(TypeError, match=message):
+        RestartAckReceiptRecord(
+            **kwargs,
+            registration_fencing_token=9,
+            registration_granted_at_unix_ms=1_000,
+            received_at_unix_ms=20_000,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("registration_fencing_token", 0),
+        ("registration_fencing_token", True),
+        ("registration_granted_at_unix_ms", 0),
+        ("registration_granted_at_unix_ms", True),
+        ("received_at_unix_ms", 0),
+        ("received_at_unix_ms", True),
+    ],
+)
+def test_restart_ack_receipt_validates_positive_metadata(field, value):
+    with pytest.raises(ValueError, match=field):
+        replace(_record(), **{field: value})
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda value: value.pop("acknowledgement"), "missing fields"),
+        (lambda value: value.update({"unknown": True}), "unknown fields"),
+        (lambda value: value.update({"schema_version": 2}), "unsupported value"),
+        (lambda value: value.update({"schema_version": True}), "unsupported value"),
+        (lambda value: value.update({"schema_version": 1.0}), "unsupported value"),
+        (
+            lambda value: value.update({"registration_fencing_token": 0}),
+            "registration_fencing_token",
+        ),
+        (
+            lambda value: value.update({"registration_granted_at_unix_ms": 0}),
+            "registration_granted_at_unix_ms",
+        ),
+        (
+            lambda value: value.update({"received_at_unix_ms": 0}),
+            "received_at_unix_ms",
+        ),
+    ],
+)
+def test_restart_ack_receipt_rejects_invalid_outer_wire_values(mutate, message):
+    value = json.loads(_record().to_json())
+    mutate(value)
+
+    with pytest.raises(ValueError, match=message):
+        RestartAckReceiptRecord.from_json(
+            json.dumps(value, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "mutate", "message"),
+    [
+        (
+            "acknowledgement",
+            lambda value: value.update({"schema_version": 1.0}),
+            "schema_version",
+        ),
+        (
+            "acknowledgement",
+            lambda value: value.update({"agent_id": ""}),
+            "acknowledgement is invalid",
+        ),
+        (
+            "intent_record",
+            lambda value: value.update({"schema_version": 1.0}),
+            "intent_record is invalid",
+        ),
+        (
+            "agent_registration",
+            lambda value: value.update({"schema_version": 1.0}),
+            "agent_registration is invalid",
+        ),
+        (
+            "agent_registration",
+            lambda value: value["agent_identity"].update({"schema_version": 1.0}),
+            "agent_identity.schema_version",
+        ),
+    ],
+)
+def test_restart_ack_receipt_rejects_invalid_nested_wire_values(field, mutate, message):
+    value = json.loads(_record().to_json())
+    mutate(value[field])
+
+    with pytest.raises(ValueError, match=message):
+        RestartAckReceiptRecord.from_json(
+            json.dumps(value, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        )
+
+
+@pytest.mark.parametrize(
+    "encoded",
+    [
+        b"not-json",
+        b"[]",
+        b'{"schema_version":1,"schema_version":1}',
+        (
+            b'{"acknowledgement":{"schema_version":1,"schema_version":1},'
+            b'"agent_registration":{},"intent_record":{},'
+            b'"received_at_unix_ms":20000,"registration_fencing_token":9,'
+            b'"registration_granted_at_unix_ms":1000,"schema_version":1}'
+        ),
+    ],
+)
+def test_restart_ack_receipt_rejects_malformed_or_duplicate_json(encoded):
+    with pytest.raises(ValueError):
+        RestartAckReceiptRecord.from_json(encoded)
+
+
+def test_restart_ack_receipt_requires_encoded_bytes():
+    with pytest.raises(ValueError, match="encoded bytes"):
+        RestartAckReceiptRecord.from_json(_record().to_json().decode("utf-8"))


### PR DESCRIPTION
## Problem

Restart preparation currently has a strict worker `RestartAck` wire record, but no durable envelope that preserves the coordinator-authenticated sender registration and receipt time. Persisting only the worker payload would allow self-reported identity or timing to be mistaken for authenticated evidence.

## Implementation

- add immutable `RestartAckReceiptRecord`
- bind the worker acknowledgement to the exact immutable restart-intent record
- bind sender identity to one agent-registration lifetime, fencing token, and authoritative grant time
- reject mismatched run/node/agent identity, registration-window violations, and late receipts
- use strict canonical JSON with duplicate-field and exact schema-version rejection
- document that the record is not self-authenticating; the later persistence layer must validate intent and registration against control-store state

This PR is records-only. It does not add storage keys, CAS operations, acknowledgement collection, quorum logic, or restart-plan selection.

## Compatibility

Internal torchrun integration only. No public API or runtime behavior is enabled.

## Validation

- `260 passed` focused protocol/record tests
- `1850 passed` full CUDA-hidden CPU suite
- `ruff check .`
- `ruff format --check .`
- targeted mypy for the new source and tests
- `git diff --check`
