### PR TITLE
[Feature][Torchrun] Resolve recovery manifest source generation

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1458,6 +1458,9 @@ and exposes its own canonical digest for the later restart-plan envelope.
 Resolving the source snapshot and validating inventory, certification,
 acknowledgement, assignment, and copy eligibility remain separate admission
 steps; constructing the record alone does not make a manifest safe to commit.
+`ResolvedRecoveryManifest` binds the record to one verified immutable
+generation snapshot and requires exact run, source-generation, topology, and
+snapshot-digest agreement. It still does not establish completeness or trust.
 
 The manifest is usable only when every required rank has at least one copy and
 every included copy is eligible for the manifest's exact positive step and the

--- a/lm_resiliency/integrations/torchrun/_restart_plan_state.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_state.py
@@ -1,0 +1,58 @@
+"""Pure resolved state for torchrun restart plans."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from lm_resiliency.integrations.torchrun._generation_reader import (
+    StoredGenerationSnapshot,
+)
+from lm_resiliency.integrations.torchrun._protocol import (
+    RankAssignment,
+    RecoveryManifest,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_records import (
+    RecoveryManifestRecord,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedRecoveryManifest:
+    """One manifest record bound to its exact immutable source generation."""
+
+    record: RecoveryManifestRecord
+    source_snapshot: StoredGenerationSnapshot
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.record, RecoveryManifestRecord):
+            raise TypeError("ResolvedRecoveryManifest.record must be RecoveryManifestRecord")
+        if not isinstance(self.source_snapshot, StoredGenerationSnapshot):
+            raise TypeError(
+                "ResolvedRecoveryManifest.source_snapshot must be StoredGenerationSnapshot"
+            )
+        snapshot_record = self.source_snapshot.record
+        if snapshot_record.digest != self.record.source_generation_snapshot_digest:
+            raise ValueError(
+                "ResolvedRecoveryManifest source snapshot digest does not match its record"
+            )
+        manifest = self.record.manifest
+        assignment = snapshot_record.assignment
+        if (
+            manifest.run_id != assignment.run_id
+            or manifest.source_generation != assignment.generation
+            or manifest.topology_digest != assignment.topology_digest
+        ):
+            raise ValueError(
+                "ResolvedRecoveryManifest manifest does not match its source generation"
+            )
+
+    @property
+    def manifest(self) -> RecoveryManifest:
+        return self.record.manifest
+
+    @property
+    def source_assignment(self) -> RankAssignment:
+        return self.source_snapshot.record.assignment
+
+
+__all__ = ["ResolvedRecoveryManifest"]

--- a/tests/unit/test_torchrun_restart_plan_state.py
+++ b/tests/unit/test_torchrun_restart_plan_state.py
@@ -1,0 +1,215 @@
+"""Contract tests for resolved torchrun restart-plan state."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._generation_reader import (
+    StoredGenerationSnapshot,
+)
+from lm_resiliency.integrations.torchrun._generation_records import (
+    GenerationSnapshotRecord,
+)
+from lm_resiliency.integrations.torchrun._protocol import (
+    CheckpointCopy,
+    RankAssignment,
+    RankCheckpointCopies,
+    RecoveryManifest,
+    SlotAssignment,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_records import (
+    RecoveryManifestRecord,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_state import (
+    ResolvedRecoveryManifest,
+)
+
+RUN_ID = "training-run"
+
+
+def _assignment(
+    *,
+    run_id: str = RUN_ID,
+    generation: int = 4,
+    topology_digest: str = "topology-v1",
+) -> RankAssignment:
+    return RankAssignment.from_assignments(
+        run_id=run_id,
+        generation=generation,
+        assignments=(
+            SlotAssignment(
+                logical_node_slot=0,
+                node_id="node-a",
+                first_global_rank=0,
+                local_world_size=2,
+            ),
+            SlotAssignment(
+                logical_node_slot=1,
+                node_id="node-b",
+                first_global_rank=2,
+                local_world_size=2,
+            ),
+        ),
+        topology_digest=topology_digest,
+    )
+
+
+def _snapshot(
+    *,
+    assignment: RankAssignment | None = None,
+) -> StoredGenerationSnapshot:
+    record = GenerationSnapshotRecord(
+        assignment=assignment or _assignment(),
+        previous_snapshot_digest="a" * 64,
+        coordinator_id="coordinator-a",
+        lease_id="lease-a",
+        coordinator_lease_duration_ms=500,
+        coordinator_fencing_token=4,
+    )
+    return StoredGenerationSnapshot(
+        record=record,
+        revision=8,
+        committed_at_unix_ms=1_000,
+        transaction_sequence=8,
+        guard_mutation_sequence=4,
+        guard_value_sequence=2,
+        guard_lifetime_sequence=1,
+        guard_committed_at_unix_ms=900,
+    )
+
+
+def _manifest(
+    *,
+    run_id: str = RUN_ID,
+    source_generation: int = 4,
+    topology_digest: str = "topology-v1",
+) -> RecoveryManifest:
+    copies = tuple(
+        RankCheckpointCopies(
+            owner_global_rank=rank,
+            copies=(
+                CheckpointCopy(
+                    owner_global_rank=rank,
+                    checkpoint_step=40,
+                    inventory_event_id=f"inventory-{rank}",
+                    checkpoint_id=None,
+                    holder_node_id="node-a" if rank < 2 else "node-b",
+                    holder_kind="owner",
+                    storage_kind="node_local",
+                    location_token=f"copy-{rank}",
+                    complete=True,
+                    checksums_available=True,
+                ),
+            ),
+        )
+        for rank in range(4)
+    )
+    return RecoveryManifest(
+        manifest_id="manifest-40",
+        run_id=run_id,
+        source_generation=source_generation,
+        step=40,
+        trust="latest",
+        topology_digest=topology_digest,
+        rank_copies=copies,
+    )
+
+
+def _resolved() -> ResolvedRecoveryManifest:
+    snapshot = _snapshot()
+    return ResolvedRecoveryManifest(
+        record=RecoveryManifestRecord(
+            manifest=_manifest(),
+            source_generation_snapshot_digest=snapshot.record.digest,
+        ),
+        source_snapshot=snapshot,
+    )
+
+
+def test_resolved_recovery_manifest_exposes_exact_manifest_and_assignment():
+    resolved = _resolved()
+
+    assert resolved.manifest == resolved.record.manifest
+    assert resolved.source_assignment == resolved.source_snapshot.record.assignment
+
+
+def test_resolved_recovery_manifest_is_immutable():
+    resolved = _resolved()
+
+    with pytest.raises(AttributeError):
+        resolved.record = resolved.record
+
+
+def test_resolved_recovery_manifest_requires_exact_types():
+    resolved = _resolved()
+
+    with pytest.raises(TypeError, match="record must be RecoveryManifestRecord"):
+        ResolvedRecoveryManifest(
+            record=resolved.record.to_dict(),
+            source_snapshot=resolved.source_snapshot,
+        )
+
+    with pytest.raises(TypeError, match="source_snapshot must be StoredGenerationSnapshot"):
+        ResolvedRecoveryManifest(
+            record=resolved.record,
+            source_snapshot=resolved.source_snapshot.record,
+        )
+
+
+def test_resolved_recovery_manifest_rejects_wrong_snapshot_digest():
+    resolved = _resolved()
+
+    with pytest.raises(ValueError, match="source snapshot digest"):
+        replace(
+            resolved,
+            record=replace(
+                resolved.record,
+                source_generation_snapshot_digest="f" * 64,
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    ("manifest", "assignment"),
+    [
+        (_manifest(run_id="other-run"), _assignment()),
+        (_manifest(source_generation=3), _assignment()),
+        (_manifest(topology_digest="topology-v2"), _assignment()),
+    ],
+)
+def test_resolved_recovery_manifest_rejects_source_identity_mismatch(
+    manifest,
+    assignment,
+):
+    snapshot = _snapshot(assignment=assignment)
+    record = RecoveryManifestRecord(
+        manifest=manifest,
+        source_generation_snapshot_digest=snapshot.record.digest,
+    )
+
+    with pytest.raises(ValueError, match="does not match its source generation"):
+        ResolvedRecoveryManifest(
+            record=record,
+            source_snapshot=snapshot,
+        )
+
+
+def test_resolved_recovery_manifest_does_not_claim_completeness():
+    snapshot = _snapshot()
+    incomplete_manifest = replace(
+        _manifest(),
+        rank_copies=_manifest().rank_copies[:-1],
+    )
+    record = RecoveryManifestRecord(
+        manifest=incomplete_manifest,
+        source_generation_snapshot_digest=snapshot.record.digest,
+    )
+
+    resolved = ResolvedRecoveryManifest(
+        record=record,
+        source_snapshot=snapshot,
+    )
+
+    assert len(resolved.manifest.rank_copies) == 3


### PR DESCRIPTION
## What changed

- add a pure `ResolvedRecoveryManifest` value that binds a persisted manifest record to one verified immutable source-generation snapshot
- require exact source snapshot digest, run ID, source generation, and topology agreement
- expose the exact manifest and source assignment without adding store access or checkpoint safety policy
- document that resolution does not establish completeness, certification, or recovery trust

## Why

The later restart-plan admission path needs to distinguish durable identity resolution from checkpoint eligibility. This small component proves which generation a manifest belongs to without conflating that fact with copy completeness or certification.

## Compatibility

This is a private torchrun integration value. It adds no public export, store mutation, or runtime activation.

## Validation

- `205 passed` focused generation/record/state tests
- `2071 passed` full CPU suite with CUDA hidden
- repository-wide Ruff check and format check
- targeted mypy for the new module and tests
- `git diff --check`