### PR TITLE
Preserve restart acknowledgement registration authority

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -953,12 +953,12 @@ The prepared-write authority is one verified durable coordinator-lease value.
 Its commit lower bound must follow the receipt, intent opening, and lease grant;
 its exclusive deadline is bounded by both the restart-intent deadline and the
 lease expiry. This immutable value still performs no store reads or writes.
-The authentication value binds the receipt to the exact committed intent,
-authenticated agent registration, active generation membership, and one
-coordinator-lease authority. It also rejects a receipt that predates the
-authoritative intent-opening commit. This value performs no store reads or
-writes. A following read-only layer constructs it from stable durable state
-before the preparation layer selects a bounded commit window.
+The authentication value binds the receipt to the exact committed intent, the
+complete store-stamped agent-registration authority, active generation
+membership, and one coordinator-lease authority. It also rejects a receipt that
+predates the authoritative intent-opening commit. This value performs no store
+reads or writes. A following read-only layer constructs it from stable durable
+state before the preparation layer selects a bounded commit window.
 
 Each retained agent-registration value is first decoded as one immutable
 authority. The strict decoder binds canonical registration bytes to the
@@ -979,8 +979,9 @@ coordinator authority without sampling a clock or mutating the store. Durable
 contradictions fail closed, while repeated-read contention remains retryable.
 The following non-mutating preparer samples a monotonic coordinator clock only
 after authentication, rejects an elapsed registration, coordinator lease, or
-intent window, and chooses the earliest exclusive deadline for the guarded
-receipt transaction.
+intent window, preserves the exact registration authority used by the atomic
+registration-revision condition, and chooses the earliest exclusive deadline
+for the guarded receipt transaction.
 
 For a crashed or unreachable node, no preparation is assumed.
 

--- a/lm_resiliency/integrations/torchrun/_restart_ack.py
+++ b/lm_resiliency/integrations/torchrun/_restart_ack.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 
+from lm_resiliency.integrations.torchrun._agent_registration_history import (
+    AgentRegistrationAuthority,
+)
+from lm_resiliency.integrations.torchrun._agent_registration_records import (
+    HeldAgentRegistration,
+)
 from lm_resiliency.integrations.torchrun._control_store import ControlStoreWrite
 from lm_resiliency.integrations.torchrun._coordinator_lease import HeldCoordinatorLease
 from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
@@ -20,6 +26,7 @@ class PreparedRestartAckWrite:
     """One immutable acknowledgement write with coordinator authority."""
 
     records: RestartAckWriteRecords
+    registration_authority: AgentRegistrationAuthority
     coordinator_authority: CoordinatorLeaseAuthority
     not_before_unix_ms: int
     deadline_unix_ms: int
@@ -27,6 +34,10 @@ class PreparedRestartAckWrite:
     def __post_init__(self) -> None:
         if not isinstance(self.records, RestartAckWriteRecords):
             raise TypeError("PreparedRestartAckWrite.records must be RestartAckWriteRecords")
+        if not isinstance(self.registration_authority, AgentRegistrationAuthority):
+            raise TypeError(
+                "PreparedRestartAckWrite.registration_authority must be AgentRegistrationAuthority"
+            )
         if not isinstance(self.coordinator_authority, CoordinatorLeaseAuthority):
             raise TypeError(
                 "PreparedRestartAckWrite.coordinator_authority must be CoordinatorLeaseAuthority"
@@ -40,6 +51,17 @@ class PreparedRestartAckWrite:
             "PreparedRestartAckWrite.deadline_unix_ms",
         )
         receipt = self.records.receipt
+        if self.registration != receipt.authenticated_registration:
+            raise ValueError(
+                "PreparedRestartAckWrite receipt does not match its registration authority"
+            )
+        expected_registration_revision = self.records.conditions[
+            self.records.agent_registration_key
+        ]
+        if expected_registration_revision != self.registration.fencing_token:
+            raise ValueError(
+                "PreparedRestartAckWrite registration condition does not match its authority"
+            )
         lease = self.coordinator_authority.lease
         if lease.record.run_id != receipt.acknowledgement.run_id:
             raise ValueError("PreparedRestartAckWrite coordinator lease belongs to another run")
