### PR TITLE
[Feature][Torchrun] Compose restart plan candidate state

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -816,6 +816,11 @@ and must match the planned local worker count and the coordinator's expected
 `environment_digest`. Trusted hardware inventory, previously committed
 quarantine state, recovery evidence, and atomic publication remain separate
 admission boundaries.
+`RestartPlanCandidateState` composes one placement state with one recovery
+evidence state only when both describe the exact same lifecycle and generation
+records. The registration observation must also precede the plan's exclusive
+restart deadline. This value is still only a publication candidate: trusted
+prior quarantine and the atomic store transaction remain separate gates.
 
 Before commit, the coordinator validates:
 

--- a/lm_resiliency/integrations/torchrun/_restart_plan_state.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_state.py
@@ -825,8 +825,43 @@ class RestartPlanPlacementState:
         return dict(sorted(histories.items()))
 
 
+@dataclass(frozen=True, slots=True)
+class RestartPlanCandidateState:
+    """One recovery- and placement-admitted plan candidate."""
+
+    recovery_state: RestartPlanRecoveryEvidenceState
+    placement_state: RestartPlanPlacementState
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.recovery_state, RestartPlanRecoveryEvidenceState):
+            raise TypeError(
+                "RestartPlanCandidateState.recovery_state must be RestartPlanRecoveryEvidenceState"
+            )
+        if not isinstance(self.placement_state, RestartPlanPlacementState):
+            raise TypeError(
+                "RestartPlanCandidateState.placement_state must be RestartPlanPlacementState"
+            )
+        recovery_generation_state = self.recovery_state.copy_state.inventory_state.quarantine_state.manifest_state.generation_state
+        if recovery_generation_state != self.placement_state.generation_state:
+            raise ValueError(
+                "RestartPlanCandidateState recovery and placement states "
+                "do not describe the same plan generation"
+            )
+        if self.placement_state.observed_at_unix_ms >= self.plan.restart_deadline_unix_ms:
+            raise ValueError("RestartPlanCandidateState restart deadline has elapsed")
+
+    @property
+    def plan(self) -> RestartPlan:
+        return self.recovery_state.plan
+
+    @property
+    def manifest(self) -> RecoveryManifest:
+        return self.recovery_state.manifest
+
+
 __all__ = [
     "ResolvedRecoveryManifest",
+    "RestartPlanCandidateState",
     "RestartPlanCertificationState",
     "RestartPlanCopyEligibilityState",
     "RestartPlanGenerationState",

--- a/tests/unit/test_torchrun_restart_plan_state.py
+++ b/tests/unit/test_torchrun_restart_plan_state.py
@@ -50,6 +50,7 @@ from lm_resiliency.integrations.torchrun._restart_plan_records import (
 )
 from lm_resiliency.integrations.torchrun._restart_plan_state import (
     ResolvedRecoveryManifest,
+    RestartPlanCandidateState,
     RestartPlanCertificationState,
     RestartPlanCopyEligibilityState,
     RestartPlanGenerationState,
@@ -1861,6 +1862,62 @@ def test_restart_plan_recovery_evidence_state_rejects_cross_inventory_evidence()
             copy_state=_copy_eligibility_state(),
             trust_state=_certification_state(),
         )
+
+
+def _candidate_state() -> RestartPlanCandidateState:
+    inventory_state = _verified_inventory_state(
+        manifest=replace(_shared_manifest(), trust="recovery_verified")
+    )
+    recovery_state = RestartPlanRecoveryEvidenceState(
+        copy_state=RestartPlanCopyEligibilityState(inventory_state),
+        trust_state=RestartPlanCertificationState(
+            inventory_state=inventory_state,
+            certifications=(_certification(inventory_state),),
+        ),
+    )
+    generation_state = inventory_state.quarantine_state.manifest_state.generation_state
+    return RestartPlanCandidateState(
+        recovery_state=recovery_state,
+        placement_state=_placement_state(generation_state=generation_state),
+    )
+
+
+def test_restart_plan_candidate_state_composes_matching_evidence_and_placement():
+    state = _candidate_state()
+
+    assert state.plan == state.recovery_state.plan
+    assert state.manifest == state.recovery_state.manifest
+
+
+def test_restart_plan_candidate_state_requires_exact_types():
+    state = _candidate_state()
+
+    with pytest.raises(TypeError, match="recovery_state must be"):
+        replace(state, recovery_state=state.recovery_state.copy_state)
+    with pytest.raises(TypeError, match="placement_state must be"):
+        replace(state, placement_state=state.placement_state.generation_state)
+
+
+def test_restart_plan_candidate_state_rejects_cross_plan_composition():
+    state = _candidate_state()
+
+    with pytest.raises(ValueError, match="same plan generation"):
+        replace(state, placement_state=_placement_state())
+
+
+def test_restart_plan_candidate_state_rejects_elapsed_restart_deadline():
+    state = _candidate_state()
+    placement = _placement_state(
+        generation_state=state.placement_state.generation_state,
+        registration_histories={
+            "node-a": _registration_history("node-a", lease_duration_ms=2_000),
+            "node-c": _registration_history("node-c", lease_duration_ms=2_000),
+        },
+        observed_at_unix_ms=state.plan.restart_deadline_unix_ms,
+    )
+
+    with pytest.raises(ValueError, match="deadline has elapsed"):
+        replace(state, placement_state=placement)
 
 
 def _verified_inventory_state(


### PR DESCRIPTION
## Summary
- add a pure `RestartPlanCandidateState` that composes exact recovery evidence with exact placement admission
- reject cross-plan/generation composition
- require the registration observation to precede the exclusive restart deadline

## Scope
This PR does not validate trusted prior quarantine or publish any control-store state.

## Validation
- 156 focused torchrun state and registration-history tests
- 2,192 full CPU tests with CUDA hidden
- repository-wide Ruff check and format check
- targeted mypy for changed Python files
- `git diff --check`