### PR TITLE
[Feature][Torchrun] Bind restart plan checkpoint certification

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -786,6 +786,10 @@ publication.
 inventory event, source-generation reporter identity, local holder, and
 compatible trust state. It does not prove copy completeness, holder
 availability, acknowledgement authorization, or trusted certification.
+For `recovery_verified` manifests, `RestartPlanCertificationState` requires
+matching trusted catalog records whose canonical event digests cover every
+referenced inventory event. It still does not prove copy completeness or
+holder availability.
 
 Before commit, the coordinator validates:
 

--- a/lm_resiliency/integrations/torchrun/_restart_plan_state.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_state.py
@@ -13,11 +13,13 @@ from lm_resiliency.integrations.torchrun._generation_records import (
     GenerationSnapshotRecord,
 )
 from lm_resiliency.integrations.torchrun._protocol import (
+    CheckpointCertification,
     CheckpointInventoryEvent,
     ProtocolValidationError,
     RankAssignment,
     RecoveryManifest,
     RestartPlan,
+    checkpoint_inventory_digest,
     validate_worker_identity,
 )
 from lm_resiliency.integrations.torchrun._quarantine_records import (
@@ -427,8 +429,78 @@ class RestartPlanInventoryState:
         return self.quarantine_state.manifest_state.manifest
 
 
+@dataclass(frozen=True, slots=True)
+class RestartPlanCertificationState:
+    """One inventory-bound plan authorized by trusted checkpoint certification."""
+
+    inventory_state: RestartPlanInventoryState
+    certifications: tuple[CheckpointCertification, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.inventory_state, RestartPlanInventoryState):
+            raise TypeError(
+                "RestartPlanCertificationState.inventory_state must be RestartPlanInventoryState"
+            )
+        if not isinstance(self.certifications, tuple):
+            raise TypeError("RestartPlanCertificationState.certifications must be a tuple")
+        manifest = self.inventory_state.manifest
+        if manifest.trust != "recovery_verified":
+            raise ValueError("RestartPlanCertificationState requires a recovery-verified manifest")
+        plan = self.inventory_state.plan
+        certification_ids: set[str] = set()
+        certified_event_digests: dict[str, str] = {}
+        for certification in self.certifications:
+            if not isinstance(certification, CheckpointCertification):
+                raise TypeError(
+                    "RestartPlanCertificationState.certifications values "
+                    "must be CheckpointCertification"
+                )
+            if certification.certification_id in certification_ids:
+                raise ValueError("RestartPlanCertificationState certification IDs must be unique")
+            certification_ids.add(certification.certification_id)
+            if (
+                certification.run_id != manifest.run_id
+                or certification.source_generation != manifest.source_generation
+                or certification.step != manifest.step
+                or certification.topology_digest != manifest.topology_digest
+                or certification.checkpoint_source != plan.checkpoint_source
+                or certification.checkpoint_id != plan.checkpoint_id
+                or certification.expected_world_size != plan.expected_world_size
+            ):
+                raise ValueError(
+                    "RestartPlanCertificationState certification does not match its plan"
+                )
+            for event_id, digest in certification.inventory_event_digests.items():
+                previous_digest = certified_event_digests.get(event_id)
+                if previous_digest is not None and previous_digest != digest:
+                    raise ValueError(
+                        "RestartPlanCertificationState certifications contain "
+                        "conflicting inventory digests"
+                    )
+                certified_event_digests[event_id] = digest
+        for event_id, event in self.inventory_state.inventory_events.items():
+            if certified_event_digests.get(event_id) != checkpoint_inventory_digest(event):
+                raise ValueError(
+                    "RestartPlanCertificationState inventory event is not exactly certified"
+                )
+        object.__setattr__(
+            self,
+            "certifications",
+            tuple(sorted(self.certifications, key=lambda value: value.certification_id)),
+        )
+
+    @property
+    def plan(self) -> RestartPlan:
+        return self.inventory_state.plan
+
+    @property
+    def manifest(self) -> RecoveryManifest:
+        return self.inventory_state.manifest
+
+
 __all__ = [
     "ResolvedRecoveryManifest",
+    "RestartPlanCertificationState",
     "RestartPlanGenerationState",
     "RestartPlanInventoryState",
     "RestartPlanManifestState",

--- a/tests/unit/test_torchrun_restart_plan_state.py
+++ b/tests/unit/test_torchrun_restart_plan_state.py
@@ -13,6 +13,7 @@ from lm_resiliency.integrations.torchrun._generation_records import (
     GenerationSnapshotRecord,
 )
 from lm_resiliency.integrations.torchrun._protocol import (
+    CheckpointCertification,
     CheckpointCopy,
     CheckpointInventoryEvent,
     RankAssignment,
@@ -22,6 +23,7 @@ from lm_resiliency.integrations.torchrun._protocol import (
     RestartPlan,
     SlotAssignment,
     WorkerIdentity,
+    checkpoint_inventory_digest,
 )
 from lm_resiliency.integrations.torchrun._quarantine_records import (
     NodeQuarantineRecord,
@@ -37,6 +39,7 @@ from lm_resiliency.integrations.torchrun._restart_plan_records import (
 )
 from lm_resiliency.integrations.torchrun._restart_plan_state import (
     ResolvedRecoveryManifest,
+    RestartPlanCertificationState,
     RestartPlanGenerationState,
     RestartPlanInventoryState,
     RestartPlanManifestState,
@@ -1219,5 +1222,255 @@ def test_restart_plan_inventory_state_does_not_claim_copy_eligibility():
     )
 
     state = _inventory_state(quarantine_state=quarantine_state)
+
+    assert not state.manifest.rank_copies[0].copies[0].complete
+
+
+def _verified_inventory_state(
+    *,
+    manifest: RecoveryManifest | None = None,
+) -> RestartPlanInventoryState:
+    selected_manifest = manifest or replace(_manifest(), trust="recovery_verified")
+    plan = replace(_plan(), recovery_mode="recovery_verified")
+    quarantine_state = _quarantine_state(
+        manifest_state=_manifest_state(
+            manifest=selected_manifest,
+            plan=plan,
+        )
+    )
+    return _inventory_state(quarantine_state=quarantine_state)
+
+
+def _certification(
+    state: RestartPlanInventoryState,
+    *,
+    certification_id: str = "certification-40",
+    inventory_event_digests: dict[str, str] | None = None,
+) -> CheckpointCertification:
+    return CheckpointCertification(
+        certification_id=certification_id,
+        run_id=state.manifest.run_id,
+        source_generation=state.manifest.source_generation,
+        step=state.manifest.step,
+        topology_digest=state.manifest.topology_digest,
+        checkpoint_source=state.plan.checkpoint_source,
+        checkpoint_id=state.plan.checkpoint_id,
+        expected_world_size=state.plan.expected_world_size,
+        certification_kind="dense_consensus",
+        inventory_event_digests=inventory_event_digests
+        or {
+            event_id: checkpoint_inventory_digest(event)
+            for event_id, event in state.inventory_events.items()
+        },
+    )
+
+
+def _certification_state() -> RestartPlanCertificationState:
+    inventory_state = _verified_inventory_state()
+    return RestartPlanCertificationState(
+        inventory_state=inventory_state,
+        certifications=(_certification(inventory_state),),
+    )
+
+
+def test_restart_plan_certification_state_binds_exact_certifications():
+    state = _certification_state()
+
+    assert state.plan == state.inventory_state.plan
+    assert state.manifest == state.inventory_state.manifest
+    assert tuple(cert.certification_id for cert in state.certifications) == ("certification-40",)
+
+
+def test_restart_plan_certification_state_requires_exact_types():
+    state = _certification_state()
+
+    with pytest.raises(TypeError, match="inventory_state must be"):
+        replace(state, inventory_state=state.inventory_state.quarantine_state)
+
+    with pytest.raises(TypeError, match="must be a tuple"):
+        replace(state, certifications=list(state.certifications))
+
+    with pytest.raises(TypeError, match="must be CheckpointCertification"):
+        replace(state, certifications=(state.certifications[0].to_dict(),))
+
+
+def test_restart_plan_certification_state_requires_verified_manifest():
+    state = _inventory_state()
+
+    with pytest.raises(ValueError, match="requires a recovery-verified manifest"):
+        RestartPlanCertificationState(
+            inventory_state=state,
+            certifications=(),
+        )
+
+
+def test_restart_plan_certification_state_sorts_and_rejects_duplicate_ids():
+    inventory_state = _verified_inventory_state()
+    first = _certification(
+        inventory_state,
+        certification_id="certification-b",
+    )
+    second = _certification(
+        inventory_state,
+        certification_id="certification-a",
+    )
+    state = RestartPlanCertificationState(
+        inventory_state=inventory_state,
+        certifications=(first, second),
+    )
+
+    assert tuple(cert.certification_id for cert in state.certifications) == (
+        "certification-a",
+        "certification-b",
+    )
+
+    with pytest.raises(ValueError, match="IDs must be unique"):
+        replace(state, certifications=(first, first))
+
+
+@pytest.mark.parametrize(
+    "certification",
+    [
+        replace(_certification(_verified_inventory_state()), run_id="other-run"),
+        replace(
+            _certification(_verified_inventory_state()),
+            source_generation=3,
+        ),
+        replace(_certification(_verified_inventory_state()), step=39),
+        replace(
+            _certification(_verified_inventory_state()),
+            topology_digest="topology-v2",
+        ),
+        replace(
+            _certification(_verified_inventory_state()),
+            checkpoint_source="durable",
+            checkpoint_id="durable-40",
+        ),
+        replace(
+            _certification(_verified_inventory_state()),
+            expected_world_size=8,
+        ),
+    ],
+)
+def test_restart_plan_certification_state_rejects_metadata_mismatch(certification):
+    with pytest.raises(ValueError, match="does not match its plan"):
+        RestartPlanCertificationState(
+            inventory_state=_verified_inventory_state(),
+            certifications=(certification,),
+        )
+
+
+def test_restart_plan_certification_state_requires_every_event_digest():
+    inventory_state = _verified_inventory_state()
+    digests = {
+        event_id: checkpoint_inventory_digest(event)
+        for event_id, event in inventory_state.inventory_events.items()
+    }
+    digests.pop("inventory-3")
+
+    with pytest.raises(ValueError, match="not exactly certified"):
+        RestartPlanCertificationState(
+            inventory_state=inventory_state,
+            certifications=(
+                _certification(
+                    inventory_state,
+                    inventory_event_digests=digests,
+                ),
+            ),
+        )
+
+
+def test_restart_plan_certification_state_rejects_wrong_event_digest():
+    inventory_state = _verified_inventory_state()
+    digests = {
+        event_id: checkpoint_inventory_digest(event)
+        for event_id, event in inventory_state.inventory_events.items()
+    }
+    digests["inventory-0"] = "0" * 64
+
+    with pytest.raises(ValueError, match="not exactly certified"):
+        RestartPlanCertificationState(
+            inventory_state=inventory_state,
+            certifications=(
+                _certification(
+                    inventory_state,
+                    inventory_event_digests=digests,
+                ),
+            ),
+        )
+
+
+def test_restart_plan_certification_state_rejects_conflicting_event_digests():
+    inventory_state = _verified_inventory_state()
+    first = _certification(
+        inventory_state,
+        certification_id="certification-a",
+    )
+    second_digests = dict(first.inventory_event_digests)
+    second_digests["inventory-0"] = "0" * 64
+    second = _certification(
+        inventory_state,
+        certification_id="certification-b",
+        inventory_event_digests=second_digests,
+    )
+
+    with pytest.raises(ValueError, match="conflicting inventory digests"):
+        RestartPlanCertificationState(
+            inventory_state=inventory_state,
+            certifications=(first, second),
+        )
+
+
+def test_restart_plan_certification_state_allows_certification_across_records():
+    inventory_state = _verified_inventory_state()
+    event_ids = tuple(inventory_state.inventory_events)
+    first = _certification(
+        inventory_state,
+        certification_id="certification-a",
+        inventory_event_digests={
+            event_id: checkpoint_inventory_digest(inventory_state.inventory_events[event_id])
+            for event_id in event_ids[:2]
+        },
+    )
+    second = _certification(
+        inventory_state,
+        certification_id="certification-b",
+        inventory_event_digests={
+            event_id: checkpoint_inventory_digest(inventory_state.inventory_events[event_id])
+            for event_id in event_ids[2:]
+        },
+    )
+
+    state = RestartPlanCertificationState(
+        inventory_state=inventory_state,
+        certifications=(second, first),
+    )
+
+    assert len(state.certifications) == 2
+
+
+def test_restart_plan_certification_state_does_not_claim_copy_eligibility():
+    manifest = replace(_manifest(), trust="recovery_verified")
+    incomplete_manifest = replace(
+        manifest,
+        rank_copies=(
+            replace(
+                manifest.rank_copies[0],
+                copies=(
+                    replace(
+                        manifest.rank_copies[0].copies[0],
+                        complete=False,
+                    ),
+                ),
+            ),
+            *manifest.rank_copies[1:],
+        ),
+    )
+    inventory_state = _verified_inventory_state(manifest=incomplete_manifest)
+
+    state = RestartPlanCertificationState(
+        inventory_state=inventory_state,
+        certifications=(_certification(inventory_state),),
+    )
 
     assert not state.manifest.rank_copies[0].copies[0].complete


### PR DESCRIPTION
## What changed

- add a pure `RestartPlanCertificationState` value for `recovery_verified` manifests
- require matching trusted certification metadata and exact canonical digests for every referenced inventory event
- merge split certification coverage fail closed and reject duplicate IDs or conflicting event digests
- explicitly leave copy completeness, holder availability, acknowledgement authorization, and publication out of scope

## Why

The restart-plan pipeline needs a reviewable trusted-catalog boundary before individual manifest copies can become recovery eligible. This component proves only certification coverage for the exact inventory events already bound to the plan.

## Compatibility

This is a private torchrun integration value. It adds no public export, store access, or runtime activation.

## Validation

- `178 passed` focused plan/certification/protocol tests
- `2142 passed` full CPU suite with CUDA hidden
- repository-wide Ruff check and format check
- targeted mypy for the state module and tests
- `git diff --check`