### PR TITLE
[Feature][Torchrun] Read restart plan publication lifecycle

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -850,6 +850,11 @@ lifecycle head from one authenticated closure. It rejects any closure whose
 successor generation is already committed. Candidate identity, live-store
 observation, transaction execution, and committed-result verification remain
 separate layers.
+`RestartPlanPublicationLifecycleReader` converts the existing stable,
+authenticated lifecycle read into that fence without mutating the store. An
+open or missing intent, repeated read contention, or an already-committed
+successor remains a retryable publication conflict; contradictory persisted
+lifecycle state fails closed as corruption.
 
 Before commit, the coordinator validates:
 

--- a/lm_resiliency/integrations/torchrun/_restart_plan_publication_lifecycle_reader.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_publication_lifecycle_reader.py
@@ -1,0 +1,71 @@
+"""Read-only preparation of restart-plan publication lifecycle fencing."""
+
+from __future__ import annotations
+
+from lm_resiliency.integrations.torchrun._control_store import ControlStore
+from lm_resiliency.integrations.torchrun._restart_intent_lifecycle_reader import (
+    InitialRestartIntentLifecycleReader,
+    RestartIntentLifecycleReadCorrupt,
+    RestartIntentLifecycleReadError,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_publication_lifecycle import (
+    RestartPlanPublicationLifecycleFence,
+)
+
+
+class RestartPlanPublicationLifecycleReadError(RuntimeError):
+    """Base error for reading restart-plan publication lifecycle fencing."""
+
+
+class RestartPlanPublicationLifecycleConflict(RestartPlanPublicationLifecycleReadError):
+    """Raised when the intent is not closed or its successor already exists."""
+
+
+class RestartPlanPublicationLifecycleCorrupt(RestartPlanPublicationLifecycleReadError):
+    """Raised when persisted restart-intent lifecycle state is contradictory."""
+
+
+class RestartPlanPublicationLifecycleReader:
+    """Read one authenticated closed-intent publication fence."""
+
+    def __init__(self, store: ControlStore, *, run_id: str) -> None:
+        self._lifecycle_reader = InitialRestartIntentLifecycleReader(
+            store,
+            run_id=run_id,
+        )
+
+    def read(self) -> RestartPlanPublicationLifecycleFence:
+        """Return the exact lifecycle revisions required for plan publication."""
+
+        try:
+            closure = self._lifecycle_reader.read()
+        except RestartIntentLifecycleReadCorrupt as error:
+            raise RestartPlanPublicationLifecycleCorrupt(
+                "persisted restart-intent lifecycle is corrupt"
+            ) from error
+        except RestartIntentLifecycleReadError as error:
+            raise RestartPlanPublicationLifecycleConflict(
+                "restart-intent lifecycle changed repeatedly during read"
+            ) from error
+        if closure is None:
+            raise RestartPlanPublicationLifecycleConflict(
+                "restart intent is not closed for plan publication"
+            )
+        if closure.immediate_successor is not None:
+            raise RestartPlanPublicationLifecycleConflict(
+                "restart plan successor generation is already committed"
+            )
+        try:
+            return RestartPlanPublicationLifecycleFence(closure)
+        except (TypeError, ValueError) as error:
+            raise RestartPlanPublicationLifecycleCorrupt(
+                "authenticated restart-intent closure cannot fence plan publication"
+            ) from error
+
+
+__all__ = [
+    "RestartPlanPublicationLifecycleConflict",
+    "RestartPlanPublicationLifecycleCorrupt",
+    "RestartPlanPublicationLifecycleReadError",
+    "RestartPlanPublicationLifecycleReader",
+]

--- a/lm_resiliency/integrations/torchrun/_restart_plan_publication_lifecycle_reader.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_publication_lifecycle_reader.py
@@ -3,6 +3,14 @@
 from __future__ import annotations
 
 from lm_resiliency.integrations.torchrun._control_store import ControlStore
+from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
+    CoordinatorLeaseHistoryCorrupt,
+    CoordinatorLeaseHistoryError,
+)
+from lm_resiliency.integrations.torchrun._generation_reader import (
+    GenerationStateCorrupt,
+    GenerationStateError,
+)
 from lm_resiliency.integrations.torchrun._restart_intent_lifecycle_reader import (
     InitialRestartIntentLifecycleReader,
     RestartIntentLifecycleReadCorrupt,
@@ -43,9 +51,17 @@ class RestartPlanPublicationLifecycleReader:
             raise RestartPlanPublicationLifecycleCorrupt(
                 "persisted restart-intent lifecycle is corrupt"
             ) from error
+        except (CoordinatorLeaseHistoryCorrupt, GenerationStateCorrupt) as error:
+            raise RestartPlanPublicationLifecycleCorrupt(
+                "persisted restart-intent lifecycle dependencies are corrupt"
+            ) from error
         except RestartIntentLifecycleReadError as error:
             raise RestartPlanPublicationLifecycleConflict(
                 "restart-intent lifecycle changed repeatedly during read"
+            ) from error
+        except (CoordinatorLeaseHistoryError, GenerationStateError) as error:
+            raise RestartPlanPublicationLifecycleConflict(
+                "restart-intent lifecycle dependencies changed repeatedly during read"
             ) from error
         if closure is None:
             raise RestartPlanPublicationLifecycleConflict(

--- a/tests/unit/test_torchrun_restart_intent_lifecycle_reader.py
+++ b/tests/unit/test_torchrun_restart_intent_lifecycle_reader.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import threading
 from dataclasses import replace
+from typing import Any, cast
 
 import pytest
 
@@ -28,6 +29,7 @@ from lm_resiliency.integrations.torchrun._restart_intent_close_records import (
 from lm_resiliency.integrations.torchrun._restart_intent_lifecycle_reader import (
     InitialRestartIntentLifecycleReader,
     RestartIntentLifecycleReadCorrupt,
+    RestartIntentLifecycleReadError,
 )
 from lm_resiliency.integrations.torchrun._restart_intent_open import (
     RestartIntentOpenPreparer,
@@ -41,6 +43,11 @@ from lm_resiliency.integrations.torchrun._restart_intent_records import (
     RestartIntentHeadRecord,
     RestartIntentLifecycleHeadRecord,
     RestartIntentLifecycleRecord,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_publication_lifecycle_reader import (
+    RestartPlanPublicationLifecycleConflict,
+    RestartPlanPublicationLifecycleCorrupt,
+    RestartPlanPublicationLifecycleReader,
 )
 
 RUN_ID = "training-run"
@@ -58,6 +65,14 @@ class ManualClock:
     def set(self, now_unix_ms: int) -> None:
         with self._lock:
             self.now_unix_ms = now_unix_ms
+
+
+class FailingLifecycleReader:
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+
+    def read(self):
+        raise self._error
 
 
 def _manager(
@@ -216,6 +231,87 @@ def test_lifecycle_reader_returns_none_before_closure():
 
     _, _, _, _, _, _, open_reader = _open_state()
     assert open_reader.read() is None
+
+
+def test_publication_lifecycle_reader_returns_exact_fence():
+    clock, store, _, _, lease, opened, _ = _open_state()
+    records = _commit_closure(clock, store, opened, lease)
+
+    fence = RestartPlanPublicationLifecycleReader(
+        store,
+        run_id=RUN_ID,
+    ).read()
+
+    intent_entry = store.get(records.intent_key)
+    intent_head_entry = store.get(records.intent_head_key)
+    closure_entry = store.get(records.closure_key)
+    lifecycle_head_entry = store.get(records.lifecycle_head_key)
+    assert intent_entry is not None
+    assert intent_head_entry is not None
+    assert closure_entry is not None
+    assert lifecycle_head_entry is not None
+    assert fence.conditions == {
+        records.intent_key: intent_entry.revision,
+        records.intent_head_key: intent_head_entry.revision,
+        records.closure_key: closure_entry.revision,
+        records.lifecycle_head_key: lifecycle_head_entry.revision,
+    }
+
+
+def test_publication_lifecycle_reader_rejects_missing_or_open_intent():
+    store = InMemoryControlStore(clock=ManualClock())
+    reader = RestartPlanPublicationLifecycleReader(store, run_id=RUN_ID)
+
+    with pytest.raises(RestartPlanPublicationLifecycleConflict, match="not closed"):
+        reader.read()
+
+    _, store, _, _, _, _, _ = _open_state()
+    with pytest.raises(RestartPlanPublicationLifecycleConflict, match="not closed"):
+        RestartPlanPublicationLifecycleReader(store, run_id=RUN_ID).read()
+
+
+def test_publication_lifecycle_reader_rejects_existing_successor():
+    clock, store, _, generation_manager, lease, opened, _ = _open_state()
+    _commit_closure(clock, store, opened, lease)
+    current = generation_manager.current()
+    assert current is not None
+    clock.set(1_020)
+    generation_manager.commit_successor(
+        lease,
+        current,
+        _assignment(generation=1, node_id="node-c"),
+    )
+
+    with pytest.raises(RestartPlanPublicationLifecycleConflict, match="already committed"):
+        RestartPlanPublicationLifecycleReader(store, run_id=RUN_ID).read()
+
+
+def test_publication_lifecycle_reader_translates_corruption():
+    clock, store, _, _, lease, opened, _ = _open_state()
+    records = _commit_closure(clock, store, opened, lease)
+    closure_entry = store.get(records.closure_key)
+    assert closure_entry is not None
+    store.compare_set(
+        records.closure_key,
+        expected_revision=closure_entry.revision,
+        value=b"{}",
+    )
+
+    with pytest.raises(RestartPlanPublicationLifecycleCorrupt, match="lifecycle is corrupt"):
+        RestartPlanPublicationLifecycleReader(store, run_id=RUN_ID).read()
+
+
+def test_publication_lifecycle_reader_translates_contention():
+    reader = RestartPlanPublicationLifecycleReader(
+        InMemoryControlStore(clock=ManualClock()),
+        run_id=RUN_ID,
+    )
+    cast(Any, reader)._lifecycle_reader = FailingLifecycleReader(
+        RestartIntentLifecycleReadError("changed repeatedly")
+    )
+
+    with pytest.raises(RestartPlanPublicationLifecycleConflict, match="changed repeatedly"):
+        reader.read()
 
 
 def test_lifecycle_reader_rejects_closed_head_without_lifecycle():

--- a/tests/unit/test_torchrun_restart_intent_lifecycle_reader.py
+++ b/tests/unit/test_torchrun_restart_intent_lifecycle_reader.py
@@ -314,6 +314,29 @@ def test_publication_lifecycle_reader_translates_contention():
         reader.read()
 
 
+@pytest.mark.parametrize(
+    "dependency_error",
+    [
+        CoordinatorLeaseHistoryError("lease history changed"),
+        GenerationStateError("generation changed"),
+    ],
+)
+def test_publication_lifecycle_reader_translates_dependency_contention(
+    dependency_error: RuntimeError,
+):
+    reader = RestartPlanPublicationLifecycleReader(
+        InMemoryControlStore(clock=ManualClock()),
+        run_id=RUN_ID,
+    )
+    cast(Any, reader)._lifecycle_reader = FailingLifecycleReader(dependency_error)
+
+    with pytest.raises(
+        RestartPlanPublicationLifecycleConflict,
+        match="dependencies changed repeatedly",
+    ):
+        reader.read()
+
+
 def test_lifecycle_reader_rejects_closed_head_without_lifecycle():
     _, store, _, _, lease, opened, reader = _open_state()
     records = _records(opened, lease)


### PR DESCRIPTION
## Summary
- add a read-only adapter from stable authenticated restart-intent lifecycle state to the publication revision fence
- preserve retryable lifecycle, coordinator-lease history, and generation-history contention separately from durable corruption
- reject publication preparation after the successor generation is already committed

## Scope
- no candidate binding
- no store mutation
- no transaction execution or result verification

## Validation
- `CUDA_VISIBLE_DEVICES="" .venv/bin/python -m pytest -q tests/unit/test_torchrun_restart_intent_lifecycle_reader.py` (34 passed)
- `CUDA_VISIBLE_DEVICES="" .venv/bin/python -m pytest -q` (2234 passed)
- `ruff check .`
- `ruff format --check .`
- `mypy lm_resiliency/integrations/torchrun/_restart_plan_publication_lifecycle_reader.py`
- `git diff --check`