### PR TITLE
[Feature][Torchrun] Prepare restart acknowledgement writes

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -977,6 +977,10 @@ intent, verified agent-registration history, and durable coordinator-lease
 history. It binds a receipt to the exact current registration and live
 coordinator authority without sampling a clock or mutating the store. Durable
 contradictions fail closed, while repeated-read contention remains retryable.
+The following non-mutating preparer samples a monotonic coordinator clock only
+after authentication, rejects an elapsed registration, coordinator lease, or
+intent window, and chooses the earliest exclusive deadline for the guarded
+receipt transaction.
 
 For a crashed or unreachable node, no preparation is assumed.
 

--- a/lm_resiliency/integrations/torchrun/_restart_ack.py
+++ b/lm_resiliency/integrations/torchrun/_restart_ack.py
@@ -53,6 +53,8 @@ class PreparedRestartAckWrite:
             raise ValueError("PreparedRestartAckWrite deadline exceeds coordinator lease")
         if self.deadline_unix_ms > receipt.intent_record.intent.prepare_deadline_unix_ms:
             raise ValueError("PreparedRestartAckWrite deadline exceeds restart intent")
+        if self.deadline_unix_ms > receipt.registration_expires_at_unix_ms:
+            raise ValueError("PreparedRestartAckWrite deadline exceeds agent registration")
 
     @property
     def lease(self) -> HeldCoordinatorLease:

