### PR TITLE
[Feature][Torchrun] Authorize restart acknowledgement writes

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -948,6 +948,13 @@ pre-intent transport data cannot be replayed as preparation evidence. The
 coordinator-lease authority and commit-time window are added by a separate
 prepared-write layer before this transaction can execute.
 
+The prepared-write authority is one verified durable coordinator-lease value.
+Its commit lower bound must follow the receipt, intent opening, and lease grant;
+its exclusive deadline is bounded by both the restart-intent deadline and the
+lease expiry. This immutable value still performs no store reads or writes.
+The next layer authenticates the authority against durable lease history before
+constructing it.
+
 For a crashed or unreachable node, no preparation is assumed.
 
 ## API: lm-resiliency to the Framework

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -922,7 +922,7 @@ The manager transport authenticates the acknowledgement sender. The
 coordinator checks the acknowledgement's run, node, and agent incarnation
 against that authenticated identity and requires the agent to match the
 inventory reporter. The coordinator also records receipt time outside the
-worker payload and rejects acknowledgements received after
+worker payload and rejects acknowledgements received at or after
 `prepare_deadline_unix_ms`. Payload identity fields and timestamps alone are
 not authentication. For latest recovery, the acknowledgement's canonical
 inventory digest must match the exact event used by the manifest; event-ID
@@ -933,10 +933,11 @@ the exact immutable restart-intent record, the authenticated agent-registration
 lifetime, its registration fencing token and authoritative grant time, and the
 coordinator-recorded receipt time. The envelope rejects a sender identity that
 does not match the acknowledgement, a receipt outside the authenticated
-registration lifetime, or a receipt after the intent deadline. The record is
-not self-authenticating: the acknowledgement persistence layer must still
-verify the registration and intent against authoritative control-store state
-before committing it.
+registration lifetime, or a receipt at or after the intent deadline. The
+deadline is exclusive so every accepted receipt has a representable guarded
+commit window. The record is not self-authenticating: the acknowledgement
+persistence layer must still verify the registration and intent against
+authoritative control-store state before committing it.
 
 Each intent/node acknowledgement key is create-once. Its guarded transaction
 conditions on the exact immutable intent revision, the still-open current

