### PR TITLE
[Feature][Torchrun] Verify agent registration history

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -964,8 +964,13 @@ Each retained agent-registration value is first decoded as one immutable
 authority. The strict decoder binds canonical registration bytes to the
 expected run and node, requires an authoritative commit time, rejects guarded
 registration writes, and preserves the store transaction, mutation, value, and
-lifetime sequences. It also rejects impossible per-entry sequence lineage. A
-following reader validates the complete registration history and current tail.
+lifetime sequences. It also rejects impossible per-entry sequence lineage. The
+following stable reader validates that the retained history begins at the
+initial sequences and contains every renewal, replacement, and recreated-key
+transition. It rejects overlapping registrations, expired renewals, recurrent
+registration identities or fencing tokens, and a current value that is not the
+retained tail. A released registration remains visible in the immutable history
+while the current value is absent.
 
 For a crashed or unreachable node, no preparation is assumed.
 

--- a/lm_resiliency/integrations/torchrun/_agent_registration_history_reader.py
+++ b/lm_resiliency/integrations/torchrun/_agent_registration_history_reader.py
@@ -1,0 +1,230 @@
+"""Stable, fail-closed reads of agent-registration authority history."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from lm_resiliency.integrations.torchrun._agent_registration import (
+    agent_registration_key,
+)
+from lm_resiliency.integrations.torchrun._agent_registration_history import (
+    AgentRegistrationAuthority,
+    AgentRegistrationAuthorityCorrupt,
+)
+from lm_resiliency.integrations.torchrun._agent_registration_records import (
+    HeldAgentRegistration,
+)
+from lm_resiliency.integrations.torchrun._control_store import ControlStore
+
+_MAX_READ_ATTEMPTS = 8
+
+
+class AgentRegistrationHistoryError(RuntimeError):
+    """Base error for agent-registration history reads."""
+
+
+class AgentRegistrationHistoryCorrupt(AgentRegistrationHistoryError):
+    """Raised when persisted registration history is contradictory."""
+
+
+@dataclass(frozen=True, slots=True)
+class AgentRegistrationHistory:
+    """One complete authority history and its optional current registration."""
+
+    authorities: tuple[AgentRegistrationAuthority, ...]
+    current: HeldAgentRegistration | None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.authorities, tuple) or not all(
+            isinstance(authority, AgentRegistrationAuthority) for authority in self.authorities
+        ):
+            raise TypeError(
+                "AgentRegistrationHistory.authorities must be a tuple of AgentRegistrationAuthority"
+            )
+        if self.current is not None and not isinstance(
+            self.current,
+            HeldAgentRegistration,
+        ):
+            raise TypeError(
+                "AgentRegistrationHistory.current must be HeldAgentRegistration or None"
+            )
+        _validate_history(self.authorities)
+        if self.current is not None and (
+            not self.authorities or self.authorities[-1].registration != self.current
+        ):
+            raise ValueError(
+                "AgentRegistrationHistory current registration is not its history tail"
+            )
+
+
+class AgentRegistrationHistoryReader:
+    """Read and verify one run/node registration's retained value history."""
+
+    def __init__(
+        self,
+        store: ControlStore,
+        *,
+        run_id: str,
+        node_id: str,
+    ) -> None:
+        self._store = store
+        self._run_id = _nonempty_string(run_id, "run_id")
+        self._node_id = _nonempty_string(node_id, "node_id")
+        self._registration_key = agent_registration_key(
+            self._run_id,
+            self._node_id,
+        )
+
+    @property
+    def registration_key(self) -> str:
+        return self._registration_key
+
+    def read(self) -> AgentRegistrationHistory:
+        """Return one stable, verified registration-history snapshot."""
+
+        for _ in range(_MAX_READ_ATTEMPTS):
+            history = self._store.get_history(self._registration_key)
+            current = self._store.get(self._registration_key)
+            has_history = self._store.has_history(self._registration_key)
+            if (
+                history != self._store.get_history(self._registration_key)
+                or current != self._store.get(self._registration_key)
+                or has_history != self._store.has_history(self._registration_key)
+            ):
+                continue
+            if bool(history) != has_history:
+                raise AgentRegistrationHistoryCorrupt(
+                    "agent-registration value history contradicts its durable marker"
+                )
+            if current is not None and (not history or history[-1] != current):
+                raise AgentRegistrationHistoryCorrupt(
+                    "current agent registration is absent from its value history"
+                )
+            try:
+                authorities = tuple(
+                    AgentRegistrationAuthority.from_entry(
+                        entry,
+                        run_id=self._run_id,
+                        node_id=self._node_id,
+                    )
+                    for entry in history
+                )
+                current_registration = (
+                    None
+                    if current is None
+                    else AgentRegistrationAuthority.from_entry(
+                        current,
+                        run_id=self._run_id,
+                        node_id=self._node_id,
+                    ).registration
+                )
+                return AgentRegistrationHistory(
+                    authorities=authorities,
+                    current=current_registration,
+                )
+            except AgentRegistrationAuthorityCorrupt as error:
+                raise AgentRegistrationHistoryCorrupt(
+                    "agent-registration history contains an invalid authority"
+                ) from error
+            except (TypeError, ValueError) as error:
+                raise AgentRegistrationHistoryCorrupt(
+                    "agent-registration history contains invalid state"
+                ) from error
+        raise AgentRegistrationHistoryError(
+            "agent-registration history changed repeatedly during read"
+        )
+
+
+def _validate_history(
+    authorities: tuple[AgentRegistrationAuthority, ...],
+) -> None:
+    if not authorities:
+        return
+    first = authorities[0]
+    if first.mutation_sequence != 1 or first.value_sequence != 1 or first.lifetime_sequence != 1:
+        raise AgentRegistrationHistoryCorrupt(
+            "agent-registration history does not begin at initial store sequences"
+        )
+    seen_registration_ids = {first.registration.record.registration_id}
+    seen_fencing_tokens = {first.registration.fencing_token}
+    for previous, current in zip(authorities, authorities[1:], strict=False):
+        _validate_transition(previous, current)
+        fencing_token = current.registration.fencing_token
+        if fencing_token in seen_fencing_tokens:
+            raise AgentRegistrationHistoryCorrupt(
+                "agent-registration fencing token reappears in history"
+            )
+        seen_fencing_tokens.add(fencing_token)
+        previous_id = previous.registration.record.registration_id
+        current_id = current.registration.record.registration_id
+        if current_id != previous_id:
+            if current_id in seen_registration_ids:
+                raise AgentRegistrationHistoryCorrupt(
+                    "agent-registration identity reappears after replacement"
+                )
+            seen_registration_ids.add(current_id)
+
+
+def _validate_transition(
+    previous: AgentRegistrationAuthority,
+    current: AgentRegistrationAuthority,
+) -> None:
+    if current.transaction_sequence <= previous.transaction_sequence:
+        raise AgentRegistrationHistoryCorrupt(
+            "agent-registration transaction sequences do not advance"
+        )
+    previous_registration = previous.registration
+    current_registration = current.registration
+    if current_registration.granted_at_unix_ms < previous_registration.granted_at_unix_ms:
+        raise AgentRegistrationHistoryCorrupt("agent-registration grant times move backward")
+    mutation_delta = current.mutation_sequence - previous.mutation_sequence
+    value_delta = current.value_sequence - previous.value_sequence
+    lifetime_delta = current.lifetime_sequence - previous.lifetime_sequence
+    transaction_delta = current.transaction_sequence - previous.transaction_sequence
+    if transaction_delta < mutation_delta:
+        raise AgentRegistrationHistoryCorrupt(
+            "agent-registration mutation count exceeds transaction ordering"
+        )
+    if lifetime_delta not in (0, 1):
+        raise AgentRegistrationHistoryCorrupt("agent-registration history omits a key lifetime")
+    if mutation_delta != (1 if lifetime_delta == 0 else 2):
+        raise AgentRegistrationHistoryCorrupt("agent-registration history omits a key mutation")
+    same_record = current_registration.record == previous_registration.record
+    expected_value_delta = 0 if lifetime_delta == 0 and same_record else 1
+    if value_delta != expected_value_delta:
+        raise AgentRegistrationHistoryCorrupt(
+            "agent-registration value sequence contradicts its records"
+        )
+    if same_record:
+        if lifetime_delta != 0:
+            raise AgentRegistrationHistoryCorrupt(
+                "one agent registration crosses a recreated key lifetime"
+            )
+        if current_registration.granted_at_unix_ms >= previous_registration.expires_at_unix_ms:
+            raise AgentRegistrationHistoryCorrupt(
+                "agent-registration history renews an expired registration"
+            )
+        return
+    if current_registration.record.registration_id == previous_registration.record.registration_id:
+        raise AgentRegistrationHistoryCorrupt(
+            "one agent-registration identity changes its persisted record"
+        )
+    if (
+        lifetime_delta == 0
+        and current_registration.granted_at_unix_ms < previous_registration.expires_at_unix_ms
+    ):
+        raise AgentRegistrationHistoryCorrupt("agent-registration replacements overlap")
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+__all__ = [
+    "AgentRegistrationHistory",
+    "AgentRegistrationHistoryCorrupt",
+    "AgentRegistrationHistoryError",
+    "AgentRegistrationHistoryReader",
+]

