### PR TITLE
[Feature][Torchrun] Add restart plan publication records

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -825,11 +825,12 @@ prior quarantine and the atomic store transaction remain separate gates.
 quarantine, successor-generation, and generation-head writes from one admitted
 candidate. It CAS-updates the generation head and conditions on the exact
 current and manifest-source snapshot revisions plus every exact successor
-registration fencing revision. Its exclusive deadline is the earliest selected
-registration expiry or plan restart deadline. It performs no store access and
-does not authenticate the live coordinator lease, lifecycle revision,
-quarantine resource evidence, transaction result, or prior committed
-quarantine state.
+registration fencing revision. When the current and manifest-source snapshots
+share one generation key, their immutable records and revisions must both
+match. Its exclusive deadline is the earliest selected registration expiry or
+plan restart deadline. It performs no store access and does not authenticate
+the live coordinator lease, lifecycle revision, quarantine resource evidence,
+transaction result, or prior committed quarantine state.
 
 Before commit, the coordinator validates:
 

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -824,10 +824,11 @@ prior quarantine and the atomic store transaction remain separate gates.
 `RestartPlanPublicationRecords` derives the canonical immutable plan, manifest,
 quarantine, successor-generation, and generation-head writes from one admitted
 candidate. It CAS-updates the generation head and conditions on the exact
-current and manifest-source snapshot revisions, but performs no store access
-and does not authenticate the live coordinator lease, lifecycle revision,
-quarantine resource evidence, deadline, transaction result, or prior committed
-quarantine state.
+current and manifest-source snapshot revisions plus every exact successor
+registration fencing revision, but performs no store access and does not
+authenticate the live coordinator lease, lifecycle revision, quarantine
+resource evidence, deadline, transaction result, or prior committed quarantine
+state.
 
 Before commit, the coordinator validates:
 

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -821,6 +821,13 @@ evidence state only when both describe the exact same lifecycle and generation
 records. The registration observation must also precede the plan's exclusive
 restart deadline. This value is still only a publication candidate: trusted
 prior quarantine and the atomic store transaction remain separate gates.
+`RestartPlanPublicationRecords` derives the canonical immutable plan, manifest,
+quarantine, successor-generation, and generation-head writes from one admitted
+candidate. It CAS-updates the generation head and conditions on the exact
+current and manifest-source snapshot revisions, but performs no store access
+and does not authenticate the live coordinator lease, lifecycle revision,
+quarantine resource evidence, deadline, transaction result, or prior committed
+quarantine state.
 
 Before commit, the coordinator validates:
 

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -825,10 +825,11 @@ prior quarantine and the atomic store transaction remain separate gates.
 quarantine, successor-generation, and generation-head writes from one admitted
 candidate. It CAS-updates the generation head and conditions on the exact
 current and manifest-source snapshot revisions plus every exact successor
-registration fencing revision, but performs no store access and does not
-authenticate the live coordinator lease, lifecycle revision, quarantine
-resource evidence, deadline, transaction result, or prior committed quarantine
-state.
+registration fencing revision. Its exclusive deadline is the earliest selected
+registration expiry or plan restart deadline. It performs no store access and
+does not authenticate the live coordinator lease, lifecycle revision,
+quarantine resource evidence, transaction result, or prior committed
+quarantine state.
 
 Before commit, the coordinator validates:
 

--- a/lm_resiliency/integrations/torchrun/_restart_plan_publication_records.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_publication_records.py
@@ -118,6 +118,19 @@ class RestartPlanPublicationRecords:
         )
 
     @property
