### PR TITLE
[Feature][Torchrun] Authenticate restart plan publication authority

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -837,6 +837,13 @@ records. Its observation must follow the candidate's generation,
 manifest-source, placement, and lease inputs, and its exclusive deadline is
 additionally capped by coordinator-lease expiry. This pure value performs no
 store access and does not prove that the supplied authority is still live.
+`RestartPlanPublicationAuthorityPreparer` reads a stable durable coordinator
+lease history around one monotonic clock sample, requires the live history tail
+to match the plan's exact coordinator identity and fencing token, and returns
+that pure authority value without mutating the store. Repeated lease changes
+remain retryable conflicts; missing, stale, expired, or contradictory authority
+fails closed. Lifecycle fencing, quarantine-resource authorization, execution,
+and committed-result verification remain separate publication layers.
 
 Before commit, the coordinator validates:
 

--- a/lm_resiliency/integrations/torchrun/_restart_plan_publication_preparation.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_publication_preparation.py
@@ -1,0 +1,192 @@
+"""Authenticated, non-mutating preparation of restart-plan publication authority."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+
+from lm_resiliency.integrations.torchrun._control_store import ControlStore
+from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
+    CoordinatorLeaseAuthority,
+    CoordinatorLeaseHistoryCorrupt,
+    CoordinatorLeaseHistoryError,
+    CoordinatorLeaseHistoryReader,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_publication_authority import (
+    RestartPlanPublicationAuthority,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_publication_records import (
+    RestartPlanPublicationRecords,
+)
+
+_MAX_READ_ATTEMPTS = 8
+
+
+class RestartPlanPublicationPreparationError(RuntimeError):
+    """Base error for authenticating restart-plan publication authority."""
+
+
+class RestartPlanPublicationPreparationConflict(RestartPlanPublicationPreparationError):
+    """Raised when coordinator authority changes repeatedly during preparation."""
+
+
+class RestartPlanPublicationPreparationLeaseLost(RestartPlanPublicationPreparationError):
+    """Raised when the plan's coordinator authority is absent, stale, or expired."""
+
+
+class RestartPlanPublicationPreparationCorrupt(RestartPlanPublicationPreparationError):
+    """Raised when durable coordinator authority is contradictory."""
+
+
+class RestartPlanPublicationPreparationClockError(RestartPlanPublicationPreparationError):
+    """Raised when the coordinator preparation clock is invalid."""
+
+
+class RestartPlanPublicationAuthorityPreparer:
+    """Authenticate publication records against the live coordinator lease."""
+
+    def __init__(
+        self,
+        store: ControlStore,
+        *,
+        run_id: str,
+        clock: Callable[[], int],
+    ) -> None:
+        self._run_id = _nonempty_string(run_id, "run_id")
+        if not callable(clock):
+            raise TypeError("clock must be callable")
+        self._clock = clock
+        self._clock_lock = threading.Lock()
+        self._last_now_unix_ms = 0
+        self._lease_history_reader = CoordinatorLeaseHistoryReader(
+            store,
+            run_id=self._run_id,
+        )
+
+    def prepare(
+        self,
+        records: RestartPlanPublicationRecords,
+    ) -> RestartPlanPublicationAuthority:
+        """Return authenticated, non-mutating publication authority."""
+
+        if not isinstance(records, RestartPlanPublicationRecords):
+            raise TypeError("records must be RestartPlanPublicationRecords")
+        if records.candidate.plan.run_id != self._run_id:
+            raise ValueError("restart-plan publication records belong to another run")
+        authority, now_unix_ms = self._read_stable_authority()
+        self._require_exact_authority(records, authority)
+        required_observation = max(
+            authority.lease.granted_at_unix_ms,
+            records.current.snapshot.committed_at_unix_ms,
+            records.candidate.placement_state.observed_at_unix_ms,
+            records.candidate.recovery_state.copy_state.inventory_state.quarantine_state.manifest_state.resolved_manifest.source_snapshot.committed_at_unix_ms,
+        )
+        if now_unix_ms < required_observation:
+            raise RestartPlanPublicationPreparationClockError(
+                "restart-plan publication clock precedes authoritative inputs"
+            )
+        deadline_unix_ms = min(
+            records.deadline_unix_ms,
+            authority.lease.expires_at_unix_ms,
+        )
+        if now_unix_ms >= deadline_unix_ms:
+            raise RestartPlanPublicationPreparationLeaseLost(
+                "restart-plan publication authority window elapsed before preparation"
+            )
+        try:
+            return RestartPlanPublicationAuthority(
+                records=records,
+                coordinator_authority=authority,
+                observed_at_unix_ms=now_unix_ms,
+            )
+        except (TypeError, ValueError) as error:
+            raise RestartPlanPublicationPreparationCorrupt(
+                "durable coordinator authority cannot authorize restart-plan publication"
+            ) from error
+
+    def _read_stable_authority(
+        self,
+    ) -> tuple[CoordinatorLeaseAuthority, int]:
+        for _ in range(_MAX_READ_ATTEMPTS):
+            history = self._read_history()
+            now_unix_ms = self._now_unix_ms()
+            if history != self._read_history():
+                continue
+            if not history:
+                raise RestartPlanPublicationPreparationLeaseLost(
+                    "no live coordinator lease can authorize restart-plan publication"
+                )
+            return history[-1], now_unix_ms
+        raise RestartPlanPublicationPreparationConflict(
+            "coordinator lease history changed repeatedly during publication preparation"
+        )
+
+    def _read_history(self) -> tuple[CoordinatorLeaseAuthority, ...]:
+        try:
+            return self._lease_history_reader.read()
+        except CoordinatorLeaseHistoryCorrupt as error:
+            raise RestartPlanPublicationPreparationCorrupt(
+                "coordinator lease history is corrupt"
+            ) from error
+        except CoordinatorLeaseHistoryError as error:
+            raise RestartPlanPublicationPreparationConflict(
+                "coordinator lease history changed repeatedly during preparation"
+            ) from error
+
+    def _require_exact_authority(
+        self,
+        records: RestartPlanPublicationRecords,
+        authority: CoordinatorLeaseAuthority,
+    ) -> None:
+        plan_record = records.candidate.placement_state.generation_state.record
+        lease = authority.lease
+        if (
+            lease.record.run_id != self._run_id
+            or lease.record.coordinator_id != plan_record.coordinator_id
+            or lease.record.lease_id != plan_record.lease_id
+            or lease.record.lease_duration_ms != plan_record.coordinator_lease_duration_ms
+            or lease.fencing_token != plan_record.coordinator_fencing_token
+        ):
+            raise RestartPlanPublicationPreparationLeaseLost(
+                "restart plan is not authorized by the live coordinator lease"
+            )
+
+    def _now_unix_ms(self) -> int:
+        with self._clock_lock:
+            try:
+                now_unix_ms = _positive_integer(
+                    self._clock(),
+                    "restart-plan publication preparation clock",
+                )
+            except (TypeError, ValueError) as error:
+                raise RestartPlanPublicationPreparationClockError(
+                    "restart-plan publication preparation clock is invalid"
+                ) from error
+            if now_unix_ms < self._last_now_unix_ms:
+                raise RestartPlanPublicationPreparationClockError(
+                    "restart-plan publication preparation clock moved backward"
+                )
+            self._last_now_unix_ms = now_unix_ms
+            return now_unix_ms
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+def _positive_integer(value: object, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{path} must be a positive integer")
+    return value
+
+
+__all__ = [
+    "RestartPlanPublicationAuthorityPreparer",
+    "RestartPlanPublicationPreparationClockError",
+    "RestartPlanPublicationPreparationConflict",
+    "RestartPlanPublicationPreparationCorrupt",
+    "RestartPlanPublicationPreparationError",
+    "RestartPlanPublicationPreparationLeaseLost",
+]

--- a/tests/unit/test_torchrun_restart_plan_state.py
+++ b/tests/unit/test_torchrun_restart_plan_state.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import hashlib
+import threading
 from dataclasses import replace
+from typing import Any, cast
 
 import pytest
 
@@ -20,13 +22,19 @@ from lm_resiliency.integrations.torchrun._agent_registration_records import (
     AgentRegistrationRecord,
     HeldAgentRegistration,
 )
-from lm_resiliency.integrations.torchrun._control_store import ControlStoreWrite
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStoreWrite,
+    InMemoryControlStore,
+)
 from lm_resiliency.integrations.torchrun._coordinator_lease import (
     CoordinatorLeaseRecord,
     HeldCoordinatorLease,
 )
 from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
     CoordinatorLeaseAuthority,