--- a/tests/unit/test_torchrun_agent_registration_history_reader.py
+++ b/tests/unit/test_torchrun_agent_registration_history_reader.py
@@ -1,0 +1,483 @@
+"""Contract tests for stable agent-registration history reads."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import replace
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._agent_registration import (
+    AgentRegistrationManager,
+    agent_registration_key,
+)
+from lm_resiliency.integrations.torchrun._agent_registration_history import (
+    AgentRegistrationAuthority,
+)
+from lm_resiliency.integrations.torchrun._agent_registration_history_reader import (
+    AgentRegistrationHistory,
+    AgentRegistrationHistoryCorrupt,
+    AgentRegistrationHistoryError,
+    AgentRegistrationHistoryReader,
+)
+from lm_resiliency.integrations.torchrun._agent_registration_records import (
+    AgentRegistrationRecord,
+)
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStoreEntry,
+    InMemoryControlStore,
+)
+from lm_resiliency.integrations.torchrun._protocol import AgentIdentity
+
+RUN_ID = "training-run"
+NODE_ID = "node-a"
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+    def set(self, now_unix_ms: int) -> None:
+        with self._lock:
+            self.now_unix_ms = now_unix_ms
+
+
+class StaticHistoryStore(InMemoryControlStore):
+    def __init__(
+        self,
+        *,
+        key: str,
+        history: tuple[ControlStoreEntry, ...],
+        current: ControlStoreEntry | None,
+        has_history: bool,
+    ) -> None:
+        self._key = key
+        self._history = history
+        self._current = current
+        self._has_history = has_history
+
+    def get_history(self, key: str) -> tuple[ControlStoreEntry, ...]:
+        return self._history if key == self._key else ()
+
+    def get(self, key: str) -> ControlStoreEntry | None:
+        return self._current if key == self._key else None
+
+    def has_history(self, key: str) -> bool:
+        return self._has_history if key == self._key else False
+
+
+class UnstableHistoryStore(StaticHistoryStore):
+    def __init__(self, *, key: str, history: tuple[ControlStoreEntry, ...]) -> None:
+        super().__init__(
+            key=key,
+            history=history,
+            current=history[-1],
+            has_history=True,
+        )
+        self._history_reads = 0
+
+    def get_history(self, key: str) -> tuple[ControlStoreEntry, ...]:
+        self._history_reads += 1
+        history = super().get_history(key)
+        return history[:-1] if self._history_reads % 2 else history
+
+
+def _identity(agent_id: str) -> AgentIdentity:
+    return AgentIdentity(
+        run_id=RUN_ID,
+        node_id=NODE_ID,
+        agent_id=agent_id,
+        hostname=f"host-{agent_id}",
+        local_world_size=2,
+        resource_ids=(f"{agent_id}-gpu-0", f"{agent_id}-gpu-1"),
+        environment_digest="environment-v1",
+    )
+
+
+def _manager(
+    store: InMemoryControlStore,
+    clock: ManualClock,
+    agent_id: str,
+) -> AgentRegistrationManager:
+    return AgentRegistrationManager(
+        store,
+        agent_identity=_identity(agent_id),
+        lease_duration_ms=100,
+        clock=clock,
+    )
+
+
+def test_registration_history_reader_returns_empty_state_before_registration():
+    reader = AgentRegistrationHistoryReader(
+        InMemoryControlStore(),
+        run_id=RUN_ID,
+        node_id=NODE_ID,
+    )
+
+    history = reader.read()
+
+    assert history.authorities == ()
+    assert history.current is None
+    assert reader.registration_key == agent_registration_key(RUN_ID, NODE_ID)
+
+
+def test_registration_history_reader_verifies_renewal_and_replacement():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    first = _manager(store, clock, "agent-a")
+    initial = first.register()
+    clock.set(1_010)
+    renewed = first.renew(initial)
+    clock.set(renewed.expires_at_unix_ms)
+    replacement = _manager(store, clock, "agent-b").register()
+
+    history = AgentRegistrationHistoryReader(
+        store,
+        run_id=RUN_ID,
+        node_id=NODE_ID,
+    ).read()
+
+    assert tuple(authority.registration for authority in history.authorities) == (
+        initial,
+        renewed,
+        replacement,
+    )
+    assert history.current == replacement
+    assert tuple(authority.mutation_sequence for authority in history.authorities) == (
+        1,
+        2,
+        3,
+    )
+    assert tuple(authority.value_sequence for authority in history.authorities) == (
+        1,
+        1,
+        2,
+    )
+
+
+def test_registration_history_reader_preserves_release_and_recreate():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    first = _manager(store, clock, "agent-a")
+    initial = first.register()
+    clock.set(1_010)
+    first.release(initial)
+    replacement = _manager(store, clock, "agent-b").register()
+
+    history = AgentRegistrationHistoryReader(
+        store,
+        run_id=RUN_ID,
+        node_id=NODE_ID,
+    ).read()
+
+    assert tuple(authority.registration for authority in history.authorities) == (
+        initial,
+        replacement,
+    )
+    assert history.current == replacement
+    assert history.authorities[-1].mutation_sequence == 3
+    assert history.authorities[-1].lifetime_sequence == 2
+
+
+def test_registration_history_reader_preserves_released_state():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    manager = _manager(store, clock, "agent-a")
+    initial = manager.register()
+    clock.set(1_010)
+    manager.release(initial)
+
+    history = AgentRegistrationHistoryReader(
+        store,
+        run_id=RUN_ID,
+        node_id=NODE_ID,
+    ).read()
+
+    assert tuple(authority.registration for authority in history.authorities) == (initial,)
+    assert history.current is None
+
+
+def test_registration_history_reader_rejects_truncated_history():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    manager = _manager(store, clock, "agent-a")
+    initial = manager.register()
+    clock.set(1_010)
+    manager.renew(initial)
+    retained = store.get_history(manager.registration_key)
+
+    with pytest.raises(AgentRegistrationHistoryCorrupt, match="initial store sequences"):
+        AgentRegistrationHistoryReader(
+            StaticHistoryStore(
+                key=manager.registration_key,
+                history=retained[1:],
+                current=retained[-1],
+                has_history=True,
+            ),
+            run_id=RUN_ID,
+            node_id=NODE_ID,
+        ).read()
+
+
+@pytest.mark.parametrize(
+    ("history", "current", "has_history", "message"),
+    [
+        ((), None, True, "durable marker"),
+        (
+            (),
+            ControlStoreEntry(value=b"value", revision=1),
+            False,
+            "absent from its value history",
+        ),
+    ],
+)
+def test_registration_history_reader_rejects_store_contradictions(
+    history: tuple[ControlStoreEntry, ...],
+    current: ControlStoreEntry | None,
+    has_history: bool,
+    message: str,
+):
+    key = agent_registration_key(RUN_ID, NODE_ID)
+
+    with pytest.raises(AgentRegistrationHistoryCorrupt, match=message):
+        AgentRegistrationHistoryReader(
+            StaticHistoryStore(
+                key=key,
+                history=history,
+                current=current,
+                has_history=has_history,
+            ),
+            run_id=RUN_ID,
+            node_id=NODE_ID,
+        ).read()
+
+
+def test_registration_history_reader_rejects_current_missing_from_history():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    manager = _manager(store, clock, "agent-a")
+    manager.register()
+    retained = store.get_history(manager.registration_key)
+    changed = replace(retained[-1], revision=retained[-1].revision + 1)
+
+    with pytest.raises(AgentRegistrationHistoryCorrupt, match="absent from its value history"):
+        AgentRegistrationHistoryReader(
+            StaticHistoryStore(
+                key=manager.registration_key,
+                history=retained,
+                current=changed,
+                has_history=True,
+            ),
+            run_id=RUN_ID,
+            node_id=NODE_ID,
+        ).read()
+
+
+@pytest.mark.parametrize(
+    (
+        "transaction_sequence",
+        "mutation_sequence",
+        "value_sequence",
+        "lifetime_sequence",
+        "committed_at_unix_ms",
+        "message",
+    ),
+    [
+        (3, 2, 1, 1, 1_010, "transaction sequences"),
+        (4, 3, 1, 1, 1_010, "omits a key mutation"),
+        (3, 2, 2, 1, 1_010, "value sequence"),
+        (5, 5, 3, 3, 1_010, "key lifetime"),
+        (3, 2, 1, 1, 999, "grant times"),
+    ],
+)
+def test_registration_history_rejects_impossible_transition(
+    transaction_sequence: int,
+    mutation_sequence: int,
+    value_sequence: int,
+    lifetime_sequence: int,
+    committed_at_unix_ms: int,
+    message: str,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    manager = _manager(store, clock, "agent-a")
+    initial = manager.register()
+    clock.set(1_010)
+    manager.renew(initial)
+    retained = store.get_history(manager.registration_key)
+    first = (
+        replace(retained[0], transaction_sequence=3)
+        if message == "transaction sequences"
+        else retained[0]
+    )
+    changed = replace(
+        retained[-1],
+        transaction_sequence=transaction_sequence,
+        mutation_sequence=mutation_sequence,
+        value_sequence=value_sequence,
+        lifetime_sequence=lifetime_sequence,
+        committed_at_unix_ms=committed_at_unix_ms,
+    )
+
+    with pytest.raises(AgentRegistrationHistoryCorrupt, match=message):
+        AgentRegistrationHistory(
+            authorities=tuple(
+                AgentRegistrationAuthority.from_entry(
+                    entry,
+                    run_id=RUN_ID,
+                    node_id=NODE_ID,
+                )
+                for entry in (first, changed)
+            ),
+            current=None,
+        )
+
+
+def test_registration_history_rejects_expired_renewal_and_overlap():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    first = _manager(store, clock, "agent-a")
+    initial = first.register()
+    first_entry = store.get(first.registration_key)
+    assert first_entry is not None
+    expired_renewal = replace(
+        first_entry,
+        revision=first_entry.revision + 1,
+        committed_at_unix_ms=initial.expires_at_unix_ms,
+        transaction_sequence=first_entry.transaction_sequence + 1,
+        mutation_sequence=2,
+    )
+    replacement_record = AgentRegistrationRecord(
+        agent_identity=_identity("agent-b"),
+        registration_id="registration-b",
+        lease_duration_ms=100,
+    )
+    overlapping = replace(
+        expired_renewal,
+        value=replacement_record.to_json(),
+        committed_at_unix_ms=initial.expires_at_unix_ms - 1,
+        value_sequence=2,
+    )
+
+    with pytest.raises(AgentRegistrationHistoryCorrupt, match="expired registration"):
+        AgentRegistrationHistory(
+            authorities=tuple(
+                AgentRegistrationAuthority.from_entry(
+                    entry,
+                    run_id=RUN_ID,
+                    node_id=NODE_ID,
+                )
+                for entry in (first_entry, expired_renewal)
+            ),
+            current=None,
+        )
+    with pytest.raises(AgentRegistrationHistoryCorrupt, match="overlap"):
+        AgentRegistrationHistory(
+            authorities=tuple(
+                AgentRegistrationAuthority.from_entry(
+                    entry,
+                    run_id=RUN_ID,
+                    node_id=NODE_ID,
+                )
+                for entry in (first_entry, overlapping)
+            ),
+            current=None,
+        )
+
+
+def test_registration_history_rejects_registration_and_token_replay():
+    records = (
+        AgentRegistrationRecord(_identity("agent-a"), "registration-a", 100),
+        AgentRegistrationRecord(_identity("agent-b"), "registration-b", 100),
+        AgentRegistrationRecord(_identity("agent-c"), "registration-a", 100),
+    )
+    entries = tuple(
+        ControlStoreEntry(
+            value=record.to_json(),
+            revision=revision,
+            committed_at_unix_ms=committed_at_unix_ms,
+            transaction_sequence=index,
+            mutation_sequence=index,
+            value_sequence=index,
+        )
+        for index, (record, revision, committed_at_unix_ms) in enumerate(
+            zip(records, (10, 20, 30), (1_000, 1_100, 1_200), strict=True),
+            start=1,
+        )
+    )
+    authorities = tuple(
+        AgentRegistrationAuthority.from_entry(
+            entry,
+            run_id=RUN_ID,
+            node_id=NODE_ID,
+        )
+        for entry in entries
+    )
+
+    with pytest.raises(AgentRegistrationHistoryCorrupt, match="identity reappears"):
+        AgentRegistrationHistory(authorities=authorities, current=None)
+
+    repeated_token = replace(entries[-1], value_sequence=3, revision=10)
+    with pytest.raises(AgentRegistrationHistoryCorrupt, match="fencing token reappears"):
+        AgentRegistrationHistory(
+            authorities=(
+                authorities[0],
+                authorities[1],
+                AgentRegistrationAuthority.from_entry(
+                    repeated_token,
+                    run_id=RUN_ID,
+                    node_id=NODE_ID,
+                ),
+            ),
+            current=None,
+        )
+
+
+def test_registration_history_reader_reports_repeated_contention():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    manager = _manager(store, clock, "agent-a")
+    manager.register()
+    retained = store.get_history(manager.registration_key)
+
+    with pytest.raises(AgentRegistrationHistoryError, match="changed repeatedly"):
+        AgentRegistrationHistoryReader(
+            UnstableHistoryStore(
+                key=manager.registration_key,
+                history=retained,
+            ),
+            run_id=RUN_ID,
+            node_id=NODE_ID,
+        ).read()
+
+
+def test_registration_history_value_rejects_invalid_types_and_current_tail():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    manager = _manager(store, clock, "agent-a")
+    registration = manager.register()
+    entry = store.get(manager.registration_key)
+    assert entry is not None
+    authority = AgentRegistrationAuthority.from_entry(
+        entry,
+        run_id=RUN_ID,
+        node_id=NODE_ID,
+    )
+
+    with pytest.raises(TypeError, match="authorities"):
+        AgentRegistrationHistory(authorities=[], current=None)
+    with pytest.raises(TypeError, match="current"):
+        AgentRegistrationHistory(authorities=(authority,), current={})
+    with pytest.raises(ValueError, match="history tail"):
+        AgentRegistrationHistory(
+            authorities=(authority,),
+            current=replace(
+                registration,
+                fencing_token=registration.fencing_token + 1,
+            ),
+        )


### PR DESCRIPTION
## Summary
- add a stable, read-only agent-registration history reader
- require initial store sequences and contiguous renewal, replacement, and delete/recreate transitions
- reject truncated histories, expired renewals, overlapping replacements, replayed registration identities or fencing tokens, and current-tail contradictions
- keep restart-acknowledgement state reading and write preparation out of this PR

## Why
Authenticating only the current registration tail can accept a truncated retained history. This layer proves the complete durable registration lineage before later restart-acknowledgement code trusts the current sender registration.

## Validation
- focused registration/control-store suite: `89 passed`
- full CPU suite: `1918 passed`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- targeted mypy for the new reader and tests
- `git diff --check`
