### PR TITLE
[Feature][Torchrun] Validate restart plan placement registrations

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -809,12 +809,13 @@ publication remain separate checks.
 `RestartPlanPlacementState` performs the registration-backed part of placement
 admission without reading or mutating the control store. It requires the
 closed intent's suspected nodes to be removed, surviving nodes to retain their
-logical slots, at least one replacement node, and exact current registration
-histories for every successor node. Each selected registration must be live at
-one observation time and must match the planned local worker count and the
-coordinator's expected `environment_digest`. Trusted hardware inventory,
-previously committed quarantine state, recovery evidence, and atomic
-publication remain separate admission boundaries.
+logical slots, the active node count to remain fixed, at least one genuinely
+new replacement node, and exact current registration histories for every
+successor node. Each selected registration must be live at one observation time
+and must match the planned local worker count and the coordinator's expected
+`environment_digest`. Trusted hardware inventory, previously committed
+quarantine state, recovery evidence, and atomic publication remain separate
+admission boundaries.
 
 Before commit, the coordinator validates:
 

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -806,6 +806,15 @@ one matching trust path: latest restart-acknowledgement evidence or
 recovery-verified checkpoint certification. Both values must describe the same
 immutable inventory state. Placement, quarantine admission, and atomic
 publication remain separate checks.
+`RestartPlanPlacementState` performs the registration-backed part of placement
+admission without reading or mutating the control store. It requires the
+closed intent's suspected nodes to be removed, surviving nodes to retain their
+logical slots, at least one replacement node, and exact current registration
+histories for every successor node. Each selected registration must be live at
+one observation time and must match the planned local worker count and the
+coordinator's expected `environment_digest`. Trusted hardware inventory,
+previously committed quarantine state, recovery evidence, and atomic
+publication remain separate admission boundaries.
 
 Before commit, the coordinator validates:
 

--- a/lm_resiliency/integrations/torchrun/_restart_plan_state.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_state.py
@@ -747,9 +747,14 @@ class RestartPlanPlacementState:
                 "RestartPlanPlacementState surviving nodes changed logical slots: "
                 f"{moved_survivors!r}"
             )
-        if planned_nodes == current_nodes:
+        if not planned_nodes - current_nodes:
             raise ValueError(
                 "RestartPlanPlacementState version 1 requires at least one replacement node"
+            )
+        if len(plan.slot_assignments) != self.generation_state.from_assignment.active_nodes:
+            raise ValueError(
+                "RestartPlanPlacementState successor active node count "
+                "does not match the source generation"
             )
         removed_nodes = current_nodes - planned_nodes
         quarantined_nodes = set(plan.quarantined_node_ids)

--- a/lm_resiliency/integrations/torchrun/_restart_plan_state.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_state.py
@@ -6,6 +6,9 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
 
+from lm_resiliency.integrations.torchrun._agent_registration_history_reader import (
+    AgentRegistrationHistory,
+)
 from lm_resiliency.integrations.torchrun._generation_reader import (
     StoredGenerationSnapshot,
 )
@@ -670,6 +673,153 @@ class RestartPlanRecoveryEvidenceState:
         return self.copy_state.manifest
 
 