+    CoordinatorLeaseHistoryCorrupt,
+    CoordinatorLeaseHistoryError,
+    CoordinatorLeaseHistoryReader,
 )
 from lm_resiliency.integrations.torchrun._generation_reader import (
     CurrentGeneration,
@@ -61,6 +69,13 @@ from lm_resiliency.integrations.torchrun._restart_intent_records import (
 from lm_resiliency.integrations.torchrun._restart_plan_publication_authority import (
     RestartPlanPublicationAuthority,
 )
+from lm_resiliency.integrations.torchrun._restart_plan_publication_preparation import (
+    RestartPlanPublicationAuthorityPreparer,
+    RestartPlanPublicationPreparationClockError,
+    RestartPlanPublicationPreparationConflict,
+    RestartPlanPublicationPreparationCorrupt,
+    RestartPlanPublicationPreparationLeaseLost,
+)
 from lm_resiliency.integrations.torchrun._restart_plan_publication_records import (
     RestartPlanPublicationRecords,
 )
@@ -82,6 +97,28 @@ from lm_resiliency.integrations.torchrun._restart_plan_state import (
 )
 
 RUN_ID = "training-run"
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+    def set(self, now_unix_ms: int) -> None:
+        with self._lock:
+            self.now_unix_ms = now_unix_ms
+
+
+class FailingLeaseHistoryReader:
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+
+    def read(self):
+        raise self._error
 
 
 def _assignment(
@@ -2287,6 +2324,149 @@ def test_restart_plan_publication_authority_rejects_elapsed_window():
 
     with pytest.raises(ValueError, match="window has elapsed"):
         replace(authority, observed_at_unix_ms=authority.deadline_unix_ms)
+
+
+def _publication_preparation_state(
+    *,
+    lease_writes: int = 9,
+) -> tuple[
+    ManualClock,
+    InMemoryControlStore,
+    RestartPlanPublicationRecords,
+]:
+    records = _publication_records()
+    plan_record = records.candidate.placement_state.generation_state.record
+    clock = ManualClock(900)
+    store = InMemoryControlStore(clock=clock)
+    lease_key = CoordinatorLeaseHistoryReader(store, run_id=RUN_ID).lease_key
+    lease_record = CoordinatorLeaseRecord(
+        run_id=RUN_ID,
+        coordinator_id=plan_record.coordinator_id,
+        lease_id=plan_record.lease_id,
+        lease_duration_ms=plan_record.coordinator_lease_duration_ms,
+    )
+    expected_revision = None
+    for _ in range(lease_writes):
+        entry = store.compare_set_in_window(
+            lease_key,
+            expected_revision=expected_revision,
+            not_before_unix_ms=900,
+            deadline_unix_ms=1_400,
+            value=lease_record.to_json(),
+        )
+        expected_revision = entry.revision
+    clock.set(1_200)
+    return clock, store, records
+
+
+def test_restart_plan_publication_preparer_authenticates_without_mutation():
+    clock, store, records = _publication_preparation_state()
+    lease_key = CoordinatorLeaseHistoryReader(store, run_id=RUN_ID).lease_key
+    history_before = store.get_history(lease_key)
+
+    authority = RestartPlanPublicationAuthorityPreparer(
+        store,
+        run_id=RUN_ID,
+        clock=clock,
+    ).prepare(records)
+
+    assert authority.records == records
+    assert authority.coordinator_authority.lease.fencing_token == 9
+    assert authority.observed_at_unix_ms == 1_200
+    assert authority.deadline_unix_ms == 1_400
+    assert store.get_history(lease_key) == history_before
+
+
+def test_restart_plan_publication_preparer_rejects_missing_or_stale_lease():
+    clock = ManualClock(1_200)
+    store = InMemoryControlStore(clock=clock)
+    records = _publication_records()
+
+    with pytest.raises(RestartPlanPublicationPreparationLeaseLost, match="no live"):
+        RestartPlanPublicationAuthorityPreparer(
+            store,
+            run_id=RUN_ID,
+            clock=clock,
+        ).prepare(records)
+
+    clock, store, records = _publication_preparation_state(lease_writes=8)
+    with pytest.raises(RestartPlanPublicationPreparationLeaseLost, match="not authorized"):
+        RestartPlanPublicationAuthorityPreparer(
+            store,
+            run_id=RUN_ID,
+            clock=clock,
+        ).prepare(records)
+
+
+def test_restart_plan_publication_preparer_rejects_elapsed_or_unsafe_clock():
+    clock, store, records = _publication_preparation_state()
+    clock.set(1_400)
+    with pytest.raises(RestartPlanPublicationPreparationLeaseLost, match="window elapsed"):
+        RestartPlanPublicationAuthorityPreparer(
+            store,
+            run_id=RUN_ID,
+            clock=clock,
+        ).prepare(records)
+
+    clock, store, records = _publication_preparation_state()
+    preparation_clock = ManualClock(1_199)
+    preparer = RestartPlanPublicationAuthorityPreparer(
+        store,
+        run_id=RUN_ID,
+        clock=preparation_clock,
+    )
+    with pytest.raises(RestartPlanPublicationPreparationClockError, match="precedes"):
+        preparer.prepare(records)
+
+    preparation_clock.set(1_200)
+    preparer.prepare(records)
+    preparation_clock.set(1_199)
+    with pytest.raises(RestartPlanPublicationPreparationClockError, match="moved backward"):
+        preparer.prepare(records)
+
+
+def test_restart_plan_publication_preparer_translates_history_failures():
+    clock, store, records = _publication_preparation_state()
+    preparer = RestartPlanPublicationAuthorityPreparer(
+        store,
+        run_id=RUN_ID,
+        clock=clock,
+    )
+    cast(Any, preparer)._lease_history_reader = FailingLeaseHistoryReader(
+        CoordinatorLeaseHistoryError("changed repeatedly")
+    )
+    with pytest.raises(RestartPlanPublicationPreparationConflict, match="changed repeatedly"):
+        preparer.prepare(records)
+
+    cast(Any, preparer)._lease_history_reader = FailingLeaseHistoryReader(
+        CoordinatorLeaseHistoryCorrupt("malformed")
+    )
+    with pytest.raises(RestartPlanPublicationPreparationCorrupt, match="history is corrupt"):
+        preparer.prepare(records)
+
+
+def test_restart_plan_publication_preparer_requires_exact_inputs():
+    clock, store, records = _publication_preparation_state()
+    preparer = RestartPlanPublicationAuthorityPreparer(
+        store,
+        run_id=RUN_ID,
+        clock=clock,
+    )
+
+    with pytest.raises(TypeError, match="records must be"):
+        preparer.prepare(records.candidate)
+    with pytest.raises(ValueError, match="another run"):
+        RestartPlanPublicationAuthorityPreparer(
+            store,
+            run_id="other-run",
+            clock=clock,
+        ).prepare(records)
+    with pytest.raises(TypeError, match="clock must be callable"):
+        RestartPlanPublicationAuthorityPreparer(
+            store,
+            run_id=RUN_ID,
+            clock=cast(Any, None),
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add a read-only preparer that authenticates restart-plan publication records against stable durable coordinator lease history
- sample a monotonic coordinator clock between identical history snapshots and fail closed on stale, corrupt, expired, or contradictory authority
- preserve lifecycle fencing, quarantine-resource admission, transaction execution, and committed-result verification as separate components

## Validation
- `CUDA_VISIBLE_DEVICES= .venv/bin/pytest -q tests/unit/test_torchrun_restart_plan_state.py tests/unit/test_torchrun_coordinator_lease_history.py` (176 passed)
- `CUDA_VISIBLE_DEVICES= .venv/bin/pytest -q tests/unit` (2221 passed)
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `mypy lm_resiliency/integrations/torchrun/_restart_plan_publication_preparation.py`
- `git diff --check`