### PR TITLE
[Feature][Torchrun] Validate restart plan copy eligibility

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -796,6 +796,11 @@ current generation, and every referenced inventory event must be authorized by
 the reporting agent's successful acknowledgement, flushed step, and canonical
 event digest. It still does not prove per-rank copy completeness, holder
 availability, or fallback eligibility.
+`RestartPlanCopyEligibilityState` independently requires exact rank coverage
+and rejects every incomplete, wrong-source, wrong-role, process-memory, or
+unavailable node-local copy advertised by the immutable manifest. Shared and
+remote copies remain independent of holder-node admission. This value does not
+establish latest acknowledgement or recovery-verified certification evidence.
 
 Before commit, the coordinator validates:
 

--- a/lm_resiliency/integrations/torchrun/_restart_plan_state.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_state.py
@@ -559,9 +559,85 @@ class RestartPlanLatestEvidenceState:
         return self.inventory_state.manifest
 
 
+@dataclass(frozen=True, slots=True)
+class RestartPlanCopyEligibilityState:
+    """One inventory-bound plan whose advertised copies are all usable."""
+
+    inventory_state: RestartPlanInventoryState
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.inventory_state, RestartPlanInventoryState):
+            raise TypeError(
+                "RestartPlanCopyEligibilityState.inventory_state must be RestartPlanInventoryState"
+            )
+        plan = self.inventory_state.plan
+        manifest = self.inventory_state.manifest
+        entries = {entry.owner_global_rank: entry for entry in manifest.rank_copies}
+        required_ranks = set(range(plan.expected_world_size))
+        if set(entries) != required_ranks:
+            missing = sorted(required_ranks - set(entries))
+            extra = sorted(set(entries) - required_ranks)
+            raise ValueError(
+                "RestartPlanCopyEligibilityState rank coverage mismatch; "
+                f"missing={missing!r}, extra={extra!r}"
+            )
+        source_assignment = (
+            self.inventory_state.quarantine_state.manifest_state.resolved_manifest.source_assignment
+        )
+        source_owner_by_rank = {
+            rank: source_assignment.slot_to_node_id[slot]
+            for slot, (first_rank, last_rank) in source_assignment.slot_to_rank_range.items()
+            for rank in range(first_rank, last_rank)
+        }
+        assigned_nodes = {assignment.node_id for assignment in plan.slot_assignments}
+        compatible_holder_kinds = (
+            {"durable"} if plan.checkpoint_source == "durable" else {"owner", "peer"}
+        )
+        for rank, entry in entries.items():
+            if not entry.copies:
+                raise ValueError(
+                    f"RestartPlanCopyEligibilityState rank {rank} has no eligible copy"
+                )
+            for copy in entry.copies:
+                if not (
+                    copy.complete
+                    and copy.checkpoint_step == manifest.step
+                    and copy.holder_kind in compatible_holder_kinds
+                    and copy.storage_kind in {"node_local", "shared", "remote"}
+                    and copy.checkpoint_id == plan.checkpoint_id
+                    and (
+                        copy.holder_kind == "durable"
+                        or (
+                            copy.holder_kind == "owner"
+                            and copy.holder_node_id == source_owner_by_rank[rank]
+                        )
+                        or (
+                            copy.holder_kind == "peer"
+                            and copy.holder_node_id != source_owner_by_rank[rank]
+                        )
+                    )
+                    and (
+                        copy.storage_kind in {"shared", "remote"}
+                        or copy.holder_node_id in assigned_nodes
+                    )
+                ):
+                    raise ValueError(
+                        f"RestartPlanCopyEligibilityState rank {rank} contains an ineligible copy"
+                    )
+
+    @property
+    def plan(self) -> RestartPlan:
+        return self.inventory_state.plan
+
+    @property
+    def manifest(self) -> RecoveryManifest:
+        return self.inventory_state.manifest
+
+
 __all__ = [
     "ResolvedRecoveryManifest",
     "RestartPlanCertificationState",
+    "RestartPlanCopyEligibilityState",
     "RestartPlanGenerationState",
     "RestartPlanInventoryState",
     "RestartPlanLatestEvidenceState",

--- a/tests/unit/test_torchrun_restart_plan_state.py
+++ b/tests/unit/test_torchrun_restart_plan_state.py
@@ -40,6 +40,7 @@ from lm_resiliency.integrations.torchrun._restart_plan_records import (
 from lm_resiliency.integrations.torchrun._restart_plan_state import (
     ResolvedRecoveryManifest,
     RestartPlanCertificationState,
+    RestartPlanCopyEligibilityState,
     RestartPlanGenerationState,
     RestartPlanInventoryState,
     RestartPlanManifestState,
@@ -952,7 +953,7 @@ def _inventory_event(
         step=manifest.step,
         trust=trust or manifest.trust,
         topology_digest=manifest.topology_digest,
-        copies=(copy,),
+        copies=rank_copies.copies,
     )
 
 
@@ -1224,6 +1225,241 @@ def test_restart_plan_inventory_state_does_not_claim_copy_eligibility():
     state = _inventory_state(quarantine_state=quarantine_state)
 
     assert not state.manifest.rank_copies[0].copies[0].complete
+
+
+def _shared_manifest() -> RecoveryManifest:
+    manifest = _manifest()
+    return replace(
+        manifest,
+        rank_copies=tuple(
+            replace(
+                entry,
+                copies=tuple(
+                    replace(
+                        copy,
+                        storage_kind="shared",
+                    )
+                    for copy in entry.copies
+                ),
+            )
+            for entry in manifest.rank_copies
+        ),
+    )
+
+
+def _inventory_state_for_manifest(
+    manifest: RecoveryManifest,
+    *,
+    plan: RestartPlan | None = None,
+) -> RestartPlanInventoryState:
+    return _inventory_state(
+        quarantine_state=_quarantine_state(
+            manifest_state=_manifest_state(
+                manifest=manifest,
+                plan=plan,
+            )
+        )
+    )
+
+
+def _copy_eligibility_state() -> RestartPlanCopyEligibilityState:
+    return RestartPlanCopyEligibilityState(
+        inventory_state=_inventory_state_for_manifest(_shared_manifest())
+    )
+
+
+def test_restart_plan_copy_eligibility_state_accepts_shared_gemini_copies():
+    state = _copy_eligibility_state()
+
+    assert state.plan == state.inventory_state.plan
+    assert state.manifest == state.inventory_state.manifest
+
+
+def test_restart_plan_copy_eligibility_state_requires_exact_type():
+    state = _copy_eligibility_state()
+
+    with pytest.raises(TypeError, match="inventory_state must be"):
+        replace(
+            state,
+            inventory_state=state.inventory_state.quarantine_state,
+        )
+
+
+def test_restart_plan_copy_eligibility_state_requires_exact_rank_coverage():
+    manifest = replace(
+        _shared_manifest(),
+        rank_copies=_shared_manifest().rank_copies[:-1],
+    )
+    quarantine_state = _quarantine_state(manifest_state=_manifest_state(manifest=manifest))
+    inventory_state = _inventory_state(
+        quarantine_state=quarantine_state,
+        inventory_events={
+            event.event_id: event
+            for event in (
+                _inventory_event(quarantine_state, rank)
+                for rank in range(manifest.rank_copies[-1].owner_global_rank + 1)
+            )
+        },
+    )
+
+    with pytest.raises(ValueError, match="rank coverage mismatch"):
+        RestartPlanCopyEligibilityState(inventory_state)
+
+
+def test_restart_plan_copy_eligibility_state_requires_one_copy_per_rank():
+    manifest = _shared_manifest()
+    manifest = replace(
+        manifest,
+        rank_copies=(
+            replace(manifest.rank_copies[0], copies=()),
+            *manifest.rank_copies[1:],
+        ),
+    )
+    quarantine_state = _quarantine_state(manifest_state=_manifest_state(manifest=manifest))
+    inventory_state = _inventory_state(
+        quarantine_state=quarantine_state,
+        inventory_events={
+            event.event_id: event
+            for event in (
+                _inventory_event(quarantine_state, rank)
+                for rank in range(1, manifest.rank_copies[-1].owner_global_rank + 1)
+            )
+        },
+    )
+
+    with pytest.raises(ValueError, match="has no eligible copy"):
+        RestartPlanCopyEligibilityState(inventory_state)
+
+
+@pytest.mark.parametrize(
+    "copy",
+    [
+        replace(
+            _shared_manifest().rank_copies[0].copies[0],
+            complete=False,
+        ),
+        replace(
+            _shared_manifest().rank_copies[0].copies[0],
+            storage_kind="memory",
+        ),
+        replace(
+            _shared_manifest().rank_copies[0].copies[0],
+            holder_node_id="node-b",
+        ),
+        replace(
+            _shared_manifest().rank_copies[0].copies[0],
+            holder_kind="peer",
+        ),
+    ],
+)
+def test_restart_plan_copy_eligibility_state_rejects_ineligible_gemini_copy(copy):
+    manifest = _shared_manifest()
+    manifest = replace(
+        manifest,
+        rank_copies=(
+            replace(manifest.rank_copies[0], copies=(copy,)),
+            *manifest.rank_copies[1:],
+        ),
+    )
+
+    with pytest.raises(ValueError, match="contains an ineligible copy"):
+        RestartPlanCopyEligibilityState(_inventory_state_for_manifest(manifest))
+
+
+def test_restart_plan_copy_eligibility_state_rejects_departing_node_local_holder():
+    with pytest.raises(ValueError, match="contains an ineligible copy"):
+        RestartPlanCopyEligibilityState(_inventory_state())
+
+
+def test_restart_plan_copy_eligibility_state_rejects_ineligible_alternative_copy():
+    manifest = _shared_manifest()
+    eligible_copy = manifest.rank_copies[0].copies[0]
+    ineligible_copy = replace(
+        eligible_copy,
+        storage_kind="memory",
+        location_token="memory-copy-0",
+    )
+    manifest = replace(
+        manifest,
+        rank_copies=(
+            replace(
+                manifest.rank_copies[0],
+                copies=(eligible_copy, ineligible_copy),
+            ),
+            *manifest.rank_copies[1:],
+        ),
+    )
+
+    with pytest.raises(ValueError, match="contains an ineligible copy"):
+        RestartPlanCopyEligibilityState(_inventory_state_for_manifest(manifest))
+
+
+def _durable_manifest(
+    *,
+    checkpoint_id: str = "durable-40",
+) -> RecoveryManifest:
+    manifest = replace(_manifest(), trust="recovery_verified")
+    return replace(
+        manifest,
+        rank_copies=tuple(
+            replace(
+                entry,
+                copies=tuple(
+                    replace(
+                        copy,
+                        checkpoint_id=checkpoint_id,
+                        holder_node_id="durable-store",
+                        holder_kind="durable",
+                        storage_kind="remote",
+                    )
+                    for copy in entry.copies
+                ),
+            )
+            for entry in manifest.rank_copies
+        ),
+    )
+
+
+def _durable_plan() -> RestartPlan:
+    return replace(
+        _plan(),
+        recovery_mode="recovery_verified",
+        checkpoint_source="durable",
+        checkpoint_id="durable-40",
+    )
+
+
+def test_restart_plan_copy_eligibility_state_accepts_remote_durable_copies():
+    state = RestartPlanCopyEligibilityState(
+        _inventory_state_for_manifest(
+            _durable_manifest(),
+            plan=_durable_plan(),
+        )
+    )
+
+    assert state.plan.checkpoint_source == "durable"
+
+
+def test_restart_plan_copy_eligibility_state_rejects_wrong_source_kind():
+    verified_manifest = replace(_shared_manifest(), trust="recovery_verified")
+
+    with pytest.raises(ValueError, match="contains an ineligible copy"):
+        RestartPlanCopyEligibilityState(
+            _inventory_state_for_manifest(
+                verified_manifest,
+                plan=_durable_plan(),
+            )
+        )
+
+
+def test_restart_plan_copy_eligibility_state_rejects_wrong_checkpoint_id():
+    with pytest.raises(ValueError, match="contains an ineligible copy"):
+        RestartPlanCopyEligibilityState(
+            _inventory_state_for_manifest(
+                _durable_manifest(checkpoint_id="durable-other"),
+                plan=_durable_plan(),
+            )
+        )
 
 
 def _verified_inventory_state(


### PR DESCRIPTION
## Summary

- add a pure `RestartPlanCopyEligibilityState` for immutable recovery manifests
- require exact rank coverage and at least one advertised copy for every rank
- reject incomplete, wrong-source, wrong-role, process-memory, unavailable node-local, and checkpoint-ID-mismatched copies
- keep latest acknowledgement, trusted certification, fallback selection, and publication out of scope

## Compatibility

This adds an internal private value contract only. It does not export a public API or activate torchrun runtime behavior.

## Validation

- `CUDA_VISIBLE_DEVICES='' .venv/bin/python -m pytest -q` (2,164 passed)
- focused restart-plan/protocol tests (179 passed)
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- targeted mypy for changed Python files
- `git diff --check`