### PR TITLE
[Feature][Torchrun] Add stable restart acknowledgement collector

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1015,6 +1015,13 @@ match its node key, and the mapping is frozen in active-slot order. The value
 separately exposes received, missing, successful, and explicitly failed node
 sets without making a quorum or restart-policy decision.
 
+A read-only collector obtains two identical full active-node observations while
+the durable restart-intent opening remains unchanged. Because acknowledgement
+keys are immutable create-once records, this double collect yields one stable
+receipt-or-absence snapshot without requiring a store-wide read transaction.
+Repeated changes are retryable conflicts; contradictory per-node state fails
+closed as corruption. The collector still makes no quorum or restart decision.
+
 For a crashed or unreachable node, no preparation is assumed.
 
 ## API: lm-resiliency to the Framework

--- a/lm_resiliency/integrations/torchrun/_restart_ack_collector.py
+++ b/lm_resiliency/integrations/torchrun/_restart_ack_collector.py
@@ -1,0 +1,172 @@
+"""Stable multi-node collections of persisted restart acknowledgements."""
+
+from __future__ import annotations
+
+from lm_resiliency.integrations.torchrun._control_store import ControlStore
+from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
+    CoordinatorLeaseHistoryCorrupt,
+    CoordinatorLeaseHistoryError,
+)
+from lm_resiliency.integrations.torchrun._generation_reader import (
+    GenerationStateCorrupt,
+    GenerationStateError,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_collection import (
+    RestartAckCollection,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_persisted import (
+    PersistedRestartAck,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_reader import (
+    RestartAckReadConflict,
+    RestartAckReadCorrupt,
+    RestartAckReader,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
+    CommittedInitialRestartIntentOpen,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_reader import (
+    RestartIntentOpenStateClosed,
+    RestartIntentOpenStateCorrupt,
+    RestartIntentOpenStateError,
+    RestartIntentOpenStateReader,
+)
+
+_MAX_READ_ATTEMPTS = 8
+
+
+class RestartAckCollectionReadError(RuntimeError):
+    """Base error for stable restart-acknowledgement collection reads."""
+
+
+class RestartAckCollectionReadConflict(RestartAckCollectionReadError):
+    """Raised when acknowledgement state changes repeatedly during collection."""
+
+
+class RestartAckCollectionReadCorrupt(RestartAckCollectionReadError):
+    """Raised when persisted acknowledgement state is contradictory."""
+
+
+class RestartAckCollector:
+    """Read one stable acknowledgement-or-absence value for every active node."""
+
+    def __init__(self, store: ControlStore, *, run_id: str) -> None:
+        self._store = store
+        self._run_id = _nonempty_string(run_id, "run_id")
+        self._open_reader = RestartIntentOpenStateReader(
+            store,
+            run_id=self._run_id,
+        )
+        self._receipt_readers: dict[str, RestartAckReader] = {}
+
+    def collect(self) -> RestartAckCollection:
+        """Return one stable active-node acknowledgement collection."""
+
+        for _ in range(_MAX_READ_ATTEMPTS):
+            opened = self._read_open()
+            node_ids = _active_node_ids(opened)
+            first = self._read_receipts(node_ids)
+            if not _same_committed_opening(opened, self._read_open()):
+                continue
+            second = self._read_receipts(node_ids)
+            current_opened = self._read_open()
+            if first != second or not _same_committed_opening(opened, current_opened):
+                continue
+            try:
+                return RestartAckCollection(
+                    opened=current_opened,
+                    receipts_by_node_id=second,
+                )
+            except (TypeError, ValueError) as error:
+                raise RestartAckCollectionReadCorrupt(
+                    "persisted acknowledgements contradict the current opening"
+                ) from error
+        raise RestartAckCollectionReadConflict(
+            "restart acknowledgements changed repeatedly during collection"
+        )
+
+    def _read_receipts(
+        self,
+        node_ids: tuple[str, ...],
+    ) -> dict[str, PersistedRestartAck | None]:
+        receipts: dict[str, PersistedRestartAck | None] = {}
+        for node_id in node_ids:
+            reader = self._receipt_readers.get(node_id)
+            if reader is None:
+                reader = RestartAckReader(
+                    self._store,
+                    run_id=self._run_id,
+                    node_id=node_id,
+                )
+                self._receipt_readers[node_id] = reader
+            try:
+                receipts[node_id] = reader.read()
+            except RestartAckReadCorrupt as error:
+                raise RestartAckCollectionReadCorrupt(
+                    f"persisted acknowledgement for node {node_id!r} is corrupt"
+                ) from error
+            except RestartAckReadConflict as error:
+                raise RestartAckCollectionReadConflict(
+                    f"acknowledgement for node {node_id!r} changed repeatedly"
+                ) from error
+        return receipts
+
+    def _read_open(self) -> CommittedInitialRestartIntentOpen:
+        try:
+            opened = self._open_reader.read()
+        except RestartIntentOpenStateClosed as error:
+            raise RestartAckCollectionReadConflict(
+                "restart intent closed during acknowledgement collection"
+            ) from error
+        except RestartIntentOpenStateCorrupt as error:
+            raise RestartAckCollectionReadCorrupt(
+                "persisted restart-intent opening is corrupt"
+            ) from error
+        except RestartIntentOpenStateError as error:
+            raise RestartAckCollectionReadConflict(
+                "restart-intent opening changed repeatedly during collection"
+            ) from error
+        except (CoordinatorLeaseHistoryCorrupt, GenerationStateCorrupt) as error:
+            raise RestartAckCollectionReadCorrupt(
+                "restart-intent opening dependencies are corrupt"
+            ) from error
+        except (CoordinatorLeaseHistoryError, GenerationStateError) as error:
+            raise RestartAckCollectionReadConflict(
+                "restart-intent opening dependencies changed repeatedly"
+            ) from error
+        if opened is None:
+            raise RestartAckCollectionReadConflict("no current restart intent is open")
+        return opened
+
+
+def _active_node_ids(
+    opened: CommittedInitialRestartIntentOpen,
+) -> tuple[str, ...]:
+    slot_to_node_id = opened.prepared.current.snapshot.record.assignment.slot_to_node_id
+    return tuple(slot_to_node_id[slot_id] for slot_id in sorted(slot_to_node_id))
+
+
+def _same_committed_opening(
+    left: CommittedInitialRestartIntentOpen,
+    right: CommittedInitialRestartIntentOpen,
+) -> bool:
+    return (
+        left.prepared.intent_key == right.prepared.intent_key
+        and left.intent_entry == right.intent_entry
+        and left.prepared.intent_head_key == right.prepared.intent_head_key
+        and left.head_entry == right.head_entry
+    )
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+__all__ = [
+    "RestartAckCollectionReadConflict",
+    "RestartAckCollectionReadCorrupt",
+    "RestartAckCollectionReadError",
+    "RestartAckCollector",
+]

--- a/tests/unit/test_torchrun_restart_ack_collector.py
+++ b/tests/unit/test_torchrun_restart_ack_collector.py
@@ -1,0 +1,312 @@
+"""Contract tests for stable multi-node restart-acknowledgement collection."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, cast
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._agent_registration import (
+    AgentRegistrationManager,
+)
+from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseManager,
+)
+from lm_resiliency.integrations.torchrun._generation_state import GenerationStateManager
+from lm_resiliency.integrations.torchrun._protocol import (
+    AgentIdentity,
+    RankAssignment,
+    RestartAck,
+    RestartIntent,
+    SlotAssignment,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_collector import (
+    RestartAckCollectionReadConflict,
+    RestartAckCollectionReadCorrupt,
+    RestartAckCollector,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_execution import (
+    RestartAckExecutor,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_persisted import (
+    PersistedRestartAck,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_preparation import (
+    RestartAckPreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_reader import (
+    RestartAckReadConflict,
+    RestartAckReadCorrupt,
+    RestartAckReader,
+)
+from lm_resiliency.integrations.torchrun._restart_ack_records import (
+    RestartAckReceiptRecord,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open import (
+    RestartIntentOpenPreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
+    RestartIntentOpenExecutor,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_open_reader import (
+    RestartIntentOpenStateClosed,
+    RestartIntentOpenStateCorrupt,
+    RestartIntentOpenStateError,
+)
+
+RUN_ID = "training-run"
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+
+def _state(
+    *,
+    committed_node_ids: tuple[str, ...],
+) -> tuple[InMemoryControlStore, dict[str, PersistedRestartAck]]:
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    lease = CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id="coordinator-a",
+        lease_duration_ms=1_000,
+        clock=clock,
+    ).acquire()
+    assignment = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=0,
+        assignments=(
+            SlotAssignment(0, "node-a", 0, 2),
+            SlotAssignment(1, "node-b", 2, 2),
+        ),
+        topology_digest="topology-v1",
+    )
+    current = GenerationStateManager(store, run_id=RUN_ID).initialize(
+        lease,
+        assignment,
+    )
+    intent = RestartIntent(
+        intent_id="intent-a",
+        run_id=RUN_ID,
+        generation=0,
+        incident_ids=("incident-a",),
+        reason_code="attributed_sdc",
+        minimum_recovery_mode="recovery_verified",
+        suspected_node_ids=("node-b",),
+        prepare_deadline_unix_ms=1_500,
+    )
+    opened = RestartIntentOpenExecutor(store, run_id=RUN_ID).execute_initial_open(
+        RestartIntentOpenPreparer(
+            store,
+            run_id=RUN_ID,
+            clock=clock,
+        ).prepare_initial_open(lease, current, intent)
+    )
+    for node_id in ("node-a", "node-b"):
+        agent_id = f"agent-{node_id}"
+        registration = AgentRegistrationManager(
+            store,
+            agent_identity=AgentIdentity(
+                run_id=RUN_ID,
+                node_id=node_id,
+                agent_id=agent_id,
+                hostname=f"host-{node_id}",
+                local_world_size=2,
+                resource_ids=(f"gpu-{node_id}-0", f"gpu-{node_id}-1"),
+                environment_digest="environment-v1",
+            ),
+            lease_duration_ms=400,
+            clock=clock,
+        ).register()
+        if node_id not in committed_node_ids:
+            continue
+        receipt = RestartAckReceiptRecord(
+            acknowledgement=RestartAck(
+                intent_id=intent.intent_id,
+                run_id=RUN_ID,
+                node_id=node_id,
+                agent_id=agent_id,
+                generation=0,
+                flushed_step=40,
+                inventory_event_digests={f"inventory-{node_id}": "b" * 64},
+                transferred_owner_ranks=(0, 1),
+                transferred_peer_ranks=(2, 3),
+                success=True,
+                reason="prepared",
+            ),
+            intent_record=opened.prepared.record,
+            agent_registration=registration.record,
+            registration_fencing_token=registration.fencing_token,
+            registration_granted_at_unix_ms=registration.granted_at_unix_ms,
+            received_at_unix_ms=clock.now_unix_ms,
+        )
+        prepared = RestartAckPreparer(
+            store,
+            run_id=RUN_ID,
+            clock=clock,
+        ).prepare(receipt, lease)
+        RestartAckExecutor(store, run_id=RUN_ID).execute(prepared)
+    persisted: dict[str, PersistedRestartAck] = {}
+    for node_id in committed_node_ids:
+        persisted_receipt = RestartAckReader(
+            store,
+            run_id=RUN_ID,
+            node_id=node_id,
+        ).read()
+        assert persisted_receipt is not None
+        persisted[node_id] = persisted_receipt
+    return store, persisted
+
+
+def test_restart_ack_collector_returns_stable_complete_snapshot():
+    store, _ = _state(committed_node_ids=("node-a", "node-b"))
+
+    collection = RestartAckCollector(store, run_id=RUN_ID).collect()
+
+    assert collection.active_node_ids == ("node-a", "node-b")
+    assert collection.received_node_ids == ("node-a", "node-b")
+    assert collection.missing_node_ids == ()
+
+
+def test_restart_ack_collector_preserves_stable_absence():
+    store, _ = _state(committed_node_ids=("node-a",))
+
+    collection = RestartAckCollector(store, run_id=RUN_ID).collect()
+
+    assert collection.received_node_ids == ("node-a",)
+    assert collection.missing_node_ids == ("node-b",)
+
+
+class SequencedCollector(RestartAckCollector):
+    def __init__(
+        self,
+        store: InMemoryControlStore,
+        *,
+        received: dict[str, PersistedRestartAck],
+    ) -> None:
+        super().__init__(store, run_id=RUN_ID)
+        self.received = received
+        self.read_count = 0
+
+    def _read_receipts(
+        self,
+        node_ids: tuple[str, ...],
+    ) -> dict[str, PersistedRestartAck | None]:
+        self.read_count += 1
+        node_b = None if self.read_count == 1 else self.received["node-b"]
+        return {
+            "node-a": self.received["node-a"],
+            "node-b": node_b,
+        }
+
+
+def test_restart_ack_collector_retries_receipt_committed_between_scans():
+    store, received = _state(committed_node_ids=("node-a", "node-b"))
+    collector = SequencedCollector(store, received=received)
+
+    collection = collector.collect()
+
+    assert collector.read_count == 4
+    assert collection.received_node_ids == ("node-a", "node-b")
+
+
+class FailingAckReader:
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
+    def read(self):
+        raise self.error
+
+
+class FailingOpenReader:
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
+    def read(self):
+        raise self.error
+
+
+@pytest.mark.parametrize(
+    ("error", "expected", "message"),
+    [
+        (
+            RestartAckReadConflict("moving"),
+            RestartAckCollectionReadConflict,
+            "changed repeatedly",
+        ),
+        (
+            RestartAckReadCorrupt("broken"),
+            RestartAckCollectionReadCorrupt,
+            "is corrupt",
+        ),
+    ],
+)
+def test_restart_ack_collector_translates_per_node_reader_errors(
+    error,
+    expected,
+    message,
+):
+    store, _ = _state(committed_node_ids=())
+    collector = RestartAckCollector(store, run_id=RUN_ID)
+    collector._receipt_readers["node-a"] = FailingAckReader(error)
+
+    with pytest.raises(expected, match=message):
+        collector.collect()
+
+
+@pytest.mark.parametrize(
+    ("error", "expected", "message"),
+    [
+        (
+            RestartIntentOpenStateClosed("closed"),
+            RestartAckCollectionReadConflict,
+            "closed",
+        ),
+        (
+            RestartIntentOpenStateError("moving"),
+            RestartAckCollectionReadConflict,
+            "changed repeatedly",
+        ),
+        (
+            RestartIntentOpenStateCorrupt("broken"),
+            RestartAckCollectionReadCorrupt,
+            "is corrupt",
+        ),
+    ],
+)
+def test_restart_ack_collector_translates_open_reader_errors(
+    error,
+    expected,
+    message,
+):
+    store = InMemoryControlStore(clock=ManualClock())
+    collector = RestartAckCollector(store, run_id=RUN_ID)
+    collector._open_reader = cast(Any, FailingOpenReader(error))
+
+    with pytest.raises(expected, match=message):
+        collector.collect()
+
+
+def test_restart_ack_collector_requires_current_open_intent():
+    store = InMemoryControlStore(clock=ManualClock())
+
+    with pytest.raises(RestartAckCollectionReadConflict, match="no current"):
+        RestartAckCollector(store, run_id=RUN_ID).collect()
+
+
+@pytest.mark.parametrize("run_id", ["", " "])
+def test_restart_ack_collector_validates_run_id(run_id):
+    store = InMemoryControlStore(clock=ManualClock())
+
+    with pytest.raises(ValueError, match="non-empty"):
+        RestartAckCollector(store, run_id=run_id)


### PR DESCRIPTION
## Summary

- add a read-only collector for one stable active-node acknowledgement snapshot
- double-collect immutable per-node receipts while the durable opening remains unchanged
- preserve retryable contention versus fail-closed corruption without making a quorum decision

## Scope

This PR adds no acknowledgement quorum, restart policy, recovery selection, or store mutation.

## Validation

- `30 passed` focused collection and reader tests
- `2004 passed` complete CPU suite with CUDA hidden
- Ruff check and format verification
- targeted mypy for the collector and tests
- `git diff --check`