--- a/lm_resiliency/integrations/torchrun/_protocol.py
+++ b/lm_resiliency/integrations/torchrun/_protocol.py
@@ -2867,9 +2867,9 @@ def validate_restart_plan(
             raise ProtocolValidationError(
                 f"restart_acks[{index}]: missing authenticated receipt time"
             )
-        if received_unix_ms > intent.prepare_deadline_unix_ms:
+        if received_unix_ms >= intent.prepare_deadline_unix_ms:
             raise ProtocolValidationError(
-                f"restart_acks[{index}]: received after restart intent deadline"
+                f"restart_acks[{index}]: received at or after restart intent deadline"
             )
         ack_by_node[ack.node_id] = ack
     if set(authenticated_ack_agents) != set(ack_by_node):

--- a/lm_resiliency/integrations/torchrun/_restart_ack.py
+++ b/lm_resiliency/integrations/torchrun/_restart_ack.py
@@ -1,0 +1,84 @@
+"""Coordinator-authorized restart acknowledgement transaction inputs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from lm_resiliency.integrations.torchrun._control_store import ControlStoreWrite
+from lm_resiliency.integrations.torchrun._coordinator_lease import HeldCoordinatorLease
+from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
+    CoordinatorLeaseAuthority,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_writes import (
+    RestartAckWriteRecords,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedRestartAckWrite:
+    """One immutable acknowledgement write with coordinator authority."""
+
+    records: RestartAckWriteRecords
+    coordinator_authority: CoordinatorLeaseAuthority
+    not_before_unix_ms: int
+    deadline_unix_ms: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.records, RestartAckWriteRecords):
+            raise TypeError("PreparedRestartAckWrite.records must be RestartAckWriteRecords")
+        if not isinstance(self.coordinator_authority, CoordinatorLeaseAuthority):
+            raise TypeError(
+                "PreparedRestartAckWrite.coordinator_authority must be CoordinatorLeaseAuthority"
+            )
+        _positive_integer(
+            self.not_before_unix_ms,
+            "PreparedRestartAckWrite.not_before_unix_ms",
+        )
+        _positive_integer(
+            self.deadline_unix_ms,
+            "PreparedRestartAckWrite.deadline_unix_ms",
+        )
+        receipt = self.records.receipt
+        lease = self.coordinator_authority.lease
+        if lease.record.run_id != receipt.acknowledgement.run_id:
+            raise ValueError("PreparedRestartAckWrite coordinator lease belongs to another run")
+        if self.not_before_unix_ms < receipt.received_at_unix_ms:
+            raise ValueError("PreparedRestartAckWrite cannot precede acknowledgement receipt")
+        if self.not_before_unix_ms < lease.granted_at_unix_ms:
+            raise ValueError("PreparedRestartAckWrite cannot precede coordinator lease grant")
+        if self.not_before_unix_ms >= self.deadline_unix_ms:
+            raise ValueError("PreparedRestartAckWrite.not_before_unix_ms must precede its deadline")
+        if self.deadline_unix_ms > lease.expires_at_unix_ms:
+            raise ValueError("PreparedRestartAckWrite deadline exceeds coordinator lease")
+        if self.deadline_unix_ms > receipt.intent_record.intent.prepare_deadline_unix_ms:
+            raise ValueError("PreparedRestartAckWrite deadline exceeds restart intent")
+
+    @property
+    def lease(self) -> HeldCoordinatorLease:
+        return self.coordinator_authority.lease
+
+    @property
+    def coordinator_lease_key(self) -> str:
+        return self.records.opened.prepared.coordinator_lease_key
+
+    @property
+    def expected_guard_revision(self) -> int:
+        return self.lease.fencing_token
+
+    @property
+    def writes(self) -> Mapping[str, ControlStoreWrite]:
+        return self.records.writes
+
+    @property
+    def conditions(self) -> Mapping[str, int]:
+        return self.records.conditions
+
+
+def _positive_integer(value: object, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{path} must be a positive integer")
+    return value
+
+
+__all__ = ["PreparedRestartAckWrite"]

--- a/lm_resiliency/integrations/torchrun/_restart_ack_records.py
+++ b/lm_resiliency/integrations/torchrun/_restart_ack_records.py
@@ -86,8 +86,10 @@ class RestartAckReceiptRecord:
             raise ValueError(
                 "RestartAckReceiptRecord receipt is outside its agent registration lifetime"
             )
-        if self.received_at_unix_ms > intent.prepare_deadline_unix_ms:
-            raise ValueError("RestartAckReceiptRecord receipt is after the restart intent deadline")
+        if self.received_at_unix_ms >= intent.prepare_deadline_unix_ms:
+            raise ValueError(
+                "RestartAckReceiptRecord receipt is at or after the restart intent deadline"
+            )
 
     @property
     def digest(self) -> str:

--- a/tests/unit/test_torchrun_protocol.py
+++ b/tests/unit/test_torchrun_protocol.py
@@ -1510,10 +1510,17 @@ def test_restart_ack_must_match_authenticated_agent():
         )
 
 
-def test_restart_ack_must_arrive_by_prepare_deadline():
-    with pytest.raises(ProtocolValidationError, match="received after"):
+@pytest.mark.parametrize(
+    "received_unix_ms",
+    [
+        2_000_000_000_000,
+        2_000_000_000_001,
+    ],
+)
+def test_restart_ack_must_arrive_before_prepare_deadline(received_unix_ms):
+    with pytest.raises(ProtocolValidationError, match="at or after"):
         _validate(
-            authenticated_ack_received_unix_ms={"node-a": 2_000_000_000_001},
+            authenticated_ack_received_unix_ms={"node-a": received_unix_ms},
         )
 
 

--- a/tests/unit/test_torchrun_restart_ack.py
+++ b/tests/unit/test_torchrun_restart_ack.py
@@ -1,0 +1,310 @@
+"""Contract tests for coordinator-authorized restart acknowledgement writes."""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+from dataclasses import replace
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._agent_registration import (
+    AgentRegistrationManager,
+    agent_registration_key,
+)
+from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseManager,
+    CoordinatorLeaseRecord,
+    HeldCoordinatorLease,
+)
+from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
+    CoordinatorLeaseAuthority,
+)
+from lm_resiliency.integrations.torchrun._generation_state import GenerationStateManager
+from lm_resiliency.integrations.torchrun._protocol import (
+    AgentIdentity,
+    RankAssignment,
+    RestartAck,
+    RestartIntent,
+    SlotAssignment,
+)
+from lm_resiliency.integrations.torchrun._restart_ack import PreparedRestartAckWrite
+from lm_resiliency.integrations.torchrun._restart_ack_records import (
+    RestartAckReceiptRecord,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_writes import (
+    RestartAckWriteRecords,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open import (
+    RestartIntentOpenPreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
+    RestartIntentOpenExecutor,
+)
+
+RUN_ID = "training-run"
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+    def set(self, now_unix_ms: int) -> None:
+        with self._lock:
+            self.now_unix_ms = now_unix_ms
+
+
+def _prepared() -> tuple[
+    ManualClock,
+    InMemoryControlStore,
+    CoordinatorLeaseManager,
+    PreparedRestartAckWrite,
+]:
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    lease_manager = CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id="coordinator-a",
+        lease_duration_ms=1_000,
+        clock=clock,
+    )
+    lease = lease_manager.acquire()
+    assignment = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=0,
+        assignments=(
+            SlotAssignment(0, "node-a", 0, 2),
+            SlotAssignment(1, "node-b", 2, 2),
+        ),
+        topology_digest="topology-v1",
+    )
+    current = GenerationStateManager(store, run_id=RUN_ID).initialize(
+        lease,
+        assignment,
+    )
+    intent = RestartIntent(
+        intent_id="intent-a",
+        run_id=RUN_ID,
+        generation=0,
+        incident_ids=("incident-a",),
+        reason_code="attributed_sdc",
+        minimum_recovery_mode="recovery_verified",
+        suspected_node_ids=("node-b",),
+        prepare_deadline_unix_ms=1_500,
+    )
+    opened = RestartIntentOpenExecutor(store, run_id=RUN_ID).execute_initial_open(
+        RestartIntentOpenPreparer(
+            store,
+            run_id=RUN_ID,
+            clock=clock,
+        ).prepare_initial_open(lease, current, intent)
+    )
+    registration = AgentRegistrationManager(
+        store,
+        agent_identity=AgentIdentity(
+            run_id=RUN_ID,
+            node_id="node-a",
+            agent_id="agent-a",
+            hostname="host-a",
+            local_world_size=2,
+            resource_ids=("gpu-a0", "gpu-a1"),
+            environment_digest="environment-v1",
+        ),
+        lease_duration_ms=400,
+        clock=clock,
+    ).register()
+    receipt = RestartAckReceiptRecord(
+        acknowledgement=RestartAck(
+            intent_id="intent-a",
+            run_id=RUN_ID,
+            node_id="node-a",
+            agent_id="agent-a",
+            generation=0,
+            flushed_step=40,
+            inventory_event_digests={"inventory-a": "b" * 64},
+            transferred_owner_ranks=(0, 1),
+            transferred_peer_ranks=(2, 3),
+            success=True,
+            reason="prepared",
+        ),
+        intent_record=opened.prepared.record,
+        agent_registration=registration.record,
+        registration_fencing_token=registration.fencing_token,
+        registration_granted_at_unix_ms=registration.granted_at_unix_ms,
+        received_at_unix_ms=clock.now_unix_ms,
+    )
+    node_digest = hashlib.sha256(b"node-a").hexdigest()
+    records = RestartAckWriteRecords(
+        receipt=receipt,
+        opened=opened,
+        acknowledgement_key=(f"{opened.prepared.intent_key}/acknowledgements/{node_digest}"),
+        agent_registration_key=agent_registration_key(RUN_ID, "node-a"),
+    )
+    lease_entry = store.get(lease_manager.lease_key)
+    assert lease_entry is not None
+    authority = CoordinatorLeaseAuthority.from_entry(
+        lease_entry,
+        run_id=RUN_ID,
+    )
+    return (
+        clock,
+        store,
+        lease_manager,
+        PreparedRestartAckWrite(
+            records=records,
+            coordinator_authority=authority,
+            not_before_unix_ms=1_000,
+            deadline_unix_ms=1_500,
+        ),
+    )
+
+
+def test_prepared_restart_ack_delegates_immutable_transaction_inputs():
+    _, _, _, prepared = _prepared()
+
+    assert prepared.lease == prepared.coordinator_authority.lease
+    assert prepared.coordinator_lease_key == prepared.records.opened.prepared.coordinator_lease_key
+    assert prepared.expected_guard_revision == prepared.lease.fencing_token
+    assert prepared.writes == prepared.records.writes
+    assert prepared.conditions == prepared.records.conditions
+
+
+def test_prepared_restart_ack_is_immutable():
+    _, _, _, prepared = _prepared()
+
+    with pytest.raises(AttributeError):
+        prepared.deadline_unix_ms = 1_499
+
+
+def test_prepared_restart_ack_accepts_renewed_coordinator_authority():
+    clock, store, lease_manager, prepared = _prepared()
+    clock.set(1_010)
+    renewed = lease_manager.renew(prepared.lease)
+    renewed_entry = store.get(lease_manager.lease_key)
+    assert renewed_entry is not None
+    renewed_authority = CoordinatorLeaseAuthority.from_entry(
+        renewed_entry,
+        run_id=RUN_ID,
+    )
+
+    renewed_prepared = replace(
+        prepared,
+        coordinator_authority=renewed_authority,
+        not_before_unix_ms=1_010,
+        deadline_unix_ms=1_500,
+    )
+
+    assert renewed_prepared.lease == renewed
+
+
+def test_prepared_restart_ack_rejects_cross_run_authority():
+    _, _, _, prepared = _prepared()
+    authority = replace(
+        prepared.coordinator_authority,
+        lease=HeldCoordinatorLease(
+            record=CoordinatorLeaseRecord(
+                run_id="other-run",
+                coordinator_id="coordinator-a",
+                lease_id="lease-a",
+                lease_duration_ms=1_000,
+            ),
+            fencing_token=prepared.lease.fencing_token,
+            granted_at_unix_ms=prepared.lease.granted_at_unix_ms,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="another run"):
+        replace(prepared, coordinator_authority=authority)
+
+
+@pytest.mark.parametrize(
+    ("not_before_unix_ms", "message"),
+    [
+        (999, "acknowledgement receipt"),
+    ],
+)
+def test_prepared_restart_ack_rejects_early_commit_lower_bound(
+    not_before_unix_ms,
+    message,
+):
+    _, _, _, prepared = _prepared()
+
+    with pytest.raises(ValueError, match=message):
+        replace(prepared, not_before_unix_ms=not_before_unix_ms)
+
+
+def test_prepared_restart_ack_rejects_lower_bound_before_lease_grant():
+    _, _, _, prepared = _prepared()
+    authority = replace(
+        prepared.coordinator_authority,
+        lease=replace(
+            prepared.lease,
+            granted_at_unix_ms=1_001,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="lease grant"):
+        replace(
+            prepared,
+            coordinator_authority=authority,
+            not_before_unix_ms=1_000,
+        )
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        ({"not_before_unix_ms": 0}, "not_before_unix_ms"),
+        ({"not_before_unix_ms": True}, "not_before_unix_ms"),
+        ({"deadline_unix_ms": 0}, "deadline_unix_ms"),
+        ({"deadline_unix_ms": True}, "deadline_unix_ms"),
+        (
+            {"not_before_unix_ms": 1_500, "deadline_unix_ms": 1_500},
+            "must precede",
+        ),
+        ({"deadline_unix_ms": 1_501}, "restart intent"),
+    ],
+)
+def test_prepared_restart_ack_validates_time_window(changes, message):
+    _, _, _, prepared = _prepared()
+
+    with pytest.raises(ValueError, match=message):
+        replace(prepared, **changes)
+
+
+def test_prepared_restart_ack_rejects_deadline_after_lease_expiry():
+    _, _, _, prepared = _prepared()
+    authority = replace(
+        prepared.coordinator_authority,
+        lease=HeldCoordinatorLease(
+            record=replace(
+                prepared.lease.record,
+                lease_duration_ms=400,
+            ),
+            fencing_token=prepared.lease.fencing_token,
+            granted_at_unix_ms=prepared.lease.granted_at_unix_ms,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="coordinator lease"):
+        replace(
+            prepared,
+            coordinator_authority=authority,
+            deadline_unix_ms=1_500,
+        )
+
+
+def test_prepared_restart_ack_requires_expected_types():
+    _, _, _, prepared = _prepared()
+
+    with pytest.raises(TypeError, match="RestartAckWriteRecords"):
+        replace(prepared, records={})
+    with pytest.raises(TypeError, match="CoordinatorLeaseAuthority"):
+        replace(prepared, coordinator_authority={})

--- a/tests/unit/test_torchrun_restart_ack_records.py
+++ b/tests/unit/test_torchrun_restart_ack_records.py
@@ -172,15 +172,6 @@ def test_restart_ack_receipt_accepts_registration_grant_boundary():
     assert record.received_at_unix_ms == record.registration_granted_at_unix_ms
 
 
-def test_restart_ack_receipt_accepts_intent_deadline_boundary():
-    record = _record(
-        registration_granted_at_unix_ms=25_000,
-        received_at_unix_ms=50_000,
-    )
-
-    assert record.received_at_unix_ms == record.intent_record.intent.prepare_deadline_unix_ms
-
-
 @pytest.mark.parametrize(
     ("received_at_unix_ms", "message"),
     [
@@ -197,11 +188,14 @@ def test_restart_ack_receipt_rejects_receipt_outside_registration_lifetime(
         _record(received_at_unix_ms=received_at_unix_ms)
 
 
-def test_restart_ack_receipt_rejects_receipt_after_intent_deadline():
+@pytest.mark.parametrize("received_at_unix_ms", [50_000, 50_001])
+def test_restart_ack_receipt_rejects_receipt_at_or_after_intent_deadline(
+    received_at_unix_ms,
+):
     with pytest.raises(ValueError, match="intent deadline"):
         _record(
             registration_granted_at_unix_ms=25_000,
-            received_at_unix_ms=50_001,
+            received_at_unix_ms=received_at_unix_ms,
         )
 
 


### PR DESCRIPTION
## Problem

The acknowledgement write records define immutable values and exact read conditions, but they still need coordinator authority and a bounded commit window before a later executor can safely submit them.

## Implementation

- add immutable \`PreparedRestartAckWrite\`
- bind one verified \`CoordinatorLeaseAuthority\`
- require the transaction lower bound to follow receipt and lease grant
- bound the exclusive deadline by both coordinator-lease expiry and restart-intent deadline
- make acknowledgement receipt admission exclusive at the intent deadline, matching the guarded commit window
- delegate the merged create-once write and exact read conditions
- expose no store reads or mutations

The following PR will authenticate the authority against durable lease history and current persisted state. Guarded execution remains separate.

## Compatibility

Internal torchrun integration only. No public API or runtime behavior is enabled.

## Validation

- \`152 passed\` focused protocol/receipt/authority tests for the review revision
- \`1874 passed\` full CUDA-hidden CPU suite
- \`ruff check .\`
- \`ruff format --check .\`
- targeted mypy for changed torchrun records/tests
- \`git diff --check\`