+    def deadline_unix_ms(self) -> int:
+        registration_expiries = []
+        for history in self.candidate.placement_state.registration_histories.values():
+            registration = history.current
+            if registration is None:
+                raise AssertionError("validated placement lost its current registration")
+            registration_expiries.append(registration.expires_at_unix_ms)
+        return min(
+            self.candidate.plan.restart_deadline_unix_ms,
+            *registration_expiries,
+        )
+
+    @property
     def writes(self) -> Mapping[str, ControlStoreWrite]:
         generation_state = self.candidate.placement_state.generation_state
         manifest_state = (

--- a/lm_resiliency/integrations/torchrun/_restart_plan_publication_records.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_publication_records.py
@@ -1,0 +1,165 @@
+"""Immutable transaction records for publishing one torchrun restart plan."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+
+from lm_resiliency.integrations.torchrun._control_store import ControlStoreWrite
+from lm_resiliency.integrations.torchrun._generation_reader import CurrentGeneration
+from lm_resiliency.integrations.torchrun._generation_records import GenerationHeadRecord
+from lm_resiliency.integrations.torchrun._quarantine_store import node_quarantine_key
+from lm_resiliency.integrations.torchrun._restart_plan_state import RestartPlanCandidateState
+
+_CONTROL_PREFIX = "lm_resiliency/torchrun/v1"
+
+
+@dataclass(frozen=True, slots=True)
+class RestartPlanPublicationRecords:
+    """Canonical records and store inputs for one restart-plan publication."""
+
+    candidate: RestartPlanCandidateState
+    current: CurrentGeneration
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.candidate, RestartPlanCandidateState):
+            raise TypeError(
+                "RestartPlanPublicationRecords.candidate must be RestartPlanCandidateState"
+            )
+        if not isinstance(self.current, CurrentGeneration):
+            raise TypeError("RestartPlanPublicationRecords.current must be CurrentGeneration")
+        generation_state = self.candidate.placement_state.generation_state
+        if self.current.snapshot.record != generation_state.from_snapshot:
+            raise ValueError(
+                "RestartPlanPublicationRecords current generation does not match its candidate"
+            )
+        _positive_integer(
+            self.current.head_revision,
+            "RestartPlanPublicationRecords.current.head_revision",
+        )
+        _positive_integer(
+            self.current.snapshot.revision,
+            "RestartPlanPublicationRecords.current.snapshot.revision",
+        )
+        manifest_source = self.candidate.recovery_state.copy_state.inventory_state.quarantine_state.manifest_state.resolved_manifest.source_snapshot
+        _positive_integer(
+            manifest_source.revision,
+            "RestartPlanPublicationRecords manifest source revision",
+        )
+        if (
+            self.manifest_source_generation_snapshot_key == self.source_generation_snapshot_key
+            and manifest_source.revision != self.current.snapshot.revision
+        ):
+            raise ValueError(
+                "RestartPlanPublicationRecords current and manifest source revisions disagree"
+            )
+
+    @property
+    def run_prefix(self) -> str:
+        run_digest = hashlib.sha256(self.candidate.plan.run_id.encode("utf-8")).hexdigest()
+        return f"{_CONTROL_PREFIX}/runs/{run_digest}"
+
+    @property
+    def plan_key(self) -> str:
+        return f"{self.run_prefix}/restart-plans/{self.candidate.plan.to_generation}"
+
+    @property
+    def recovery_manifest_key(self) -> str:
+        return f"{self.plan_key}/recovery-manifest"
+
+    @property
+    def generation_head_key(self) -> str:
+        return f"{self.run_prefix}/generation-head"
+
+    @property
+    def source_generation_snapshot_key(self) -> str:
+        return f"{self.run_prefix}/generations/{self.candidate.plan.from_generation}"
+
+    @property
+    def successor_generation_snapshot_key(self) -> str:
+        return f"{self.run_prefix}/generations/{self.candidate.plan.to_generation}"
+
+    @property
+    def manifest_source_generation_snapshot_key(self) -> str:
+        source_generation = self.candidate.recovery_state.copy_state.inventory_state.quarantine_state.manifest_state.resolved_manifest.manifest.source_generation
+        return f"{self.run_prefix}/generations/{source_generation}"
+
+    @property
+    def quarantine_keys(self) -> Mapping[str, str]:
+        records = self.candidate.recovery_state.copy_state.inventory_state.quarantine_state
+        return MappingProxyType(
+            {
+                node_id: node_quarantine_key(self.candidate.plan.run_id, node_id)
+                for node_id in records.quarantine_records
+            }
+        )
+
+    @property
+    def generation_head(self) -> GenerationHeadRecord:
+        generation_state = self.candidate.placement_state.generation_state
+        return GenerationHeadRecord(
+            run_id=self.candidate.plan.run_id,
+            generation=self.candidate.plan.to_generation,
+            snapshot_digest=generation_state.to_snapshot.digest,
+        )
+
+    @property
+    def writes(self) -> Mapping[str, ControlStoreWrite]:
+        generation_state = self.candidate.placement_state.generation_state
+        manifest_state = (
+            self.candidate.recovery_state.copy_state.inventory_state.quarantine_state.manifest_state
+        )
+        quarantine_state = self.candidate.recovery_state.copy_state.inventory_state.quarantine_state
+        writes = {
+            self.generation_head_key: ControlStoreWrite(
+                expected_revision=self.current.head_revision,
+                value=self.generation_head.to_json(),
+            ),
+            self.successor_generation_snapshot_key: ControlStoreWrite(
+                expected_revision=None,
+                value=generation_state.to_snapshot.to_json(),
+                require_never_created=True,
+            ),
+            self.recovery_manifest_key: ControlStoreWrite(
+                expected_revision=None,
+                value=manifest_state.resolved_manifest.record.to_json(),
+                require_never_created=True,
+            ),
+            self.plan_key: ControlStoreWrite(
+                expected_revision=None,
+                value=generation_state.record.to_json(),
+                require_never_created=True,
+            ),
+        }
+        writes.update(
+            {
+                self.quarantine_keys[node_id]: ControlStoreWrite(
+                    expected_revision=None,
+                    value=record.to_json(),
+                    require_never_created=True,
+                )
+                for node_id, record in quarantine_state.quarantine_records.items()
+            }
+        )
+        return MappingProxyType(writes)
+
+    @property
+    def conditions(self) -> Mapping[str, int]:
+        manifest_source = self.candidate.recovery_state.copy_state.inventory_state.quarantine_state.manifest_state.resolved_manifest.source_snapshot
+        return MappingProxyType(
+            {
+                self.source_generation_snapshot_key: self.current.snapshot.revision,
+                self.manifest_source_generation_snapshot_key: manifest_source.revision,
+            }
+        )
+
+
+def _positive_integer(value: object, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{path} must be a positive integer")
+    return value
+
+
+__all__ = ["RestartPlanPublicationRecords"]

--- a/lm_resiliency/integrations/torchrun/_restart_plan_publication_records.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_publication_records.py
@@ -7,6 +7,9 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
 
+from lm_resiliency.integrations.torchrun._agent_registration import (
+    agent_registration_key,
+)
 from lm_resiliency.integrations.torchrun._control_store import ControlStoreWrite
 from lm_resiliency.integrations.torchrun._generation_reader import CurrentGeneration
 from lm_resiliency.integrations.torchrun._generation_records import GenerationHeadRecord
@@ -97,6 +100,15 @@ class RestartPlanPublicationRecords:
         )
 
     @property
+    def registration_keys(self) -> Mapping[str, str]:
+        return MappingProxyType(
+            {
+                node_id: agent_registration_key(self.candidate.plan.run_id, node_id)
+                for node_id in self.candidate.placement_state.registration_histories
+            }
+        )
+
+    @property
     def generation_head(self) -> GenerationHeadRecord:
         generation_state = self.candidate.placement_state.generation_state
         return GenerationHeadRecord(
@@ -148,12 +160,16 @@ class RestartPlanPublicationRecords:
     @property
     def conditions(self) -> Mapping[str, int]:
         manifest_source = self.candidate.recovery_state.copy_state.inventory_state.quarantine_state.manifest_state.resolved_manifest.source_snapshot
-        return MappingProxyType(
-            {
-                self.source_generation_snapshot_key: self.current.snapshot.revision,
-                self.manifest_source_generation_snapshot_key: manifest_source.revision,
-            }
-        )
+        conditions = {
+            self.source_generation_snapshot_key: self.current.snapshot.revision,
+            self.manifest_source_generation_snapshot_key: manifest_source.revision,
+        }
+        for node_id, history in self.candidate.placement_state.registration_histories.items():
+            registration = history.current
+            if registration is None:
+                raise AssertionError("validated placement lost its current registration")
+            conditions[self.registration_keys[node_id]] = registration.fencing_token
+        return MappingProxyType(conditions)
 
 
 def _positive_integer(value: object, path: str) -> int:

--- a/lm_resiliency/integrations/torchrun/_restart_plan_publication_records.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_publication_records.py
@@ -51,12 +51,12 @@ class RestartPlanPublicationRecords:
             manifest_source.revision,
             "RestartPlanPublicationRecords manifest source revision",
         )
-        if (
-            self.manifest_source_generation_snapshot_key == self.source_generation_snapshot_key
-            and manifest_source.revision != self.current.snapshot.revision
+        if self.manifest_source_generation_snapshot_key == self.source_generation_snapshot_key and (
+            manifest_source.revision != self.current.snapshot.revision
+            or manifest_source.record != self.current.snapshot.record
         ):
             raise ValueError(
-                "RestartPlanPublicationRecords current and manifest source revisions disagree"
+                "RestartPlanPublicationRecords current and manifest source snapshots disagree"
             )
 
     @property

--- a/tests/unit/test_torchrun_restart_plan_state.py
+++ b/tests/unit/test_torchrun_restart_plan_state.py
@@ -1992,6 +1992,7 @@ def test_restart_plan_publication_records_build_canonical_atomic_inputs():
         records.registration_keys["node-a"]: 11,
         records.registration_keys["node-c"]: 11,
     }
+    assert records.deadline_unix_ms == 1_600
 
 
 def test_restart_plan_publication_records_derive_run_scoped_keys():
@@ -2062,6 +2063,28 @@ def test_restart_plan_publication_records_require_matching_shared_source_revisio
                 snapshot=replace(records.current.snapshot, revision=9),
             ),
         )
+
+
+def test_restart_plan_publication_records_use_earliest_registration_expiry():
+    records = _publication_records()
+    generation_state = records.candidate.placement_state.generation_state
+    placement = _placement_state(
+        generation_state=generation_state,
+        registration_histories={
+            "node-a": _registration_history(
+                "node-a",
+                lease_duration_ms=200,
+            ),
+            "node-c": _registration_history("node-c"),
+        },
+    )
+
+    updated = replace(
+        records,
+        candidate=replace(records.candidate, placement_state=placement),
+    )
+
+    assert updated.deadline_unix_ms == 1_300
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_torchrun_restart_plan_state.py
+++ b/tests/unit/test_torchrun_restart_plan_state.py
@@ -1932,12 +1932,60 @@ def test_restart_plan_candidate_state_rejects_elapsed_restart_deadline():
 
 def _publication_records() -> RestartPlanPublicationRecords:
     candidate = _candidate_state()
-    source_record = candidate.placement_state.generation_state.from_snapshot
+    inventory_state = candidate.recovery_state.copy_state.inventory_state
+    quarantine_state = inventory_state.quarantine_state
+    manifest_state = quarantine_state.manifest_state
+    source_snapshot = replace(
+        manifest_state.resolved_manifest.source_snapshot,
+        record=manifest_state.generation_state.from_snapshot,
+    )
+    manifest_record = replace(
+        manifest_state.resolved_manifest.record,
+        source_generation_snapshot_digest=source_snapshot.record.digest,
+    )
+    generation_state = replace(
+        manifest_state.generation_state,
+        record=replace(
+            manifest_state.generation_state.record,
+            recovery_manifest_record_digest=manifest_record.digest,
+        ),
+    )
+    manifest_state = RestartPlanManifestState(
+        generation_state=generation_state,
+        resolved_manifest=ResolvedRecoveryManifest(
+            record=manifest_record,
+            source_snapshot=source_snapshot,
+        ),
+    )
+    quarantine_state = RestartPlanQuarantineState(
+        manifest_state=manifest_state,
+        quarantine_records=quarantine_state.quarantine_records,
+    )
+    inventory_state = RestartPlanInventoryState(
+        quarantine_state=quarantine_state,
+        inventory_events=inventory_state.inventory_events,
+    )
+    copy_state = RestartPlanCopyEligibilityState(inventory_state)
+    trust_state = candidate.recovery_state.trust_state
+    assert isinstance(trust_state, RestartPlanCertificationState)
+    candidate = RestartPlanCandidateState(
+        recovery_state=RestartPlanRecoveryEvidenceState(
+            copy_state=copy_state,
+            trust_state=RestartPlanCertificationState(
+                inventory_state=inventory_state,
+                certifications=trust_state.certifications,
+            ),
+        ),
+        placement_state=replace(
+            candidate.placement_state,
+            generation_state=generation_state,
+        ),
+    )
     return RestartPlanPublicationRecords(
         candidate=candidate,
         current=CurrentGeneration(
             snapshot=StoredGenerationSnapshot(
-                record=source_record,
+                record=generation_state.from_snapshot,
                 revision=8,
                 committed_at_unix_ms=1_000,
                 transaction_sequence=17,
@@ -2055,12 +2103,28 @@ def test_restart_plan_publication_records_require_exact_current_generation():
 def test_restart_plan_publication_records_require_matching_shared_source_revision():
     records = _publication_records()
 
-    with pytest.raises(ValueError, match="source revisions disagree"):
+    with pytest.raises(ValueError, match="source snapshots disagree"):
         replace(
             records,
             current=replace(
                 records.current,
                 snapshot=replace(records.current.snapshot, revision=9),
+            ),
+        )
+
+
+def test_restart_plan_publication_records_reject_divergent_shared_source_record():
+    candidate = _candidate_state()
+
+    with pytest.raises(ValueError, match="source snapshots disagree"):
+        RestartPlanPublicationRecords(
+            candidate=candidate,
+            current=CurrentGeneration(
+                snapshot=replace(
+                    _publication_records().current.snapshot,
+                    record=candidate.placement_state.generation_state.from_snapshot,
+                ),
+                head_revision=18,
             ),
         )
 

--- a/tests/unit/test_torchrun_restart_plan_state.py
+++ b/tests/unit/test_torchrun_restart_plan_state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import replace
 
 import pytest
@@ -16,10 +17,13 @@ from lm_resiliency.integrations.torchrun._agent_registration_records import (
     AgentRegistrationRecord,
     HeldAgentRegistration,
 )
+from lm_resiliency.integrations.torchrun._control_store import ControlStoreWrite
 from lm_resiliency.integrations.torchrun._generation_reader import (
+    CurrentGeneration,
     StoredGenerationSnapshot,
 )
 from lm_resiliency.integrations.torchrun._generation_records import (
+    GenerationHeadRecord,
     GenerationSnapshotRecord,
 )
 from lm_resiliency.integrations.torchrun._protocol import (
@@ -43,6 +47,9 @@ from lm_resiliency.integrations.torchrun._restart_intent_records import (
     RestartIntentHeadRecord,
     RestartIntentLifecycleRecord,
     RestartIntentRecord,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_publication_records import (
+    RestartPlanPublicationRecords,
 )
 from lm_resiliency.integrations.torchrun._restart_plan_records import (
     RecoveryManifestRecord,
@@ -1918,6 +1925,149 @@ def test_restart_plan_candidate_state_rejects_elapsed_restart_deadline():
 
     with pytest.raises(ValueError, match="deadline has elapsed"):
         replace(state, placement_state=placement)
+
+
+def _publication_records() -> RestartPlanPublicationRecords:
+    candidate = _candidate_state()
+    source_record = candidate.placement_state.generation_state.from_snapshot
+    return RestartPlanPublicationRecords(
+        candidate=candidate,
+        current=CurrentGeneration(
+            snapshot=StoredGenerationSnapshot(
+                record=source_record,
+                revision=8,
+                committed_at_unix_ms=1_000,
+                transaction_sequence=17,
+                guard_mutation_sequence=9,
+                guard_value_sequence=5,
+                guard_lifetime_sequence=1,
+                guard_committed_at_unix_ms=900,
+            ),
+            head_revision=18,
+        ),
+    )
+
+
+def test_restart_plan_publication_records_build_canonical_atomic_inputs():
+    records = _publication_records()
+    generation_state = records.candidate.placement_state.generation_state
+    quarantine_state = records.candidate.recovery_state.copy_state.inventory_state.quarantine_state
+    manifest_record = quarantine_state.manifest_state.resolved_manifest.record
+
+    assert records.generation_head == GenerationHeadRecord(
+        run_id=RUN_ID,
+        generation=records.candidate.plan.to_generation,
+        snapshot_digest=generation_state.to_snapshot.digest,
+    )
+    assert records.writes[records.generation_head_key] == ControlStoreWrite(
+        expected_revision=18,
+        value=records.generation_head.to_json(),
+    )
+    assert records.writes[records.successor_generation_snapshot_key] == ControlStoreWrite(
+        expected_revision=None,
+        value=generation_state.to_snapshot.to_json(),
+        require_never_created=True,
+    )
+    assert records.writes[records.recovery_manifest_key] == ControlStoreWrite(
+        expected_revision=None,
+        value=manifest_record.to_json(),
+        require_never_created=True,
+    )
+    assert records.writes[records.plan_key] == ControlStoreWrite(
+        expected_revision=None,
+        value=generation_state.record.to_json(),
+        require_never_created=True,
+    )
+    quarantine_record = quarantine_state.quarantine_records["node-b"]
+    assert records.writes[records.quarantine_keys["node-b"]] == ControlStoreWrite(
+        expected_revision=None,
+        value=quarantine_record.to_json(),
+        require_never_created=True,
+    )
+    assert records.conditions == {
+        records.source_generation_snapshot_key: 8,
+    }
+
+
+def test_restart_plan_publication_records_derive_run_scoped_keys():
+    records = _publication_records()
+    expected_run_digest = hashlib.sha256(RUN_ID.encode()).hexdigest()
+
+    assert records.run_prefix == f"lm_resiliency/torchrun/v1/runs/{expected_run_digest}"
+    assert records.plan_key.endswith("/restart-plans/5")
+    assert records.recovery_manifest_key.endswith("/restart-plans/5/recovery-manifest")
+    assert records.generation_head_key.endswith("/generation-head")
+    assert records.source_generation_snapshot_key.endswith("/generations/4")
+    assert records.manifest_source_generation_snapshot_key.endswith("/generations/4")
+    assert records.successor_generation_snapshot_key.endswith("/generations/5")
+    assert RUN_ID not in records.plan_key
+
+
+def test_restart_plan_publication_records_freeze_mappings():
+    records = _publication_records()
+
+    with pytest.raises(TypeError):
+        records.writes["other"] = next(iter(records.writes.values()))
+    with pytest.raises(TypeError):
+        records.conditions["other"] = 1
+    with pytest.raises(TypeError):
+        records.quarantine_keys["node-b"] = "other"
+
+
+def test_restart_plan_publication_records_require_exact_types():
+    records = _publication_records()
+
+    with pytest.raises(TypeError, match="candidate must be"):
+        replace(records, candidate=records.candidate.recovery_state)
+    with pytest.raises(TypeError, match="current must be"):
+        replace(records, current=records.current.snapshot)
+
+
+def test_restart_plan_publication_records_require_exact_current_generation():
+    records = _publication_records()
+    changed_snapshot = replace(
+        records.current.snapshot,
+        record=replace(
+            records.current.snapshot.record,
+            coordinator_fencing_token=10,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="current generation does not match"):
+        replace(
+            records,
+            current=replace(records.current, snapshot=changed_snapshot),
+        )
+
+
+def test_restart_plan_publication_records_require_matching_shared_source_revision():
+    records = _publication_records()
+
+    with pytest.raises(ValueError, match="source revisions disagree"):
+        replace(
+            records,
+            current=replace(
+                records.current,
+                snapshot=replace(records.current.snapshot, revision=9),
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    "current",
+    [
+        lambda records: replace(records.current, head_revision=0),
+        lambda records: replace(
+            records.current,
+            snapshot=replace(records.current.snapshot, revision=0),
+        ),
+    ],
+)
+def test_restart_plan_publication_records_require_positive_revisions(current):
+    records = _publication_records()
+
+    with pytest.raises(ValueError, match="positive integer"):
+        replace(records, current=current(records))
 
 
 def _verified_inventory_state(

--- a/tests/unit/test_torchrun_restart_plan_state.py
+++ b/tests/unit/test_torchrun_restart_plan_state.py
@@ -7,6 +7,9 @@ from dataclasses import replace
 
 import pytest
 
+from lm_resiliency.integrations.torchrun._agent_registration import (
+    agent_registration_key,
+)
 from lm_resiliency.integrations.torchrun._agent_registration_history import (
     AgentRegistrationAuthority,
 )
@@ -1986,6 +1989,8 @@ def test_restart_plan_publication_records_build_canonical_atomic_inputs():
     )
     assert records.conditions == {
         records.source_generation_snapshot_key: 8,
+        records.registration_keys["node-a"]: 11,
+        records.registration_keys["node-c"]: 11,
     }
 
 
@@ -2000,6 +2005,10 @@ def test_restart_plan_publication_records_derive_run_scoped_keys():
     assert records.source_generation_snapshot_key.endswith("/generations/4")
     assert records.manifest_source_generation_snapshot_key.endswith("/generations/4")
     assert records.successor_generation_snapshot_key.endswith("/generations/5")
+    assert records.registration_keys == {
+        "node-a": agent_registration_key(RUN_ID, "node-a"),
+        "node-c": agent_registration_key(RUN_ID, "node-c"),
+    }
     assert RUN_ID not in records.plan_key
 
 
@@ -2012,6 +2021,8 @@ def test_restart_plan_publication_records_freeze_mappings():
         records.conditions["other"] = 1
     with pytest.raises(TypeError):
         records.quarantine_keys["node-b"] = "other"
+    with pytest.raises(TypeError):
+        records.registration_keys["node-a"] = "other"
 
 
 def test_restart_plan_publication_records_require_exact_types():


### PR DESCRIPTION
## Summary
- add a pure `RestartPlanPublicationRecords` transaction bundle
- derive canonical plan, manifest, quarantine, generation-head, and successor-snapshot writes from one admitted candidate
- condition publication on exact source snapshot records/revisions and successor registration revisions
- bound the transaction by the earliest successor registration expiry or plan restart deadline

## Scope
This PR performs no store reads or mutations. Live coordinator-lease authentication, lifecycle revision fencing, quarantine resource evidence, execution, committed-result verification, and prior committed quarantine state remain separate follow-up components.

## Validation
- `129 passed` focused restart-plan state tests
- `2202 passed` full CPU suite with CUDA hidden
- `ruff check`
- `ruff format --check`
- targeted `mypy`
- `git diff --check`