+@dataclass(frozen=True, slots=True)
+class RestartPlanPlacementState:
+    """One successor placement backed by exact live agent registrations."""
+
+    generation_state: RestartPlanGenerationState
+    registration_histories: Mapping[str, AgentRegistrationHistory]
+    observed_at_unix_ms: int
+    environment_digest: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.generation_state, RestartPlanGenerationState):
+            raise TypeError(
+                "RestartPlanPlacementState.generation_state must be RestartPlanGenerationState"
+            )
+        if not isinstance(self.registration_histories, Mapping):
+            raise TypeError("RestartPlanPlacementState.registration_histories must be a mapping")
+        if (
+            isinstance(self.observed_at_unix_ms, bool)
+            or not isinstance(self.observed_at_unix_ms, int)
+            or self.observed_at_unix_ms < 1
+        ):
+            raise ValueError(
+                "RestartPlanPlacementState.observed_at_unix_ms must be a positive integer"
+            )
+        if not isinstance(self.environment_digest, str) or not self.environment_digest.strip():
+            raise ValueError(
+                "RestartPlanPlacementState.environment_digest must be a non-empty string"
+            )
+        self._validate_topology()
+        histories = self._validate_registrations()
+        object.__setattr__(
+            self,
+            "registration_histories",
+            MappingProxyType(histories),
+        )
+
+    @property
+    def plan(self) -> RestartPlan:
+        return self.generation_state.plan
+
+    def _validate_topology(self) -> None:
+        plan = self.plan
+        intent = self.generation_state.intent_record.intent
+        current_slots = {
+            node_id: slot
+            for slot, node_id in self.generation_state.from_assignment.slot_to_node_id.items()
+        }
+        planned_slots = {
+            assignment.node_id: assignment.logical_node_slot for assignment in plan.slot_assignments
+        }
+        current_nodes = set(current_slots)
+        planned_nodes = set(planned_slots)
+        suspected_nodes = set(intent.suspected_node_ids)
+        unknown_suspects = sorted(suspected_nodes - current_nodes)
+        if unknown_suspects:
+            raise ValueError(
+                "RestartPlanPlacementState suspected nodes are not active in "
+                f"the source generation: {unknown_suspects!r}"
+            )
+        retained_suspects = sorted(suspected_nodes & planned_nodes)
+        if retained_suspects:
+            raise ValueError(
+                f"RestartPlanPlacementState suspected nodes remain assigned: {retained_suspects!r}"
+            )
+        moved_survivors = sorted(
+            node_id
+            for node_id in current_nodes & planned_nodes
+            if current_slots[node_id] != planned_slots[node_id]
+        )
+        if moved_survivors:
+            raise ValueError(
+                "RestartPlanPlacementState surviving nodes changed logical slots: "
+                f"{moved_survivors!r}"
+            )
+        if planned_nodes == current_nodes:
+            raise ValueError(
+                "RestartPlanPlacementState version 1 requires at least one replacement node"
+            )
+        removed_nodes = current_nodes - planned_nodes
+        quarantined_nodes = set(plan.quarantined_node_ids)
+        unsupported_quarantine = sorted(quarantined_nodes - suspected_nodes)
+        if unsupported_quarantine:
+            raise ValueError(
+                "RestartPlanPlacementState quarantines nodes outside the intent scope: "
+                f"{unsupported_quarantine!r}"
+            )
+        unremoved_quarantine = sorted(quarantined_nodes - removed_nodes)
+        if unremoved_quarantine:
+            raise ValueError(
+                "RestartPlanPlacementState quarantined nodes remain in the successor "
+                f"assignment: {unremoved_quarantine!r}"
+            )
+
+    def _validate_registrations(self) -> dict[str, AgentRegistrationHistory]:
+        plan = self.plan
+        assignments = {assignment.node_id: assignment for assignment in plan.slot_assignments}
+        histories: dict[str, AgentRegistrationHistory] = {}
+        for node_id, history in self.registration_histories.items():
+            if not isinstance(node_id, str) or not node_id.strip():
+                raise ValueError(
+                    "RestartPlanPlacementState.registration_histories keys "
+                    "must be non-empty node IDs"
+                )
+            if not isinstance(history, AgentRegistrationHistory):
+                raise TypeError(
+                    "RestartPlanPlacementState.registration_histories values "
+                    "must be AgentRegistrationHistory"
+                )
+            histories[node_id] = history
+        if set(histories) != set(assignments):
+            raise ValueError(
+                "RestartPlanPlacementState registration histories must exactly "
+                "cover the successor assignment"
+            )
+        for node_id, assignment in assignments.items():
+            registration = histories[node_id].current
+            if registration is None:
+                raise ValueError(
+                    f"RestartPlanPlacementState node {node_id!r} has no current registration"
+                )
+            identity = registration.record.agent_identity
+            if identity.run_id != plan.run_id or identity.node_id != node_id:
+                raise ValueError(
+                    f"RestartPlanPlacementState node {node_id!r} registration "
+                    "has the wrong identity"
+                )
+            if registration.granted_at_unix_ms > self.observed_at_unix_ms:
+                raise ValueError(
+                    f"RestartPlanPlacementState node {node_id!r} registration "
+                    "was granted after the observation"
+                )
+            if registration.expires_at_unix_ms <= self.observed_at_unix_ms:
+                raise ValueError(
+                    f"RestartPlanPlacementState node {node_id!r} registration is not live"
+                )
+            if identity.local_world_size != assignment.local_world_size:
+                raise ValueError(
+                    f"RestartPlanPlacementState node {node_id!r} local world size "
+                    "does not match its slot"
+                )
+            if identity.environment_digest != self.environment_digest:
+                raise ValueError(
+                    f"RestartPlanPlacementState node {node_id!r} environment is incompatible"
+                )
+        return dict(sorted(histories.items()))
+
+
 __all__ = [
     "ResolvedRecoveryManifest",
     "RestartPlanCertificationState",
@@ -678,6 +828,7 @@ __all__ = [
     "RestartPlanInventoryState",
     "RestartPlanLatestEvidenceState",
     "RestartPlanManifestState",
+    "RestartPlanPlacementState",
     "RestartPlanQuarantineState",
     "RestartPlanRecoveryEvidenceState",
 ]

--- a/tests/unit/test_torchrun_restart_plan_state.py
+++ b/tests/unit/test_torchrun_restart_plan_state.py
@@ -600,6 +600,58 @@ def test_restart_plan_placement_state_requires_replacement():
         )
 
 