--- a/lm_resiliency/integrations/torchrun/_restart_ack_preparation.py
+++ b/lm_resiliency/integrations/torchrun/_restart_ack_preparation.py
@@ -1,0 +1,199 @@
+"""Authenticated, non-mutating preparation of restart acknowledgements."""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+from collections.abc import Callable
+
+from lm_resiliency.integrations.torchrun._agent_registration import (
+    agent_registration_key,
+)
+from lm_resiliency.integrations.torchrun._control_store import ControlStore
+from lm_resiliency.integrations.torchrun._coordinator_lease import HeldCoordinatorLease
+from lm_resiliency.integrations.torchrun._restart_ack import PreparedRestartAckWrite
+from lm_resiliency.integrations.torchrun._restart_ack_records import (
+    RestartAckReceiptRecord,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_state import (
+    AuthenticatedRestartAckState,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_state_reader import (
+    RestartAckStateConflict,
+    RestartAckStateCorrupt,
+    RestartAckStateLeaseLost,
+    RestartAckStateReader,
+    RestartAckStateRegistrationLost,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_writes import (
+    RestartAckWriteRecords,
+)
+
+
+class RestartAckPreparationError(RuntimeError):
+    """Base error for restart-acknowledgement preparation."""
+
+
+class RestartAckPreparationConflict(RestartAckPreparationError):
+    """Raised when the restart-intent state changes or is no longer open."""
+
+
+class RestartAckPreparationRegistrationLost(RestartAckPreparationError):
+    """Raised when the authenticated agent registration changed or expired."""
+
+
+class RestartAckPreparationLeaseLost(RestartAckPreparationError):
+    """Raised when the coordinator lease changed or expired."""
+
+
+class RestartAckPreparationDeadlineElapsed(RestartAckPreparationError):
+    """Raised when the restart-intent preparation deadline elapsed."""
+
+
+class RestartAckPreparationClockError(RestartAckPreparationError):
+    """Raised when the coordinator preparation clock is invalid."""
+
+
+class RestartAckPreparationCorrupt(RestartAckPreparationError):
+    """Raised when persisted acknowledgement dependencies are contradictory."""
+
+
+class RestartAckPreparer:
+    """Add a bounded commit window to authenticated acknowledgement state."""
+
+    def __init__(
+        self,
+        store: ControlStore,
+        *,
+        run_id: str,
+        clock: Callable[[], int],
+    ) -> None:
+        self._run_id = _nonempty_string(run_id, "run_id")
+        if not callable(clock):
+            raise TypeError("clock must be callable")
+        self._clock = clock
+        self._clock_lock = threading.Lock()
+        self._last_now_unix_ms = 0
+        self._state_reader = RestartAckStateReader(store, run_id=self._run_id)
+
+    def prepare(
+        self,
+        receipt: RestartAckReceiptRecord,
+        lease: HeldCoordinatorLease,
+    ) -> PreparedRestartAckWrite:
+        """Return authenticated, non-mutating inputs for one receipt write."""
+
+        state = self._read_state(receipt, lease)
+        now_unix_ms = self._now_unix_ms()
+        authoritative_times = (
+            state.receipt.received_at_unix_ms,
+            state.opened.committed_at_unix_ms,
+            state.registration.granted_at_unix_ms,
+            state.coordinator_authority.lease.granted_at_unix_ms,
+        )
+        if now_unix_ms < max(authoritative_times):
+            raise RestartAckPreparationClockError(
+                "restart-acknowledgement preparation clock precedes authoritative state"
+            )
+        if now_unix_ms >= state.registration.expires_at_unix_ms:
+            raise RestartAckPreparationRegistrationLost(
+                "authenticated agent registration expired before preparation"
+            )
+        coordinator_lease = state.coordinator_authority.lease
+        if now_unix_ms >= coordinator_lease.expires_at_unix_ms:
+            raise RestartAckPreparationLeaseLost(
+                "coordinator lease expired before acknowledgement preparation"
+            )
+        intent_deadline = state.receipt.intent_record.intent.prepare_deadline_unix_ms
+        if now_unix_ms >= intent_deadline:
+            raise RestartAckPreparationDeadlineElapsed(
+                "restart-intent preparation deadline elapsed before acknowledgement preparation"
+            )
+        try:
+            records = _write_records(state)
+            return PreparedRestartAckWrite(
+                records=records,
+                coordinator_authority=state.coordinator_authority,
+                not_before_unix_ms=now_unix_ms,
+                deadline_unix_ms=min(
+                    state.registration.expires_at_unix_ms,
+                    coordinator_lease.expires_at_unix_ms,
+                    intent_deadline,
+                ),
+            )
+        except (TypeError, ValueError) as error:
+            raise RestartAckPreparationCorrupt(
+                "persisted state cannot authorize the restart acknowledgement"
+            ) from error
+
+    def _read_state(
+        self,
+        receipt: RestartAckReceiptRecord,
+        lease: HeldCoordinatorLease,
+    ) -> AuthenticatedRestartAckState:
+        try:
+            return self._state_reader.read(receipt, lease)
+        except RestartAckStateRegistrationLost as error:
+            raise RestartAckPreparationRegistrationLost(str(error)) from error
+        except RestartAckStateLeaseLost as error:
+            raise RestartAckPreparationLeaseLost(str(error)) from error
+        except RestartAckStateConflict as error:
+            raise RestartAckPreparationConflict(str(error)) from error
+        except RestartAckStateCorrupt as error:
+            raise RestartAckPreparationCorrupt(str(error)) from error
+
+    def _now_unix_ms(self) -> int:
+        with self._clock_lock:
+            try:
+                now_unix_ms = _positive_integer(
+                    self._clock(),
+                    "restart-acknowledgement preparation clock",
+                )
+            except (TypeError, ValueError) as error:
+                raise RestartAckPreparationClockError(
+                    "restart-acknowledgement preparation clock is invalid"
+                ) from error
+            if now_unix_ms < self._last_now_unix_ms:
+                raise RestartAckPreparationClockError(
+                    "restart-acknowledgement preparation clock moved backward"
+                )
+            self._last_now_unix_ms = now_unix_ms
+            return now_unix_ms
+
+
+def _write_records(state: AuthenticatedRestartAckState) -> RestartAckWriteRecords:
+    acknowledgement = state.receipt.acknowledgement
+    node_digest = hashlib.sha256(acknowledgement.node_id.encode("utf-8")).hexdigest()
+    return RestartAckWriteRecords(
+        receipt=state.receipt,
+        opened=state.opened,
+        acknowledgement_key=(f"{state.opened.prepared.intent_key}/acknowledgements/{node_digest}"),
+        agent_registration_key=agent_registration_key(
+            acknowledgement.run_id,
+            acknowledgement.node_id,
+        ),
+    )
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+def _positive_integer(value: object, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{path} must be a positive integer")
+    return value
+
+
+__all__ = [
+    "RestartAckPreparationClockError",
+    "RestartAckPreparationConflict",
+    "RestartAckPreparationCorrupt",
+    "RestartAckPreparationDeadlineElapsed",
+    "RestartAckPreparationError",
+    "RestartAckPreparationLeaseLost",
+    "RestartAckPreparationRegistrationLost",
+    "RestartAckPreparer",
+]

--- a/tests/unit/test_torchrun_restart_ack.py
+++ b/tests/unit/test_torchrun_restart_ack.py
@@ -161,7 +161,7 @@ def _prepared() -> tuple[
             records=records,
             coordinator_authority=authority,
             not_before_unix_ms=1_000,
-            deadline_unix_ms=1_500,
+            deadline_unix_ms=1_400,
         ),
     )
 
@@ -198,7 +198,7 @@ def test_prepared_restart_ack_accepts_renewed_coordinator_authority():
         prepared,
         coordinator_authority=renewed_authority,
         not_before_unix_ms=1_010,
-        deadline_unix_ms=1_500,
+        deadline_unix_ms=1_400,
     )
 
     assert renewed_prepared.lease == renewed
@@ -299,6 +299,13 @@ def test_prepared_restart_ack_rejects_deadline_after_lease_expiry():
             coordinator_authority=authority,
             deadline_unix_ms=1_500,
         )
+
+
+def test_prepared_restart_ack_rejects_deadline_after_registration_expiry():
+    _, _, _, prepared = _prepared()
+
+    with pytest.raises(ValueError, match="agent registration"):
+        replace(prepared, deadline_unix_ms=1_450)
 
 
 def test_prepared_restart_ack_requires_expected_types():

--- a/tests/unit/test_torchrun_restart_ack_preparation.py
+++ b/tests/unit/test_torchrun_restart_ack_preparation.py
@@ -1,0 +1,325 @@
+"""Contract tests for restart-acknowledgement preparation."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, cast
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._agent_registration import (
+    AgentRegistrationManager,
+)
+from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseManager,
+    HeldCoordinatorLease,
+)
+from lm_resiliency.integrations.torchrun._generation_state import GenerationStateManager
+from lm_resiliency.integrations.torchrun._protocol import (
+    AgentIdentity,
+    RankAssignment,
+    RestartAck,
+    RestartIntent,
+    SlotAssignment,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_preparation import (
+    RestartAckPreparationClockError,
+    RestartAckPreparationConflict,
+    RestartAckPreparationCorrupt,
+    RestartAckPreparationDeadlineElapsed,
+    RestartAckPreparationLeaseLost,
+    RestartAckPreparationRegistrationLost,
+    RestartAckPreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_records import (
+    RestartAckReceiptRecord,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_state_reader import (
+    RestartAckStateConflict,
+    RestartAckStateCorrupt,
+    RestartAckStateLeaseLost,
+    RestartAckStateRegistrationLost,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open import (
+    RestartIntentOpenPreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
+    CommittedInitialRestartIntentOpen,
+    RestartIntentOpenExecutor,
+)
+
+RUN_ID = "training-run"
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+    def set(self, now_unix_ms: int) -> None:
+        with self._lock:
+            self.now_unix_ms = now_unix_ms
+
+
+class FailingStateReader:
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+
+    def read(self, receipt, lease):
+        raise self._error
+
+
+def _state(
+    *,
+    coordinator_lease_duration_ms: int = 1_000,
+    registration_lease_duration_ms: int = 400,
+    intent_deadline_unix_ms: int = 1_500,
+) -> tuple[
+    ManualClock,
+    InMemoryControlStore,
+    CoordinatorLeaseManager,
+    HeldCoordinatorLease,
+    AgentRegistrationManager,
+    RestartAckReceiptRecord,
+    CommittedInitialRestartIntentOpen,
+]:
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    lease_manager = CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id="coordinator-a",
+        lease_duration_ms=coordinator_lease_duration_ms,
+        clock=clock,
+    )
+    lease = lease_manager.acquire()
+    assignment = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=0,
+        assignments=(
+            SlotAssignment(0, "node-a", 0, 2),
+            SlotAssignment(1, "node-b", 2, 2),
+        ),
+        topology_digest="topology-v1",
+    )
+    current = GenerationStateManager(store, run_id=RUN_ID).initialize(
+        lease,
+        assignment,
+    )
+    intent = RestartIntent(
+        intent_id="intent-a",
+        run_id=RUN_ID,
+        generation=0,
+        incident_ids=("incident-a",),
+        reason_code="attributed_sdc",
+        minimum_recovery_mode="recovery_verified",
+        suspected_node_ids=("node-b",),
+        prepare_deadline_unix_ms=intent_deadline_unix_ms,
+    )
+    opened = RestartIntentOpenExecutor(store, run_id=RUN_ID).execute_initial_open(
+        RestartIntentOpenPreparer(
+            store,
+            run_id=RUN_ID,
+            clock=clock,
+        ).prepare_initial_open(lease, current, intent)
+    )
+    registration_manager = AgentRegistrationManager(
+        store,
+        agent_identity=AgentIdentity(
+            run_id=RUN_ID,
+            node_id="node-a",
+            agent_id="agent-a",
+            hostname="host-node-a",
+            local_world_size=2,
+            resource_ids=("gpu-node-a-0", "gpu-node-a-1"),
+            environment_digest="environment-v1",
+        ),
+        lease_duration_ms=registration_lease_duration_ms,
+        clock=clock,
+    )
+    registration = registration_manager.register()
+    receipt = RestartAckReceiptRecord(
+        acknowledgement=RestartAck(
+            intent_id=intent.intent_id,
+            run_id=RUN_ID,
+            node_id="node-a",
+            agent_id="agent-a",
+            generation=0,
+            flushed_step=40,
+            inventory_event_digests={"inventory-a": "b" * 64},
+            transferred_owner_ranks=(0, 1),
+            transferred_peer_ranks=(2, 3),
+            success=True,
+            reason="prepared",
+        ),
+        intent_record=opened.prepared.record,
+        agent_registration=registration.record,
+        registration_fencing_token=registration.fencing_token,
+        registration_granted_at_unix_ms=registration.granted_at_unix_ms,
+        received_at_unix_ms=clock.now_unix_ms,
+    )
+    return (
+        clock,
+        store,
+        lease_manager,
+        lease,
+        registration_manager,
+        receipt,
+        opened,
+    )
+
+
+def test_restart_ack_preparer_adds_window_without_mutating_store():
+    clock, store, lease_manager, lease, registration_manager, receipt, opened = _state()
+    watched_keys = (
+        opened.prepared.intent_key,
+        opened.prepared.intent_head_key,
+        registration_manager.registration_key,
+        lease_manager.lease_key,
+    )
+    histories_before = {key: store.get_history(key) for key in watched_keys}
+
+    prepared = RestartAckPreparer(
+        store,
+        run_id=RUN_ID,
+        clock=clock,
+    ).prepare(receipt, lease)
+
+    assert prepared.records.receipt == receipt
+    assert prepared.records.opened == opened
+    assert prepared.lease == lease
+    assert prepared.not_before_unix_ms == 1_000
+    assert prepared.deadline_unix_ms == 1_400
+    assert {key: store.get_history(key) for key in watched_keys} == histories_before
+
+
+def test_restart_ack_preparer_accepts_live_renewed_coordinator_lease():
+    clock, store, lease_manager, lease, _, receipt, _ = _state()
+    clock.set(1_010)
+    renewed = lease_manager.renew(lease)
+
+    prepared = RestartAckPreparer(
+        store,
+        run_id=RUN_ID,
+        clock=clock,
+    ).prepare(receipt, renewed)
+
+    assert prepared.lease == renewed
+    assert prepared.coordinator_authority.mutation_sequence == 2
+    assert prepared.not_before_unix_ms == 1_010
+
+
+@pytest.mark.parametrize(
+    ("state_kwargs", "now_unix_ms", "error", "message"),
+    [
+        (
+            {"registration_lease_duration_ms": 100},
+            1_100,
+            RestartAckPreparationRegistrationLost,
+            "registration expired",
+        ),
+        (
+            {"coordinator_lease_duration_ms": 100},
+            1_100,
+            RestartAckPreparationLeaseLost,
+            "coordinator lease expired",
+        ),
+        (
+            {
+                "coordinator_lease_duration_ms": 1_000,
+                "registration_lease_duration_ms": 1_000,
+                "intent_deadline_unix_ms": 1_100,
+            },
+            1_100,
+            RestartAckPreparationDeadlineElapsed,
+            "deadline elapsed",
+        ),
+    ],
+)
+def test_restart_ack_preparer_classifies_elapsed_windows(
+    state_kwargs,
+    now_unix_ms,
+    error,
+    message,
+):
+    clock, store, _, lease, _, receipt, _ = _state(**state_kwargs)
+    clock.set(now_unix_ms)
+
+    with pytest.raises(error, match=message):
+        RestartAckPreparer(
+            store,
+            run_id=RUN_ID,
+            clock=clock,
+        ).prepare(receipt, lease)
+
+
+def test_restart_ack_preparer_rejects_clock_before_state_and_rollback():
+    clock, store, _, lease, _, receipt, _ = _state()
+    clock.set(999)
+    preparer = RestartAckPreparer(store, run_id=RUN_ID, clock=clock)
+
+    with pytest.raises(RestartAckPreparationClockError, match="precedes"):
+        preparer.prepare(receipt, lease)
+
+    clock.set(1_000)
+    preparer.prepare(receipt, lease)
+    clock.set(999)
+
+    with pytest.raises(RestartAckPreparationClockError, match="moved backward"):
+        preparer.prepare(receipt, lease)
+
+
+@pytest.mark.parametrize(
+    ("state_error", "preparation_error"),
+    [
+        (RestartAckStateConflict("intent changed"), RestartAckPreparationConflict),
+        (
+            RestartAckStateRegistrationLost("registration changed"),
+            RestartAckPreparationRegistrationLost,
+        ),
+        (RestartAckStateLeaseLost("lease changed"), RestartAckPreparationLeaseLost),
+        (RestartAckStateCorrupt("state corrupt"), RestartAckPreparationCorrupt),
+    ],
+)
+def test_restart_ack_preparer_translates_state_errors(
+    state_error,
+    preparation_error,
+):
+    clock, store, _, lease, _, receipt, _ = _state()
+    preparer = RestartAckPreparer(store, run_id=RUN_ID, clock=clock)
+    preparer._state_reader = cast(Any, FailingStateReader(state_error))
+
+    with pytest.raises(preparation_error):
+        preparer.prepare(receipt, lease)
+
+
+@pytest.mark.parametrize("clock_value", (0, True, "invalid"))
+def test_restart_ack_preparer_rejects_invalid_clock(clock_value):
+    _, store, _, lease, _, receipt, _ = _state()
+
+    with pytest.raises(RestartAckPreparationClockError, match="clock is invalid"):
+        RestartAckPreparer(
+            store,
+            run_id=RUN_ID,
+            clock=lambda: clock_value,
+        ).prepare(receipt, lease)
+
+
+def test_restart_ack_preparer_validates_constructor_and_input_types():
+    clock, store, _, lease, _, receipt, _ = _state()
+
+    with pytest.raises(ValueError, match="run_id"):
+        RestartAckPreparer(store, run_id="", clock=clock)
+    with pytest.raises(TypeError, match="clock"):
+        RestartAckPreparer(store, run_id=RUN_ID, clock=None)
+
+    preparer = RestartAckPreparer(store, run_id=RUN_ID, clock=clock)
+    with pytest.raises(TypeError, match="receipt"):
+        preparer.prepare({}, lease)
+    with pytest.raises(TypeError, match="lease"):
+        preparer.prepare(receipt, {})


### PR DESCRIPTION
## Summary
- add a non-mutating restart-acknowledgement preparer on top of the authenticated state reader
- sample a monotonic coordinator clock only after durable authentication
- classify elapsed agent-registration, coordinator-lease, and restart-intent windows
- choose the earliest exclusive deadline for the guarded acknowledgement transaction
- require `PreparedRestartAckWrite` deadlines to remain within the authenticated registration lifetime
- keep guarded store execution and committed-result verification out of this PR

## Why
The authenticated dependency snapshot is necessary but not sufficient to commit a receipt. Preparation must prove that all three authorities are still live at one coordinator observation time and must carry a store-side deadline that cannot outlive any of them.

## Validation
- focused acknowledgement preparation/write suite: `49 passed`
- full CPU suite: `1944 passed`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- targeted mypy for the changed modules and tests
- `git diff --check`
