### PR TITLE
[Feature][Torchrun] Fence restart plan publication lifecycle

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -844,6 +844,12 @@ that pure authority value without mutating the store. Repeated lease changes
 remain retryable conflicts; missing, stale, expired, or contradictory authority
 fails closed. Lifecycle fencing, quarantine-resource authorization, execution,
 and committed-result verification remain separate publication layers.
+`RestartPlanPublicationLifecycleFence` derives immutable revision conditions
+for the exact closed intent, durable closed head, lifecycle record, and
+lifecycle head from one authenticated closure. It rejects any closure whose
+successor generation is already committed. Candidate identity, live-store
+observation, transaction execution, and committed-result verification remain
+separate layers.
 
 Before commit, the coordinator validates:
 

--- a/lm_resiliency/integrations/torchrun/_restart_plan_publication_lifecycle.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_publication_lifecycle.py
@@ -1,0 +1,81 @@
+"""Closed-lifecycle revision fencing for restart-plan publication."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+
+from lm_resiliency.integrations.torchrun._restart_intent_lifecycle_auth import (
+    AuthenticatedInitialRestartIntentClosure,
+)
+
+_CONTROL_PREFIX = "lm_resiliency/torchrun/v1"
+
+
+@dataclass(frozen=True, slots=True)
+class RestartPlanPublicationLifecycleFence:
+    """Exact closed-intent revisions that must survive plan publication."""
+
+    closure: AuthenticatedInitialRestartIntentClosure
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.closure, AuthenticatedInitialRestartIntentClosure):
+            raise TypeError(
+                "RestartPlanPublicationLifecycleFence.closure must be "
+                "AuthenticatedInitialRestartIntentClosure"
+            )
+        if self.closure.immediate_successor is not None:
+            raise ValueError(
+                "RestartPlanPublicationLifecycleFence successor generation is already committed"
+            )
+
+    @property
+    def run_prefix(self) -> str:
+        run_digest = hashlib.sha256(self.closure.intent.intent.run_id.encode("utf-8")).hexdigest()
+        return f"{_CONTROL_PREFIX}/runs/{run_digest}"
+
+    @property
+    def intent_key(self) -> str:
+        intent_digest = hashlib.sha256(
+            self.closure.intent.intent.intent_id.encode("utf-8")
+        ).hexdigest()
+        return f"{self.run_prefix}/restart-intents/{intent_digest}"
+
+    @property
+    def intent_head_key(self) -> str:
+        return f"{self.run_prefix}/restart-intent-head"
+
+    @property
+    def closure_key(self) -> str:
+        return (
+            f"{self.run_prefix}/restart-intent-closures/{self.closure.lifecycle_head.closure_index}"
+        )
+
+    @property
+    def lifecycle_head_key(self) -> str:
+        return f"{self.run_prefix}/restart-intent-lifecycle-head"
+
+    @property
+    def conditions(self) -> Mapping[str, int]:
+        state = self.closure.state
+        return MappingProxyType(
+            {
+                self.intent_key: state.intent_entry.revision,
+                self.intent_head_key: state.closed_head_entry.revision,
+                self.closure_key: state.lifecycle_entry.revision,
+                self.lifecycle_head_key: state.lifecycle_head_entry.revision,
+            }
+        )
+
+    @property
+    def closed_at_unix_ms(self) -> int:
+        return self.closure.closed_at_unix_ms
+
+    @property
+    def transaction_sequence(self) -> int:
+        return self.closure.transaction_sequence
+
+
+__all__ = ["RestartPlanPublicationLifecycleFence"]

--- a/tests/unit/test_torchrun_restart_intent_lifecycle_auth.py
+++ b/tests/unit/test_torchrun_restart_intent_lifecycle_auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import threading
 from dataclasses import dataclass, replace
 from typing import Any, cast
@@ -46,6 +47,9 @@ from lm_resiliency.integrations.torchrun._restart_intent_records import (
     RestartIntentClosedHeadRecord,
     RestartIntentLifecycleHeadRecord,
     RestartIntentLifecycleRecord,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_publication_lifecycle import (
+    RestartPlanPublicationLifecycleFence,
 )
 
 RUN_ID = "training-run"
@@ -234,6 +238,73 @@ def test_authenticated_closure_resolves_exact_authorities(closing_mode: str):
     assert authenticated.closing_authority == fixture.lease_history[-1]
     assert authenticated.closed_at_unix_ms == fixture.state.closed_at_unix_ms
     assert authenticated.transaction_sequence == fixture.state.closing_transaction_sequence
+
+
+@pytest.mark.parametrize("closing_mode", ["opening", "renewed", "replacement"])
+def test_restart_plan_publication_lifecycle_fence_preserves_exact_revisions(
+    closing_mode: str,
+):
+    fixture = _fixture(closing_mode=closing_mode)
+    closure = _authenticate(fixture)
+
+    fence = RestartPlanPublicationLifecycleFence(closure)
+
+    run_digest = hashlib.sha256(RUN_ID.encode("utf-8")).hexdigest()
+    intent_digest = hashlib.sha256(closure.intent.intent.intent_id.encode("utf-8")).hexdigest()
+    run_prefix = f"lm_resiliency/torchrun/v1/runs/{run_digest}"
+    assert fence.run_prefix == run_prefix
+    assert fence.intent_key == f"{run_prefix}/restart-intents/{intent_digest}"
+    assert fence.intent_head_key == f"{run_prefix}/restart-intent-head"
+    assert fence.closure_key == f"{run_prefix}/restart-intent-closures/1"
+    assert fence.lifecycle_head_key == f"{run_prefix}/restart-intent-lifecycle-head"
+    assert fence.conditions == {
+        fence.intent_key: fixture.state.intent_entry.revision,
+        fence.intent_head_key: fixture.state.closed_head_entry.revision,
+        fence.closure_key: fixture.state.lifecycle_entry.revision,
+        fence.lifecycle_head_key: fixture.state.lifecycle_head_entry.revision,
+    }
+    assert fence.closed_at_unix_ms == fixture.state.closed_at_unix_ms
+    assert fence.transaction_sequence == fixture.state.closing_transaction_sequence
+
+
+def test_restart_plan_publication_lifecycle_fence_is_immutable():
+    fence = RestartPlanPublicationLifecycleFence(_authenticate(_fixture()))
+
+    with pytest.raises(AttributeError):
+        fence.closure = fence.closure
+    with pytest.raises(TypeError):
+        fence.conditions[fence.intent_key] = 99
+
+
+def test_restart_plan_publication_lifecycle_fence_requires_authenticated_closure():
+    with pytest.raises(TypeError, match="must be AuthenticatedInitialRestartIntentClosure"):
+        RestartPlanPublicationLifecycleFence(_fixture().state)
+
+
+def test_restart_plan_publication_lifecycle_fence_rejects_existing_successor():
+    fixture = _fixture()
+    current = fixture.generation_manager.current()
+    assert current is not None
+    fixture.clock.set(1_020)
+    fixture.generation_manager.commit_successor(
+        fixture.opening_lease,
+        current,
+        _assignment(generation=1, node_id="node-c"),
+    )
+    successor = GenerationStateReader(fixture.store, run_id=RUN_ID).get(1)
+    assert successor is not None
+    closure = AuthenticatedInitialRestartIntentClosure(
+        state=fixture.state,
+        generation_snapshot=fixture.generation,
+        immediate_successor=successor,
+        lease_history=CoordinatorLeaseHistoryReader(
+            fixture.store,
+            run_id=RUN_ID,
+        ).read(),
+    )
+
+    with pytest.raises(ValueError, match="successor generation is already committed"):
+        RestartPlanPublicationLifecycleFence(closure)
 
 
 def test_authenticated_closure_accepts_immediate_generation_successor():


### PR DESCRIPTION
## Summary
- add a pure lifecycle fence derived from one authenticated restart-intent closure
- expose immutable revision conditions for the intent record, durable closed head, closure record, and lifecycle head
- reject publication preparation after a successor generation is already committed

## Scope
- no candidate binding
- no store reads or mutations
- no transaction execution or committed-result verification

## Validation
- `CUDA_VISIBLE_DEVICES= .venv/bin/pytest -q tests/unit/test_torchrun_restart_intent_lifecycle_auth.py tests/unit/test_torchrun_restart_plan_state.py` (169 passed)
- `CUDA_VISIBLE_DEVICES= .venv/bin/pytest -q tests/unit` (2227 passed)
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `mypy lm_resiliency/integrations/torchrun/_restart_plan_publication_lifecycle.py`
- `git diff --check`