### PR TITLE
Read persisted restart acknowledgements

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1000,6 +1000,14 @@ membership, causal transaction order, and a commit inside all three authority
 windows. It performs no store reads; a following stable reader supplies the
 durable dependencies before acknowledgement collection or quorum logic.
 
+The per-node receipt reader double-collects the current open intent, the
+create-once acknowledgement key, complete agent-registration history, and
+complete coordinator-lease history. A never-created receipt key returns no
+acknowledgement. Deleted, rewritten, malformed, or orphaned receipts fail
+closed. Renewed registrations and coordinator leases do not invalidate an
+already committed receipt because the reader resolves the exact historical
+authorities stamped into that receipt.
+
 For a crashed or unreachable node, no preparation is assumed.
 
 ## API: lm-resiliency to the Framework

--- a/lm_resiliency/integrations/torchrun/_restart_ack_reader.py
+++ b/lm_resiliency/integrations/torchrun/_restart_ack_reader.py
@@ -1,0 +1,284 @@
+"""Stable reads of persisted restart acknowledgements."""
+
+from __future__ import annotations
+
+import hashlib
+
+from lm_resiliency.integrations.torchrun._agent_registration_history import (
+    AgentRegistrationAuthority,
+)
+from lm_resiliency.integrations.torchrun._agent_registration_history_reader import (
+    AgentRegistrationHistory,
+    AgentRegistrationHistoryCorrupt,
+    AgentRegistrationHistoryError,
+    AgentRegistrationHistoryReader,
+)
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStore,
+    ControlStoreEntry,
+)
+from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
+    CoordinatorLeaseAuthority,
+    CoordinatorLeaseHistoryCorrupt,
+    CoordinatorLeaseHistoryError,
+    CoordinatorLeaseHistoryReader,
+)
+from lm_resiliency.integrations.torchrun._generation_reader import (
+    GenerationStateCorrupt,
+    GenerationStateError,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_persisted import (
+    PersistedRestartAck,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_records import (
+    RestartAckReceiptRecord,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
+    CommittedInitialRestartIntentOpen,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_reader import (
+    RestartIntentOpenStateClosed,
+    RestartIntentOpenStateCorrupt,
+    RestartIntentOpenStateError,
+    RestartIntentOpenStateReader,
+)
+
+_MAX_READ_ATTEMPTS = 8
+
+
+class RestartAckReadError(RuntimeError):
+    """Base error for persisted restart-acknowledgement reads."""
+
+
+class RestartAckReadConflict(RestartAckReadError):
+    """Raised when the current restart-intent state changes repeatedly."""
+
+
+class RestartAckReadCorrupt(RestartAckReadError):
+    """Raised when persisted acknowledgement state is contradictory."""
+
+
+class RestartAckReader:
+    """Read one node's receipt for the current restart intent."""
+
+    def __init__(
+        self,
+        store: ControlStore,
+        *,
+        run_id: str,
+        node_id: str,
+    ) -> None:
+        self._store = store
+        self._run_id = _nonempty_string(run_id, "run_id")
+        self._node_id = _nonempty_string(node_id, "node_id")
+        self._open_reader = RestartIntentOpenStateReader(
+            store,
+            run_id=self._run_id,
+        )
+        self._registration_reader = AgentRegistrationHistoryReader(
+            store,
+            run_id=self._run_id,
+            node_id=self._node_id,
+        )
+        self._lease_reader = CoordinatorLeaseHistoryReader(
+            store,
+            run_id=self._run_id,
+        )
+
+    def read(self) -> PersistedRestartAck | None:
+        """Return the current intent's receipt for this node, if committed."""
+
+        for _ in range(_MAX_READ_ATTEMPTS):
+            opened = self._read_open()
+            acknowledgement_key = _acknowledgement_key(opened, self._node_id)
+            receipt_state = self._receipt_state(acknowledgement_key)
+            registration_history = self._read_registration_history()
+            lease_history = self._read_lease_history()
+            if (
+                opened != self._read_open()
+                or receipt_state != self._receipt_state(acknowledgement_key)
+                or registration_history != self._read_registration_history()
+                or lease_history != self._read_lease_history()
+            ):
+                continue
+            receipt_entry = _current_receipt(receipt_state)
+            if receipt_entry is None:
+                return None
+            return self._authenticate(
+                receipt_entry,
+                opened=opened,
+                registration_history=registration_history,
+                lease_history=lease_history,
+            )
+        raise RestartAckReadConflict(
+            "restart-acknowledgement dependencies changed repeatedly during read"
+        )
+
+    def _authenticate(
+        self,
+        receipt_entry: ControlStoreEntry,
+        *,
+        opened: CommittedInitialRestartIntentOpen,
+        registration_history: AgentRegistrationHistory,
+        lease_history: tuple[CoordinatorLeaseAuthority, ...],
+    ) -> PersistedRestartAck:
+        try:
+            receipt = RestartAckReceiptRecord.from_json(receipt_entry.value)
+        except (TypeError, ValueError) as error:
+            raise RestartAckReadCorrupt("persisted restart acknowledgement is malformed") from error
+        if receipt.acknowledgement.node_id != self._node_id:
+            raise RestartAckReadCorrupt("persisted restart acknowledgement belongs to another node")
+        registration_authority = _registration_authority(
+            registration_history,
+            receipt,
+        )
+        coordinator_authority = _coordinator_authority(
+            lease_history,
+            receipt_entry,
+        )
+        try:
+            return PersistedRestartAck(
+                receipt=receipt,
+                receipt_entry=receipt_entry,
+                opened=opened,
+                registration_authority=registration_authority,
+                coordinator_authority=coordinator_authority,
+            )
+        except (TypeError, ValueError) as error:
+            raise RestartAckReadCorrupt(
+                "persisted restart acknowledgement contradicts its durable dependencies"
+            ) from error
+
+    def _read_open(self) -> CommittedInitialRestartIntentOpen:
+        try:
+            opened = self._open_reader.read()
+        except RestartIntentOpenStateClosed as error:
+            raise RestartAckReadConflict(
+                "restart intent closed during acknowledgement read"
+            ) from error
+        except RestartIntentOpenStateCorrupt as error:
+            raise RestartAckReadCorrupt("persisted restart-intent opening is corrupt") from error
+        except RestartIntentOpenStateError as error:
+            raise RestartAckReadConflict(
+                "restart-intent opening changed repeatedly during read"
+            ) from error
+        except (CoordinatorLeaseHistoryCorrupt, GenerationStateCorrupt) as error:
+            raise RestartAckReadCorrupt(
+                "restart-intent opening dependencies are corrupt"
+            ) from error
+        except (CoordinatorLeaseHistoryError, GenerationStateError) as error:
+            raise RestartAckReadConflict(
+                "restart-intent opening dependencies changed repeatedly during read"
+            ) from error
+        if opened is None:
+            raise RestartAckReadConflict("no current restart intent is open")
+        return opened
+
+    def _read_registration_history(self) -> AgentRegistrationHistory:
+        try:
+            return self._registration_reader.read()
+        except AgentRegistrationHistoryCorrupt as error:
+            raise RestartAckReadCorrupt("agent registration history is corrupt") from error
+        except AgentRegistrationHistoryError as error:
+            raise RestartAckReadConflict(
+                "agent registration history changed repeatedly during read"
+            ) from error
+
+    def _read_lease_history(self) -> tuple[CoordinatorLeaseAuthority, ...]:
+        try:
+            return self._lease_reader.read()
+        except CoordinatorLeaseHistoryCorrupt as error:
+            raise RestartAckReadCorrupt("coordinator lease history is corrupt") from error
+        except CoordinatorLeaseHistoryError as error:
+            raise RestartAckReadConflict(
+                "coordinator lease history changed repeatedly during read"
+            ) from error
+
+    def _receipt_state(
+        self,
+        acknowledgement_key: str,
+    ) -> tuple[tuple[ControlStoreEntry, ...], ControlStoreEntry | None, bool]:
+        return (
+            self._store.get_history(acknowledgement_key),
+            self._store.get(acknowledgement_key),
+            self._store.has_history(acknowledgement_key),
+        )
+
+
+def _current_receipt(
+    state: tuple[tuple[ControlStoreEntry, ...], ControlStoreEntry | None, bool],
+) -> ControlStoreEntry | None:
+    history, current, has_history = state
+    if bool(history) != has_history:
+        raise RestartAckReadCorrupt(
+            "restart-acknowledgement history contradicts its durable marker"
+        )
+    if current is None:
+        if history:
+            raise RestartAckReadCorrupt("restart acknowledgement was deleted after commit")
+        return None
+    if len(history) != 1 or history[0] != current:
+        raise RestartAckReadCorrupt("restart acknowledgement is not one immutable creation")
+    return current
+
+
+def _registration_authority(
+    history: AgentRegistrationHistory,
+    receipt: RestartAckReceiptRecord,
+) -> AgentRegistrationAuthority:
+    matches = tuple(
+        authority
+        for authority in history.authorities
+        if authority.registration == receipt.authenticated_registration
+    )
+    if len(matches) != 1:
+        raise RestartAckReadCorrupt(
+            "restart acknowledgement has no unique agent-registration authority"
+        )
+    return matches[0]
+
+
+def _coordinator_authority(
+    history: tuple[CoordinatorLeaseAuthority, ...],
+    receipt_entry: ControlStoreEntry,
+) -> CoordinatorLeaseAuthority:
+    matches = tuple(
+        authority
+        for authority in history
+        if (
+            receipt_entry.guard_revision == authority.lease.fencing_token
+            and receipt_entry.guard_value_digest
+            == hashlib.sha256(authority.lease.record.to_json()).hexdigest()
+            and receipt_entry.guard_committed_at_unix_ms == authority.lease.granted_at_unix_ms
+            and receipt_entry.guard_mutation_sequence == authority.mutation_sequence
+            and receipt_entry.guard_value_sequence == authority.value_sequence
+            and receipt_entry.guard_lifetime_sequence == authority.lifetime_sequence
+        )
+    )
+    if len(matches) != 1:
+        raise RestartAckReadCorrupt(
+            "restart acknowledgement has no unique coordinator-lease authority"
+        )
+    return matches[0]
+
+
+def _acknowledgement_key(
+    opened: CommittedInitialRestartIntentOpen,
+    node_id: str,
+) -> str:
+    node_digest = hashlib.sha256(node_id.encode("utf-8")).hexdigest()
+    return f"{opened.prepared.intent_key}/acknowledgements/{node_digest}"
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+__all__ = [
+    "RestartAckReadConflict",
+    "RestartAckReadCorrupt",
+    "RestartAckReadError",
+    "RestartAckReader",
+]

--- a/tests/unit/test_torchrun_restart_ack_reader.py
+++ b/tests/unit/test_torchrun_restart_ack_reader.py
@@ -1,0 +1,284 @@
+"""Contract tests for stable persisted restart-acknowledgement reads."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import replace
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._agent_registration import (
+    AgentRegistrationManager,
+)
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStoreEntry,
+    InMemoryControlStore,
+)
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseManager,
+)
+from lm_resiliency.integrations.torchrun._generation_state import GenerationStateManager
+from lm_resiliency.integrations.torchrun._protocol import (
+    AgentIdentity,
+    RankAssignment,
+    RestartAck,
+    RestartIntent,
+    SlotAssignment,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_execution import (
+    RestartAckExecutor,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_preparation import (
+    RestartAckPreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_reader import (
+    RestartAckReadConflict,
+    RestartAckReadCorrupt,
+    RestartAckReader,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_records import (
+    RestartAckReceiptRecord,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open import (
+    RestartIntentOpenPreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
+    RestartIntentOpenExecutor,
+)
+
+RUN_ID = "training-run"
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+    def set(self, now_unix_ms: int) -> None:
+        with self._lock:
+            self.now_unix_ms = now_unix_ms
+
+
+class CorruptibleStore(InMemoryControlStore):
+    def replace_current(self, key: str, entry: ControlStoreEntry) -> None:
+        with self._lock:
+            self._entries[key] = entry
+            self._histories[key][-1] = entry
+
+    def drop_history(self, key: str) -> None:
+        with self._lock:
+            self._histories[key] = []
+
+
+def _state(*, commit_receipt: bool):
+    clock = ManualClock()
+    store = CorruptibleStore(clock=clock)
+    lease_manager = CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id="coordinator-a",
+        lease_duration_ms=1_000,
+        clock=clock,
+    )
+    lease = lease_manager.acquire()
+    assignment = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=0,
+        assignments=(
+            SlotAssignment(0, "node-a", 0, 2),
+            SlotAssignment(1, "node-b", 2, 2),
+        ),
+        topology_digest="topology-v1",
+    )
+    current = GenerationStateManager(store, run_id=RUN_ID).initialize(
+        lease,
+        assignment,
+    )
+    intent = RestartIntent(
+        intent_id="intent-a",
+        run_id=RUN_ID,
+        generation=0,
+        incident_ids=("incident-a",),
+        reason_code="attributed_sdc",
+        minimum_recovery_mode="recovery_verified",
+        suspected_node_ids=("node-b",),
+        prepare_deadline_unix_ms=1_500,
+    )
+    opened = RestartIntentOpenExecutor(store, run_id=RUN_ID).execute_initial_open(
+        RestartIntentOpenPreparer(
+            store,
+            run_id=RUN_ID,
+            clock=clock,
+        ).prepare_initial_open(lease, current, intent)
+    )
+    registration_manager = AgentRegistrationManager(
+        store,
+        agent_identity=AgentIdentity(
+            run_id=RUN_ID,
+            node_id="node-a",
+            agent_id="agent-a",
+            hostname="host-node-a",
+            local_world_size=2,
+            resource_ids=("gpu-node-a-0", "gpu-node-a-1"),
+            environment_digest="environment-v1",
+        ),
+        lease_duration_ms=400,
+        clock=clock,
+    )
+    registration = registration_manager.register()
+    receipt = RestartAckReceiptRecord(
+        acknowledgement=RestartAck(
+            intent_id=intent.intent_id,
+            run_id=RUN_ID,
+            node_id="node-a",
+            agent_id="agent-a",
+            generation=0,
+            flushed_step=40,
+            inventory_event_digests={"inventory-a": "b" * 64},
+            transferred_owner_ranks=(0, 1),
+            transferred_peer_ranks=(2, 3),
+            success=True,
+            reason="prepared",
+        ),
+        intent_record=opened.prepared.record,
+        agent_registration=registration.record,
+        registration_fencing_token=registration.fencing_token,
+        registration_granted_at_unix_ms=registration.granted_at_unix_ms,
+        received_at_unix_ms=clock.now_unix_ms,
+    )
+    acknowledgement_key = None
+    if commit_receipt:
+        prepared = RestartAckPreparer(
+            store,
+            run_id=RUN_ID,
+            clock=clock,
+        ).prepare(receipt, lease)
+        RestartAckExecutor(store, run_id=RUN_ID).execute(prepared)
+        acknowledgement_key = prepared.records.acknowledgement_key
+    return (
+        clock,
+        store,
+        lease_manager,
+        lease,
+        registration_manager,
+        registration,
+        acknowledgement_key,
+    )
+
+
+def test_restart_ack_reader_returns_none_for_never_created_receipt():
+    _, store, _, _, _, _, _ = _state(commit_receipt=False)
+
+    assert RestartAckReader(store, run_id=RUN_ID, node_id="node-a").read() is None
+
+
+def test_restart_ack_reader_reconstructs_committed_receipt():
+    _, store, _, _, _, _, acknowledgement_key = _state(commit_receipt=True)
+
+    persisted = RestartAckReader(store, run_id=RUN_ID, node_id="node-a").read()
+
+    assert persisted is not None
+    assert persisted.receipt_entry == store.get(acknowledgement_key)
+    assert persisted.receipt.acknowledgement.node_id == "node-a"
+
+
+def test_restart_ack_reader_accepts_historical_authorities_after_renewal():
+    clock, store, lease_manager, lease, registration_manager, registration, _ = _state(
+        commit_receipt=True
+    )
+    clock.set(1_010)
+    registration_manager.renew(registration)
+    lease_manager.renew(lease)
+
+    persisted = RestartAckReader(store, run_id=RUN_ID, node_id="node-a").read()
+
+    assert persisted is not None
+    assert persisted.registration_authority.registration == registration
+    assert persisted.coordinator_authority.lease == lease
+
+
+def test_restart_ack_reader_is_node_scoped():
+    _, store, _, _, _, _, _ = _state(commit_receipt=True)
+
+    assert RestartAckReader(store, run_id=RUN_ID, node_id="node-b").read() is None
+
+
+def test_restart_ack_reader_rejects_deleted_or_rewritten_receipt():
+    _, store, _, _, _, _, acknowledgement_key = _state(commit_receipt=True)
+    assert acknowledgement_key is not None
+    entry = store.get(acknowledgement_key)
+    assert entry is not None
+    store.compare_delete(acknowledgement_key, expected_revision=entry.revision)
+
+    with pytest.raises(RestartAckReadCorrupt, match="deleted"):
+        RestartAckReader(store, run_id=RUN_ID, node_id="node-a").read()
+
+    _, store, _, _, _, _, acknowledgement_key = _state(commit_receipt=True)
+    assert acknowledgement_key is not None
+    entry = store.get(acknowledgement_key)
+    assert entry is not None
+    store.compare_set(
+        acknowledgement_key,
+        expected_revision=entry.revision,
+        value=entry.value,
+    )
+
+    with pytest.raises(RestartAckReadCorrupt, match="immutable"):
+        RestartAckReader(store, run_id=RUN_ID, node_id="node-a").read()
+
+
+def test_restart_ack_reader_rejects_malformed_receipt():
+    _, store, _, _, _, _, acknowledgement_key = _state(commit_receipt=True)
+    assert acknowledgement_key is not None
+    entry = store.get(acknowledgement_key)
+    assert entry is not None
+    store.replace_current(
+        acknowledgement_key,
+        replace(entry, value=b"{}"),
+    )
+
+    with pytest.raises(RestartAckReadCorrupt, match="malformed"):
+        RestartAckReader(store, run_id=RUN_ID, node_id="node-a").read()
+
+
+def test_restart_ack_reader_rejects_missing_registration_history():
+    _, store, _, _, registration_manager, _, _ = _state(commit_receipt=True)
+    store.drop_history(registration_manager.registration_key)
+
+    with pytest.raises(RestartAckReadCorrupt, match="registration history"):
+        RestartAckReader(store, run_id=RUN_ID, node_id="node-a").read()
+
+
+def test_restart_ack_reader_rejects_missing_coordinator_authority():
+    _, store, lease_manager, _, _, _, acknowledgement_key = _state(commit_receipt=True)
+    assert acknowledgement_key is not None
+    entry = store.get(acknowledgement_key)
+    assert entry is not None
+    store.replace_current(
+        acknowledgement_key,
+        replace(entry, guard_value_digest="0" * 64),
+    )
+
+    with pytest.raises(RestartAckReadCorrupt, match="coordinator-lease authority"):
+        RestartAckReader(store, run_id=RUN_ID, node_id="node-a").read()
+    assert store.get(lease_manager.lease_key) is not None
+
+
+def test_restart_ack_reader_rejects_missing_current_intent():
+    store = InMemoryControlStore(clock=ManualClock())
+
+    with pytest.raises(RestartAckReadConflict, match="no current"):
+        RestartAckReader(store, run_id=RUN_ID, node_id="node-a").read()
+
+
+def test_restart_ack_reader_validates_constructor_inputs():
+    store = InMemoryControlStore(clock=ManualClock())
+
+    with pytest.raises(ValueError, match="run_id"):
+        RestartAckReader(store, run_id="", node_id="node-a")
+    with pytest.raises(ValueError, match="node_id"):
+        RestartAckReader(store, run_id=RUN_ID, node_id="")


### PR DESCRIPTION
## Summary

- add a stable, read-only per-node receipt reader for the current restart intent
- resolve exact historical agent-registration and coordinator-lease authorities stamped into each receipt
- return absence only for a never-created key and fail closed on deleted, rewritten, malformed, or orphaned receipts

## Scope

This PR reads one node receipt. It does not enumerate active nodes, decide acknowledgement quorum, or select a restart plan.

## Validation

- 99 focused receipt-reader, persisted-decoder, execution, open-reader, registration-history, and lease-history tests
- 1,984 full CPU tests with CUDA hidden
- repository-wide Ruff check and format check
- targeted mypy for the reader
- git diff --check