### PR TITLE
[Feature][Torchrun] Prepare restart plan publication

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -862,6 +862,12 @@ the publication authority to be at or after the closing authority in the same
 durable lease history; and merges the lifecycle and candidate revision
 conditions into immutable transaction inputs. It still performs no store
 access, quarantine-resource authorization, execution, or result verification.
+`RestartPlanPublicationPreparer` sequences the existing live-authority
+preparer before the stable lifecycle reader and returns that composed value
+without mutating the store. It exposes one error boundary for retryable
+authority/lifecycle contention, lost coordinator authority, unsafe clocks, and
+durable corruption. A closure committed after the authority observation or
+other cross-read mismatch remains retryable contention.
 
 Before commit, the coordinator validates:
 

--- a/lm_resiliency/integrations/torchrun/_restart_plan_publication.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_publication.py
@@ -1,0 +1,127 @@
+"""Read-only preparation of one complete restart-plan publication."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from lm_resiliency.integrations.torchrun._control_store import ControlStore
+from lm_resiliency.integrations.torchrun._restart_plan_publication_authority import (
+    RestartPlanPublicationAuthority,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_publication_lifecycle import (
+    RestartPlanPublicationLifecycleFence,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_publication_lifecycle_reader import (
+    RestartPlanPublicationLifecycleConflict,
+    RestartPlanPublicationLifecycleCorrupt,
+    RestartPlanPublicationLifecycleReader,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_publication_preparation import (
+    RestartPlanPublicationAuthorityPreparer,
+    RestartPlanPublicationPreparationClockError,
+    RestartPlanPublicationPreparationConflict,
+    RestartPlanPublicationPreparationCorrupt,
+    RestartPlanPublicationPreparationLeaseLost,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_publication_records import (
+    RestartPlanPublicationRecords,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_publication_state import (
+    PreparedRestartPlanPublication,
+)
+
+
+class RestartPlanPublicationError(RuntimeError):
+    """Base error for preparing one complete restart-plan publication."""
+
+
+class RestartPlanPublicationConflict(RestartPlanPublicationError):
+    """Raised when publication inputs change or no closed intent is available."""
+
+
+class RestartPlanPublicationLeaseLost(RestartPlanPublicationError):
+    """Raised when the plan's coordinator authority is no longer live."""
+
+
+class RestartPlanPublicationClockError(RestartPlanPublicationError):
+    """Raised when the publication preparation clock is unsafe."""
+
+
+class RestartPlanPublicationCorrupt(RestartPlanPublicationError):
+    """Raised when durable publication dependencies are contradictory."""
+
+
+class RestartPlanPublicationPreparer:
+    """Compose authenticated authority and lifecycle state without mutation."""
+
+    def __init__(
+        self,
+        store: ControlStore,
+        *,
+        run_id: str,
+        clock: Callable[[], int],
+    ) -> None:
+        self._authority_preparer = RestartPlanPublicationAuthorityPreparer(
+            store,
+            run_id=run_id,
+            clock=clock,
+        )
+        self._lifecycle_reader = RestartPlanPublicationLifecycleReader(
+            store,
+            run_id=run_id,
+        )
+
+    def prepare(
+        self,
+        records: RestartPlanPublicationRecords,
+    ) -> PreparedRestartPlanPublication:
+        """Return one authenticated, lifecycle-fenced publication value."""
+
+        authority = self._prepare_authority(records)
+        lifecycle_fence = self._read_lifecycle()
+        try:
+            return PreparedRestartPlanPublication(
+                authority=authority,
+                lifecycle_fence=lifecycle_fence,
+            )
+        except TypeError as error:
+            raise RestartPlanPublicationCorrupt(
+                "authenticated publication inputs have invalid types"
+            ) from error
+        except ValueError as error:
+            raise RestartPlanPublicationConflict(
+                "restart-plan publication inputs changed during preparation"
+            ) from error
+
+    def _prepare_authority(
+        self,
+        records: RestartPlanPublicationRecords,
+    ) -> RestartPlanPublicationAuthority:
+        try:
+            return self._authority_preparer.prepare(records)
+        except RestartPlanPublicationPreparationClockError as error:
+            raise RestartPlanPublicationClockError(str(error)) from error
+        except RestartPlanPublicationPreparationLeaseLost as error:
+            raise RestartPlanPublicationLeaseLost(str(error)) from error
+        except RestartPlanPublicationPreparationConflict as error:
+            raise RestartPlanPublicationConflict(str(error)) from error
+        except RestartPlanPublicationPreparationCorrupt as error:
+            raise RestartPlanPublicationCorrupt(str(error)) from error
+
+    def _read_lifecycle(self) -> RestartPlanPublicationLifecycleFence:
+        try:
+            return self._lifecycle_reader.read()
+        except RestartPlanPublicationLifecycleConflict as error:
+            raise RestartPlanPublicationConflict(str(error)) from error
+        except RestartPlanPublicationLifecycleCorrupt as error:
+            raise RestartPlanPublicationCorrupt(str(error)) from error
+
+
+__all__ = [
+    "RestartPlanPublicationClockError",
+    "RestartPlanPublicationConflict",
+    "RestartPlanPublicationCorrupt",
+    "RestartPlanPublicationError",
+    "RestartPlanPublicationLeaseLost",
+    "RestartPlanPublicationPreparer",
+]

