### PR TITLE
[Feature][Torchrun] Bind restart plan intent and generations

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -770,6 +770,10 @@ digest map; and the coordinator lease identity that authorized publication.
 Its quarantine keys must exactly match `quarantined_node_ids`. The envelope is
 strict and immutable, but it is not a substitute for `validate_restart_plan()`
 or for the later atomic publication transaction.
+`RestartPlanGenerationState` binds that envelope to the exact closed intent,
+current generation, successor generation, successor assignment, and shared
+coordinator publication authority. Manifest and quarantine resolution remain
+separate cross-record checks.
 
 Before commit, the coordinator validates:
 

--- a/lm_resiliency/integrations/torchrun/_restart_plan_state.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_state.py
@@ -7,12 +7,21 @@ from dataclasses import dataclass
 from lm_resiliency.integrations.torchrun._generation_reader import (
     StoredGenerationSnapshot,
 )
+from lm_resiliency.integrations.torchrun._generation_records import (
+    GenerationSnapshotRecord,
+)
 from lm_resiliency.integrations.torchrun._protocol import (
     RankAssignment,
     RecoveryManifest,
+    RestartPlan,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_records import (
+    RestartIntentLifecycleRecord,
+    RestartIntentRecord,
 )
 from lm_resiliency.integrations.torchrun._restart_plan_records import (
     RecoveryManifestRecord,
+    RestartPlanRecord,
 )
 
 
@@ -55,4 +64,131 @@ class ResolvedRecoveryManifest:
         return self.source_snapshot.record.assignment
 
 
-__all__ = ["ResolvedRecoveryManifest"]
+@dataclass(frozen=True, slots=True)
+class RestartPlanGenerationState:
+    """One plan envelope bound to its intent and generation records."""
+
+    record: RestartPlanRecord
+    intent_record: RestartIntentRecord
+    lifecycle_record: RestartIntentLifecycleRecord
+    from_snapshot: GenerationSnapshotRecord
+    to_snapshot: GenerationSnapshotRecord
+
+    def __post_init__(self) -> None:
+        expected_types = (
+            ("record", self.record, RestartPlanRecord),
+            ("intent_record", self.intent_record, RestartIntentRecord),
+            (
+                "lifecycle_record",
+                self.lifecycle_record,
+                RestartIntentLifecycleRecord,
+            ),
+            ("from_snapshot", self.from_snapshot, GenerationSnapshotRecord),
+            ("to_snapshot", self.to_snapshot, GenerationSnapshotRecord),
+        )
+        for path, value, expected_type in expected_types:
+            if not isinstance(value, expected_type):
+                raise TypeError(
+                    f"RestartPlanGenerationState.{path} must be {expected_type.__name__}"
+                )
+        self._validate_digests()
+        self._validate_intent()
+        self._validate_generations()
+        self._validate_publication_authority()
+
+    @property
+    def plan(self) -> RestartPlan:
+        return self.record.plan
+
+    @property
+    def from_assignment(self) -> RankAssignment:
+        return self.from_snapshot.assignment
+
+    @property
+    def to_assignment(self) -> RankAssignment:
+        return self.to_snapshot.assignment
+
+    def _validate_digests(self) -> None:
+        if (
+            self.record.intent_lifecycle_record_digest != self.lifecycle_record.digest
+            or self.record.from_generation_snapshot_digest != self.from_snapshot.digest
+            or self.record.to_generation_snapshot_digest != self.to_snapshot.digest
+            or self.intent_record.generation_snapshot_digest != self.from_snapshot.digest
+        ):
+            raise ValueError(
+                "RestartPlanGenerationState records do not match their envelope digests"
+            )
+        closed_intent = self.lifecycle_record.closed_intent
+        intent = self.intent_record.intent
+        if (
+            closed_intent.run_id != intent.run_id
+            or closed_intent.generation != intent.generation
+            or closed_intent.intent_id != intent.intent_id
+            or closed_intent.intent_digest != self.intent_record.digest
+        ):
+            raise ValueError(
+                "RestartPlanGenerationState lifecycle does not close its intent record"
+            )
+
+    def _validate_intent(self) -> None:
+        plan = self.record.plan
+        intent = self.intent_record.intent
+        if (
+            plan.intent_id != intent.intent_id
+            or plan.run_id != intent.run_id
+            or plan.from_generation != intent.generation
+            or plan.incident_ids != intent.incident_ids
+            or plan.reason_code != intent.reason_code
+        ):
+            raise ValueError("RestartPlanGenerationState plan does not match its restart intent")
+        if (
+            intent.minimum_recovery_mode == "recovery_verified"
+            and plan.recovery_mode != "recovery_verified"
+        ):
+            raise ValueError(
+                "RestartPlanGenerationState plan recovery mode is weaker than its intent"
+            )
+
+    def _validate_generations(self) -> None:
+        plan = self.record.plan
+        from_assignment = self.from_snapshot.assignment
+        if (
+            from_assignment.run_id != plan.run_id
+            or from_assignment.generation != plan.from_generation
+            or from_assignment.topology_digest != plan.topology_digest
+            or from_assignment.active_nodes * from_assignment.local_world_size
+            != plan.expected_world_size
+        ):
+            raise ValueError("RestartPlanGenerationState source generation does not match its plan")
+        if self.to_snapshot.previous_snapshot_digest != self.from_snapshot.digest:
+            raise ValueError(
+                "RestartPlanGenerationState successor does not reference its source generation"
+            )
+        expected_assignment = RankAssignment.from_assignments(
+            run_id=plan.run_id,
+            generation=plan.to_generation,
+            assignments=plan.slot_assignments,
+            topology_digest=plan.topology_digest,
+        )
+        if self.to_snapshot.assignment != expected_assignment:
+            raise ValueError(
+                "RestartPlanGenerationState successor assignment does not match its plan"
+            )
+
+    def _validate_publication_authority(self) -> None:
+        if (
+            self.record.coordinator_id != self.to_snapshot.coordinator_id
+            or self.record.lease_id != self.to_snapshot.lease_id
+            or self.record.coordinator_lease_duration_ms
+            != self.to_snapshot.coordinator_lease_duration_ms
+            or self.record.coordinator_fencing_token != self.to_snapshot.coordinator_fencing_token
+        ):
+            raise ValueError(
+                "RestartPlanGenerationState plan and successor use different publication authority"
+            )
+
+
+__all__ = [
+    "ResolvedRecoveryManifest",
+    "RestartPlanGenerationState",
+]

--- a/tests/unit/test_torchrun_restart_plan_state.py
+++ b/tests/unit/test_torchrun_restart_plan_state.py
@@ -17,13 +17,22 @@ from lm_resiliency.integrations.torchrun._protocol import (
     RankAssignment,
     RankCheckpointCopies,
     RecoveryManifest,
+    RestartIntent,
+    RestartPlan,
     SlotAssignment,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_records import (
+    RestartIntentHeadRecord,
+    RestartIntentLifecycleRecord,
+    RestartIntentRecord,
 )
 from lm_resiliency.integrations.torchrun._restart_plan_records import (
     RecoveryManifestRecord,
+    RestartPlanRecord,
 )
 from lm_resiliency.integrations.torchrun._restart_plan_state import (
     ResolvedRecoveryManifest,
+    RestartPlanGenerationState,
 )
 
 RUN_ID = "training-run"
@@ -213,3 +222,276 @@ def test_resolved_recovery_manifest_does_not_claim_completeness():
     )
 
     assert len(resolved.manifest.rank_copies) == 3
+
+
+def _intent_record() -> RestartIntentRecord:
+    return RestartIntentRecord(
+        intent=RestartIntent(
+            intent_id="intent-4",
+            run_id=RUN_ID,
+            generation=4,
+            incident_ids=("incident-1",),
+            reason_code="confirmed_straggler",
+            minimum_recovery_mode="latest",
+            suspected_node_ids=("node-b",),
+            prepare_deadline_unix_ms=1_500,
+        ),
+        generation_snapshot_digest=_generation_record(4).digest,
+        coordinator_id="coordinator-a",
+        lease_id="lease-open",
+        coordinator_lease_duration_ms=500,
+        coordinator_fencing_token=4,
+    )
+
+
+def _lifecycle_record() -> RestartIntentLifecycleRecord:
+    intent_record = _intent_record()
+    return RestartIntentLifecycleRecord(
+        closed_intent=RestartIntentHeadRecord(
+            run_id=RUN_ID,
+            generation=4,
+            intent_id="intent-4",
+            intent_digest=intent_record.digest,
+        ),
+        coordinator_id="coordinator-a",
+        lease_id="lease-close",
+        coordinator_lease_duration_ms=500,
+        coordinator_fencing_token=6,
+    )
+
+
+def _generation_record(
+    generation: int,
+    *,
+    assignment: RankAssignment | None = None,
+    previous_snapshot_digest: str | None = None,
+) -> GenerationSnapshotRecord:
+    if assignment is None:
+        assignment = _assignment(generation=generation)
+    return GenerationSnapshotRecord(
+        assignment=assignment,
+        previous_snapshot_digest=(
+            previous_snapshot_digest if previous_snapshot_digest is not None else "a" * 64
+        ),
+        coordinator_id="coordinator-plan",
+        lease_id="lease-plan",
+        coordinator_lease_duration_ms=500,
+        coordinator_fencing_token=9,
+    )
+
+
+def _plan() -> RestartPlan:
+    return RestartPlan(
+        plan_id="plan-5",
+        intent_id="intent-4",
+        run_id=RUN_ID,
+        from_generation=4,
+        to_generation=5,
+        incident_ids=("incident-1",),
+        reason_code="confirmed_straggler",
+        recovery_mode="latest",
+        checkpoint_source="gemini",
+        checkpoint_step=40,
+        checkpoint_id=None,
+        checkpoint_manifest_id="manifest-40",
+        slot_assignments=(
+            SlotAssignment(
+                logical_node_slot=0,
+                node_id="node-a",
+                first_global_rank=0,
+                local_world_size=2,
+            ),
+            SlotAssignment(
+                logical_node_slot=1,
+                node_id="node-c",
+                first_global_rank=2,
+                local_world_size=2,
+            ),
+        ),
+        quarantined_node_ids=(),
+        expected_world_size=4,
+        topology_digest="topology-v1",
+        restart_deadline_unix_ms=2_000,
+    )
+
+
+def _generation_state() -> RestartPlanGenerationState:
+    from_snapshot = _generation_record(4)
+    to_assignment = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=5,
+        assignments=_plan().slot_assignments,
+        topology_digest="topology-v1",
+    )
+    to_snapshot = _generation_record(
+        5,
+        assignment=to_assignment,
+        previous_snapshot_digest=from_snapshot.digest,
+    )
+    lifecycle = _lifecycle_record()
+    record = RestartPlanRecord(
+        plan=_plan(),
+        recovery_manifest_record_digest="b" * 64,
+        intent_lifecycle_record_digest=lifecycle.digest,
+        from_generation_snapshot_digest=from_snapshot.digest,
+        to_generation_snapshot_digest=to_snapshot.digest,
+        quarantine_record_digests={},
+        coordinator_id=to_snapshot.coordinator_id,
+        lease_id=to_snapshot.lease_id,
+        coordinator_lease_duration_ms=to_snapshot.coordinator_lease_duration_ms,
+        coordinator_fencing_token=to_snapshot.coordinator_fencing_token,
+    )
+    return RestartPlanGenerationState(
+        record=record,
+        intent_record=_intent_record(),
+        lifecycle_record=lifecycle,
+        from_snapshot=from_snapshot,
+        to_snapshot=to_snapshot,
+    )
+
+
+def test_restart_plan_generation_state_binds_exact_records():
+    state = _generation_state()
+
+    assert state.plan == state.record.plan
+    assert state.from_assignment == state.from_snapshot.assignment
+    assert state.to_assignment == state.to_snapshot.assignment
+
+
+def test_restart_plan_generation_state_is_immutable():
+    state = _generation_state()
+
+    with pytest.raises(AttributeError):
+        state.record = state.record
+
+
+def test_restart_plan_generation_state_requires_exact_types():
+    state = _generation_state()
+
+    with pytest.raises(TypeError, match="record must be RestartPlanRecord"):
+        replace(state, record=state.record.to_dict())
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("intent_lifecycle_record_digest", "0" * 64),
+        ("from_generation_snapshot_digest", "1" * 64),
+        ("to_generation_snapshot_digest", "2" * 64),
+    ],
+)
+def test_restart_plan_generation_state_rejects_envelope_digest_mismatch(
+    field,
+    value,
+):
+    state = _generation_state()
+
+    with pytest.raises(ValueError, match="envelope digests"):
+        replace(state, record=replace(state.record, **{field: value}))
+
+
+def test_restart_plan_generation_state_rejects_wrong_closed_intent():
+    state = _generation_state()
+    wrong_lifecycle = replace(
+        state.lifecycle_record,
+        closed_intent=replace(
+            state.lifecycle_record.closed_intent,
+            intent_digest="0" * 64,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="does not close"):
+        replace(
+            state,
+            record=replace(
+                state.record,
+                intent_lifecycle_record_digest=wrong_lifecycle.digest,
+            ),
+            lifecycle_record=wrong_lifecycle,
+        )
+
+
+def test_restart_plan_generation_state_rejects_plan_intent_mismatch():
+    state = _generation_state()
+
+    with pytest.raises(ValueError, match="does not match its restart intent"):
+        replace(
+            state,
+            record=replace(
+                state.record,
+                plan=replace(state.plan, reason_code="other"),
+            ),
+        )
+
+
+def test_restart_plan_generation_state_rejects_weaker_recovery_mode():
+    state = _generation_state()
+    verified_intent = replace(
+        state.intent_record.intent,
+        minimum_recovery_mode="recovery_verified",
+    )
+    intent_record = replace(state.intent_record, intent=verified_intent)
+    lifecycle = replace(
+        state.lifecycle_record,
+        closed_intent=replace(
+            state.lifecycle_record.closed_intent,
+            intent_digest=intent_record.digest,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="recovery mode is weaker"):
+        replace(
+            state,
+            intent_record=intent_record,
+            lifecycle_record=lifecycle,
+            record=replace(
+                state.record,
+                intent_lifecycle_record_digest=lifecycle.digest,
+            ),
+        )
+
+
+def test_restart_plan_generation_state_rejects_wrong_successor_link():
+    state = _generation_state()
+
+    with pytest.raises(ValueError, match="does not reference"):
+        replace(
+            state,
+            to_snapshot=replace(
+                state.to_snapshot,
+                previous_snapshot_digest="0" * 64,
+            ),
+            record=replace(
+                state.record,
+                to_generation_snapshot_digest=replace(
+                    state.to_snapshot,
+                    previous_snapshot_digest="0" * 64,
+                ).digest,
+            ),
+        )
+
+
+def test_restart_plan_generation_state_rejects_wrong_successor_assignment():
+    state = _generation_state()
+    wrong_assignment = _assignment(generation=5)
+    wrong_snapshot = replace(state.to_snapshot, assignment=wrong_assignment)
+
+    with pytest.raises(ValueError, match="successor assignment"):
+        replace(
+            state,
+            to_snapshot=wrong_snapshot,
+            record=replace(
+                state.record,
+                to_generation_snapshot_digest=wrong_snapshot.digest,
+            ),
+        )
+
+
+def test_restart_plan_generation_state_rejects_different_publication_authority():
+    state = _generation_state()
+
+    with pytest.raises(ValueError, match="different publication authority"):
+        replace(
+            state,
+            record=replace(state.record, lease_id="other-lease"),
+        )


### PR DESCRIPTION
## What changed

- add a pure `RestartPlanGenerationState` value that binds a persisted plan envelope to its exact restart intent, closed lifecycle record, current generation, and successor generation
- require the successor snapshot to reference the current snapshot and exactly match the plan's slot assignment
- require the plan envelope and successor snapshot to use the same coordinator publication authority
- keep manifest, quarantine, checkpoint evidence, and store mutation out of this component

## Why

Atomic plan publication needs durable cross-record identity before policy and store execution can be reviewed safely. This PR isolates the lifecycle and generation topology contract from checkpoint and quarantine admission.

## Compatibility

This is a private torchrun integration value. It adds no public export, store access, or runtime activation.

## Validation

- `277 passed` focused record/state/protocol tests
- `2083 passed` full CPU suite with CUDA hidden
- repository-wide Ruff check and format check
- targeted mypy for the state module and tests
- `git diff --check`