@@ -59,6 +81,10 @@ class PreparedRestartAckWrite:
     @property
     def lease(self) -> HeldCoordinatorLease:
         return self.coordinator_authority.lease
+
+    @property
+    def registration(self) -> HeldAgentRegistration:
+        return self.registration_authority.registration
 
     @property
     def coordinator_lease_key(self) -> str:

--- a/lm_resiliency/integrations/torchrun/_restart_ack_preparation.py
+++ b/lm_resiliency/integrations/torchrun/_restart_ack_preparation.py
@@ -113,6 +113,7 @@ class RestartAckPreparer:
             records = _write_records(state)
             return PreparedRestartAckWrite(
                 records=records,
+                registration_authority=state.registration_authority,
                 coordinator_authority=state.coordinator_authority,
                 not_before_unix_ms=now_unix_ms,
                 deadline_unix_ms=min(

--- a/lm_resiliency/integrations/torchrun/_restart_ack_state.py
+++ b/lm_resiliency/integrations/torchrun/_restart_ack_state.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from lm_resiliency.integrations.torchrun._agent_registration_history import (
+    AgentRegistrationAuthority,
+)
 from lm_resiliency.integrations.torchrun._agent_registration_records import (
     HeldAgentRegistration,
 )
@@ -24,7 +27,7 @@ class AuthenticatedRestartAckState:
 
     receipt: RestartAckReceiptRecord
     opened: CommittedInitialRestartIntentOpen
-    registration: HeldAgentRegistration
+    registration_authority: AgentRegistrationAuthority
     coordinator_authority: CoordinatorLeaseAuthority
 
     def __post_init__(self) -> None:
@@ -34,9 +37,10 @@ class AuthenticatedRestartAckState:
             raise TypeError(
                 "AuthenticatedRestartAckState.opened must be CommittedInitialRestartIntentOpen"
             )
-        if not isinstance(self.registration, HeldAgentRegistration):
+        if not isinstance(self.registration_authority, AgentRegistrationAuthority):
             raise TypeError(
-                "AuthenticatedRestartAckState.registration must be HeldAgentRegistration"
+                "AuthenticatedRestartAckState.registration_authority must be "
+                "AgentRegistrationAuthority"
             )
         if not isinstance(self.coordinator_authority, CoordinatorLeaseAuthority):
             raise TypeError(
@@ -63,6 +67,12 @@ class AuthenticatedRestartAckState:
         )
         if self.receipt.acknowledgement.node_id not in active_node_ids:
             raise ValueError("AuthenticatedRestartAckState acknowledgement node is not active")
+
+    @property
+    def registration(self) -> HeldAgentRegistration:
+        """Return the authenticated held registration."""
+
+        return self.registration_authority.registration
 
 
 __all__ = ["AuthenticatedRestartAckState"]

--- a/lm_resiliency/integrations/torchrun/_restart_ack_state_reader.py
+++ b/lm_resiliency/integrations/torchrun/_restart_ack_state_reader.py
@@ -124,13 +124,14 @@ class RestartAckStateReader:
             raise RestartAckStateRegistrationLost(
                 "authenticated agent registration is no longer current"
             )
+        registration_authority = registration_history.authorities[-1]
         if not lease_history or lease_history[-1].lease != lease:
             raise RestartAckStateLeaseLost("coordinator lease is not the live durable authority")
         try:
             return AuthenticatedRestartAckState(
                 receipt=receipt,
                 opened=opened,
-                registration=registration,
+                registration_authority=registration_authority,
                 coordinator_authority=lease_history[-1],
             )
         except (TypeError, ValueError) as error:

--- a/tests/unit/test_torchrun_restart_ack.py
+++ b/tests/unit/test_torchrun_restart_ack.py
@@ -12,6 +12,9 @@ from lm_resiliency.integrations.torchrun._agent_registration import (
     AgentRegistrationManager,
     agent_registration_key,
 )
+from lm_resiliency.integrations.torchrun._agent_registration_history import (
+    AgentRegistrationAuthority,
+)
 from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
 from lm_resiliency.integrations.torchrun._coordinator_lease import (
     CoordinatorLeaseManager,
@@ -106,7 +109,7 @@ def _prepared() -> tuple[
             clock=clock,
         ).prepare_initial_open(lease, current, intent)
     )
-    registration = AgentRegistrationManager(
+    registration_manager = AgentRegistrationManager(
         store,
         agent_identity=AgentIdentity(
             run_id=RUN_ID,
@@ -119,7 +122,8 @@ def _prepared() -> tuple[
         ),
         lease_duration_ms=400,
         clock=clock,
-    ).register()
+    )
+    registration = registration_manager.register()
     receipt = RestartAckReceiptRecord(
         acknowledgement=RestartAck(
             intent_id="intent-a",
@@ -148,7 +152,9 @@ def _prepared() -> tuple[
         agent_registration_key=agent_registration_key(RUN_ID, "node-a"),
     )
     lease_entry = store.get(lease_manager.lease_key)
+    registration_entry = store.get(registration_manager.registration_key)
     assert lease_entry is not None
+    assert registration_entry is not None
     authority = CoordinatorLeaseAuthority.from_entry(
         lease_entry,
         run_id=RUN_ID,
@@ -159,6 +165,11 @@ def _prepared() -> tuple[
         lease_manager,
         PreparedRestartAckWrite(
             records=records,
+            registration_authority=AgentRegistrationAuthority.from_entry(
+                registration_entry,
+                run_id=RUN_ID,
+                node_id="node-a",
+            ),
             coordinator_authority=authority,
             not_before_unix_ms=1_000,
             deadline_unix_ms=1_400,
@@ -170,6 +181,11 @@ def test_prepared_restart_ack_delegates_immutable_transaction_inputs():
     _, _, _, prepared = _prepared()
 
     assert prepared.lease == prepared.coordinator_authority.lease
+    assert prepared.registration == prepared.records.receipt.authenticated_registration
+    assert (
+        prepared.conditions[prepared.records.agent_registration_key]
+        == prepared.registration_authority.registration.fencing_token
+    )
     assert prepared.coordinator_lease_key == prepared.records.opened.prepared.coordinator_lease_key
     assert prepared.expected_guard_revision == prepared.lease.fencing_token
     assert prepared.writes == prepared.records.writes
@@ -222,6 +238,20 @@ def test_prepared_restart_ack_rejects_cross_run_authority():
 
     with pytest.raises(ValueError, match="another run"):
         replace(prepared, coordinator_authority=authority)
+
+
+def test_prepared_restart_ack_rejects_different_registration_authority():
+    _, _, _, prepared = _prepared()
+    authority = replace(
+        prepared.registration_authority,
+        registration=replace(
+            prepared.registration,
+            fencing_token=prepared.registration.fencing_token + 1,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="registration authority"):
+        replace(prepared, registration_authority=authority)
 
 
 @pytest.mark.parametrize(
@@ -313,5 +343,7 @@ def test_prepared_restart_ack_requires_expected_types():
 
     with pytest.raises(TypeError, match="RestartAckWriteRecords"):
         replace(prepared, records={})
+    with pytest.raises(TypeError, match="AgentRegistrationAuthority"):
+        replace(prepared, registration_authority={})
     with pytest.raises(TypeError, match="CoordinatorLeaseAuthority"):
         replace(prepared, coordinator_authority={})

--- a/tests/unit/test_torchrun_restart_ack_preparation.py
+++ b/tests/unit/test_torchrun_restart_ack_preparation.py
@@ -192,6 +192,8 @@ def test_restart_ack_preparer_adds_window_without_mutating_store():
 
     assert prepared.records.receipt == receipt
     assert prepared.records.opened == opened
+    assert prepared.registration == receipt.authenticated_registration
+    assert prepared.registration_authority.transaction_sequence > 0
     assert prepared.lease == lease
     assert prepared.not_before_unix_ms == 1_000
     assert prepared.deadline_unix_ms == 1_400

--- a/tests/unit/test_torchrun_restart_ack_state.py
+++ b/tests/unit/test_torchrun_restart_ack_state.py
@@ -10,6 +10,9 @@ import pytest
 from lm_resiliency.integrations.torchrun._agent_registration import (
     AgentRegistrationManager,
 )
+from lm_resiliency.integrations.torchrun._agent_registration_history import (
+    AgentRegistrationAuthority,
+)
 from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
 from lm_resiliency.integrations.torchrun._coordinator_lease import (
     CoordinatorLeaseManager,
@@ -96,7 +99,7 @@ def _state(
             clock=clock,
         ).prepare_initial_open(lease, current, intent)
     )
-    registration = AgentRegistrationManager(
+    registration_manager = AgentRegistrationManager(
         store,
         agent_identity=AgentIdentity(
             run_id=RUN_ID,
@@ -109,7 +112,8 @@ def _state(
         ),
         lease_duration_ms=400,
         clock=clock,
-    ).register()
+    )
+    registration = registration_manager.register()
     receipt = RestartAckReceiptRecord(
         acknowledgement=RestartAck(
             intent_id=intent.intent_id,
@@ -131,11 +135,17 @@ def _state(
         received_at_unix_ms=clock.now_unix_ms,
     )
     lease_entry = store.get(lease_manager.lease_key)
+    registration_entry = store.get(registration_manager.registration_key)
     assert lease_entry is not None
+    assert registration_entry is not None
     return store, AuthenticatedRestartAckState(
         receipt=receipt,
         opened=opened,
-        registration=registration,
+        registration_authority=AgentRegistrationAuthority.from_entry(
+            registration_entry,
+            run_id=RUN_ID,
+            node_id=node_id,
+        ),
         coordinator_authority=CoordinatorLeaseAuthority.from_entry(
             lease_entry,
             run_id=RUN_ID,
@@ -155,11 +165,12 @@ def test_authenticated_restart_ack_state_binds_inputs_without_mutation():
 
     assert state.receipt.intent_record == state.opened.prepared.record
     assert state.registration == state.receipt.authenticated_registration
+    assert state.registration_authority.registration == state.registration
     assert state.coordinator_authority.lease.record.run_id == RUN_ID
     assert {key: store.get_history(key) for key in histories_before} == histories_before
 
     with pytest.raises(AttributeError):
-        state.registration = state.registration
+        state.registration_authority = state.registration_authority
 
 
 def test_authenticated_restart_ack_state_rejects_different_intent():
@@ -201,9 +212,12 @@ def test_authenticated_restart_ack_state_rejects_different_registration():
     with pytest.raises(ValueError, match="current registration"):
         replace(
             state,
-            registration=replace(
-                state.registration,
-                fencing_token=state.registration.fencing_token + 1,
+            registration_authority=replace(
+                state.registration_authority,
+                registration=replace(
+                    state.registration,
+                    fencing_token=state.registration.fencing_token + 1,
+                ),
             ),
         )
 
@@ -238,6 +252,6 @@ def test_authenticated_restart_ack_state_requires_expected_types():
     with pytest.raises(TypeError, match="opened"):
         replace(state, opened={})
     with pytest.raises(TypeError, match="registration"):
-        replace(state, registration={})
+        replace(state, registration_authority={})
     with pytest.raises(TypeError, match="coordinator_authority"):
         replace(state, coordinator_authority={})


### PR DESCRIPTION
## Summary

- preserve the complete store-stamped agent-registration authority in authenticated restart-acknowledgement state
- carry that authority into prepared receipt writes while retaining the held-registration convenience property
- bind the atomic registration revision condition to the exact authenticated authority

## Why

The guarded acknowledgement executor must verify that a committed receipt follows the sender registration transaction. A held registration alone drops the transaction, mutation, value, and lifetime lineage required for fail-closed result verification.

## Scope

This PR changes no store mutation or execution behavior. Guarded acknowledgement execution remains a separate follow-up PR.

## Validation

- 85 focused restart-acknowledgement and registration-history tests
- 1,945 full CPU tests with CUDA hidden
- repository-wide Ruff check and format check
- targeted mypy for the changed torchrun modules
- git diff --check