### PR TITLE
Decode persisted restart acknowledgements

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -992,6 +992,14 @@ coordinator authority in store transaction order. Conflicts distinguish
 changed intent state, lost registration, lost coordinator ownership, elapsed
 intent time, and contradictory store time.
 
+After coordinator failover, one strict persisted-receipt value reconstructs a
+committed acknowledgement from its canonical store entry, committed intent
+opening, complete agent-registration authority, and coordinator authority. It
+requires immutable key lineage, exact guard provenance, active generation
+membership, causal transaction order, and a commit inside all three authority
+windows. It performs no store reads; a following stable reader supplies the
+durable dependencies before acknowledgement collection or quorum logic.
+
 For a crashed or unreachable node, no preparation is assumed.
 
 ## API: lm-resiliency to the Framework

--- a/lm_resiliency/integrations/torchrun/_restart_ack_persisted.py
+++ b/lm_resiliency/integrations/torchrun/_restart_ack_persisted.py
@@ -1,0 +1,161 @@
+"""Canonical persisted restart-acknowledgement state."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+from lm_resiliency.integrations.torchrun._agent_registration_history import (
+    AgentRegistrationAuthority,
+)
+from lm_resiliency.integrations.torchrun._control_store import ControlStoreEntry
+from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
+    CoordinatorLeaseAuthority,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_records import (
+    RestartAckReceiptRecord,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
+    CommittedInitialRestartIntentOpen,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PersistedRestartAck:
+    """One committed receipt authenticated against durable dependencies."""
+
+    receipt: RestartAckReceiptRecord
+    receipt_entry: ControlStoreEntry
+    opened: CommittedInitialRestartIntentOpen
+    registration_authority: AgentRegistrationAuthority
+    coordinator_authority: CoordinatorLeaseAuthority
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.receipt, RestartAckReceiptRecord):
+            raise TypeError("PersistedRestartAck.receipt must be RestartAckReceiptRecord")
+        if not isinstance(self.receipt_entry, ControlStoreEntry):
+            raise TypeError("PersistedRestartAck.receipt_entry must be ControlStoreEntry")
+        if not isinstance(self.opened, CommittedInitialRestartIntentOpen):
+            raise TypeError("PersistedRestartAck.opened must be CommittedInitialRestartIntentOpen")
+        if not isinstance(self.registration_authority, AgentRegistrationAuthority):
+            raise TypeError(
+                "PersistedRestartAck.registration_authority must be AgentRegistrationAuthority"
+            )
+        if not isinstance(self.coordinator_authority, CoordinatorLeaseAuthority):
+            raise TypeError(
+                "PersistedRestartAck.coordinator_authority must be CoordinatorLeaseAuthority"
+            )
+        self._validate_records()
+        self._validate_entry()
+
+    @classmethod
+    def from_entry(
+        cls,
+        *,
+        run_id: str,
+        receipt_entry: ControlStoreEntry,
+        opened: CommittedInitialRestartIntentOpen,
+        registration_authority: AgentRegistrationAuthority,
+        coordinator_authority: CoordinatorLeaseAuthority,
+    ) -> PersistedRestartAck:
+        """Decode and authenticate one persisted acknowledgement receipt."""
+
+        normalized_run_id = _nonempty_string(run_id, "run_id")
+        if not isinstance(receipt_entry, ControlStoreEntry):
+            raise TypeError("receipt_entry must be ControlStoreEntry")
+        try:
+            receipt = RestartAckReceiptRecord.from_json(receipt_entry.value)
+        except (TypeError, ValueError) as error:
+            raise ValueError("persisted restart acknowledgement is malformed") from error
+        persisted = cls(
+            receipt=receipt,
+            receipt_entry=receipt_entry,
+            opened=opened,
+            registration_authority=registration_authority,
+            coordinator_authority=coordinator_authority,
+        )
+        if persisted.receipt.acknowledgement.run_id != normalized_run_id:
+            raise ValueError("persisted restart acknowledgement belongs to another run")
+        return persisted
+
+    @property
+    def committed_at_unix_ms(self) -> int:
+        committed_at_unix_ms = self.receipt_entry.committed_at_unix_ms
+        if committed_at_unix_ms is None:
+            raise AssertionError("validated restart acknowledgement lost its commit time")
+        return committed_at_unix_ms
+
+    @property
+    def transaction_sequence(self) -> int:
+        return self.receipt_entry.transaction_sequence
+
+    def _validate_records(self) -> None:
+        if self.receipt.intent_record != self.opened.prepared.record:
+            raise ValueError("PersistedRestartAck does not answer its committed restart intent")
+        if self.receipt.received_at_unix_ms < self.opened.committed_at_unix_ms:
+            raise ValueError("PersistedRestartAck receipt predates its committed restart intent")
+        if self.receipt.authenticated_registration != self.registration_authority.registration:
+            raise ValueError("PersistedRestartAck does not match its agent-registration authority")
+        run_id = self.receipt.acknowledgement.run_id
+        if self.coordinator_authority.lease.record.run_id != run_id:
+            raise ValueError("PersistedRestartAck coordinator authority belongs to another run")
+        active_node_ids = set(
+            self.opened.prepared.current.snapshot.record.assignment.slot_to_node_id.values()
+        )
+        if self.receipt.acknowledgement.node_id not in active_node_ids:
+            raise ValueError("PersistedRestartAck acknowledgement node is not active")
+
+    def _validate_entry(self) -> None:
+        entry = self.receipt_entry
+        if entry.value != self.receipt.to_json():
+            raise ValueError("PersistedRestartAck receipt entry is noncanonical")
+        if (
+            entry.mutation_sequence != 1
+            or entry.value_sequence != 1
+            or entry.lifetime_sequence != 1
+        ):
+            raise ValueError("PersistedRestartAck receipt entry is not an immutable creation")
+        if entry.committed_at_unix_ms is None:
+            raise ValueError("PersistedRestartAck receipt entry has no authoritative commit time")
+        authority = self.coordinator_authority
+        expected_guard_digest = hashlib.sha256(authority.lease.record.to_json()).hexdigest()
+        if (
+            entry.guard_key != self.opened.prepared.coordinator_lease_key
+            or entry.guard_revision != authority.lease.fencing_token
+            or entry.guard_value_digest != expected_guard_digest
+            or entry.guard_committed_at_unix_ms != authority.lease.granted_at_unix_ms
+            or entry.guard_mutation_sequence != authority.mutation_sequence
+            or entry.guard_value_sequence != authority.value_sequence
+            or entry.guard_lifetime_sequence != authority.lifetime_sequence
+        ):
+            raise ValueError("PersistedRestartAck receipt entry has invalid lease provenance")
+        if self.transaction_sequence <= max(
+            self.opened.transaction_sequence,
+            self.registration_authority.transaction_sequence,
+            authority.transaction_sequence,
+        ):
+            raise ValueError(
+                "PersistedRestartAck does not follow its intent, registration, and lease"
+            )
+        lower_bound = max(
+            self.receipt.received_at_unix_ms,
+            self.opened.committed_at_unix_ms,
+            self.registration_authority.registration.granted_at_unix_ms,
+            authority.lease.granted_at_unix_ms,
+        )
+        upper_bound = min(
+            self.receipt.intent_record.intent.prepare_deadline_unix_ms,
+            self.registration_authority.registration.expires_at_unix_ms,
+            authority.lease.expires_at_unix_ms,
+        )
+        if self.committed_at_unix_ms < lower_bound or self.committed_at_unix_ms >= upper_bound:
+            raise ValueError("PersistedRestartAck commit is outside its authority window")
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+__all__ = ["PersistedRestartAck"]

--- a/tests/unit/test_torchrun_restart_ack_persisted.py
+++ b/tests/unit/test_torchrun_restart_ack_persisted.py
@@ -1,0 +1,296 @@
+"""Contract tests for canonical persisted restart acknowledgements."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import replace
+from typing import Any, cast
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._agent_registration import (
+    AgentRegistrationManager,
+)
+from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseManager,
+)
+from lm_resiliency.integrations.torchrun._generation_state import GenerationStateManager
+from lm_resiliency.integrations.torchrun._protocol import (
+    AgentIdentity,
+    RankAssignment,
+    RestartAck,
+    RestartIntent,
+    SlotAssignment,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_execution import (
+    RestartAckExecutor,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_persisted import (
+    PersistedRestartAck,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_preparation import (
+    RestartAckPreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_records import (
+    RestartAckReceiptRecord,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open import (
+    RestartIntentOpenPreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
+    RestartIntentOpenExecutor,
+)
+
+RUN_ID = "training-run"
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+
+def _persisted() -> PersistedRestartAck:
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    lease = CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id="coordinator-a",
+        lease_duration_ms=1_000,
+        clock=clock,
+    ).acquire()
+    assignment = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=0,
+        assignments=(
+            SlotAssignment(0, "node-a", 0, 2),
+            SlotAssignment(1, "node-b", 2, 2),
+        ),
+        topology_digest="topology-v1",
+    )
+    current = GenerationStateManager(store, run_id=RUN_ID).initialize(
+        lease,
+        assignment,
+    )
+    intent = RestartIntent(
+        intent_id="intent-a",
+        run_id=RUN_ID,
+        generation=0,
+        incident_ids=("incident-a",),
+        reason_code="attributed_sdc",
+        minimum_recovery_mode="recovery_verified",
+        suspected_node_ids=("node-b",),
+        prepare_deadline_unix_ms=1_500,
+    )
+    opened = RestartIntentOpenExecutor(store, run_id=RUN_ID).execute_initial_open(
+        RestartIntentOpenPreparer(
+            store,
+            run_id=RUN_ID,
+            clock=clock,
+        ).prepare_initial_open(lease, current, intent)
+    )
+    registration = AgentRegistrationManager(
+        store,
+        agent_identity=AgentIdentity(
+            run_id=RUN_ID,
+            node_id="node-a",
+            agent_id="agent-a",
+            hostname="host-node-a",
+            local_world_size=2,
+            resource_ids=("gpu-node-a-0", "gpu-node-a-1"),
+            environment_digest="environment-v1",
+        ),
+        lease_duration_ms=400,
+        clock=clock,
+    ).register()
+    receipt = RestartAckReceiptRecord(
+        acknowledgement=RestartAck(
+            intent_id=intent.intent_id,
+            run_id=RUN_ID,
+            node_id="node-a",
+            agent_id="agent-a",
+            generation=0,
+            flushed_step=40,
+            inventory_event_digests={"inventory-a": "b" * 64},
+            transferred_owner_ranks=(0, 1),
+            transferred_peer_ranks=(2, 3),
+            success=True,
+            reason="prepared",
+        ),
+        intent_record=opened.prepared.record,
+        agent_registration=registration.record,
+        registration_fencing_token=registration.fencing_token,
+        registration_granted_at_unix_ms=registration.granted_at_unix_ms,
+        received_at_unix_ms=clock.now_unix_ms,
+    )
+    prepared = RestartAckPreparer(
+        store,
+        run_id=RUN_ID,
+        clock=clock,
+    ).prepare(receipt, lease)
+    committed = RestartAckExecutor(store, run_id=RUN_ID).execute(prepared)
+    return PersistedRestartAck.from_entry(
+        run_id=RUN_ID,
+        receipt_entry=committed.receipt_entry,
+        opened=prepared.records.opened,
+        registration_authority=prepared.registration_authority,
+        coordinator_authority=prepared.coordinator_authority,
+    )
+
+
+def test_persisted_restart_ack_decodes_one_canonical_receipt():
+    persisted = _persisted()
+
+    assert persisted.receipt_entry.value == persisted.receipt.to_json()
+    assert persisted.receipt.intent_record == persisted.opened.prepared.record
+    assert (
+        persisted.receipt.authenticated_registration
+        == persisted.registration_authority.registration
+    )
+    assert persisted.committed_at_unix_ms == 1_000
+    assert persisted.transaction_sequence > persisted.opened.transaction_sequence
+
+
+def test_persisted_restart_ack_is_immutable():
+    persisted = _persisted()
+
+    with pytest.raises(AttributeError):
+        persisted.receipt_entry = persisted.receipt_entry
+
+
+def test_persisted_restart_ack_rejects_malformed_or_noncanonical_receipt():
+    persisted = _persisted()
+
+    with pytest.raises(ValueError, match="malformed"):
+        PersistedRestartAck.from_entry(
+            run_id=RUN_ID,
+            receipt_entry=replace(persisted.receipt_entry, value=b"{}"),
+            opened=persisted.opened,
+            registration_authority=persisted.registration_authority,
+            coordinator_authority=persisted.coordinator_authority,
+        )
+
+    with pytest.raises(ValueError, match="noncanonical"):
+        replace(
+            persisted,
+            receipt_entry=replace(
+                persisted.receipt_entry,
+                value=b" " + persisted.receipt.to_json(),
+            ),
+        )
+
+
+def test_persisted_restart_ack_rejects_wrong_intent_or_registration():
+    persisted = _persisted()
+
+    with pytest.raises(ValueError, match="restart intent"):
+        replace(
+            persisted,
+            receipt=replace(
+                persisted.receipt,
+                intent_record=replace(
+                    persisted.receipt.intent_record,
+                    intent=replace(
+                        persisted.receipt.intent_record.intent,
+                        intent_id="intent-b",
+                    ),
+                ),
+            ),
+        )
+    with pytest.raises(ValueError, match="registration authority"):
+        replace(
+            persisted,
+            registration_authority=replace(
+                persisted.registration_authority,
+                registration=replace(
+                    persisted.registration_authority.registration,
+                    fencing_token=persisted.registration_authority.registration.fencing_token + 1,
+                ),
+            ),
+        )
+
+
+def test_persisted_restart_ack_rejects_receipt_before_intent_opening():
+    persisted = _persisted()
+    later_opened = replace(
+        persisted.opened,
+        intent_entry=replace(
+            persisted.opened.intent_entry,
+            committed_at_unix_ms=persisted.receipt.received_at_unix_ms + 1,
+        ),
+        head_entry=replace(
+            persisted.opened.head_entry,
+            committed_at_unix_ms=persisted.receipt.received_at_unix_ms + 1,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="predates"):
+        replace(persisted, opened=later_opened)
+
+
+def test_persisted_restart_ack_rejects_cross_run_coordinator_authority():
+    persisted = _persisted()
+
+    with pytest.raises(ValueError, match="another run"):
+        replace(
+            persisted,
+            coordinator_authority=replace(
+                persisted.coordinator_authority,
+                lease=replace(
+                    persisted.coordinator_authority.lease,
+                    record=replace(
+                        persisted.coordinator_authority.lease.record,
+                        run_id="other-run",
+                    ),
+                ),
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    ("entry_changes", "message"),
+    [
+        ({"mutation_sequence": 2, "value_sequence": 2}, "immutable creation"),
+        ({"guard_value_digest": "0" * 64}, "lease provenance"),
+        ({"transaction_sequence": 1}, "does not follow"),
+        ({"committed_at_unix_ms": None}, "commit time"),
+        ({"committed_at_unix_ms": 1_500}, "authority window"),
+    ],
+)
+def test_persisted_restart_ack_rejects_invalid_entry(entry_changes, message):
+    persisted = _persisted()
+
+    with pytest.raises(ValueError, match=message):
+        replace(
+            persisted,
+            receipt_entry=replace(persisted.receipt_entry, **entry_changes),
+        )
+
+
+def test_persisted_restart_ack_requires_expected_types_and_run():
+    persisted = _persisted()
+
+    with pytest.raises(TypeError, match="receipt"):
+        replace(persisted, receipt={})
+    with pytest.raises(TypeError, match="ControlStoreEntry"):
+        PersistedRestartAck.from_entry(
+            run_id=RUN_ID,
+            receipt_entry=cast(Any, {}),
+            opened=persisted.opened,
+            registration_authority=persisted.registration_authority,
+            coordinator_authority=persisted.coordinator_authority,
+        )
+    with pytest.raises(ValueError, match="another run"):
+        PersistedRestartAck.from_entry(
+            run_id="other-run",
+            receipt_entry=persisted.receipt_entry,
+            opened=persisted.opened,
+            registration_authority=persisted.registration_authority,
+            coordinator_authority=persisted.coordinator_authority,
+        )


### PR DESCRIPTION
## Summary

- add a strict restart-safe decoder for one committed acknowledgement receipt
- bind canonical receipt bytes to the committed intent, full agent-registration authority, and coordinator authority
- enforce immutable key lineage, guard provenance, active-node scope, causal order, and authority time windows

## Scope

This PR performs no store reads and adds no acknowledgement collection or quorum logic. A later stable reader will supply the durable dependencies after coordinator failover.

## Validation

- 119 focused persisted receipt, execution, record, registration-authority, and coordinator-authority tests
- 1,974 full CPU tests with CUDA hidden
- repository-wide Ruff check and format check
- targeted mypy for the decoder
- git diff --check