### PR TITLE
[Feature][Torchrun] Read authenticated restart acknowledgement state

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -972,6 +972,12 @@ registration identities or fencing tokens, and a current value that is not the
 retained tail. A released registration remains visible in the immutable history
 while the current value is absent.
 
+The restart-acknowledgement state reader double-collects the current open
+intent, verified agent-registration history, and durable coordinator-lease
+history. It binds a receipt to the exact current registration and live
+coordinator authority without sampling a clock or mutating the store. Durable
+contradictions fail closed, while repeated-read contention remains retryable.
+
 For a crashed or unreachable node, no preparation is assumed.
 
 ## API: lm-resiliency to the Framework

--- a/lm_resiliency/integrations/torchrun/_restart_ack_state_reader.py
+++ b/lm_resiliency/integrations/torchrun/_restart_ack_state_reader.py
@@ -1,0 +1,224 @@
+"""Stable reads of authenticated restart-acknowledgement state."""
+
+from __future__ import annotations
+
+from lm_resiliency.integrations.torchrun._agent_registration_history_reader import (
+    AgentRegistrationHistory,
+    AgentRegistrationHistoryCorrupt,
+    AgentRegistrationHistoryError,
+    AgentRegistrationHistoryReader,
+)
+from lm_resiliency.integrations.torchrun._control_store import ControlStore
+from lm_resiliency.integrations.torchrun._coordinator_lease import HeldCoordinatorLease
+from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
+    CoordinatorLeaseAuthority,
+    CoordinatorLeaseHistoryCorrupt,
+    CoordinatorLeaseHistoryError,
+    CoordinatorLeaseHistoryReader,
+)
+from lm_resiliency.integrations.torchrun._generation_reader import (
+    GenerationStateCorrupt,
+    GenerationStateError,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_records import (
+    RestartAckReceiptRecord,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_state import (
+    AuthenticatedRestartAckState,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
+    CommittedInitialRestartIntentOpen,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_reader import (
+    RestartIntentOpenStateClosed,
+    RestartIntentOpenStateCorrupt,
+    RestartIntentOpenStateError,
+    RestartIntentOpenStateReader,
+)
+
+_MAX_READ_ATTEMPTS = 8
+
+
+class RestartAckStateReaderError(RuntimeError):
+    """Base error for restart-acknowledgement dependency reads."""
+
+
+class RestartAckStateConflict(RestartAckStateReaderError):
+    """Raised when the restart-intent state changes or is no longer open."""
+
+
+class RestartAckStateRegistrationLost(RestartAckStateReaderError):
+    """Raised when the authenticated agent registration is no longer current."""
+
+
+class RestartAckStateLeaseLost(RestartAckStateReaderError):
+    """Raised when the supplied coordinator lease is no longer current."""
+
+
+class RestartAckStateCorrupt(RestartAckStateReaderError):
+    """Raised when persisted acknowledgement dependencies are contradictory."""
+
+
+class RestartAckStateReader:
+    """Read one stable, authenticated restart-acknowledgement state."""
+
+    def __init__(self, store: ControlStore, *, run_id: str) -> None:
+        self._store = store
+        self._run_id = _nonempty_string(run_id, "run_id")
+        self._open_reader = RestartIntentOpenStateReader(
+            store,
+            run_id=self._run_id,
+        )
+        self._lease_history_reader = CoordinatorLeaseHistoryReader(
+            store,
+            run_id=self._run_id,
+        )
+
+    def read(
+        self,
+        receipt: RestartAckReceiptRecord,
+        lease: HeldCoordinatorLease,
+    ) -> AuthenticatedRestartAckState:
+        """Return one stable authenticated dependency snapshot."""
+
+        self._validate_inputs(receipt, lease)
+        registration_reader = self._registration_history_reader(receipt.acknowledgement.node_id)
+        for _ in range(_MAX_READ_ATTEMPTS):
+            opened = self._read_open()
+            registration_history = self._read_registration_history(registration_reader)
+            lease_history = self._read_lease_history()
+            if (
+                opened != self._read_open()
+                or registration_history != self._read_registration_history(registration_reader)
+                or lease_history != self._read_lease_history()
+            ):
+                continue
+            return self._authenticate(
+                receipt,
+                lease,
+                opened=opened,
+                registration_history=registration_history,
+                lease_history=lease_history,
+            )
+        raise RestartAckStateConflict(
+            "restart-acknowledgement dependencies changed repeatedly during read"
+        )
+
+    def _authenticate(
+        self,
+        receipt: RestartAckReceiptRecord,
+        lease: HeldCoordinatorLease,
+        *,
+        opened: CommittedInitialRestartIntentOpen | None,
+        registration_history: AgentRegistrationHistory,
+        lease_history: tuple[CoordinatorLeaseAuthority, ...],
+    ) -> AuthenticatedRestartAckState:
+        if opened is None:
+            raise RestartAckStateConflict("no current restart intent is open")
+        if receipt.intent_record != opened.prepared.record:
+            raise RestartAckStateConflict(
+                "restart acknowledgement does not answer the current restart intent"
+            )
+        registration = registration_history.current
+        if registration is None or registration != receipt.authenticated_registration:
+            raise RestartAckStateRegistrationLost(
+                "authenticated agent registration is no longer current"
+            )
+        if not lease_history or lease_history[-1].lease != lease:
+            raise RestartAckStateLeaseLost("coordinator lease is not the live durable authority")
+        try:
+            return AuthenticatedRestartAckState(
+                receipt=receipt,
+                opened=opened,
+                registration=registration,
+                coordinator_authority=lease_history[-1],
+            )
+        except (TypeError, ValueError) as error:
+            raise RestartAckStateCorrupt(
+                "restart acknowledgement contradicts persisted state"
+            ) from error
+
+    def _read_open(self) -> CommittedInitialRestartIntentOpen | None:
+        try:
+            return self._open_reader.read()
+        except RestartIntentOpenStateClosed as error:
+            raise RestartAckStateConflict(
+                "restart intent closed before acknowledgement authentication"
+            ) from error
+        except RestartIntentOpenStateCorrupt as error:
+            raise RestartAckStateCorrupt("persisted restart-intent opening is corrupt") from error
+        except RestartIntentOpenStateError as error:
+            raise RestartAckStateConflict(
+                "restart-intent opening changed repeatedly during read"
+            ) from error
+        except (CoordinatorLeaseHistoryCorrupt, GenerationStateCorrupt) as error:
+            raise RestartAckStateCorrupt(
+                "restart-intent opening dependencies are corrupt"
+            ) from error
+        except (CoordinatorLeaseHistoryError, GenerationStateError) as error:
+            raise RestartAckStateConflict(
+                "restart-intent opening dependencies changed repeatedly during read"
+            ) from error
+
+    @staticmethod
+    def _read_registration_history(
+        reader: AgentRegistrationHistoryReader,
+    ) -> AgentRegistrationHistory:
+        try:
+            return reader.read()
+        except AgentRegistrationHistoryCorrupt as error:
+            raise RestartAckStateCorrupt("agent registration history is corrupt") from error
+        except AgentRegistrationHistoryError as error:
+            raise RestartAckStateConflict(
+                "agent registration history changed repeatedly during read"
+            ) from error
+
+    def _registration_history_reader(
+        self,
+        node_id: str,
+    ) -> AgentRegistrationHistoryReader:
+        return AgentRegistrationHistoryReader(
+            self._store,
+            run_id=self._run_id,
+            node_id=node_id,
+        )
+
+    def _read_lease_history(self) -> tuple[CoordinatorLeaseAuthority, ...]:
+        try:
+            return self._lease_history_reader.read()
+        except CoordinatorLeaseHistoryCorrupt as error:
+            raise RestartAckStateCorrupt("coordinator lease history is corrupt") from error
+        except CoordinatorLeaseHistoryError as error:
+            raise RestartAckStateConflict(
+                "coordinator lease history changed repeatedly during read"
+            ) from error
+
+    def _validate_inputs(
+        self,
+        receipt: RestartAckReceiptRecord,
+        lease: HeldCoordinatorLease,
+    ) -> None:
+        if not isinstance(receipt, RestartAckReceiptRecord):
+            raise TypeError("receipt must be RestartAckReceiptRecord")
+        if not isinstance(lease, HeldCoordinatorLease):
+            raise TypeError("lease must be HeldCoordinatorLease")
+        if receipt.acknowledgement.run_id != self._run_id:
+            raise ValueError("restart acknowledgement belongs to another run")
+        if lease.record.run_id != self._run_id:
+            raise ValueError("coordinator lease belongs to another run")
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+__all__ = [
+    "RestartAckStateConflict",
+    "RestartAckStateCorrupt",
+    "RestartAckStateLeaseLost",
+    "RestartAckStateReader",
+    "RestartAckStateReaderError",
+    "RestartAckStateRegistrationLost",
+]

--- a/tests/unit/test_torchrun_restart_ack_state_reader.py
+++ b/tests/unit/test_torchrun_restart_ack_state_reader.py
@@ -1,0 +1,364 @@
+"""Contract tests for stable restart-acknowledgement state reads."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import replace
+from typing import Any, cast
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._agent_registration import (
+    AgentRegistrationManager,
+)
+from lm_resiliency.integrations.torchrun._agent_registration_history_reader import (
+    AgentRegistrationHistoryCorrupt,
+    AgentRegistrationHistoryError,
+)
+from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseManager,
+    HeldCoordinatorLease,
+)
+from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
+    CoordinatorLeaseHistoryError,
+)
+from lm_resiliency.integrations.torchrun._generation_reader import GenerationStateError
+from lm_resiliency.integrations.torchrun._generation_state import GenerationStateManager
+from lm_resiliency.integrations.torchrun._protocol import (
+    AgentIdentity,
+    RankAssignment,
+    RestartAck,
+    RestartIntent,
+    SlotAssignment,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_records import (
+    RestartAckReceiptRecord,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_state_reader import (
+    RestartAckStateConflict,
+    RestartAckStateCorrupt,
+    RestartAckStateLeaseLost,
+    RestartAckStateReader,
+    RestartAckStateRegistrationLost,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open import (
+    RestartIntentOpenPreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
+    CommittedInitialRestartIntentOpen,
+    RestartIntentOpenExecutor,
+)
+
+RUN_ID = "training-run"
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+    def set(self, now_unix_ms: int) -> None:
+        with self._lock:
+            self.now_unix_ms = now_unix_ms
+
+
+class FailingReader:
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+
+    def read(self):
+        raise self._error
+
+
+class TruncatedRegistrationHistoryStore(InMemoryControlStore):
+    def __init__(
+        self,
+        delegate: InMemoryControlStore,
+        registration_key: str,
+    ) -> None:
+        self._delegate = delegate
+        self._registration_key = registration_key
+
+    def get_history(self, key: str):
+        history = self._delegate.get_history(key)
+        if key == self._registration_key and history:
+            return history[-1:]
+        return history
+
+    def __getattr__(self, name: str):
+        return getattr(self._delegate, name)
+
+
+def _identity() -> AgentIdentity:
+    return AgentIdentity(
+        run_id=RUN_ID,
+        node_id="node-a",
+        agent_id="agent-a",
+        hostname="host-node-a",
+        local_world_size=2,
+        resource_ids=("gpu-node-a-0", "gpu-node-a-1"),
+        environment_digest="environment-v1",
+    )
+
+
+def _state() -> tuple[
+    ManualClock,
+    InMemoryControlStore,
+    CoordinatorLeaseManager,
+    HeldCoordinatorLease,
+    AgentRegistrationManager,
+    RestartAckReceiptRecord,
+    CommittedInitialRestartIntentOpen,
+]:
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    lease_manager = CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id="coordinator-a",
+        lease_duration_ms=1_000,
+        clock=clock,
+    )
+    lease = lease_manager.acquire()
+    assignment = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=0,
+        assignments=(
+            SlotAssignment(0, "node-a", 0, 2),
+            SlotAssignment(1, "node-b", 2, 2),
+        ),
+        topology_digest="topology-v1",
+    )
+    current = GenerationStateManager(store, run_id=RUN_ID).initialize(
+        lease,
+        assignment,
+    )
+    intent = RestartIntent(
+        intent_id="intent-a",
+        run_id=RUN_ID,
+        generation=0,
+        incident_ids=("incident-a",),
+        reason_code="attributed_sdc",
+        minimum_recovery_mode="recovery_verified",
+        suspected_node_ids=("node-b",),
+        prepare_deadline_unix_ms=1_500,
+    )
+    opened = RestartIntentOpenExecutor(store, run_id=RUN_ID).execute_initial_open(
+        RestartIntentOpenPreparer(
+            store,
+            run_id=RUN_ID,
+            clock=clock,
+        ).prepare_initial_open(lease, current, intent)
+    )
+    registration_manager = AgentRegistrationManager(
+        store,
+        agent_identity=_identity(),
+        lease_duration_ms=400,
+        clock=clock,
+    )
+    registration = registration_manager.register()
+    receipt = RestartAckReceiptRecord(
+        acknowledgement=RestartAck(
+            intent_id=intent.intent_id,
+            run_id=RUN_ID,
+            node_id="node-a",
+            agent_id="agent-a",
+            generation=0,
+            flushed_step=40,
+            inventory_event_digests={"inventory-a": "b" * 64},
+            transferred_owner_ranks=(0, 1),
+            transferred_peer_ranks=(2, 3),
+            success=True,
+            reason="prepared",
+        ),
+        intent_record=opened.prepared.record,
+        agent_registration=registration.record,
+        registration_fencing_token=registration.fencing_token,
+        registration_granted_at_unix_ms=registration.granted_at_unix_ms,
+        received_at_unix_ms=clock.now_unix_ms,
+    )
+    return (
+        clock,
+        store,
+        lease_manager,
+        lease,
+        registration_manager,
+        receipt,
+        opened,
+    )
+
+
+def test_restart_ack_state_reader_authenticates_without_mutating_store():
+    _, store, lease_manager, lease, registration_manager, receipt, opened = _state()
+    watched_keys = (
+        opened.prepared.intent_key,
+        opened.prepared.intent_head_key,
+        registration_manager.registration_key,
+        lease_manager.lease_key,
+    )
+    histories_before = {key: store.get_history(key) for key in watched_keys}
+
+    state = RestartAckStateReader(store, run_id=RUN_ID).read(receipt, lease)
+
+    assert state.receipt == receipt
+    assert state.opened == opened
+    assert state.registration == receipt.authenticated_registration
+    assert state.coordinator_authority.lease == lease
+    assert {key: store.get_history(key) for key in watched_keys} == histories_before
+
+
+def test_restart_ack_state_reader_accepts_live_renewed_coordinator_lease():
+    clock, store, lease_manager, lease, _, receipt, _ = _state()
+    clock.set(1_010)
+    renewed = lease_manager.renew(lease)
+
+    state = RestartAckStateReader(store, run_id=RUN_ID).read(receipt, renewed)
+
+    assert state.coordinator_authority.lease == renewed
+    assert state.coordinator_authority.mutation_sequence == 2
+
+
+def test_restart_ack_state_reader_rejects_changed_registration_and_lease():
+    clock, store, lease_manager, lease, registration_manager, receipt, _ = _state()
+    clock.set(1_010)
+    renewed_registration = registration_manager.renew(receipt.authenticated_registration)
+
+    with pytest.raises(RestartAckStateRegistrationLost, match="no longer current"):
+        RestartAckStateReader(store, run_id=RUN_ID).read(receipt, lease)
+
+    current_receipt = replace(
+        receipt,
+        agent_registration=renewed_registration.record,
+        registration_fencing_token=renewed_registration.fencing_token,
+        registration_granted_at_unix_ms=renewed_registration.granted_at_unix_ms,
+        received_at_unix_ms=clock.now_unix_ms,
+    )
+    lease_manager.renew(lease)
+
+    with pytest.raises(RestartAckStateLeaseLost, match="live durable"):
+        RestartAckStateReader(store, run_id=RUN_ID).read(current_receipt, lease)
+
+
+def test_restart_ack_state_reader_rejects_missing_or_different_open_intent():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    lease = CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id="coordinator-a",
+        lease_duration_ms=1_000,
+        clock=clock,
+    ).acquire()
+    _, _, _, _, _, receipt, _ = _state()
+
+    with pytest.raises(RestartAckStateConflict, match="no current"):
+        RestartAckStateReader(store, run_id=RUN_ID).read(receipt, lease)
+
+    _, store, _, lease, _, receipt, _ = _state()
+    different_receipt = replace(
+        receipt,
+        acknowledgement=replace(
+            receipt.acknowledgement,
+            intent_id="intent-b",
+        ),
+        intent_record=replace(
+            receipt.intent_record,
+            intent=replace(
+                receipt.intent_record.intent,
+                intent_id="intent-b",
+            ),
+        ),
+    )
+
+    with pytest.raises(RestartAckStateConflict, match="current restart intent"):
+        RestartAckStateReader(store, run_id=RUN_ID).read(different_receipt, lease)
+
+
+def test_restart_ack_state_reader_rejects_truncated_registration_history():
+    clock, source, _, lease, registration_manager, receipt, _ = _state()
+    clock.set(1_010)
+    renewed = registration_manager.renew(receipt.authenticated_registration)
+    current_receipt = replace(
+        receipt,
+        agent_registration=renewed.record,
+        registration_fencing_token=renewed.fencing_token,
+        registration_granted_at_unix_ms=renewed.granted_at_unix_ms,
+        received_at_unix_ms=clock.now_unix_ms,
+    )
+    store = TruncatedRegistrationHistoryStore(
+        source,
+        registration_manager.registration_key,
+    )
+
+    with pytest.raises(RestartAckStateCorrupt, match="registration history"):
+        RestartAckStateReader(store, run_id=RUN_ID).read(current_receipt, lease)
+
+
+@pytest.mark.parametrize(
+    "dependency_error",
+    [
+        CoordinatorLeaseHistoryError("lease history changed"),
+        GenerationStateError("generation changed"),
+    ],
+)
+def test_restart_ack_state_reader_preserves_open_dependency_contention(
+    dependency_error,
+):
+    _, store, _, lease, _, receipt, _ = _state()
+    reader = RestartAckStateReader(store, run_id=RUN_ID)
+    reader._open_reader = cast(Any, FailingReader(dependency_error))
+
+    with pytest.raises(RestartAckStateConflict, match="dependencies changed"):
+        reader.read(receipt, lease)
+
+
+@pytest.mark.parametrize(
+    ("dependency_error", "error_type"),
+    [
+        (
+            AgentRegistrationHistoryError("registration changed"),
+            RestartAckStateConflict,
+        ),
+        (
+            AgentRegistrationHistoryCorrupt("registration corrupt"),
+            RestartAckStateCorrupt,
+        ),
+        (
+            CoordinatorLeaseHistoryError("lease changed"),
+            RestartAckStateConflict,
+        ),
+    ],
+)
+def test_restart_ack_state_reader_translates_history_errors(
+    dependency_error,
+    error_type,
+):
+    _, store, _, lease, _, receipt, _ = _state()
+    reader = RestartAckStateReader(store, run_id=RUN_ID)
+    if isinstance(dependency_error, AgentRegistrationHistoryError):
+        reader._registration_history_reader = lambda _: cast(
+            Any,
+            FailingReader(dependency_error),
+        )
+    else:
+        reader._lease_history_reader = cast(Any, FailingReader(dependency_error))
+
+    with pytest.raises(error_type):
+        reader.read(receipt, lease)
+
+
+def test_restart_ack_state_reader_validates_input_types_and_runs():
+    _, store, _, lease, _, receipt, _ = _state()
+    reader = RestartAckStateReader(store, run_id=RUN_ID)
+
+    with pytest.raises(TypeError, match="receipt"):
+        reader.read({}, lease)
+    with pytest.raises(TypeError, match="lease"):
+        reader.read(receipt, {})
+    with pytest.raises(ValueError, match="another run"):
+        RestartAckStateReader(store, run_id="other-run").read(receipt, lease)


### PR DESCRIPTION
## Summary
- add a stable, read-only restart-acknowledgement state reader
- double-collect the current open intent, complete agent-registration history, and coordinator-lease history
- require the receipt registration and supplied coordinator lease to remain the exact durable live authorities
- preserve retryable dependency contention separately from persisted corruption
- keep clock/deadline preparation and guarded execution out of this PR

## Why
A restart acknowledgement must not be authorized from a current registration tail alone. This reader consumes the complete registration-history prerequisite and binds the receipt to one stable cross-key dependency snapshot without mutating the control store.

## Validation
- focused acknowledgement/dependency suite: `78 passed`
- full CPU suite: `1929 passed`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- targeted mypy for the new reader and tests
- `git diff --check`
