### PR TITLE
[Feature][Torchrun] Bind restart plan publication authority

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -831,6 +831,12 @@ match. Its exclusive deadline is the earliest selected registration expiry or
 plan restart deadline. It performs no store access and does not authenticate
 the live coordinator lease, lifecycle revision, quarantine resource evidence,
 transaction result, or prior committed quarantine state.
+`RestartPlanPublicationAuthority` binds that bundle to the exact coordinator
+lease identity already embedded in its plan, successor, and quarantine
+records. Its observation must follow the candidate's generation,
+manifest-source, placement, and lease inputs, and its exclusive deadline is
+additionally capped by coordinator-lease expiry. This pure value performs no
+store access and does not prove that the supplied authority is still live.
 
 Before commit, the coordinator validates:
 

--- a/lm_resiliency/integrations/torchrun/_restart_plan_publication_authority.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_publication_authority.py
@@ -1,0 +1,84 @@
+"""Coordinator authority for one admitted restart-plan publication."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
+    CoordinatorLeaseAuthority,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_publication_records import (
+    RestartPlanPublicationRecords,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RestartPlanPublicationAuthority:
+    """One publication bundle bound to its coordinator lease and time window."""
+
+    records: RestartPlanPublicationRecords
+    coordinator_authority: CoordinatorLeaseAuthority
+    observed_at_unix_ms: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.records, RestartPlanPublicationRecords):
+            raise TypeError(
+                "RestartPlanPublicationAuthority.records must be RestartPlanPublicationRecords"
+            )
+        if not isinstance(self.coordinator_authority, CoordinatorLeaseAuthority):
+            raise TypeError(
+                "RestartPlanPublicationAuthority.coordinator_authority must be "
+                "CoordinatorLeaseAuthority"
+            )
+        _positive_integer(
+            self.observed_at_unix_ms,
+            "RestartPlanPublicationAuthority.observed_at_unix_ms",
+        )
+        self._validate_authority()
+        required_observation = max(
+            self.coordinator_authority.lease.granted_at_unix_ms,
+            self.records.current.snapshot.committed_at_unix_ms,
+            self.records.candidate.placement_state.observed_at_unix_ms,
+            self.records.candidate.recovery_state.copy_state.inventory_state.quarantine_state.manifest_state.resolved_manifest.source_snapshot.committed_at_unix_ms,
+        )
+        if self.observed_at_unix_ms < required_observation:
+            raise ValueError(
+                "RestartPlanPublicationAuthority observation precedes one of its inputs"
+            )
+        if self.observed_at_unix_ms >= self.deadline_unix_ms:
+            raise ValueError("RestartPlanPublicationAuthority publication window has elapsed")
+
+    def _validate_authority(self) -> None:
+        authority = self.coordinator_authority.lease
+        plan_record = self.records.candidate.placement_state.generation_state.record
+        if (
+            authority.record.run_id != self.records.candidate.plan.run_id
+            or authority.record.coordinator_id != plan_record.coordinator_id
+            or authority.record.lease_id != plan_record.lease_id
+            or authority.record.lease_duration_ms != plan_record.coordinator_lease_duration_ms
+            or authority.fencing_token != plan_record.coordinator_fencing_token
+        ):
+            raise ValueError(
+                "RestartPlanPublicationAuthority coordinator lease does not "
+                "authorize its plan records"
+            )
+
+    @property
+    def not_before_unix_ms(self) -> int:
+        return self.observed_at_unix_ms
+
+    @property
+    def deadline_unix_ms(self) -> int:
+        return min(
+            self.records.deadline_unix_ms,
+            self.coordinator_authority.lease.expires_at_unix_ms,
+        )
+
+
+def _positive_integer(value: object, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{path} must be a positive integer")
+    return value
+
+
+__all__ = ["RestartPlanPublicationAuthority"]

--- a/tests/unit/test_torchrun_restart_plan_state.py
+++ b/tests/unit/test_torchrun_restart_plan_state.py
@@ -21,6 +21,13 @@ from lm_resiliency.integrations.torchrun._agent_registration_records import (
     HeldAgentRegistration,
 )
 from lm_resiliency.integrations.torchrun._control_store import ControlStoreWrite
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseRecord,
+    HeldCoordinatorLease,
+)
+from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
+    CoordinatorLeaseAuthority,
+)
 from lm_resiliency.integrations.torchrun._generation_reader import (
     CurrentGeneration,
     StoredGenerationSnapshot,
@@ -50,6 +57,9 @@ from lm_resiliency.integrations.torchrun._restart_intent_records import (
     RestartIntentHeadRecord,
     RestartIntentLifecycleRecord,
     RestartIntentRecord,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_publication_authority import (
+    RestartPlanPublicationAuthority,
 )
 from lm_resiliency.integrations.torchrun._restart_plan_publication_records import (
     RestartPlanPublicationRecords,
@@ -2149,6 +2159,134 @@ def test_restart_plan_publication_records_use_earliest_registration_expiry():
     )
 
     assert updated.deadline_unix_ms == 1_300
+
+
+def _publication_authority() -> RestartPlanPublicationAuthority:
+    records = _publication_records()
+    plan_record = records.candidate.placement_state.generation_state.record
+    return RestartPlanPublicationAuthority(
+        records=records,
+        coordinator_authority=CoordinatorLeaseAuthority(
+            lease=HeldCoordinatorLease(
+                record=CoordinatorLeaseRecord(
+                    run_id=RUN_ID,
+                    coordinator_id=plan_record.coordinator_id,
+                    lease_id=plan_record.lease_id,
+                    lease_duration_ms=plan_record.coordinator_lease_duration_ms,
+                ),
+                fencing_token=plan_record.coordinator_fencing_token,
+                granted_at_unix_ms=900,
+            ),
+            transaction_sequence=9,
+            mutation_sequence=9,
+            value_sequence=5,
+            lifetime_sequence=1,
+        ),
+        observed_at_unix_ms=1_200,
+    )
+
+
+def test_restart_plan_publication_authority_binds_exact_lease_window():
+    authority = _publication_authority()
+
+    assert authority.not_before_unix_ms == 1_200
+    assert authority.deadline_unix_ms == 1_400
+
+
+def test_restart_plan_publication_authority_is_immutable():
+    authority = _publication_authority()
+
+    with pytest.raises(AttributeError):
+        authority.observed_at_unix_ms = 1_201
+
+
+def test_restart_plan_publication_authority_requires_exact_types():
+    authority = _publication_authority()
+
+    with pytest.raises(TypeError, match="records must be"):
+        replace(authority, records=authority.records.candidate)
+    with pytest.raises(TypeError, match="coordinator_authority must be"):
+        replace(
+            authority,
+            coordinator_authority=authority.coordinator_authority.lease,
+        )
+
+
+@pytest.mark.parametrize("observed_at_unix_ms", [0, True])
+def test_restart_plan_publication_authority_requires_positive_observation(
+    observed_at_unix_ms,
+):
+    authority = _publication_authority()
+
+    with pytest.raises(ValueError, match="observed_at_unix_ms"):
+        replace(authority, observed_at_unix_ms=observed_at_unix_ms)
+
+
+@pytest.mark.parametrize(
+    "lease",
+    [
+        lambda authority: replace(
+            authority.coordinator_authority.lease,
+            record=replace(
+                authority.coordinator_authority.lease.record,
+                run_id="other-run",
+            ),
+        ),
+        lambda authority: replace(
+            authority.coordinator_authority.lease,
+            record=replace(
+                authority.coordinator_authority.lease.record,
+                coordinator_id="other-coordinator",
+            ),
+        ),
+        lambda authority: replace(
+            authority.coordinator_authority.lease,
+            record=replace(
+                authority.coordinator_authority.lease.record,
+                lease_id="other-lease",
+            ),
+        ),
+        lambda authority: replace(
+            authority.coordinator_authority.lease,
+            record=replace(
+                authority.coordinator_authority.lease.record,
+                lease_duration_ms=501,
+            ),
+        ),
+        lambda authority: replace(
+            authority.coordinator_authority.lease,
+            fencing_token=10,
+        ),
+    ],
+)
+def test_restart_plan_publication_authority_rejects_wrong_lease(lease):
+    authority = _publication_authority()
+
+    with pytest.raises(ValueError, match="does not authorize"):
+        replace(
+            authority,
+            coordinator_authority=replace(
+                authority.coordinator_authority,
+                lease=lease(authority),
+            ),
+        )
+
+
+@pytest.mark.parametrize("observed_at_unix_ms", [899, 999, 1_199])
+def test_restart_plan_publication_authority_rejects_early_observation(
+    observed_at_unix_ms,
+):
+    authority = _publication_authority()
+
+    with pytest.raises(ValueError, match="precedes one of its inputs"):
+        replace(authority, observed_at_unix_ms=observed_at_unix_ms)
+
+
+def test_restart_plan_publication_authority_rejects_elapsed_window():
+    authority = _publication_authority()
+
+    with pytest.raises(ValueError, match="window has elapsed"):
+        replace(authority, observed_at_unix_ms=authority.deadline_unix_ms)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add a pure `RestartPlanPublicationAuthority` value
- bind publication records to the exact coordinator lease identity embedded in plan records
- require the observation to follow all admitted inputs and cap the exclusive window by lease expiry

## Scope
This PR performs no store reads or mutations. Live coordinator-lease authentication, closed-lifecycle revision fencing, quarantine resource evidence, execution, and committed-result verification remain separate follow-up components.

## Validation
- `143 passed` focused restart-plan state tests
- `2216 passed` full CPU suite with CUDA hidden
- `ruff check .`
- `ruff format --check .`
- targeted `mypy`
- `git diff --check`