### PR TITLE
[Feature][Torchrun] Add persisted recovery manifest record

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1444,6 +1444,13 @@ class RecoveryManifest(TypedDict):
     rank_copies: list[RankCheckpointCopies]
 ```
 
+The persisted `RecoveryManifestRecord` contains the canonical manifest and the
+digest of its immutable source-generation snapshot. This record is create-once
+and exposes its own canonical digest for the later restart-plan envelope.
+Resolving the source snapshot and validating inventory, certification,
+acknowledgement, assignment, and copy eligibility remain separate admission
+steps; constructing the record alone does not make a manifest safe to commit.
+
 The manifest is usable only when every required rank has at least one copy and
 every included copy is eligible for the manifest's exact positive step and the
 plan's selected source. The coordinator must omit rejected alternatives before

--- a/lm_resiliency/integrations/torchrun/_restart_plan_records.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_records.py
@@ -1,0 +1,162 @@
+"""Strict persisted records for torchrun restart plans."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import ClassVar
+
+from lm_resiliency.integrations.torchrun._protocol import (
+    ProtocolValidationError,
+    RecoveryManifest,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryManifestRecord:
+    """One immutable recovery manifest bound to its source generation."""
+
+    SCHEMA_VERSION: ClassVar[int] = 1
+
+    manifest: RecoveryManifest
+    source_generation_snapshot_digest: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.manifest, RecoveryManifest):
+            raise TypeError("RecoveryManifestRecord.manifest must be RecoveryManifest")
+        _digest(
+            self.source_generation_snapshot_digest,
+            "RecoveryManifestRecord.source_generation_snapshot_digest",
+        )
+
+    @property
+    def digest(self) -> str:
+        return hashlib.sha256(self.to_json()).hexdigest()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "manifest": self.manifest.to_dict(),
+            "source_generation_snapshot_digest": self.source_generation_snapshot_digest,
+        }
+
+    def to_json(self) -> bytes:
+        return _canonical_json(self.to_dict())
+
+    @classmethod
+    def from_json(cls, encoded: bytes) -> RecoveryManifestRecord:
+        value = _json_object(encoded, cls.__name__)
+        _fields(
+            value,
+            path=cls.__name__,
+            required={
+                "schema_version",
+                "manifest",
+                "source_generation_snapshot_digest",
+            },
+        )
+        _schema_version(
+            value["schema_version"],
+            cls.__name__,
+            expected=cls.SCHEMA_VERSION,
+        )
+        manifest_value = _mapping(
+            value["manifest"],
+            "RecoveryManifestRecord.manifest",
+        )
+        _schema_version(
+            manifest_value.get("schema_version"),
+            "RecoveryManifestRecord.manifest",
+            expected=RecoveryManifest.SCHEMA_VERSION,
+        )
+        try:
+            manifest = RecoveryManifest.from_dict(manifest_value)
+        except ProtocolValidationError as error:
+            raise ValueError("RecoveryManifestRecord.manifest is invalid") from error
+        return cls(
+            manifest=manifest,
+            source_generation_snapshot_digest=_digest(
+                value["source_generation_snapshot_digest"],
+                "RecoveryManifestRecord.source_generation_snapshot_digest",
+            ),
+        )
+
+
+def _canonical_json(value: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _json_object(encoded: bytes, path: str) -> Mapping[str, object]:
+    if not isinstance(encoded, bytes):
+        raise ValueError(f"{path}: expected encoded bytes")
+    try:
+        value = json.loads(
+            encoded,
+            object_pairs_hook=_reject_duplicate_object_fields,
+        )
+    except _DuplicateRestartPlanField as error:
+        raise ValueError(f"{path}: {error}") from error
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{path}: invalid JSON") from error
+    return _mapping(value, path)
+
+
+def _mapping(value: object, path: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping) or not all(isinstance(key, str) for key in value):
+        raise ValueError(f"{path}: expected a JSON object")
+    return value
+
+
+def _fields(
+    value: Mapping[str, object],
+    *,
+    path: str,
+    required: set[str],
+) -> None:
+    missing = required - set(value)
+    unknown = set(value) - required
+    if missing:
+        raise ValueError(f"{path}: missing fields {sorted(missing)!r}")
+    if unknown:
+        raise ValueError(f"{path}: unknown fields {sorted(unknown)!r}")
+
+
+def _schema_version(value: object, path: str, *, expected: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value != expected:
+        raise ValueError(f"{path}.schema_version: unsupported value {value!r}")
+    return value
+
+
+def _digest(value: object, path: str) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise ValueError(f"{path} must be a lowercase SHA-256 digest")
+    return value
+
+
+class _DuplicateRestartPlanField(ValueError):
+    pass
+
+
+def _reject_duplicate_object_fields(
+    pairs: list[tuple[str, object]],
+) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            raise _DuplicateRestartPlanField(f"duplicate field {key!r}")
+        value[key] = item
+    return value
+
+
+__all__ = ["RecoveryManifestRecord"]

--- a/tests/unit/test_torchrun_restart_plan_records.py
+++ b/tests/unit/test_torchrun_restart_plan_records.py
@@ -1,0 +1,176 @@
+"""Contract tests for persisted torchrun restart-plan records."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import replace
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._protocol import (
+    CheckpointCopy,
+    RankCheckpointCopies,
+    RecoveryManifest,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_records import (
+    RecoveryManifestRecord,
+)
+
+RUN_ID = "training-run"
+SOURCE_SNAPSHOT_DIGEST = "a" * 64
+
+
+def _copy(rank: int) -> CheckpointCopy:
+    return CheckpointCopy(
+        owner_global_rank=rank,
+        checkpoint_step=40,
+        inventory_event_id=f"inventory-{rank}",
+        checkpoint_id=None,
+        holder_node_id="node-a" if rank < 2 else "node-b",
+        holder_kind="owner",
+        storage_kind="node_local",
+        location_token=f"copy-{rank}",
+        complete=True,
+        checksums_available=True,
+    )
+
+
+def _manifest() -> RecoveryManifest:
+    return RecoveryManifest(
+        manifest_id="manifest-40",
+        run_id=RUN_ID,
+        source_generation=4,
+        step=40,
+        trust="latest",
+        topology_digest="topology-v1",
+        rank_copies=tuple(
+            RankCheckpointCopies(
+                owner_global_rank=rank,
+                copies=(_copy(rank),),
+            )
+            for rank in range(4)
+        ),
+    )
+
+
+def _record() -> RecoveryManifestRecord:
+    return RecoveryManifestRecord(
+        manifest=_manifest(),
+        source_generation_snapshot_digest=SOURCE_SNAPSHOT_DIGEST,
+    )
+
+
+def test_recovery_manifest_record_round_trips_as_canonical_json():
+    record = _record()
+
+    assert RecoveryManifestRecord.from_json(record.to_json()) == record
+    assert json.loads(record.to_json()) == record.to_dict()
+    assert record.digest == hashlib.sha256(record.to_json()).hexdigest()
+    assert record.to_json() == record.to_json()
+
+
+def test_recovery_manifest_record_is_immutable():
+    record = _record()
+
+    with pytest.raises(AttributeError):
+        record.source_generation_snapshot_digest = "b" * 64
+
+
+def test_recovery_manifest_record_requires_exact_types():
+    with pytest.raises(TypeError, match="manifest must be RecoveryManifest"):
+        RecoveryManifestRecord(
+            manifest=_manifest().to_dict(),
+            source_generation_snapshot_digest=SOURCE_SNAPSHOT_DIGEST,
+        )
+
+    with pytest.raises(ValueError, match="lowercase SHA-256"):
+        replace(
+            _record(),
+            source_generation_snapshot_digest="A" * 64,
+        )
+
+
+def test_recovery_manifest_record_rejects_duplicate_fields_at_any_depth():
+    outer_duplicate = (
+        b'{"manifest":'
+        + _record().manifest.to_json().encode()
+        + b',"schema_version":1,"schema_version":1,'
+        + b'"source_generation_snapshot_digest":"'
+        + SOURCE_SNAPSHOT_DIGEST.encode()
+        + b'"}'
+    )
+    with pytest.raises(ValueError, match="duplicate field 'schema_version'"):
+        RecoveryManifestRecord.from_json(outer_duplicate)
+
+    nested = (
+        _record()
+        .to_json()
+        .decode()
+        .replace(
+            '"manifest_id":"manifest-40"',
+            '"manifest_id":"manifest-40","manifest_id":"other"',
+        )
+    )
+    with pytest.raises(ValueError, match="duplicate field 'manifest_id'"):
+        RecoveryManifestRecord.from_json(nested.encode())
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value.pop("manifest"),
+        lambda value: value.pop("source_generation_snapshot_digest"),
+        lambda value: value.update({"unknown": "field"}),
+        lambda value: value.update({"schema_version": 2}),
+        lambda value: value.update({"schema_version": True}),
+        lambda value: value.update({"manifest": []}),
+        lambda value: value.update({"source_generation_snapshot_digest": "not-a-digest"}),
+    ],
+)
+def test_recovery_manifest_record_rejects_invalid_wire_shapes(mutation):
+    value = _record().to_dict()
+    mutation(value)
+
+    with pytest.raises(ValueError):
+        RecoveryManifestRecord.from_json(
+            json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+        )
+
+
+@pytest.mark.parametrize("schema_version", [1.0, "1", None, False])
+def test_recovery_manifest_record_requires_exact_nested_manifest_schema(
+    schema_version,
+):
+    value = _record().to_dict()
+    manifest = dict(value["manifest"])
+    manifest["schema_version"] = schema_version
+    value["manifest"] = manifest
+
+    with pytest.raises(ValueError, match="manifest.schema_version"):
+        RecoveryManifestRecord.from_json(
+            json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+        )
+
+
+def test_recovery_manifest_record_rejects_invalid_nested_manifest():
+    value = _record().to_dict()
+    manifest = dict(value["manifest"])
+    manifest["step"] = 0
+    value["manifest"] = manifest
+
+    with pytest.raises(ValueError, match="manifest is invalid"):
+        RecoveryManifestRecord.from_json(
+            json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+        )
+
+
+@pytest.mark.parametrize("encoded", [b"[]", b"null", b"not-json"])
+def test_recovery_manifest_record_requires_json_object(encoded):
+    with pytest.raises(ValueError):
+        RecoveryManifestRecord.from_json(encoded)
+
+
+def test_recovery_manifest_record_requires_encoded_bytes():
+    with pytest.raises(ValueError, match="expected encoded bytes"):
+        RecoveryManifestRecord.from_json(_record().to_json().decode())


### PR DESCRIPTION
## What changed

- add a strict internal `RecoveryManifestRecord` containing the canonical recovery manifest and its source-generation snapshot digest
- reject duplicate fields, unsupported or non-integer schema versions, unknown fields, malformed nested manifests, and invalid digests
- document that the record is create-once input to a later restart-plan envelope and does not itself establish checkpoint safety

## Why

The restart-plan publication path needs an immutable persisted manifest identity before it can atomically bind checkpoint selection, generation advancement, quarantine, and coordinator authority. This PR adds only that records boundary so later policy and mutation changes remain independently reviewable.

## Compatibility

This is a private torchrun integration record. It is not exported publicly and adds no runtime activation or store mutation.

## Validation

- `126 passed` focused protocol/record tests
- `2036 passed` full CPU suite with CUDA hidden
- repository-wide Ruff check and format check
- targeted mypy for the new module and tests
- `git diff --check`