### PR TITLE
[Feature][Torchrun] Compose restart plan publication state

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -855,6 +855,13 @@ authenticated lifecycle read into that fence without mutating the store. An
 open or missing intent, repeated read contention, or an already-committed
 successor remains a retryable publication conflict; contradictory persisted
 lifecycle state fails closed as corruption.
+`PreparedRestartPlanPublication` then composes the authenticated coordinator
+authority with that exact lifecycle fence. It requires the candidate's intent,
+closure, and source generation to match the authenticated lifecycle; requires
+the publication authority to be at or after the closing authority in the same
+durable lease history; and merges the lifecycle and candidate revision
+conditions into immutable transaction inputs. It still performs no store
+access, quarantine-resource authorization, execution, or result verification.
 
 Before commit, the coordinator validates:
 

--- a/lm_resiliency/integrations/torchrun/_restart_plan_publication_state.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_publication_state.py
@@ -1,0 +1,136 @@
+"""Pure prepared state for one restart-plan publication transaction."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+
+from lm_resiliency.integrations.torchrun._control_store import ControlStoreWrite
+from lm_resiliency.integrations.torchrun._restart_plan_publication_authority import (
+    RestartPlanPublicationAuthority,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_publication_lifecycle import (
+    RestartPlanPublicationLifecycleFence,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedRestartPlanPublication:
+    """One admitted publication bundle bound to its closed lifecycle."""
+
+    authority: RestartPlanPublicationAuthority
+    lifecycle_fence: RestartPlanPublicationLifecycleFence
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.authority, RestartPlanPublicationAuthority):
+            raise TypeError(
+                "PreparedRestartPlanPublication.authority must be RestartPlanPublicationAuthority"
+            )
+        if not isinstance(self.lifecycle_fence, RestartPlanPublicationLifecycleFence):
+            raise TypeError(
+                "PreparedRestartPlanPublication.lifecycle_fence must be "
+                "RestartPlanPublicationLifecycleFence"
+            )
+        self._validate_records()
+        self._validate_authority_history()
+        self._validate_conditions()
+
+    def _validate_records(self) -> None:
+        records = self.authority.records
+        generation_state = records.candidate.placement_state.generation_state
+        closure = self.lifecycle_fence.closure
+        if (
+            generation_state.intent_record != closure.intent
+            or generation_state.lifecycle_record != closure.lifecycle
+            or generation_state.from_snapshot != closure.generation_snapshot.record
+            or records.current.snapshot != closure.generation_snapshot
+        ):
+            raise ValueError(
+                "PreparedRestartPlanPublication candidate does not match its closed lifecycle"
+            )
+        if self.authority.observed_at_unix_ms < closure.closed_at_unix_ms:
+            raise ValueError(
+                "PreparedRestartPlanPublication authority observation precedes closure"
+            )
+
+    def _validate_authority_history(self) -> None:
+        closure = self.lifecycle_fence.closure
+        history = closure.lease_history
+        closing_matches = tuple(
+            index
+            for index, authority in enumerate(history)
+            if authority == closure.closing_authority
+        )
+        publication_matches = tuple(
+            index
+            for index, authority in enumerate(history)
+            if authority == self.authority.coordinator_authority
+        )
+        if len(closing_matches) != 1 or len(publication_matches) != 1:
+            raise ValueError(
+                "PreparedRestartPlanPublication authorities are absent from durable lease history"
+            )
+        if publication_matches[0] < closing_matches[0]:
+            raise ValueError("PreparedRestartPlanPublication authority predates closure authority")
+
+    def _validate_conditions(self) -> None:
+        publication_conditions = self.authority.records.conditions
+        lifecycle_conditions = self.lifecycle_fence.conditions
+        conflicting = sorted(
+            key
+            for key in set(publication_conditions) & set(lifecycle_conditions)
+            if publication_conditions[key] != lifecycle_conditions[key]
+        )
+        if conflicting:
+            raise ValueError(
+                "PreparedRestartPlanPublication condition revisions disagree for "
+                f"keys: {conflicting!r}"
+            )
+        overlapping_targets = sorted(
+            set(self.authority.records.writes)
+            & (set(publication_conditions) | set(lifecycle_conditions))
+        )
+        if overlapping_targets:
+            raise ValueError(
+                "PreparedRestartPlanPublication conditions must not also be "
+                f"transaction targets: {overlapping_targets!r}"
+            )
+        if self.guard_key in publication_conditions or self.guard_key in lifecycle_conditions:
+            raise ValueError("PreparedRestartPlanPublication guard key must not be a condition")
+        if self.guard_key in self.authority.records.writes:
+            raise ValueError(
+                "PreparedRestartPlanPublication guard key must not be a transaction target"
+            )
+
+    @property
+    def writes(self) -> Mapping[str, ControlStoreWrite]:
+        return self.authority.records.writes
+
+    @property
+    def conditions(self) -> Mapping[str, int]:
+        return MappingProxyType(
+            {
+                **self.authority.records.conditions,
+                **self.lifecycle_fence.conditions,
+            }
+        )
+
+    @property
+    def guard_key(self) -> str:
+        return f"{self.authority.records.run_prefix}/coordinator-lease"
+
+    @property
+    def expected_guard_revision(self) -> int:
+        return self.authority.coordinator_authority.lease.fencing_token
+
+    @property
+    def not_before_unix_ms(self) -> int:
+        return self.authority.not_before_unix_ms
+
+    @property
+    def deadline_unix_ms(self) -> int:
+        return self.authority.deadline_unix_ms
+
+
+__all__ = ["PreparedRestartPlanPublication"]

--- a/tests/unit/test_torchrun_restart_plan_publication_state.py
+++ b/tests/unit/test_torchrun_restart_plan_publication_state.py
@@ -1,0 +1,276 @@
+"""Contract tests for pure restart-plan publication state."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import Mock
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._control_store import ControlStoreWrite
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseRecord,
+    HeldCoordinatorLease,
+)
+from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
+    CoordinatorLeaseAuthority,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_publication_authority import (
+    RestartPlanPublicationAuthority,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_publication_lifecycle import (
+    RestartPlanPublicationLifecycleFence,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_publication_state import (
+    PreparedRestartPlanPublication,
+)
+
+RUN_ID = "training-run"
+
+
+def _lease_authority(
+    *,
+    lease_id: str,
+    fencing_token: int,
+    transaction_sequence: int,
+    mutation_sequence: int,
+) -> CoordinatorLeaseAuthority:
+    return CoordinatorLeaseAuthority(
+        lease=HeldCoordinatorLease(
+            record=CoordinatorLeaseRecord(
+                run_id=RUN_ID,
+                coordinator_id="coordinator-a",
+                lease_id=lease_id,
+                lease_duration_ms=500,
+            ),
+            fencing_token=fencing_token,
+            granted_at_unix_ms=900 + mutation_sequence,
+        ),
+        transaction_sequence=transaction_sequence,
+        mutation_sequence=mutation_sequence,
+        value_sequence=mutation_sequence,
+        lifetime_sequence=1,
+    )
+
+
+def _prepared() -> PreparedRestartPlanPublication:
+    closing_authority = _lease_authority(
+        lease_id="lease-a",
+        fencing_token=3,
+        transaction_sequence=3,
+        mutation_sequence=3,
+    )
+    publication_authority = _lease_authority(
+        lease_id="lease-a",
+        fencing_token=4,
+        transaction_sequence=6,
+        mutation_sequence=4,
+    )
+    intent_record = object()
+    lifecycle_record = object()
+    generation_record = object()
+    generation_snapshot = SimpleNamespace(record=generation_record)
+
+    authority = Mock(spec=RestartPlanPublicationAuthority)
+    authority.records = SimpleNamespace(
+        candidate=SimpleNamespace(
+            placement_state=SimpleNamespace(
+                generation_state=SimpleNamespace(
+                    intent_record=intent_record,
+                    lifecycle_record=lifecycle_record,
+                    from_snapshot=generation_record,
+                )
+            )
+        ),
+        current=SimpleNamespace(snapshot=generation_snapshot),
+        run_prefix="lm_resiliency/torchrun/v1/runs/run-digest",
+        writes={
+            "generation-head": ControlStoreWrite(
+                expected_revision=7,
+                value=b"head",
+            )
+        },
+        conditions={
+            "source-generation": 11,
+            "agent-registration": 13,
+        },
+    )
+    authority.coordinator_authority = publication_authority
+    authority.observed_at_unix_ms = 1_100
+    authority.not_before_unix_ms = 1_100
+    authority.deadline_unix_ms = 1_300
+
+    lifecycle_fence = Mock(spec=RestartPlanPublicationLifecycleFence)
+    lifecycle_fence.closure = SimpleNamespace(
+        intent=intent_record,
+        lifecycle=lifecycle_record,
+        generation_snapshot=generation_snapshot,
+        closing_authority=closing_authority,
+        lease_history=(closing_authority, publication_authority),
+        closed_at_unix_ms=1_050,
+    )
+    lifecycle_fence.conditions = {
+        "restart-intent": 17,
+        "restart-intent-head": 19,
+    }
+    return PreparedRestartPlanPublication(
+        authority=authority,
+        lifecycle_fence=lifecycle_fence,
+    )
+
+
+def test_prepared_publication_exposes_atomic_inputs():
+    prepared = _prepared()
+
+    assert prepared.writes == {
+        "generation-head": ControlStoreWrite(
+            expected_revision=7,
+            value=b"head",
+        )
+    }
+    assert prepared.conditions == {
+        "source-generation": 11,
+        "agent-registration": 13,
+        "restart-intent": 17,
+        "restart-intent-head": 19,
+    }
+    assert prepared.guard_key.endswith("/coordinator-lease")
+    assert prepared.expected_guard_revision == 4
+    assert prepared.not_before_unix_ms == 1_100
+    assert prepared.deadline_unix_ms == 1_300
+
+
+def test_prepared_publication_is_immutable():
+    prepared = _prepared()
+
+    with pytest.raises(AttributeError):
+        prepared.authority = prepared.authority
+    with pytest.raises(TypeError):
+        prepared.conditions["other"] = 1
+
+
+def test_prepared_publication_requires_exact_types():
+    prepared = _prepared()
+
+    with pytest.raises(TypeError, match="authority must be"):
+        replace(prepared, authority=cast(Any, prepared.lifecycle_fence))
+    with pytest.raises(TypeError, match="lifecycle_fence must be"):
+        replace(prepared, lifecycle_fence=cast(Any, prepared.authority))
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["intent_record", "lifecycle_record", "from_snapshot", "current_snapshot"],
+)
+def test_prepared_publication_requires_exact_closed_lifecycle(path: str):
+    prepared = _prepared()
+    authority = prepared.authority
+    generation_state = authority.records.candidate.placement_state.generation_state
+    if path == "intent_record":
+        generation_state.intent_record = object()
+    elif path == "lifecycle_record":
+        generation_state.lifecycle_record = object()
+    elif path == "from_snapshot":
+        generation_state.from_snapshot = object()
+    else:
+        authority.records.current.snapshot = object()
+
+    with pytest.raises(ValueError, match="does not match its closed lifecycle"):
+        PreparedRestartPlanPublication(
+            authority=authority,
+            lifecycle_fence=prepared.lifecycle_fence,
+        )
+
+
+def test_prepared_publication_rejects_observation_before_closure():
+    prepared = _prepared()
+    prepared.authority.observed_at_unix_ms = 1_049
+
+    with pytest.raises(ValueError, match="observation precedes closure"):
+        PreparedRestartPlanPublication(
+            authority=prepared.authority,
+            lifecycle_fence=prepared.lifecycle_fence,
+        )
+
+
+def test_prepared_publication_requires_authority_in_durable_history():
+    prepared = _prepared()
+    prepared.lifecycle_fence.closure.lease_history = (
+        prepared.lifecycle_fence.closure.closing_authority,
+    )
+
+    with pytest.raises(ValueError, match="absent from durable lease history"):
+        PreparedRestartPlanPublication(
+            authority=prepared.authority,
+            lifecycle_fence=prepared.lifecycle_fence,
+        )
+
+
+def test_prepared_publication_accepts_closing_authority_for_publication():
+    prepared = _prepared()
+    closing_authority = prepared.lifecycle_fence.closure.closing_authority
+    prepared.authority.coordinator_authority = closing_authority
+    prepared.lifecycle_fence.closure.lease_history = (closing_authority,)
+
+    recomposed = PreparedRestartPlanPublication(
+        authority=prepared.authority,
+        lifecycle_fence=prepared.lifecycle_fence,
+    )
+
+    assert recomposed.expected_guard_revision == closing_authority.lease.fencing_token
+
+
+def test_prepared_publication_rejects_authority_before_closure_authority():
+    prepared = _prepared()
+    prepared.lifecycle_fence.closure.lease_history = tuple(
+        reversed(prepared.lifecycle_fence.closure.lease_history)
+    )
+
+    with pytest.raises(ValueError, match="predates closure authority"):
+        PreparedRestartPlanPublication(
+            authority=prepared.authority,
+            lifecycle_fence=prepared.lifecycle_fence,
+        )
+
+
+def test_prepared_publication_rejects_conflicting_condition_revision():
+    prepared = _prepared()
+    prepared.lifecycle_fence.conditions = {"source-generation": 12}
+
+    with pytest.raises(ValueError, match="condition revisions disagree"):
+        PreparedRestartPlanPublication(
+            authority=prepared.authority,
+            lifecycle_fence=prepared.lifecycle_fence,
+        )
+
+
+def test_prepared_publication_rejects_condition_target_overlap():
+    prepared = _prepared()
+    prepared.lifecycle_fence.conditions = {"generation-head": 7}
+
+    with pytest.raises(ValueError, match="must not also be transaction targets"):
+        PreparedRestartPlanPublication(
+            authority=prepared.authority,
+            lifecycle_fence=prepared.lifecycle_fence,
+        )
+
+
+@pytest.mark.parametrize("location", ["conditions", "writes"])
+def test_prepared_publication_rejects_guard_key_reuse(location: str):
+    prepared = _prepared()
+    guard_key = prepared.guard_key
+    if location == "conditions":
+        prepared.authority.records.conditions[guard_key] = 23
+    else:
+        prepared.authority.records.writes[guard_key] = ControlStoreWrite(
+            expected_revision=None,
+            value=b"guard",
+        )
+
+    with pytest.raises(ValueError, match="guard key must not"):
+        PreparedRestartPlanPublication(
+            authority=prepared.authority,
+            lifecycle_fence=prepared.lifecycle_fence,
+        )


### PR DESCRIPTION
## Summary
- compose authenticated coordinator publication authority with the exact closed-lifecycle revision fence
- require exact intent, lifecycle, and current-generation identity plus durable lease-authority ordering
- expose immutable merged conditions, writes, guard inputs, and commit window without store access or mutation

## Scope
- no store reads or mutation
- no quarantine-resource authorization
- no transaction execution or committed-result verification

## Validation
- `CUDA_VISIBLE_DEVICES="" .venv/bin/python -m pytest -q tests/unit/test_torchrun_restart_plan_publication_state.py tests/unit/test_torchrun_restart_plan_state.py tests/unit/test_torchrun_restart_intent_lifecycle_auth.py` (184 passed)
- `CUDA_VISIBLE_DEVICES="" .venv/bin/python -m pytest -q` (2249 passed)
- `ruff check .`
- `ruff format --check .`
- `mypy lm_resiliency/integrations/torchrun/_restart_plan_publication_state.py`
- `git diff --check`