### PR TITLE
Execute guarded restart acknowledgement writes

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -983,6 +983,15 @@ intent window, preserves the exact registration authority used by the atomic
 registration-revision condition, and chooses the earliest exclusive deadline
 for the guarded receipt transaction.
 
+The guarded acknowledgement executor publishes the create-once receipt while
+the intent, current-intent head, agent registration, and coordinator lease
+remain unchanged. Its committed result must match the exact receipt bytes,
+carry the prepared coordinator-lease provenance, remain inside the prepared
+time window, and follow the durable intent opening, registration authority, and
+coordinator authority in store transaction order. Conflicts distinguish
+changed intent state, lost registration, lost coordinator ownership, elapsed
+intent time, and contradictory store time.
+
 For a crashed or unreachable node, no preparation is assumed.
 
 ## API: lm-resiliency to the Framework

--- a/lm_resiliency/integrations/torchrun/_restart_ack_execution.py
+++ b/lm_resiliency/integrations/torchrun/_restart_ack_execution.py
@@ -1,0 +1,199 @@
+"""Guarded execution of prepared restart acknowledgements."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStore,
+    ControlStoreClockError,
+    ControlStoreConflict,
+    ControlStoreDeadlineExceeded,
+    ControlStoreEntry,
+    ControlStoreHistoryConflict,
+    ControlStoreTooEarly,
+)
+from lm_resiliency.integrations.torchrun._restart_ack import PreparedRestartAckWrite
+
+
+class RestartAckExecutionError(RuntimeError):
+    """Base error for committing a prepared restart acknowledgement."""
+
+
+class RestartAckExecutionConflict(RestartAckExecutionError):
+    """Raised when restart-intent state changed before commit."""
+
+
+class RestartAckExecutionRegistrationLost(RestartAckExecutionError):
+    """Raised when the authenticated agent registration changed or expired."""
+
+
+class RestartAckExecutionLeaseLost(RestartAckExecutionError):
+    """Raised when the coordinator lease changed or expired."""
+
+
+class RestartAckExecutionDeadlineElapsed(RestartAckExecutionError):
+    """Raised when the prepared acknowledgement deadline elapsed."""
+
+
+class RestartAckExecutionClockError(RestartAckExecutionError):
+    """Raised when authoritative store time contradicts preparation."""
+
+
+class RestartAckExecutionCorrupt(RestartAckExecutionError):
+    """Raised when the transaction returns contradictory committed state."""
+
+
+@dataclass(frozen=True, slots=True)
+class CommittedRestartAck:
+    """One verified committed restart-acknowledgement receipt."""
+
+    prepared: PreparedRestartAckWrite
+    receipt_entry: ControlStoreEntry
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.prepared, PreparedRestartAckWrite):
+            raise TypeError("CommittedRestartAck.prepared must be PreparedRestartAckWrite")
+        if not isinstance(self.receipt_entry, ControlStoreEntry):
+            raise TypeError("CommittedRestartAck.receipt_entry must be ControlStoreEntry")
+        entry = self.receipt_entry
+        if entry.value != self.prepared.records.receipt.to_json():
+            raise ValueError("CommittedRestartAck receipt does not match its preparation")
+        if (
+            entry.mutation_sequence != 1
+            or entry.value_sequence != 1
+            or entry.lifetime_sequence != 1
+        ):
+            raise ValueError("CommittedRestartAck receipt is not an immutable creation")
+        committed_at_unix_ms = entry.committed_at_unix_ms
+        if committed_at_unix_ms is None:
+            raise ValueError("CommittedRestartAck receipt has no authoritative commit time")
+        authority = self.prepared.coordinator_authority
+        expected_guard_digest = hashlib.sha256(authority.lease.record.to_json()).hexdigest()
+        if (
+            entry.guard_key != self.prepared.coordinator_lease_key
+            or entry.guard_revision != self.prepared.expected_guard_revision
+            or entry.guard_value_digest != expected_guard_digest
+            or entry.guard_committed_at_unix_ms != authority.lease.granted_at_unix_ms
+            or entry.guard_mutation_sequence != authority.mutation_sequence
+            or entry.guard_value_sequence != authority.value_sequence
+            or entry.guard_lifetime_sequence != authority.lifetime_sequence
+        ):
+            raise ValueError("CommittedRestartAck receipt has invalid lease provenance")
+        if (
+            committed_at_unix_ms < self.prepared.not_before_unix_ms
+            or committed_at_unix_ms >= self.prepared.deadline_unix_ms
+        ):
+            raise ValueError("CommittedRestartAck commit is outside its prepared time window")
+        if entry.transaction_sequence <= max(
+            self.prepared.records.opened.transaction_sequence,
+            self.prepared.registration_authority.transaction_sequence,
+            authority.transaction_sequence,
+        ):
+            raise ValueError(
+                "CommittedRestartAck does not follow its intent, registration, and lease"
+            )
+
+    @property
+    def committed_at_unix_ms(self) -> int:
+        committed_at_unix_ms = self.receipt_entry.committed_at_unix_ms
+        if committed_at_unix_ms is None:
+            raise AssertionError("validated restart acknowledgement lost its commit time")
+        return committed_at_unix_ms
+
+    @property
+    def transaction_sequence(self) -> int:
+        return self.receipt_entry.transaction_sequence
+
+
+class RestartAckExecutor:
+    """Commit and verify one prepared restart acknowledgement."""
+
+    def __init__(self, store: ControlStore, *, run_id: str) -> None:
+        self._store = store
+        self._run_id = _nonempty_string(run_id, "run_id")
+
+    def execute(self, prepared: PreparedRestartAckWrite) -> CommittedRestartAck:
+        """Commit and verify one acknowledgement receipt."""
+
+        if not isinstance(prepared, PreparedRestartAckWrite):
+            raise TypeError("prepared must be PreparedRestartAckWrite")
+        if prepared.records.receipt.acknowledgement.run_id != self._run_id:
+            raise ValueError("prepared restart acknowledgement belongs to another run")
+        try:
+            committed = self._store.compare_set_many_guarded(
+                prepared.writes,
+                guard_key=prepared.coordinator_lease_key,
+                expected_guard_revision=prepared.expected_guard_revision,
+                not_before_unix_ms=prepared.not_before_unix_ms,
+                deadline_unix_ms=prepared.deadline_unix_ms,
+                conditions=prepared.conditions,
+            )
+        except ControlStoreConflict as error:
+            if error.key == prepared.coordinator_lease_key:
+                raise RestartAckExecutionLeaseLost(
+                    "coordinator lease changed before restart acknowledgement"
+                ) from error
+            if error.key == prepared.records.agent_registration_key:
+                raise RestartAckExecutionRegistrationLost(
+                    "agent registration changed before restart acknowledgement"
+                ) from error
+            raise RestartAckExecutionConflict(
+                f"restart-acknowledgement state changed at {error.key!r}"
+            ) from error
+        except ControlStoreHistoryConflict as error:
+            raise RestartAckExecutionConflict(
+                f"restart-acknowledgement key {error.key!r} has prior history"
+            ) from error
+        except ControlStoreDeadlineExceeded as error:
+            registration_expiry = prepared.registration.expires_at_unix_ms
+            lease_expiry = prepared.lease.expires_at_unix_ms
+            if prepared.deadline_unix_ms == registration_expiry:
+                raise RestartAckExecutionRegistrationLost(
+                    "agent registration expired before restart acknowledgement"
+                ) from error
+            if prepared.deadline_unix_ms == lease_expiry:
+                raise RestartAckExecutionLeaseLost(
+                    "coordinator lease expired before restart acknowledgement"
+                ) from error
+            raise RestartAckExecutionDeadlineElapsed(
+                "prepared restart-acknowledgement deadline elapsed before commit"
+            ) from error
+        except (ControlStoreTooEarly, ControlStoreClockError) as error:
+            raise RestartAckExecutionClockError(
+                "control-store time contradicts restart-acknowledgement preparation"
+            ) from error
+        acknowledgement_key = prepared.records.acknowledgement_key
+        if set(committed) != {acknowledgement_key}:
+            raise RestartAckExecutionCorrupt(
+                "restart-acknowledgement transaction returned an unexpected committed key set"
+            )
+        try:
+            return CommittedRestartAck(
+                prepared=prepared,
+                receipt_entry=committed[acknowledgement_key],
+            )
+        except (TypeError, ValueError) as error:
+            raise RestartAckExecutionCorrupt(
+                "restart-acknowledgement transaction returned contradictory committed state"
+            ) from error
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+__all__ = [
+    "CommittedRestartAck",
+    "RestartAckExecutionClockError",
+    "RestartAckExecutionConflict",
+    "RestartAckExecutionCorrupt",
+    "RestartAckExecutionDeadlineElapsed",
+    "RestartAckExecutionError",
+    "RestartAckExecutionLeaseLost",
+    "RestartAckExecutionRegistrationLost",
+    "RestartAckExecutor",
+]

--- a/tests/unit/test_torchrun_restart_ack_execution.py
+++ b/tests/unit/test_torchrun_restart_ack_execution.py
@@ -1,0 +1,363 @@
+"""Contract tests for guarded restart-acknowledgement execution."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Collection, Mapping
+from dataclasses import replace
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._agent_registration import (
+    AgentRegistrationManager,
+)
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStoreEntry,
+    ControlStoreWrite,
+    InMemoryControlStore,
+)
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseManager,
+)
+from lm_resiliency.integrations.torchrun._generation_state import GenerationStateManager
+from lm_resiliency.integrations.torchrun._protocol import (
+    AgentIdentity,
+    RankAssignment,
+    RestartAck,
+    RestartIntent,
+    SlotAssignment,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_execution import (
+    RestartAckExecutionClockError,
+    RestartAckExecutionConflict,
+    RestartAckExecutionCorrupt,
+    RestartAckExecutionDeadlineElapsed,
+    RestartAckExecutionLeaseLost,
+    RestartAckExecutionRegistrationLost,
+    RestartAckExecutor,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_preparation import (
+    RestartAckPreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_records import (
+    RestartAckReceiptRecord,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open import (
+    RestartIntentOpenPreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
+    RestartIntentOpenExecutor,
+)
+
+RUN_ID = "training-run"
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+    def set(self, now_unix_ms: int) -> None:
+        with self._lock:
+            self.now_unix_ms = now_unix_ms
+
+
+class TamperedAckResultStore(InMemoryControlStore):
+    def __init__(self, *, clock: ManualClock, tamper: str) -> None:
+        super().__init__(clock=clock)
+        self._tamper = tamper
+
+    def compare_set_many_guarded(
+        self,
+        writes: Mapping[str, ControlStoreWrite],
+        *,
+        guard_key: str,
+        expected_guard_revision: int,
+        not_before_unix_ms: int,
+        deadline_unix_ms: int,
+        conditions: Mapping[str, int | None] | None = None,
+        never_created_conditions: Collection[str] | None = None,
+    ) -> Mapping[str, ControlStoreEntry]:
+        committed = dict(
+            super().compare_set_many_guarded(
+                writes,
+                guard_key=guard_key,
+                expected_guard_revision=expected_guard_revision,
+                not_before_unix_ms=not_before_unix_ms,
+                deadline_unix_ms=deadline_unix_ms,
+                conditions=conditions,
+                never_created_conditions=never_created_conditions,
+            )
+        )
+        acknowledgement_keys = [key for key in committed if "/acknowledgements/" in key]
+        if not acknowledgement_keys:
+            return committed
+        acknowledgement_key = acknowledgement_keys[0]
+        if self._tamper == "missing":
+            return {}
+        if self._tamper == "unexpected":
+            committed[f"{acknowledgement_key}/extra"] = committed[acknowledgement_key]
+        elif self._tamper == "value":
+            committed[acknowledgement_key] = replace(
+                committed[acknowledgement_key],
+                value=b"{}",
+            )
+        elif self._tamper == "lineage":
+            committed[acknowledgement_key] = replace(
+                committed[acknowledgement_key],
+                mutation_sequence=2,
+                value_sequence=2,
+            )
+        elif self._tamper == "guard":
+            committed[acknowledgement_key] = replace(
+                committed[acknowledgement_key],
+                guard_value_digest="0" * 64,
+            )
+        elif self._tamper == "time":
+            committed[acknowledgement_key] = replace(
+                committed[acknowledgement_key],
+                committed_at_unix_ms=None,
+            )
+        elif self._tamper == "order":
+            committed[acknowledgement_key] = replace(
+                committed[acknowledgement_key],
+                transaction_sequence=1,
+            )
+        else:
+            raise AssertionError(f"unsupported tamper {self._tamper!r}")
+        return committed
+
+
+def _state(
+    *,
+    tamper: str | None = None,
+    coordinator_lease_duration_ms: int = 1_000,
+    registration_lease_duration_ms: int = 400,
+    intent_deadline_unix_ms: int = 1_500,
+):
+    clock = ManualClock()
+    store = (
+        InMemoryControlStore(clock=clock)
+        if tamper is None
+        else TamperedAckResultStore(clock=clock, tamper=tamper)
+    )
+    lease_manager = CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id="coordinator-a",
+        lease_duration_ms=coordinator_lease_duration_ms,
+        clock=clock,
+    )
+    lease = lease_manager.acquire()
+    assignment = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=0,
+        assignments=(
+            SlotAssignment(0, "node-a", 0, 2),
+            SlotAssignment(1, "node-b", 2, 2),
+        ),
+        topology_digest="topology-v1",
+    )
+    current = GenerationStateManager(store, run_id=RUN_ID).initialize(
+        lease,
+        assignment,
+    )
+    intent = RestartIntent(
+        intent_id="intent-a",
+        run_id=RUN_ID,
+        generation=0,
+        incident_ids=("incident-a",),
+        reason_code="attributed_sdc",
+        minimum_recovery_mode="recovery_verified",
+        suspected_node_ids=("node-b",),
+        prepare_deadline_unix_ms=intent_deadline_unix_ms,
+    )
+    opened = RestartIntentOpenExecutor(store, run_id=RUN_ID).execute_initial_open(
+        RestartIntentOpenPreparer(
+            store,
+            run_id=RUN_ID,
+            clock=clock,
+        ).prepare_initial_open(lease, current, intent)
+    )
+    registration_manager = AgentRegistrationManager(
+        store,
+        agent_identity=AgentIdentity(
+            run_id=RUN_ID,
+            node_id="node-a",
+            agent_id="agent-a",
+            hostname="host-node-a",
+            local_world_size=2,
+            resource_ids=("gpu-node-a-0", "gpu-node-a-1"),
+            environment_digest="environment-v1",
+        ),
+        lease_duration_ms=registration_lease_duration_ms,
+        clock=clock,
+    )
+    registration = registration_manager.register()
+    receipt = RestartAckReceiptRecord(
+        acknowledgement=RestartAck(
+            intent_id=intent.intent_id,
+            run_id=RUN_ID,
+            node_id="node-a",
+            agent_id="agent-a",
+            generation=0,
+            flushed_step=40,
+            inventory_event_digests={"inventory-a": "b" * 64},
+            transferred_owner_ranks=(0, 1),
+            transferred_peer_ranks=(2, 3),
+            success=True,
+            reason="prepared",
+        ),
+        intent_record=opened.prepared.record,
+        agent_registration=registration.record,
+        registration_fencing_token=registration.fencing_token,
+        registration_granted_at_unix_ms=registration.granted_at_unix_ms,
+        received_at_unix_ms=clock.now_unix_ms,
+    )
+    prepared = RestartAckPreparer(
+        store,
+        run_id=RUN_ID,
+        clock=clock,
+    ).prepare(receipt, lease)
+    return (
+        clock,
+        store,
+        lease_manager,
+        lease,
+        registration_manager,
+        registration,
+        prepared,
+    )
+
+
+def test_restart_ack_executor_commits_and_verifies_receipt():
+    _, store, _, _, _, _, prepared = _state()
+
+    committed = RestartAckExecutor(store, run_id=RUN_ID).execute(prepared)
+
+    assert committed.prepared == prepared
+    assert committed.receipt_entry == store.get(prepared.records.acknowledgement_key)
+    assert committed.committed_at_unix_ms == 1_000
+    assert committed.transaction_sequence > max(
+        prepared.records.opened.transaction_sequence,
+        prepared.registration_authority.transaction_sequence,
+        prepared.coordinator_authority.transaction_sequence,
+    )
+
+
+def test_restart_ack_executor_rejects_changed_intent_and_duplicate_execution():
+    _, store, _, _, _, _, prepared = _state()
+    intent_entry = store.get(prepared.records.opened.prepared.intent_key)
+    assert intent_entry is not None
+    store.compare_set(
+        prepared.records.opened.prepared.intent_key,
+        expected_revision=intent_entry.revision,
+        value=intent_entry.value,
+    )
+    executor = RestartAckExecutor(store, run_id=RUN_ID)
+
+    with pytest.raises(RestartAckExecutionConflict, match="state changed"):
+        executor.execute(prepared)
+
+    _, store, _, _, _, _, prepared = _state()
+    executor = RestartAckExecutor(store, run_id=RUN_ID)
+    executor.execute(prepared)
+    with pytest.raises(RestartAckExecutionConflict):
+        executor.execute(prepared)
+
+
+def test_restart_ack_executor_rejects_changed_registration():
+    clock, store, _, _, registration_manager, registration, prepared = _state()
+    clock.set(1_010)
+    registration_manager.renew(registration)
+
+    with pytest.raises(RestartAckExecutionRegistrationLost, match="changed"):
+        RestartAckExecutor(store, run_id=RUN_ID).execute(prepared)
+
+
+def test_restart_ack_executor_rejects_changed_lease():
+    clock, store, lease_manager, lease, _, _, prepared = _state()
+    clock.set(1_010)
+    lease_manager.renew(lease)
+
+    with pytest.raises(RestartAckExecutionLeaseLost, match="changed"):
+        RestartAckExecutor(store, run_id=RUN_ID).execute(prepared)
+
+
+@pytest.mark.parametrize(
+    ("state_kwargs", "expected_error"),
+    [
+        (
+            {"registration_lease_duration_ms": 100},
+            RestartAckExecutionRegistrationLost,
+        ),
+        (
+            {
+                "registration_lease_duration_ms": 1_000,
+                "coordinator_lease_duration_ms": 100,
+            },
+            RestartAckExecutionLeaseLost,
+        ),
+        (
+            {
+                "registration_lease_duration_ms": 1_000,
+                "coordinator_lease_duration_ms": 1_000,
+                "intent_deadline_unix_ms": 1_100,
+            },
+            RestartAckExecutionDeadlineElapsed,
+        ),
+    ],
+)
+def test_restart_ack_executor_classifies_elapsed_deadline(
+    state_kwargs,
+    expected_error,
+):
+    clock, store, _, _, _, _, prepared = _state(**state_kwargs)
+    clock.set(prepared.deadline_unix_ms)
+
+    with pytest.raises(expected_error):
+        RestartAckExecutor(store, run_id=RUN_ID).execute(prepared)
+
+
+def test_restart_ack_executor_reports_defensively_shortened_deadline():
+    clock, store, _, _, _, _, prepared = _state()
+    prepared = replace(prepared, deadline_unix_ms=1_050)
+    clock.set(prepared.deadline_unix_ms)
+
+    with pytest.raises(RestartAckExecutionDeadlineElapsed):
+        RestartAckExecutor(store, run_id=RUN_ID).execute(prepared)
+
+
+def test_restart_ack_executor_rejects_store_time_before_preparation():
+    _, store, _, _, _, _, prepared = _state()
+    prepared = replace(
+        prepared,
+        not_before_unix_ms=1_010,
+    )
+
+    with pytest.raises(RestartAckExecutionClockError, match="contradicts"):
+        RestartAckExecutor(store, run_id=RUN_ID).execute(prepared)
+
+
+@pytest.mark.parametrize(
+    "tamper",
+    ("missing", "unexpected", "value", "lineage", "guard", "time", "order"),
+)
+def test_restart_ack_executor_rejects_tampered_results(tamper: str):
+    _, store, _, _, _, _, prepared = _state(tamper=tamper)
+
+    with pytest.raises(RestartAckExecutionCorrupt):
+        RestartAckExecutor(store, run_id=RUN_ID).execute(prepared)
+
+
+def test_restart_ack_executor_validates_run_and_input_type():
+    _, store, _, _, _, _, prepared = _state()
+
+    with pytest.raises(ValueError, match="another run"):
+        RestartAckExecutor(store, run_id="other-run").execute(prepared)
+    with pytest.raises(TypeError, match="prepared"):
+        RestartAckExecutor(store, run_id=RUN_ID).execute({})


### PR DESCRIPTION
## Summary

- add guarded execution for prepared restart-acknowledgement receipts
- classify intent, registration, lease, deadline, and clock failures independently
- verify exact receipt bytes, immutable creation lineage, coordinator guard provenance, commit window, and transaction ordering

## Scope

This PR commits one already-prepared acknowledgement receipt. It does not add acknowledgement collection, quorum decisions, restart-plan selection, or runtime activation.

## Validation

- 100 focused acknowledgement execution, preparation, state, and control-store tests
- 1,962 full CPU tests with CUDA hidden
- repository-wide Ruff check and format check
- targeted mypy for the executor
- git diff --check