### PR TITLE
[Feature][Torchrun] Add persisted restart plan record

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -763,6 +763,14 @@ class RestartPlan(TypedDict):
     restart_deadline_unix_ms: int
 ```
 
+The persisted `RestartPlanRecord` contains the canonical plan; digests for the
+selected recovery-manifest record, closed-intent lifecycle record, source
+generation, and successor generation; the exact node-to-quarantine-record
+digest map; and the coordinator lease identity that authorized publication.
+Its quarantine keys must exactly match `quarantined_node_ids`. The envelope is
+strict and immutable, but it is not a substitute for `validate_restart_plan()`
+or for the later atomic publication transaction.
+
 Before commit, the coordinator validates:
 
 - the plan is fenced to the same intent ID, run, generation, incidents, and

--- a/lm_resiliency/integrations/torchrun/_restart_plan_records.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_records.py
@@ -6,11 +6,16 @@ import hashlib
 import json
 from collections.abc import Mapping
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import ClassVar
 
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseRecord,
+)
 from lm_resiliency.integrations.torchrun._protocol import (
     ProtocolValidationError,
     RecoveryManifest,
+    RestartPlan,
 )
 
 
@@ -84,6 +89,179 @@ class RecoveryManifestRecord:
         )
 
 
+@dataclass(frozen=True, slots=True)
+class RestartPlanRecord:
+    """One immutable plan envelope for atomic restart publication."""
+
+    SCHEMA_VERSION: ClassVar[int] = 1
+
+    plan: RestartPlan
+    recovery_manifest_record_digest: str
+    intent_lifecycle_record_digest: str
+    from_generation_snapshot_digest: str
+    to_generation_snapshot_digest: str
+    quarantine_record_digests: Mapping[str, str]
+    coordinator_id: str
+    lease_id: str
+    coordinator_lease_duration_ms: int
+    coordinator_fencing_token: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.plan, RestartPlan):
+            raise TypeError("RestartPlanRecord.plan must be RestartPlan")
+        for value, path in (
+            (
+                self.recovery_manifest_record_digest,
+                "RestartPlanRecord.recovery_manifest_record_digest",
+            ),
+            (
+                self.intent_lifecycle_record_digest,
+                "RestartPlanRecord.intent_lifecycle_record_digest",
+            ),
+            (
+                self.from_generation_snapshot_digest,
+                "RestartPlanRecord.from_generation_snapshot_digest",
+            ),
+            (
+                self.to_generation_snapshot_digest,
+                "RestartPlanRecord.to_generation_snapshot_digest",
+            ),
+        ):
+            _digest(value, path)
+        quarantine_digests = _digest_mapping(
+            self.quarantine_record_digests,
+            "RestartPlanRecord.quarantine_record_digests",
+        )
+        expected_quarantine_nodes = set(self.plan.quarantined_node_ids)
+        if set(quarantine_digests) != expected_quarantine_nodes:
+            raise ValueError(
+                "RestartPlanRecord.quarantine_record_digests keys must exactly "
+                "match the plan's quarantined nodes"
+            )
+        object.__setattr__(
+            self,
+            "quarantine_record_digests",
+            MappingProxyType(quarantine_digests),
+        )
+        _nonempty_string(self.coordinator_id, "RestartPlanRecord.coordinator_id")
+        _nonempty_string(self.lease_id, "RestartPlanRecord.lease_id")
+        _positive_integer(
+            self.coordinator_lease_duration_ms,
+            "RestartPlanRecord.coordinator_lease_duration_ms",
+        )
+        _positive_integer(
+            self.coordinator_fencing_token,
+            "RestartPlanRecord.coordinator_fencing_token",
+        )
+
+    @property
+    def digest(self) -> str:
+        return hashlib.sha256(self.to_json()).hexdigest()
+
+    @property
+    def coordinator_lease_digest(self) -> str:
+        record = CoordinatorLeaseRecord(
+            run_id=self.plan.run_id,
+            coordinator_id=self.coordinator_id,
+            lease_id=self.lease_id,
+            lease_duration_ms=self.coordinator_lease_duration_ms,
+        )
+        return hashlib.sha256(record.to_json()).hexdigest()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "plan": self.plan.to_dict(),
+            "recovery_manifest_record_digest": self.recovery_manifest_record_digest,
+            "intent_lifecycle_record_digest": self.intent_lifecycle_record_digest,
+            "from_generation_snapshot_digest": self.from_generation_snapshot_digest,
+            "to_generation_snapshot_digest": self.to_generation_snapshot_digest,
+            "quarantine_record_digests": dict(self.quarantine_record_digests),
+            "coordinator_id": self.coordinator_id,
+            "lease_id": self.lease_id,
+            "coordinator_lease_duration_ms": self.coordinator_lease_duration_ms,
+            "coordinator_fencing_token": self.coordinator_fencing_token,
+        }
+
+    def to_json(self) -> bytes:
+        return _canonical_json(self.to_dict())
+
+    @classmethod
+    def from_json(cls, encoded: bytes) -> RestartPlanRecord:
+        value = _json_object(encoded, cls.__name__)
+        _fields(
+            value,
+            path=cls.__name__,
+            required={
+                "schema_version",
+                "plan",
+                "recovery_manifest_record_digest",
+                "intent_lifecycle_record_digest",
+                "from_generation_snapshot_digest",
+                "to_generation_snapshot_digest",
+                "quarantine_record_digests",
+                "coordinator_id",
+                "lease_id",
+                "coordinator_lease_duration_ms",
+                "coordinator_fencing_token",
+            },
+        )
+        _schema_version(
+            value["schema_version"],
+            cls.__name__,
+            expected=cls.SCHEMA_VERSION,
+        )
+        plan_value = _mapping(value["plan"], "RestartPlanRecord.plan")
+        _schema_version(
+            plan_value.get("schema_version"),
+            "RestartPlanRecord.plan",
+            expected=RestartPlan.SCHEMA_VERSION,
+        )
+        try:
+            plan = RestartPlan.from_dict(plan_value)
+        except ProtocolValidationError as error:
+            raise ValueError("RestartPlanRecord.plan is invalid") from error
+        return cls(
+            plan=plan,
+            recovery_manifest_record_digest=_digest(
+                value["recovery_manifest_record_digest"],
+                "RestartPlanRecord.recovery_manifest_record_digest",
+            ),
+            intent_lifecycle_record_digest=_digest(
+                value["intent_lifecycle_record_digest"],
+                "RestartPlanRecord.intent_lifecycle_record_digest",
+            ),
+            from_generation_snapshot_digest=_digest(
+                value["from_generation_snapshot_digest"],
+                "RestartPlanRecord.from_generation_snapshot_digest",
+            ),
+            to_generation_snapshot_digest=_digest(
+                value["to_generation_snapshot_digest"],
+                "RestartPlanRecord.to_generation_snapshot_digest",
+            ),
+            quarantine_record_digests=_digest_mapping(
+                value["quarantine_record_digests"],
+                "RestartPlanRecord.quarantine_record_digests",
+            ),
+            coordinator_id=_nonempty_string(
+                value["coordinator_id"],
+                "RestartPlanRecord.coordinator_id",
+            ),
+            lease_id=_nonempty_string(
+                value["lease_id"],
+                "RestartPlanRecord.lease_id",
+            ),
+            coordinator_lease_duration_ms=_positive_integer(
+                value["coordinator_lease_duration_ms"],
+                "RestartPlanRecord.coordinator_lease_duration_ms",
+            ),
+            coordinator_fencing_token=_positive_integer(
+                value["coordinator_fencing_token"],
+                "RestartPlanRecord.coordinator_fencing_token",
+            ),
+        )
+
+
 def _canonical_json(value: Mapping[str, object]) -> bytes:
     return json.dumps(
         value,
@@ -144,6 +322,27 @@ def _digest(value: object, path: str) -> str:
     return value
 
 
+def _digest_mapping(value: object, path: str) -> dict[str, str]:
+    mapping = _mapping(value, path)
+    result: dict[str, str] = {}
+    for key, digest in mapping.items():
+        normalized_key = _nonempty_string(key, f"{path}.key")
+        result[normalized_key] = _digest(digest, f"{path}[{normalized_key!r}]")
+    return dict(sorted(result.items()))
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+def _positive_integer(value: object, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{path} must be a positive integer")
+    return value
+
+
 class _DuplicateRestartPlanField(ValueError):
     pass
 
@@ -159,4 +358,7 @@ def _reject_duplicate_object_fields(
     return value
 
 
-__all__ = ["RecoveryManifestRecord"]
+__all__ = [
+    "RecoveryManifestRecord",
+    "RestartPlanRecord",
+]

--- a/tests/unit/test_torchrun_restart_plan_records.py
+++ b/tests/unit/test_torchrun_restart_plan_records.py
@@ -12,13 +12,21 @@ from lm_resiliency.integrations.torchrun._protocol import (
     CheckpointCopy,
     RankCheckpointCopies,
     RecoveryManifest,
+    RestartPlan,
+    SlotAssignment,
 )
 from lm_resiliency.integrations.torchrun._restart_plan_records import (
     RecoveryManifestRecord,
+    RestartPlanRecord,
 )
 
 RUN_ID = "training-run"
 SOURCE_SNAPSHOT_DIGEST = "a" * 64
+MANIFEST_RECORD_DIGEST = "b" * 64
+LIFECYCLE_RECORD_DIGEST = "c" * 64
+FROM_SNAPSHOT_DIGEST = "d" * 64
+TO_SNAPSHOT_DIGEST = "e" * 64
+QUARANTINE_RECORD_DIGEST = "f" * 64
 
 
 def _copy(rank: int) -> CheckpointCopy:
@@ -58,6 +66,56 @@ def _record() -> RecoveryManifestRecord:
     return RecoveryManifestRecord(
         manifest=_manifest(),
         source_generation_snapshot_digest=SOURCE_SNAPSHOT_DIGEST,
+    )
+
+
+def _plan() -> RestartPlan:
+    return RestartPlan(
+        plan_id="plan-5",
+        intent_id="intent-4",
+        run_id=RUN_ID,
+        from_generation=4,
+        to_generation=5,
+        incident_ids=("incident-1",),
+        reason_code="confirmed_straggler",
+        recovery_mode="latest",
+        checkpoint_source="gemini",
+        checkpoint_step=40,
+        checkpoint_id=None,
+        checkpoint_manifest_id="manifest-40",
+        slot_assignments=(
+            SlotAssignment(
+                logical_node_slot=0,
+                node_id="node-a",
+                first_global_rank=0,
+                local_world_size=2,
+            ),
+            SlotAssignment(
+                logical_node_slot=1,
+                node_id="node-c",
+                first_global_rank=2,
+                local_world_size=2,
+            ),
+        ),
+        quarantined_node_ids=("node-b",),
+        expected_world_size=4,
+        topology_digest="topology-v1",
+        restart_deadline_unix_ms=2_000,
+    )
+
+
+def _plan_record() -> RestartPlanRecord:
+    return RestartPlanRecord(
+        plan=_plan(),
+        recovery_manifest_record_digest=MANIFEST_RECORD_DIGEST,
+        intent_lifecycle_record_digest=LIFECYCLE_RECORD_DIGEST,
+        from_generation_snapshot_digest=FROM_SNAPSHOT_DIGEST,
+        to_generation_snapshot_digest=TO_SNAPSHOT_DIGEST,
+        quarantine_record_digests={"node-b": QUARANTINE_RECORD_DIGEST},
+        coordinator_id="coordinator-a",
+        lease_id="lease-a",
+        coordinator_lease_duration_ms=500,
+        coordinator_fencing_token=9,
     )
 
 
@@ -174,3 +232,165 @@ def test_recovery_manifest_record_requires_json_object(encoded):
 def test_recovery_manifest_record_requires_encoded_bytes():
     with pytest.raises(ValueError, match="expected encoded bytes"):
         RecoveryManifestRecord.from_json(_record().to_json().decode())
+
+
+def test_restart_plan_record_round_trips_as_canonical_json():
+    record = _plan_record()
+
+    assert RestartPlanRecord.from_json(record.to_json()) == record
+    assert json.loads(record.to_json()) == record.to_dict()
+    assert record.digest == hashlib.sha256(record.to_json()).hexdigest()
+    assert len(record.coordinator_lease_digest) == 64
+    assert record.to_json() == record.to_json()
+
+
+def test_restart_plan_record_freezes_quarantine_digests():
+    quarantine_digests = {"node-b": QUARANTINE_RECORD_DIGEST}
+    record = replace(
+        _plan_record(),
+        quarantine_record_digests=quarantine_digests,
+    )
+
+    quarantine_digests["node-b"] = "0" * 64
+
+    assert record.quarantine_record_digests == {
+        "node-b": QUARANTINE_RECORD_DIGEST,
+    }
+    with pytest.raises(TypeError):
+        record.quarantine_record_digests["node-b"] = "0" * 64
+
+
+def test_restart_plan_record_requires_exact_quarantine_digest_coverage():
+    with pytest.raises(ValueError, match="exactly match"):
+        replace(_plan_record(), quarantine_record_digests={})
+
+    with pytest.raises(ValueError, match="exactly match"):
+        replace(
+            _plan_record(),
+            quarantine_record_digests={
+                "node-b": QUARANTINE_RECORD_DIGEST,
+                "node-c": "0" * 64,
+            },
+        )
+
+
+def test_restart_plan_record_allows_no_quarantine_records_when_plan_has_none():
+    plan = replace(_plan(), quarantined_node_ids=())
+
+    record = replace(
+        _plan_record(),
+        plan=plan,
+        quarantine_record_digests={},
+    )
+
+    assert record.quarantine_record_digests == {}
+
+
+def test_restart_plan_record_requires_exact_types():
+    with pytest.raises(TypeError, match="plan must be RestartPlan"):
+        replace(_plan_record(), plan=_plan().to_dict())
+
+    with pytest.raises(ValueError, match="positive integer"):
+        replace(_plan_record(), coordinator_fencing_token=0)
+
+    with pytest.raises(ValueError, match="lowercase SHA-256"):
+        replace(_plan_record(), recovery_manifest_record_digest="B" * 64)
+
+
+def test_restart_plan_record_rejects_duplicate_fields_at_any_depth():
+    outer_duplicate = (
+        _plan_record()
+        .to_json()
+        .decode()
+        .replace(
+            '"schema_version":1',
+            '"schema_version":1,"schema_version":1',
+            1,
+        )
+    )
+    with pytest.raises(ValueError, match="duplicate field 'schema_version'"):
+        RestartPlanRecord.from_json(outer_duplicate.encode())
+
+    nested_duplicate = (
+        _plan_record()
+        .to_json()
+        .decode()
+        .replace(
+            '"plan_id":"plan-5"',
+            '"plan_id":"plan-5","plan_id":"other"',
+        )
+    )
+    with pytest.raises(ValueError, match="duplicate field 'plan_id'"):
+        RestartPlanRecord.from_json(nested_duplicate.encode())
+
+    mapping_duplicate = (
+        _plan_record()
+        .to_json()
+        .decode()
+        .replace(
+            f'"node-b":"{QUARANTINE_RECORD_DIGEST}"',
+            f'"node-b":"{QUARANTINE_RECORD_DIGEST}","node-b":"{"0" * 64}"',
+        )
+    )
+    with pytest.raises(ValueError, match="duplicate field 'node-b'"):
+        RestartPlanRecord.from_json(mapping_duplicate.encode())
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value.pop("plan"),
+        lambda value: value.pop("recovery_manifest_record_digest"),
+        lambda value: value.pop("intent_lifecycle_record_digest"),
+        lambda value: value.pop("from_generation_snapshot_digest"),
+        lambda value: value.pop("to_generation_snapshot_digest"),
+        lambda value: value.pop("quarantine_record_digests"),
+        lambda value: value.pop("coordinator_id"),
+        lambda value: value.pop("lease_id"),
+        lambda value: value.pop("coordinator_lease_duration_ms"),
+        lambda value: value.pop("coordinator_fencing_token"),
+        lambda value: value.update({"unknown": "field"}),
+        lambda value: value.update({"schema_version": 2}),
+        lambda value: value.update({"schema_version": True}),
+        lambda value: value.update({"plan": []}),
+        lambda value: value.update({"quarantine_record_digests": []}),
+    ],
+)
+def test_restart_plan_record_rejects_invalid_wire_shapes(mutation):
+    value = _plan_record().to_dict()
+    mutation(value)
+
+    with pytest.raises(ValueError):
+        RestartPlanRecord.from_json(
+            json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+        )
+
+
+@pytest.mark.parametrize("schema_version", [1.0, "1", None, False])
+def test_restart_plan_record_requires_exact_nested_plan_schema(schema_version):
+    value = _plan_record().to_dict()
+    plan = dict(value["plan"])
+    plan["schema_version"] = schema_version
+    value["plan"] = plan
+
+    with pytest.raises(ValueError, match="plan.schema_version"):
+        RestartPlanRecord.from_json(
+            json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+        )
+
+
+def test_restart_plan_record_rejects_invalid_nested_plan():
+    value = _plan_record().to_dict()
+    plan = dict(value["plan"])
+    plan["to_generation"] = 7
+    value["plan"] = plan
+
+    with pytest.raises(ValueError, match="plan is invalid"):
+        RestartPlanRecord.from_json(
+            json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+        )
+
+
+def test_restart_plan_record_requires_encoded_bytes():
+    with pytest.raises(ValueError, match="expected encoded bytes"):
+        RestartPlanRecord.from_json(_plan_record().to_json().decode())


### PR DESCRIPTION
## What changed

- add a strict internal `RestartPlanRecord` containing the canonical plan and exact digests for its recovery manifest, closed intent lifecycle, source generation, successor generation, and quarantine records
- bind the record to the coordinator lease identity and fencing token that will authorize publication
- require quarantine-record digest keys to exactly match the plan's quarantined nodes
- extend strict wire tests for canonical JSON, duplicate fields, exact nested schema types, immutable mappings, malformed plans, and invalid authority metadata

## Why

Atomic restart publication needs one immutable envelope that names every artifact the plan transaction must publish or condition on. This PR adds only that records boundary so validation and guarded publication remain separate reviewable components.

## Compatibility

This is a private torchrun integration record. It is not exported publicly and adds no store mutation, checkpoint selection, or runtime activation.

## Validation

- `184 passed` focused protocol/record tests
- `2063 passed` full CPU suite with CUDA hidden
- repository-wide Ruff check and format check
- targeted mypy for the records module and tests
- `git diff --check`