### PR TITLE
[Feature][Torchrun] Compose restart plan recovery evidence

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -801,6 +801,11 @@ and rejects every incomplete, wrong-source, wrong-role, process-memory, or
 unavailable node-local copy advertised by the immutable manifest. Shared and
 remote copies remain independent of holder-node admission. This value does not
 establish latest acknowledgement or recovery-verified certification evidence.
+`RestartPlanRecoveryEvidenceState` composes that copy eligibility with exactly
+one matching trust path: latest restart-acknowledgement evidence or
+recovery-verified checkpoint certification. Both values must describe the same
+immutable inventory state. Placement, quarantine admission, and atomic
+publication remain separate checks.
 
 Before commit, the coordinator validates:
 

--- a/lm_resiliency/integrations/torchrun/_restart_plan_state.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_state.py
@@ -634,6 +634,42 @@ class RestartPlanCopyEligibilityState:
         return self.inventory_state.manifest
 
 
+@dataclass(frozen=True, slots=True)
+class RestartPlanRecoveryEvidenceState:
+    """One copy-eligible plan authorized by one exact recovery trust path."""
+
+    copy_state: RestartPlanCopyEligibilityState
+    trust_state: RestartPlanLatestEvidenceState | RestartPlanCertificationState
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.copy_state, RestartPlanCopyEligibilityState):
+            raise TypeError(
+                "RestartPlanRecoveryEvidenceState.copy_state "
+                "must be RestartPlanCopyEligibilityState"
+            )
+        if not isinstance(
+            self.trust_state,
+            (RestartPlanLatestEvidenceState, RestartPlanCertificationState),
+        ):
+            raise TypeError(
+                "RestartPlanRecoveryEvidenceState.trust_state must be "
+                "RestartPlanLatestEvidenceState or RestartPlanCertificationState"
+            )
+        if self.copy_state.inventory_state != self.trust_state.inventory_state:
+            raise ValueError(
+                "RestartPlanRecoveryEvidenceState copy and trust evidence "
+                "do not describe the same inventory state"
+            )
+
+    @property
+    def plan(self) -> RestartPlan:
+        return self.copy_state.plan
+
+    @property
+    def manifest(self) -> RecoveryManifest:
+        return self.copy_state.manifest
+
+
 __all__ = [
     "ResolvedRecoveryManifest",
     "RestartPlanCertificationState",
@@ -643,4 +679,5 @@ __all__ = [
     "RestartPlanLatestEvidenceState",
     "RestartPlanManifestState",
     "RestartPlanQuarantineState",
+    "RestartPlanRecoveryEvidenceState",
 ]

--- a/tests/unit/test_torchrun_restart_ack_evidence.py
+++ b/tests/unit/test_torchrun_restart_ack_evidence.py
@@ -65,11 +65,13 @@ from lm_resiliency.integrations.torchrun._restart_plan_records import (
 )
 from lm_resiliency.integrations.torchrun._restart_plan_state import (
     ResolvedRecoveryManifest,
+    RestartPlanCopyEligibilityState,
     RestartPlanGenerationState,
     RestartPlanInventoryState,
     RestartPlanLatestEvidenceState,
     RestartPlanManifestState,
     RestartPlanQuarantineState,
+    RestartPlanRecoveryEvidenceState,
 )
 
 RUN_ID = "training-run"
@@ -656,3 +658,20 @@ def test_restart_plan_latest_evidence_state_does_not_claim_copy_eligibility():
     )
 
     assert not state.manifest.rank_copies[0].copies[0].complete
+
+
+def test_restart_plan_recovery_evidence_state_accepts_latest_acknowledgements():
+    event = _latest_event()
+    evidence, _ = _evidence(event=event)
+    inventory_state = _latest_inventory_state(evidence, event)
+
+    state = RestartPlanRecoveryEvidenceState(
+        copy_state=RestartPlanCopyEligibilityState(inventory_state),
+        trust_state=RestartPlanLatestEvidenceState(
+            inventory_state=inventory_state,
+            acknowledgement_evidence=evidence,
+        ),
+    )
+
+    assert state.plan == inventory_state.plan
+    assert state.manifest == inventory_state.manifest

--- a/tests/unit/test_torchrun_restart_plan_state.py
+++ b/tests/unit/test_torchrun_restart_plan_state.py
@@ -45,6 +45,7 @@ from lm_resiliency.integrations.torchrun._restart_plan_state import (
     RestartPlanInventoryState,
     RestartPlanManifestState,
     RestartPlanQuarantineState,
+    RestartPlanRecoveryEvidenceState,
 )
 
 RUN_ID = "training-run"
@@ -1459,6 +1460,48 @@ def test_restart_plan_copy_eligibility_state_rejects_wrong_checkpoint_id():
                 _durable_manifest(checkpoint_id="durable-other"),
                 plan=_durable_plan(),
             )
+        )
+
+
+def test_restart_plan_recovery_evidence_state_accepts_verified_certification():
+    inventory_state = _verified_inventory_state(
+        manifest=replace(_shared_manifest(), trust="recovery_verified")
+    )
+    certification_state = RestartPlanCertificationState(
+        inventory_state=inventory_state,
+        certifications=(_certification(inventory_state),),
+    )
+
+    state = RestartPlanRecoveryEvidenceState(
+        copy_state=RestartPlanCopyEligibilityState(inventory_state),
+        trust_state=certification_state,
+    )
+
+    assert state.plan == inventory_state.plan
+    assert state.manifest == inventory_state.manifest
+
+
+def test_restart_plan_recovery_evidence_state_requires_exact_types():
+    copy_state = _copy_eligibility_state()
+    certification_state = _certification_state()
+
+    with pytest.raises(TypeError, match="copy_state must be"):
+        RestartPlanRecoveryEvidenceState(
+            copy_state=copy_state.inventory_state,
+            trust_state=certification_state,
+        )
+    with pytest.raises(TypeError, match="trust_state must be"):
+        RestartPlanRecoveryEvidenceState(
+            copy_state=copy_state,
+            trust_state=copy_state,
+        )
+
+
+def test_restart_plan_recovery_evidence_state_rejects_cross_inventory_evidence():
+    with pytest.raises(ValueError, match="same inventory state"):
+        RestartPlanRecoveryEvidenceState(
+            copy_state=_copy_eligibility_state(),
+            trust_state=_certification_state(),
         )
 
 


### PR DESCRIPTION
## Summary

- add a pure `RestartPlanRecoveryEvidenceState`
- require eligible copies and exactly one matching trust path
- accept either latest acknowledgement evidence or recovery-verified certification
- reject evidence reconstructed from a different immutable inventory state
- keep placement, quarantine admission, and publication out of scope

## Compatibility

This adds an internal private value contract only. It does not export a public API or activate torchrun runtime behavior.

## Validation

- `CUDA_VISIBLE_DEVICES='' .venv/bin/python -m pytest -q` (2,168 passed)
- focused evidence/plan-state tests (117 passed)
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- targeted mypy for changed Python files
- `git diff --check`