### PR TITLE
[Feature][Torchrun] Bind restart plan quarantine records

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -778,6 +778,10 @@ separate cross-record checks.
 checks plan/manifest metadata, source world size, exact current-generation
 assignment when applicable, and trust compatibility. It still does not prove
 per-rank copy completeness or inventory certification.
+`RestartPlanQuarantineState` binds the exact node quarantine records and
+requires their digests, plan metadata, and coordinator authority to match the
+manifest-bound plan. It does not validate resource evidence or prove atomic
+publication.
 
 Before commit, the coordinator validates:
 

--- a/lm_resiliency/integrations/torchrun/_restart_plan_state.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_state.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
+from types import MappingProxyType
 
 from lm_resiliency.integrations.torchrun._generation_reader import (
     StoredGenerationSnapshot,
@@ -14,6 +16,9 @@ from lm_resiliency.integrations.torchrun._protocol import (
     RankAssignment,
     RecoveryManifest,
     RestartPlan,
+)
+from lm_resiliency.integrations.torchrun._quarantine_records import (
+    NodeQuarantineRecord,
 )
 from lm_resiliency.integrations.torchrun._restart_intent_records import (
     RestartIntentLifecycleRecord,
@@ -249,8 +254,85 @@ class RestartPlanManifestState:
         return self.resolved_manifest.manifest
 
 
+@dataclass(frozen=True, slots=True)
+class RestartPlanQuarantineState:
+    """One manifest-bound plan linked to its exact quarantine records."""
+
+    manifest_state: RestartPlanManifestState
+    quarantine_records: Mapping[str, NodeQuarantineRecord]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.manifest_state, RestartPlanManifestState):
+            raise TypeError(
+                "RestartPlanQuarantineState.manifest_state must be RestartPlanManifestState"
+            )
+        if not isinstance(self.quarantine_records, Mapping):
+            raise TypeError("RestartPlanQuarantineState.quarantine_records must be a mapping")
+        records: dict[str, NodeQuarantineRecord] = {}
+        for node_id, record in self.quarantine_records.items():
+            if not isinstance(node_id, str) or not node_id.strip():
+                raise ValueError(
+                    "RestartPlanQuarantineState.quarantine_records keys must be non-empty node IDs"
+                )
+            if not isinstance(record, NodeQuarantineRecord):
+                raise TypeError(
+                    "RestartPlanQuarantineState.quarantine_records values "
+                    "must be NodeQuarantineRecord"
+                )
+            if record.node_id != node_id:
+                raise ValueError(
+                    "RestartPlanQuarantineState quarantine record node does not match its key"
+                )
+            records[node_id] = record
+        records = dict(sorted(records.items()))
+        plan_record = self.manifest_state.generation_state.record
+        expected_digests = plan_record.quarantine_record_digests
+        if set(records) != set(expected_digests):
+            raise ValueError(
+                "RestartPlanQuarantineState records must exactly cover the plan's quarantined nodes"
+            )
+        plan = plan_record.plan
+        for node_id, record in records.items():
+            if record.digest != expected_digests[node_id]:
+                raise ValueError(
+                    "RestartPlanQuarantineState quarantine record digest does not match its plan"
+                )
+            if (
+                record.run_id != plan.run_id
+                or record.plan_id != plan.plan_id
+                or record.intent_id != plan.intent_id
+                or record.from_generation != plan.from_generation
+                or record.effective_generation != plan.to_generation
+                or record.incident_ids != plan.incident_ids
+                or record.reason_code != plan.reason_code
+            ):
+                raise ValueError(
+                    "RestartPlanQuarantineState quarantine record does not match its plan"
+                )
+            if (
+                record.coordinator_id != plan_record.coordinator_id
+                or record.lease_id != plan_record.lease_id
+                or record.coordinator_lease_duration_ms != plan_record.coordinator_lease_duration_ms
+                or record.coordinator_fencing_token != plan_record.coordinator_fencing_token
+            ):
+                raise ValueError(
+                    "RestartPlanQuarantineState quarantine record uses different "
+                    "publication authority"
+                )
+        object.__setattr__(
+            self,
+            "quarantine_records",
+            MappingProxyType(records),
+        )
+
+    @property
+    def plan(self) -> RestartPlan:
+        return self.manifest_state.plan
+
+
 __all__ = [
     "ResolvedRecoveryManifest",
     "RestartPlanGenerationState",
     "RestartPlanManifestState",
+    "RestartPlanQuarantineState",
 ]

--- a/tests/unit/test_torchrun_restart_plan_state.py
+++ b/tests/unit/test_torchrun_restart_plan_state.py
@@ -21,6 +21,9 @@ from lm_resiliency.integrations.torchrun._protocol import (
     RestartPlan,
     SlotAssignment,
 )
+from lm_resiliency.integrations.torchrun._quarantine_records import (
+    NodeQuarantineRecord,
+)
 from lm_resiliency.integrations.torchrun._restart_intent_records import (
     RestartIntentHeadRecord,
     RestartIntentLifecycleRecord,
@@ -34,6 +37,7 @@ from lm_resiliency.integrations.torchrun._restart_plan_state import (
     ResolvedRecoveryManifest,
     RestartPlanGenerationState,
     RestartPlanManifestState,
+    RestartPlanQuarantineState,
 )
 
 RUN_ID = "training-run"
@@ -706,3 +710,203 @@ def test_restart_plan_manifest_state_does_not_claim_copy_completeness():
     state = _manifest_state(manifest=incomplete)
 
     assert len(state.manifest.rank_copies) == 3
+
+
+def _quarantine_state() -> RestartPlanQuarantineState:
+    manifest_state = _manifest_state()
+    plan = replace(
+        manifest_state.plan,
+        quarantined_node_ids=("node-b",),
+    )
+    plan_record = manifest_state.generation_state.record
+    quarantine_record = NodeQuarantineRecord(
+        run_id=plan.run_id,
+        node_id="node-b",
+        plan_id=plan.plan_id,
+        intent_id=plan.intent_id,
+        from_generation=plan.from_generation,
+        effective_generation=plan.to_generation,
+        incident_ids=plan.incident_ids,
+        reason_code=plan.reason_code,
+        resource_ids=("gpu-b0",),
+        coordinator_id=plan_record.coordinator_id,
+        lease_id=plan_record.lease_id,
+        coordinator_lease_duration_ms=plan_record.coordinator_lease_duration_ms,
+        coordinator_fencing_token=plan_record.coordinator_fencing_token,
+    )
+    generation_state = replace(
+        manifest_state.generation_state,
+        record=replace(
+            plan_record,
+            plan=plan,
+            quarantine_record_digests={"node-b": quarantine_record.digest},
+        ),
+    )
+    return RestartPlanQuarantineState(
+        manifest_state=replace(
+            manifest_state,
+            generation_state=generation_state,
+        ),
+        quarantine_records={"node-b": quarantine_record},
+    )
+
+
+def test_restart_plan_quarantine_state_binds_exact_records():
+    state = _quarantine_state()
+
+    assert state.plan == state.manifest_state.plan
+    assert state.quarantine_records["node-b"].node_id == "node-b"
+
+    with pytest.raises(TypeError):
+        state.quarantine_records["node-b"] = state.quarantine_records["node-b"]
+
+
+def test_restart_plan_quarantine_state_allows_no_quarantine_records():
+    state = RestartPlanQuarantineState(
+        manifest_state=_manifest_state(),
+        quarantine_records={},
+    )
+
+    assert not state.quarantine_records
+
+
+def test_restart_plan_quarantine_state_requires_exact_types():
+    state = _quarantine_state()
+
+    with pytest.raises(TypeError, match="manifest_state must be"):
+        replace(state, manifest_state=state.manifest_state.generation_state)
+
+    with pytest.raises(TypeError, match="must be a mapping"):
+        replace(state, quarantine_records=())
+
+    with pytest.raises(TypeError, match="must be NodeQuarantineRecord"):
+        replace(state, quarantine_records={"node-b": state.quarantine_records["node-b"].to_dict()})
+
+
+@pytest.mark.parametrize(
+    "quarantine_records",
+    [
+        {},
+        {
+            "node-b": _quarantine_state().quarantine_records["node-b"],
+            "node-c": replace(
+                _quarantine_state().quarantine_records["node-b"],
+                node_id="node-c",
+            ),
+        },
+    ],
+)
+def test_restart_plan_quarantine_state_requires_exact_node_coverage(quarantine_records):
+    with pytest.raises(ValueError, match="exactly cover"):
+        replace(
+            _quarantine_state(),
+            quarantine_records=quarantine_records,
+        )
+
+
+def test_restart_plan_quarantine_state_rejects_record_node_key_mismatch():
+    state = _quarantine_state()
+
+    with pytest.raises(ValueError, match="node does not match"):
+        replace(
+            state,
+            quarantine_records={
+                "node-b": replace(
+                    state.quarantine_records["node-b"],
+                    node_id="node-c",
+                )
+            },
+        )
+
+
+def test_restart_plan_quarantine_state_rejects_wrong_record_digest():
+    state = _quarantine_state()
+
+    with pytest.raises(ValueError, match="record digest"):
+        replace(
+            state,
+            quarantine_records={
+                "node-b": replace(
+                    state.quarantine_records["node-b"],
+                    resource_ids=("gpu-b1",),
+                )
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        replace(_quarantine_state().quarantine_records["node-b"], run_id="other-run"),
+        replace(_quarantine_state().quarantine_records["node-b"], plan_id="other-plan"),
+        replace(_quarantine_state().quarantine_records["node-b"], intent_id="other-intent"),
+        replace(
+            _quarantine_state().quarantine_records["node-b"],
+            from_generation=3,
+            effective_generation=4,
+        ),
+        replace(
+            _quarantine_state().quarantine_records["node-b"],
+            incident_ids=("other-incident",),
+        ),
+        replace(_quarantine_state().quarantine_records["node-b"], reason_code="other-reason"),
+    ],
+)
+def test_restart_plan_quarantine_state_rejects_plan_metadata_mismatch(record):
+    state = _quarantine_state()
+    plan_record = replace(
+        state.manifest_state.generation_state.record,
+        quarantine_record_digests={"node-b": record.digest},
+    )
+
+    with pytest.raises(ValueError, match="does not match its plan"):
+        replace(
+            state,
+            manifest_state=replace(
+                state.manifest_state,
+                generation_state=replace(
+                    state.manifest_state.generation_state,
+                    record=plan_record,
+                ),
+            ),
+            quarantine_records={"node-b": record},
+        )
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        replace(
+            _quarantine_state().quarantine_records["node-b"],
+            coordinator_id="other-coordinator",
+        ),
+        replace(_quarantine_state().quarantine_records["node-b"], lease_id="other-lease"),
+        replace(
+            _quarantine_state().quarantine_records["node-b"],
+            coordinator_lease_duration_ms=1_000,
+        ),
+        replace(
+            _quarantine_state().quarantine_records["node-b"],
+            coordinator_fencing_token=10,
+        ),
+    ],
+)
+def test_restart_plan_quarantine_state_rejects_publication_authority_mismatch(record):
+    state = _quarantine_state()
+    plan_record = replace(
+        state.manifest_state.generation_state.record,
+        quarantine_record_digests={"node-b": record.digest},
+    )
+
+    with pytest.raises(ValueError, match="publication authority"):
+        replace(
+            state,
+            manifest_state=replace(
+                state.manifest_state,
+                generation_state=replace(
+                    state.manifest_state.generation_state,
+                    record=plan_record,
+                ),
+            ),
+            quarantine_records={"node-b": record},
+        )


### PR DESCRIPTION
## What changed

- add a pure `RestartPlanQuarantineState` value that binds a manifest-bound plan to its exact node-quarantine records
- require exact quarantined-node coverage, record digests, plan metadata, and coordinator publication authority
- freeze the record mapping and explicitly leave resource-evidence validation and atomic publication out of scope

## Why

The restart-plan pipeline needs a reviewable cross-record boundary before quarantine writes can be composed into an atomic publication transaction. This component proves only that the supplied immutable records are the records named by the plan.

## Compatibility

This is a private torchrun integration value. It adds no public export, store access, or runtime activation.

## Validation

- `232 passed` focused plan/quarantine/protocol tests
- `2113 passed` full CPU suite with CUDA hidden
- repository-wide Ruff check and format check
- targeted mypy for the state module and tests
- `git diff --check`