+def test_restart_plan_placement_state_rejects_shrink_without_replacement():
+    state = _generation_state()
+    changed = _replace_generation_plan(
+        state,
+        replace(
+            state.plan,
+            slot_assignments=(
+                SlotAssignment(
+                    logical_node_slot=0,
+                    node_id="node-a",
+                    first_global_rank=0,
+                    local_world_size=4,
+                ),
+            ),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="requires at least one replacement"):
+        _placement_state(
+            generation_state=changed,
+            registration_histories={
+                "node-a": _registration_history("node-a", local_world_size=4),
+            },
+        )
+
+
+def test_restart_plan_placement_state_preserves_active_node_count():
+    state = _generation_state()
+    changed = _replace_generation_plan(
+        state,
+        replace(
+            state.plan,
+            slot_assignments=(
+                SlotAssignment(
+                    logical_node_slot=0,
+                    node_id="node-c",
+                    first_global_rank=0,
+                    local_world_size=4,
+                ),
+            ),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="active node count"):
+        _placement_state(
+            generation_state=changed,
+            registration_histories={
+                "node-c": _registration_history("node-c", local_world_size=4),
+            },
+        )
+
+
 def test_restart_plan_placement_state_rejects_quarantine_outside_intent_scope():
     state = _generation_state()
     changed = _replace_generation_plan(

--- a/tests/unit/test_torchrun_restart_plan_state.py
+++ b/tests/unit/test_torchrun_restart_plan_state.py
@@ -6,6 +6,16 @@ from dataclasses import replace
 
 import pytest
 
+from lm_resiliency.integrations.torchrun._agent_registration_history import (
+    AgentRegistrationAuthority,
+)
+from lm_resiliency.integrations.torchrun._agent_registration_history_reader import (
+    AgentRegistrationHistory,
+)
+from lm_resiliency.integrations.torchrun._agent_registration_records import (
+    AgentRegistrationRecord,
+    HeldAgentRegistration,
+)
 from lm_resiliency.integrations.torchrun._generation_reader import (
     StoredGenerationSnapshot,
 )
@@ -13,6 +23,7 @@ from lm_resiliency.integrations.torchrun._generation_records import (
     GenerationSnapshotRecord,
 )
 from lm_resiliency.integrations.torchrun._protocol import (
+    AgentIdentity,
     CheckpointCertification,
     CheckpointCopy,
     CheckpointInventoryEvent,
@@ -44,6 +55,7 @@ from lm_resiliency.integrations.torchrun._restart_plan_state import (
     RestartPlanGenerationState,
     RestartPlanInventoryState,
     RestartPlanManifestState,
+    RestartPlanPlacementState,
     RestartPlanQuarantineState,
     RestartPlanRecoveryEvidenceState,
 )
@@ -361,6 +373,300 @@ def _generation_state() -> RestartPlanGenerationState:
         from_snapshot=from_snapshot,
         to_snapshot=to_snapshot,
     )
+
+
+def _registration_history(
+    node_id: str,
+    *,
+    local_world_size: int = 2,
+    environment_digest: str = "environment-v1",
+    granted_at_unix_ms: int = 1_100,
+    lease_duration_ms: int = 500,
+    current: bool = True,
+) -> AgentRegistrationHistory:
+    record = AgentRegistrationRecord(
+        agent_identity=AgentIdentity(
+            run_id=RUN_ID,
+            node_id=node_id,
+            agent_id=f"agent-{node_id}",
+            hostname=f"host-{node_id}",
+            local_world_size=local_world_size,
+            resource_ids=(f"{node_id}-gpu-0", f"{node_id}-gpu-1"),
+            environment_digest=environment_digest,
+        ),
+        registration_id=f"registration-{node_id}",
+        lease_duration_ms=lease_duration_ms,
+    )
+    held = HeldAgentRegistration(
+        record=record,
+        fencing_token=11,
+        granted_at_unix_ms=granted_at_unix_ms,
+    )
+    authority = AgentRegistrationAuthority(
+        registration=held,
+        transaction_sequence=11,
+        mutation_sequence=1,
+        value_sequence=1,
+        lifetime_sequence=1,
+    )
+    return AgentRegistrationHistory(
+        authorities=(authority,),
+        current=held if current else None,
+    )
+
+
+def _placement_state(
+    *,
+    generation_state: RestartPlanGenerationState | None = None,
+    registration_histories: dict[str, AgentRegistrationHistory] | None = None,
+    observed_at_unix_ms: int = 1_200,
+    environment_digest: str = "environment-v1",
+) -> RestartPlanPlacementState:
+    return RestartPlanPlacementState(
+        generation_state=generation_state or _generation_state(),
+        registration_histories=registration_histories
+        or {
+            "node-a": _registration_history("node-a"),
+            "node-c": _registration_history("node-c"),
+        },
+        observed_at_unix_ms=observed_at_unix_ms,
+        environment_digest=environment_digest,
+    )
+
+
+def _replace_generation_intent(
+    state: RestartPlanGenerationState,
+    intent: RestartIntent,
+) -> RestartPlanGenerationState:
+    intent_record = replace(state.intent_record, intent=intent)
+    lifecycle = replace(
+        state.lifecycle_record,
+        closed_intent=replace(
+            state.lifecycle_record.closed_intent,
+            intent_digest=intent_record.digest,
+        ),
+    )
+    return replace(
+        state,
+        intent_record=intent_record,
+        lifecycle_record=lifecycle,
+        record=replace(
+            state.record,
+            intent_lifecycle_record_digest=lifecycle.digest,
+        ),
+    )
+
+
+def _replace_generation_plan(
+    state: RestartPlanGenerationState,
+    plan: RestartPlan,
+) -> RestartPlanGenerationState:
+    assignment = RankAssignment.from_assignments(
+        run_id=plan.run_id,
+        generation=plan.to_generation,
+        assignments=plan.slot_assignments,
+        topology_digest=plan.topology_digest,
+    )
+    to_snapshot = replace(state.to_snapshot, assignment=assignment)
+    return replace(
+        state,
+        to_snapshot=to_snapshot,
+        record=replace(
+            state.record,
+            plan=plan,
+            to_generation_snapshot_digest=to_snapshot.digest,
+            quarantine_record_digests={node_id: "0" * 64 for node_id in plan.quarantined_node_ids},
+        ),
+    )
+
+
+def test_restart_plan_placement_state_binds_live_compatible_registrations():
+    state = _placement_state()
+
+    assert state.plan == state.generation_state.plan
+    assert tuple(state.registration_histories) == ("node-a", "node-c")
+    assert state.registration_histories["node-c"].current is not None
+
+
+def test_restart_plan_placement_state_requires_exact_types():
+    state = _placement_state()
+
+    with pytest.raises(TypeError, match="generation_state must be RestartPlanGenerationState"):
+        replace(state, generation_state=state.generation_state.record)
+    with pytest.raises(TypeError, match="registration_histories must be a mapping"):
+        replace(state, registration_histories=())
+    with pytest.raises(TypeError, match="values must be AgentRegistrationHistory"):
+        replace(
+            state,
+            registration_histories={
+                "node-a": _registration_history("node-a"),
+                "node-c": _registration_history("node-c").current,
+            },
+        )
+
+
+@pytest.mark.parametrize("observed_at_unix_ms", [0, True])
+def test_restart_plan_placement_state_rejects_invalid_observation_time(
+    observed_at_unix_ms,
+):
+    with pytest.raises(ValueError, match="observed_at_unix_ms"):
+        _placement_state(observed_at_unix_ms=observed_at_unix_ms)
+
+
+def test_restart_plan_placement_state_rejects_invalid_environment_digest():
+    with pytest.raises(ValueError, match="environment_digest"):
+        _placement_state(environment_digest=" ")
+
+
+@pytest.mark.parametrize(
+    ("suspected_node_ids", "message"),
+    [
+        (("node-z",), "not active"),
+        (("node-a",), "remain assigned"),
+    ],
+)
+def test_restart_plan_placement_state_rejects_invalid_suspect_scope(
+    suspected_node_ids,
+    message,
+):
+    state = _generation_state()
+    changed = _replace_generation_intent(
+        state,
+        replace(
+            state.intent_record.intent,
+            suspected_node_ids=suspected_node_ids,
+        ),
+    )
+
+    with pytest.raises(ValueError, match=message):
+        _placement_state(generation_state=changed)
+
+
+def test_restart_plan_placement_state_rejects_moved_survivor():
+    state = _generation_state()
+    changed = _replace_generation_plan(
+        state,
+        replace(
+            state.plan,
+            slot_assignments=(
+                SlotAssignment(
+                    logical_node_slot=0,
+                    node_id="node-c",
+                    first_global_rank=0,
+                    local_world_size=2,
+                ),
+                SlotAssignment(
+                    logical_node_slot=1,
+                    node_id="node-a",
+                    first_global_rank=2,
+                    local_world_size=2,
+                ),
+            ),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="changed logical slots"):
+        _placement_state(generation_state=changed)
+
+
+def test_restart_plan_placement_state_requires_replacement():
+    state = _replace_generation_intent(
+        _generation_state(),
+        replace(_intent_record().intent, suspected_node_ids=()),
+    )
+    changed = _replace_generation_plan(
+        state,
+        replace(
+            state.plan,
+            slot_assignments=tuple(
+                SlotAssignment(
+                    logical_node_slot=slot,
+                    node_id=node_id,
+                    first_global_rank=slot * 2,
+                    local_world_size=2,
+                )
+                for slot, node_id in state.from_assignment.slot_to_node_id.items()
+            ),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="requires at least one replacement"):
+        _placement_state(
+            generation_state=changed,
+            registration_histories={
+                "node-a": _registration_history("node-a"),
+                "node-b": _registration_history("node-b"),
+            },
+        )
+
+
+def test_restart_plan_placement_state_rejects_quarantine_outside_intent_scope():
+    state = _generation_state()
+    changed = _replace_generation_plan(
+        state,
+        replace(state.plan, quarantined_node_ids=("node-z",)),
+    )
+
+    with pytest.raises(ValueError, match="outside the intent scope"):
+        _placement_state(generation_state=changed)
+
+
+@pytest.mark.parametrize(
+    "registration_histories",
+    [
+        {"node-a": _registration_history("node-a")},
+        {
+            "node-a": _registration_history("node-a"),
+            "node-c": _registration_history("node-c"),
+            "node-d": _registration_history("node-d"),
+        },
+    ],
+)
+def test_restart_plan_placement_state_requires_exact_registration_coverage(
+    registration_histories,
+):
+    with pytest.raises(ValueError, match="exactly cover"):
+        _placement_state(registration_histories=registration_histories)
+
+
+@pytest.mark.parametrize(
+    ("history", "message"),
+    [
+        (_registration_history("node-c", current=False), "no current registration"),
+        (
+            _registration_history("node-c", granted_at_unix_ms=1_201),
+            "granted after",
+        ),
+        (
+            _registration_history(
+                "node-c",
+                granted_at_unix_ms=1_100,
+                lease_duration_ms=100,
+            ),
+            "not live",
+        ),
+        (
+            _registration_history("node-c", local_world_size=1),
+            "local world size",
+        ),
+        (
+            _registration_history("node-c", environment_digest="environment-v2"),
+            "environment is incompatible",
+        ),
+        (_registration_history("node-z"), "wrong identity"),
+    ],
+)
+def test_restart_plan_placement_state_rejects_ineligible_registration(
+    history,
+    message,
+):
+    with pytest.raises(ValueError, match=message):
+        _placement_state(
+            registration_histories={
+                "node-a": _registration_history("node-a"),
+                "node-c": history,
+            },
+        )
 
 
 def test_restart_plan_generation_state_binds_exact_records():


### PR DESCRIPTION
## Summary
- add a pure `RestartPlanPlacementState` over the committed intent and generation records
- require suspect removal, stable survivor slots, a fixed active-node count, and at least one genuinely new replacement node
- require exact live successor-node registrations with matching local worker count and environment digest

## Scope
This PR does not validate trusted hardware inventory, previously committed quarantine state, recovery evidence, or atomic publication.

## Validation
- 152 focused torchrun state and registration-history tests
- 2,188 full CPU tests with CUDA hidden
- repository-wide Ruff check and format check
- targeted mypy for changed Python files
- `git diff --check`