--- a/tests/unit/test_torchrun_restart_plan_publication_state.py
+++ b/tests/unit/test_torchrun_restart_plan_publication_state.py
@@ -17,17 +17,57 @@ from lm_resiliency.integrations.torchrun._coordinator_lease import (
 from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
     CoordinatorLeaseAuthority,
 )
+from lm_resiliency.integrations.torchrun._restart_plan_publication import (
+    RestartPlanPublicationClockError,
+    RestartPlanPublicationConflict,
+    RestartPlanPublicationCorrupt,
+    RestartPlanPublicationError,
+    RestartPlanPublicationLeaseLost,
+    RestartPlanPublicationPreparer,
+)
 from lm_resiliency.integrations.torchrun._restart_plan_publication_authority import (
     RestartPlanPublicationAuthority,
 )
 from lm_resiliency.integrations.torchrun._restart_plan_publication_lifecycle import (
     RestartPlanPublicationLifecycleFence,
 )
+from lm_resiliency.integrations.torchrun._restart_plan_publication_lifecycle_reader import (
+    RestartPlanPublicationLifecycleConflict,
+    RestartPlanPublicationLifecycleCorrupt,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_publication_preparation import (
+    RestartPlanPublicationPreparationClockError,
+    RestartPlanPublicationPreparationConflict,
+    RestartPlanPublicationPreparationCorrupt,
+    RestartPlanPublicationPreparationLeaseLost,
+)
 from lm_resiliency.integrations.torchrun._restart_plan_publication_state import (
     PreparedRestartPlanPublication,
 )
 
 RUN_ID = "training-run"
+
+
+class FailingReader:
+    def __init__(self, value=None, error: Exception | None = None) -> None:
+        self._value = value
+        self._error = error
+
+    def read(self):
+        if self._error is not None:
+            raise self._error
+        return self._value
+
+
+class FailingPreparer:
+    def __init__(self, value=None, error: Exception | None = None) -> None:
+        self._value = value
+        self._error = error
+
+    def prepare(self, records):
+        if self._error is not None:
+            raise self._error
+        return self._value
 
 
 def _lease_authority(
@@ -273,4 +313,112 @@ def test_prepared_publication_rejects_guard_key_reuse(location: str):
         PreparedRestartPlanPublication(
             authority=prepared.authority,
             lifecycle_fence=prepared.lifecycle_fence,
+        )
+
+
+def _preparer_for(prepared: PreparedRestartPlanPublication) -> RestartPlanPublicationPreparer:
+    preparer = RestartPlanPublicationPreparer(
+        cast(Any, object()),
+        run_id=RUN_ID,
+        clock=lambda: 1_100,
+    )
+    preparer._authority_preparer = cast(
+        Any,
+        FailingPreparer(value=prepared.authority),
+    )
+    preparer._lifecycle_reader = cast(
+        Any,
+        FailingReader(value=prepared.lifecycle_fence),
+    )
+    return preparer
+
+
+def test_publication_preparer_composes_authenticated_inputs_without_mutation():
+    expected = _prepared()
+    preparer = _preparer_for(expected)
+
+    prepared = preparer.prepare(expected.authority.records)
+
+    assert prepared == expected
+
+
+@pytest.mark.parametrize(
+    ("dependency_error", "expected_error"),
+    [
+        (
+            RestartPlanPublicationPreparationConflict("authority changed"),
+            RestartPlanPublicationConflict,
+        ),
+        (
+            RestartPlanPublicationPreparationLeaseLost("lease lost"),
+            RestartPlanPublicationLeaseLost,
+        ),
+        (
+            RestartPlanPublicationPreparationClockError("clock moved"),
+            RestartPlanPublicationClockError,
+        ),
+        (
+            RestartPlanPublicationPreparationCorrupt("lease corrupt"),
+            RestartPlanPublicationCorrupt,
+        ),
+    ],
+)
+def test_publication_preparer_translates_authority_failures(
+    dependency_error: RuntimeError,
+    expected_error: type[RestartPlanPublicationError],
+):
+    expected = _prepared()
+    preparer = _preparer_for(expected)
+    preparer._authority_preparer = cast(Any, FailingPreparer(error=dependency_error))
+
+    with pytest.raises(expected_error):
+        preparer.prepare(expected.authority.records)
+
+
+@pytest.mark.parametrize(
+    ("dependency_error", "expected_error"),
+    [
+        (
+            RestartPlanPublicationLifecycleConflict("lifecycle changed"),
+            RestartPlanPublicationConflict,
+        ),
+        (
+            RestartPlanPublicationLifecycleCorrupt("lifecycle corrupt"),
+            RestartPlanPublicationCorrupt,
+        ),
+    ],
+)
+def test_publication_preparer_translates_lifecycle_failures(
+    dependency_error: RuntimeError,
+    expected_error: type[RestartPlanPublicationError],
+):
+    expected = _prepared()
+    preparer = _preparer_for(expected)
+    preparer._lifecycle_reader = cast(Any, FailingReader(error=dependency_error))
+
+    with pytest.raises(expected_error):
+        preparer.prepare(expected.authority.records)
+
+
+def test_publication_preparer_classifies_cross_read_mismatch_as_conflict():
+    expected = _prepared()
+    preparer = _preparer_for(expected)
+    expected.authority.observed_at_unix_ms = 1_049
+
+    with pytest.raises(RestartPlanPublicationConflict, match="changed during preparation"):
+        preparer.prepare(expected.authority.records)
+
+
+def test_publication_preparer_requires_valid_constructor_inputs():
+    with pytest.raises(ValueError, match="non-empty"):
+        RestartPlanPublicationPreparer(
+            cast(Any, object()),
+            run_id="",
+            clock=lambda: 1,
+        )
+    with pytest.raises(TypeError, match="callable"):
+        RestartPlanPublicationPreparer(
+            cast(Any, object()),
+            run_id=RUN_ID,
+            clock=cast(Any, None),
         )


### PR DESCRIPTION
## Summary
- sequence live coordinator-authority authentication before the stable closed-lifecycle read
- compose the merged `PreparedRestartPlanPublication` value without mutating the store
- expose one error boundary for contention, lost authority, unsafe clocks, and durable corruption

## Scope
- no store mutation
- no transaction execution or committed-result verification

## Validation
- `CUDA_VISIBLE_DEVICES="" .venv/bin/python -m pytest -q tests/unit/test_torchrun_restart_plan_publication_state.py tests/unit/test_torchrun_restart_plan_state.py tests/unit/test_torchrun_restart_intent_lifecycle_reader.py` (206 passed)
- `CUDA_VISIBLE_DEVICES="" .venv/bin/python -m pytest -q` (2258 passed)
- `ruff check .`
- `ruff format --check .`
- `mypy lm_resiliency/integrations/torchrun/_restart_plan_publication.py`
- `git diff --check`