### PR TITLE
[Feature][Torchrun] Execute restart-plan publication

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -868,6 +868,13 @@ without mutating the store. It exposes one error boundary for retryable
 authority/lifecycle contention, lost coordinator authority, unsafe clocks, and
 durable corruption. A closure committed after the authority observation or
 other cross-read mismatch remains retryable contention.
+`RestartPlanPublicationExecutor` then submits those exact writes, guard,
+revision conditions, and store-time window in one atomic transaction. Its
+committed result verifies the exact key/value set, generation-head and
+immutable-record lineage, common transaction identity, coordinator-lease
+provenance, input ordering, and commit window before the publication is
+accepted. Lifecycle, generation, or registration churn remains a classified
+conflict; substituted store responses fail closed as corruption.
 
 Before commit, the coordinator validates:
 

--- a/lm_resiliency/integrations/torchrun/_restart_plan_publication_execution.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_publication_execution.py
@@ -110,7 +110,8 @@ class CommittedRestartPlanPublication:
         if key == records.generation_head_key:
             generation = records.candidate.plan.to_generation
             if (
-                entry.mutation_sequence != generation + 1
+                entry.revision == records.current.head_revision
+                or entry.mutation_sequence != generation + 1
                 or entry.value_sequence != generation + 1
                 or entry.lifetime_sequence != 1
             ):

--- a/lm_resiliency/integrations/torchrun/_restart_plan_publication_execution.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_publication_execution.py
@@ -1,0 +1,287 @@
+"""Guarded execution of prepared restart-plan publications."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStore,
+    ControlStoreClockError,
+    ControlStoreConflict,
+    ControlStoreDeadlineExceeded,
+    ControlStoreEntry,
+    ControlStoreHistoryConflict,
+    ControlStoreTooEarly,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_publication_state import (
+    PreparedRestartPlanPublication,
+)
+
+
+class RestartPlanPublicationExecutionError(RuntimeError):
+    """Base error for committing one prepared restart-plan publication."""
+
+
+class RestartPlanPublicationExecutionConflict(RestartPlanPublicationExecutionError):
+    """Raised when lifecycle or generation state changes before publication."""
+
+
+class RestartPlanPublicationExecutionRegistrationLost(RestartPlanPublicationExecutionError):
+    """Raised when a selected successor registration changes or expires."""
+
+
+class RestartPlanPublicationExecutionLeaseLost(RestartPlanPublicationExecutionError):
+    """Raised when the coordinator lease changes or expires."""
+
+
+class RestartPlanPublicationExecutionDeadlineElapsed(RestartPlanPublicationExecutionError):
+    """Raised when the prepared restart deadline elapses."""
+
+
+class RestartPlanPublicationExecutionClockError(RestartPlanPublicationExecutionError):
+    """Raised when authoritative store time contradicts preparation."""
+
+
+class RestartPlanPublicationExecutionCorrupt(RestartPlanPublicationExecutionError):
+    """Raised when the transaction returns contradictory committed state."""
+
+
+@dataclass(frozen=True, slots=True)
+class CommittedRestartPlanPublication:
+    """One verified committed restart-plan publication transaction."""
+
+    prepared: PreparedRestartPlanPublication
+    entries: Mapping[str, ControlStoreEntry]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.prepared, PreparedRestartPlanPublication):
+            raise TypeError(
+                "CommittedRestartPlanPublication.prepared must be PreparedRestartPlanPublication"
+            )
+        if not isinstance(self.entries, Mapping):
+            raise TypeError("CommittedRestartPlanPublication.entries must be a mapping")
+        object.__setattr__(self, "entries", MappingProxyType(dict(self.entries)))
+        self._validate_entries()
+
+    def _validate_entries(self) -> None:
+        writes = self.prepared.writes
+        if set(self.entries) != set(writes):
+            raise ValueError(
+                "CommittedRestartPlanPublication entries do not match the prepared key set"
+            )
+        commit_times: set[int | None] = set()
+        transaction_sequences: set[int] = set()
+        for key, write in writes.items():
+            entry = self.entries[key]
+            if not isinstance(entry, ControlStoreEntry):
+                raise TypeError(
+                    "CommittedRestartPlanPublication entries must contain ControlStoreEntry"
+                )
+            if entry.value != write.value:
+                raise ValueError(
+                    f"CommittedRestartPlanPublication entry {key!r} does not match preparation"
+                )
+            self._validate_lineage(key, entry)
+            self._validate_guard(key, entry)
+            commit_times.add(entry.committed_at_unix_ms)
+            transaction_sequences.add(entry.transaction_sequence)
+        if len(commit_times) != 1 or None in commit_times or len(transaction_sequences) != 1:
+            raise ValueError("CommittedRestartPlanPublication entries do not share one transaction")
+        committed_at_unix_ms = next(iter(commit_times))
+        if committed_at_unix_ms is None:
+            raise AssertionError("validated publication lost its commit time")
+        if (
+            committed_at_unix_ms < self.prepared.not_before_unix_ms
+            or committed_at_unix_ms >= self.prepared.deadline_unix_ms
+        ):
+            raise ValueError(
+                "CommittedRestartPlanPublication commit is outside its prepared time window"
+            )
+        if self.transaction_sequence <= self._latest_input_transaction_sequence():
+            raise ValueError(
+                "CommittedRestartPlanPublication does not follow all authenticated inputs"
+            )
+
+    def _validate_lineage(self, key: str, entry: ControlStoreEntry) -> None:
+        records = self.prepared.authority.records
+        if key == records.generation_head_key:
+            generation = records.candidate.plan.to_generation
+            if (
+                entry.mutation_sequence != generation + 1
+                or entry.value_sequence != generation + 1
+                or entry.lifetime_sequence != 1
+            ):
+                raise ValueError(
+                    "CommittedRestartPlanPublication generation head has invalid lineage"
+                )
+            return
+        if (
+            entry.mutation_sequence != 1
+            or entry.value_sequence != 1
+            or entry.lifetime_sequence != 1
+        ):
+            raise ValueError(
+                f"CommittedRestartPlanPublication entry {key!r} is not an immutable creation"
+            )
+
+    def _validate_guard(self, key: str, entry: ControlStoreEntry) -> None:
+        authority = self.prepared.authority.coordinator_authority
+        expected_digest = hashlib.sha256(authority.lease.record.to_json()).hexdigest()
+        if (
+            entry.guard_key != self.prepared.guard_key
+            or entry.guard_revision != self.prepared.expected_guard_revision
+            or entry.guard_value_digest != expected_digest
+            or entry.guard_committed_at_unix_ms != authority.lease.granted_at_unix_ms
+            or entry.guard_mutation_sequence != authority.mutation_sequence
+            or entry.guard_value_sequence != authority.value_sequence
+            or entry.guard_lifetime_sequence != authority.lifetime_sequence
+        ):
+            raise ValueError(
+                f"CommittedRestartPlanPublication entry {key!r} has invalid lease provenance"
+            )
+
+    def _latest_input_transaction_sequence(self) -> int:
+        records = self.prepared.authority.records
+        manifest_source = records.candidate.recovery_state.copy_state.inventory_state.quarantine_state.manifest_state.resolved_manifest.source_snapshot
+        transaction_sequences = [
+            self.prepared.authority.coordinator_authority.transaction_sequence,
+            self.prepared.lifecycle_fence.transaction_sequence,
+            records.current.snapshot.transaction_sequence,
+            manifest_source.transaction_sequence,
+        ]
+        for history in records.candidate.placement_state.registration_histories.values():
+            registration = history.current
+            if registration is None or not history.authorities:
+                raise ValueError(
+                    "CommittedRestartPlanPublication placement lost a selected registration"
+                )
+            transaction_sequences.append(history.authorities[-1].transaction_sequence)
+        return max(transaction_sequences)
+
+    @property
+    def committed_at_unix_ms(self) -> int:
+        committed_at_unix_ms = next(iter(self.entries.values())).committed_at_unix_ms
+        if committed_at_unix_ms is None:
+            raise AssertionError("validated publication lost its commit time")
+        return committed_at_unix_ms
+
+    @property
+    def transaction_sequence(self) -> int:
+        return next(iter(self.entries.values())).transaction_sequence
+
+    @property
+    def generation_head_entry(self) -> ControlStoreEntry:
+        return self.entries[self.prepared.authority.records.generation_head_key]
+
+    @property
+    def successor_snapshot_entry(self) -> ControlStoreEntry:
+        return self.entries[self.prepared.authority.records.successor_generation_snapshot_key]
+
+
+class RestartPlanPublicationExecutor:
+    """Commit and verify one prepared restart-plan publication."""
+
+    def __init__(self, store: ControlStore, *, run_id: str) -> None:
+        self._store = store
+        self._run_id = _nonempty_string(run_id, "run_id")
+
+    def execute(
+        self,
+        prepared: PreparedRestartPlanPublication,
+    ) -> CommittedRestartPlanPublication:
+        """Commit and verify one restart-plan publication."""
+
+        if not isinstance(prepared, PreparedRestartPlanPublication):
+            raise TypeError("prepared must be PreparedRestartPlanPublication")
+        if prepared.authority.records.candidate.plan.run_id != self._run_id:
+            raise ValueError("prepared restart-plan publication belongs to another run")
+        try:
+            committed = self._store.compare_set_many_guarded(
+                prepared.writes,
+                guard_key=prepared.guard_key,
+                expected_guard_revision=prepared.expected_guard_revision,
+                not_before_unix_ms=prepared.not_before_unix_ms,
+                deadline_unix_ms=prepared.deadline_unix_ms,
+                conditions=prepared.conditions,
+            )
+        except ControlStoreConflict as error:
+            if error.key == prepared.guard_key:
+                raise RestartPlanPublicationExecutionLeaseLost(
+                    "coordinator lease changed before restart-plan publication"
+                ) from error
+            registration_keys = set(prepared.authority.records.registration_keys.values())
+            if error.key in registration_keys:
+                raise RestartPlanPublicationExecutionRegistrationLost(
+                    f"selected registration changed at {error.key!r}"
+                ) from error
+            raise RestartPlanPublicationExecutionConflict(
+                f"restart-plan publication state changed at {error.key!r}"
+            ) from error
+        except ControlStoreHistoryConflict as error:
+            raise RestartPlanPublicationExecutionConflict(
+                f"restart-plan publication key {error.key!r} has prior history"
+            ) from error
+        except ControlStoreDeadlineExceeded as error:
+            if prepared.deadline_unix_ms == (
+                prepared.authority.coordinator_authority.lease.expires_at_unix_ms
+            ):
+                raise RestartPlanPublicationExecutionLeaseLost(
+                    "coordinator lease expired before restart-plan publication"
+                ) from error
+            if prepared.deadline_unix_ms in _registration_expiries(prepared):
+                raise RestartPlanPublicationExecutionRegistrationLost(
+                    "selected registration expired before restart-plan publication"
+                ) from error
+            raise RestartPlanPublicationExecutionDeadlineElapsed(
+                "prepared restart-plan publication deadline elapsed before commit"
+            ) from error
+        except (ControlStoreTooEarly, ControlStoreClockError) as error:
+            raise RestartPlanPublicationExecutionClockError(
+                "control-store time contradicts restart-plan publication preparation"
+            ) from error
+        if set(committed) != set(prepared.writes):
+            raise RestartPlanPublicationExecutionCorrupt(
+                "restart-plan transaction returned an unexpected committed key set"
+            )
+        try:
+            return CommittedRestartPlanPublication(
+                prepared=prepared,
+                entries=dict(committed),
+            )
+        except (TypeError, ValueError) as error:
+            raise RestartPlanPublicationExecutionCorrupt(
+                "restart-plan transaction returned contradictory committed state"
+            ) from error
+
+
+def _registration_expiries(prepared: PreparedRestartPlanPublication) -> set[int]:
+    expiries: set[int] = set()
+    histories = prepared.authority.records.candidate.placement_state.registration_histories
+    for history in histories.values():
+        registration = history.current
+        if registration is None:
+            continue
+        expiries.add(registration.expires_at_unix_ms)
+    return expiries
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path} must be a non-empty string")
+    return value
+
+
+__all__ = [
+    "CommittedRestartPlanPublication",
+    "RestartPlanPublicationExecutionClockError",
+    "RestartPlanPublicationExecutionConflict",
+    "RestartPlanPublicationExecutionCorrupt",
+    "RestartPlanPublicationExecutionDeadlineElapsed",
+    "RestartPlanPublicationExecutionError",
+    "RestartPlanPublicationExecutionLeaseLost",
+    "RestartPlanPublicationExecutionRegistrationLost",
+    "RestartPlanPublicationExecutor",
+]

--- a/tests/unit/test_torchrun_restart_plan_publication_execution.py
+++ b/tests/unit/test_torchrun_restart_plan_publication_execution.py
@@ -1,0 +1,466 @@
+"""Contract tests for guarded restart-plan publication execution."""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+from collections.abc import Collection, Mapping
+from dataclasses import replace
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStoreEntry,
+    ControlStoreWrite,
+    InMemoryControlStore,
+)
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseRecord,
+    HeldCoordinatorLease,
+)
+from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
+    CoordinatorLeaseAuthority,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_publication_authority import (
+    RestartPlanPublicationAuthority,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_publication_execution import (
+    RestartPlanPublicationExecutionClockError,
+    RestartPlanPublicationExecutionConflict,
+    RestartPlanPublicationExecutionCorrupt,
+    RestartPlanPublicationExecutionDeadlineElapsed,
+    RestartPlanPublicationExecutionLeaseLost,
+    RestartPlanPublicationExecutionRegistrationLost,
+    RestartPlanPublicationExecutor,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_publication_lifecycle import (
+    RestartPlanPublicationLifecycleFence,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_publication_state import (
+    PreparedRestartPlanPublication,
+)
+
+RUN_ID = "training-run"
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 900) -> None:
+        self.now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self.now_unix_ms
+
+    def set(self, now_unix_ms: int) -> None:
+        with self._lock:
+            self.now_unix_ms = now_unix_ms
+
+
+class TamperedPublicationResultStore(InMemoryControlStore):
+    def __init__(self, *, clock: ManualClock, tamper: str) -> None:
+        super().__init__(clock=clock)
+        self._tamper = tamper
+
+    def compare_set_many_guarded(
+        self,
+        writes: Mapping[str, ControlStoreWrite],
+        *,
+        guard_key: str,
+        expected_guard_revision: int,
+        not_before_unix_ms: int,
+        deadline_unix_ms: int,
+        conditions: Mapping[str, int | None] | None = None,
+        never_created_conditions: Collection[str] | None = None,
+    ) -> Mapping[str, ControlStoreEntry]:
+        committed = dict(
+            super().compare_set_many_guarded(
+                writes,
+                guard_key=guard_key,
+                expected_guard_revision=expected_guard_revision,
+                not_before_unix_ms=not_before_unix_ms,
+                deadline_unix_ms=deadline_unix_ms,
+                conditions=conditions,
+                never_created_conditions=never_created_conditions,
+            )
+        )
+        plan_keys = [key for key in committed if "/restart-plans/" in key]
+        if not plan_keys:
+            return committed
+        plan_key = next(key for key in plan_keys if not key.endswith("/recovery-manifest"))
+        generation_head_key = next(key for key in committed if key.endswith("/generation-head"))
+        immutable_key = next(key for key in committed if key not in {plan_key, generation_head_key})
+        if self._tamper == "missing":
+            committed.pop(plan_key)
+        elif self._tamper == "unexpected":
+            committed[f"{plan_key}/extra"] = committed[plan_key]
+        elif self._tamper == "value":
+            committed[plan_key] = replace(committed[plan_key], value=b"{}")
+        elif self._tamper == "transaction":
+            committed[plan_key] = replace(
+                committed[plan_key],
+                transaction_sequence=committed[plan_key].transaction_sequence + 1,
+            )
+        elif self._tamper == "guard":
+            committed[plan_key] = replace(
+                committed[plan_key],
+                guard_value_digest="0" * 64,
+            )
+        elif self._tamper == "head_lineage":
+            committed[generation_head_key] = replace(
+                committed[generation_head_key],
+                mutation_sequence=4,
+                value_sequence=4,
+            )
+        elif self._tamper == "immutable_lineage":
+            committed[immutable_key] = replace(
+                committed[immutable_key],
+                mutation_sequence=2,
+                value_sequence=2,
+            )
+        elif self._tamper == "time":
+            committed[plan_key] = replace(
+                committed[plan_key],
+                committed_at_unix_ms=None,
+            )
+        elif self._tamper == "order":
+            for key, entry in tuple(committed.items()):
+                committed[key] = replace(entry, transaction_sequence=1)
+        else:
+            raise AssertionError(f"unsupported tamper {self._tamper!r}")
+        return committed
+
+
+def _seed_value(
+    store: InMemoryControlStore,
+    key: str,
+    *,
+    revisions: int = 1,
+) -> ControlStoreEntry:
+    entry = None
+    expected_revision = None
+    for revision in range(revisions):
+        entry = store.compare_set(
+            key,
+            expected_revision=expected_revision,
+            value=f"{key}:{revision}".encode(),
+        )
+        expected_revision = entry.revision
+    assert entry is not None
+    return entry
+
+
+def _state(
+    *,
+    tamper: str | None = None,
+) -> tuple[ManualClock, InMemoryControlStore, PreparedRestartPlanPublication]:
+    clock = ManualClock()
+    store = (
+        InMemoryControlStore(clock=clock)
+        if tamper is None
+        else TamperedPublicationResultStore(clock=clock, tamper=tamper)
+    )
+    run_digest = hashlib.sha256(RUN_ID.encode()).hexdigest()
+    run_prefix = f"lm_resiliency/torchrun/v1/runs/{run_digest}"
+    guard_key = f"{run_prefix}/coordinator-lease"
+    lease_record = CoordinatorLeaseRecord(
+        run_id=RUN_ID,
+        coordinator_id="coordinator-a",
+        lease_id="lease-a",
+        lease_duration_ms=500,
+    )
+    guard_entry = None
+    expected_guard_revision = None
+    for _ in range(4):
+        guard_entry = store.compare_set_in_window(
+            guard_key,
+            expected_revision=expected_guard_revision,
+            not_before_unix_ms=900,
+            deadline_unix_ms=1_400,
+            value=lease_record.to_json(),
+        )
+        expected_guard_revision = guard_entry.revision
+    assert guard_entry is not None
+    authority = CoordinatorLeaseAuthority(
+        lease=HeldCoordinatorLease(
+            record=lease_record,
+            fencing_token=guard_entry.revision,
+            granted_at_unix_ms=900,
+        ),
+        transaction_sequence=guard_entry.transaction_sequence,
+        mutation_sequence=guard_entry.mutation_sequence,
+        value_sequence=guard_entry.value_sequence,
+        lifetime_sequence=guard_entry.lifetime_sequence,
+    )
+
+    generation_head_key = f"{run_prefix}/generation-head"
+    generation_head_entry = _seed_value(store, generation_head_key, revisions=2)
+    source_key = f"{run_prefix}/generations/1"
+    registration_keys = {
+        "node-a": f"{run_prefix}/agents/node-a",
+        "node-c": f"{run_prefix}/agents/node-c",
+    }
+    lifecycle_conditions = {
+        f"{run_prefix}/restart-intents/intent-a": 1,
+        f"{run_prefix}/restart-intent-head": 1,
+        f"{run_prefix}/restart-intent-closures/1": 1,
+        f"{run_prefix}/restart-intent-lifecycle-head": 1,
+    }
+    _seed_value(store, source_key)
+    for key in registration_keys.values():
+        _seed_value(store, key)
+    for key in lifecycle_conditions:
+        _seed_value(store, key)
+
+    writes = {
+        generation_head_key: ControlStoreWrite(
+            expected_revision=generation_head_entry.revision,
+            value=b"generation-head-2",
+        ),
+        f"{run_prefix}/generations/2": ControlStoreWrite(
+            expected_revision=None,
+            value=b"generation-snapshot-2",
+            require_never_created=True,
+        ),
+        f"{run_prefix}/restart-plans/2/recovery-manifest": ControlStoreWrite(
+            expected_revision=None,
+            value=b"recovery-manifest",
+            require_never_created=True,
+        ),
+        f"{run_prefix}/restart-plans/2": ControlStoreWrite(
+            expected_revision=None,
+            value=b"restart-plan",
+            require_never_created=True,
+        ),
+        f"{run_prefix}/quarantines/node-b": ControlStoreWrite(
+            expected_revision=None,
+            value=b"quarantine-node-b",
+            require_never_created=True,
+        ),
+    }
+    intent_record = object()
+    lifecycle_record = object()
+    generation_record = object()
+    current_snapshot = SimpleNamespace(
+        record=generation_record,
+        transaction_sequence=5,
+    )
+    registration_histories = {
+        node_id: SimpleNamespace(
+            current=SimpleNamespace(
+                expires_at_unix_ms=1_300,
+            ),
+            authorities=(SimpleNamespace(transaction_sequence=7),),
+        )
+        for node_id in registration_keys
+    }
+    generation_state = SimpleNamespace(
+        intent_record=intent_record,
+        lifecycle_record=lifecycle_record,
+        from_snapshot=generation_record,
+    )
+    candidate = SimpleNamespace(
+        plan=SimpleNamespace(
+            run_id=RUN_ID,
+            to_generation=2,
+        ),
+        placement_state=SimpleNamespace(
+            generation_state=generation_state,
+            registration_histories=registration_histories,
+        ),
+        recovery_state=SimpleNamespace(
+            copy_state=SimpleNamespace(
+                inventory_state=SimpleNamespace(
+                    quarantine_state=SimpleNamespace(
+                        manifest_state=SimpleNamespace(
+                            resolved_manifest=SimpleNamespace(
+                                source_snapshot=SimpleNamespace(
+                                    transaction_sequence=5,
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        ),
+    )
+    records = SimpleNamespace(
+        candidate=candidate,
+        current=SimpleNamespace(
+            snapshot=current_snapshot,
+            head_revision=generation_head_entry.revision,
+        ),
+        run_prefix=run_prefix,
+        generation_head_key=generation_head_key,
+        successor_generation_snapshot_key=f"{run_prefix}/generations/2",
+        registration_keys=registration_keys,
+        writes=writes,
+        conditions={
+            source_key: 1,
+            **{key: 1 for key in registration_keys.values()},
+        },
+    )
+    publication_authority = Mock(spec=RestartPlanPublicationAuthority)
+    publication_authority.records = records
+    publication_authority.coordinator_authority = authority
+    publication_authority.observed_at_unix_ms = 1_000
+    publication_authority.not_before_unix_ms = 1_000
+    publication_authority.deadline_unix_ms = 1_300
+
+    lifecycle_fence = Mock(spec=RestartPlanPublicationLifecycleFence)
+    lifecycle_fence.closure = SimpleNamespace(
+        intent=intent_record,
+        lifecycle=lifecycle_record,
+        generation_snapshot=current_snapshot,
+        closing_authority=authority,
+        lease_history=(authority,),
+        closed_at_unix_ms=1_000,
+    )
+    lifecycle_fence.conditions = lifecycle_conditions
+    lifecycle_fence.transaction_sequence = 8
+    prepared = PreparedRestartPlanPublication(
+        authority=publication_authority,
+        lifecycle_fence=lifecycle_fence,
+    )
+    clock.set(1_100)
+    return clock, store, prepared
+
+
+def test_executor_commits_and_verifies_publication():
+    _, store, prepared = _state()
+
+    committed = RestartPlanPublicationExecutor(store, run_id=RUN_ID).execute(prepared)
+
+    assert set(committed.entries) == set(prepared.writes)
+    assert committed.generation_head_entry == store.get(
+        prepared.authority.records.generation_head_key
+    )
+    assert committed.successor_snapshot_entry == store.get(
+        prepared.authority.records.successor_generation_snapshot_key
+    )
+    assert committed.committed_at_unix_ms == 1_100
+    assert committed.transaction_sequence > prepared.lifecycle_fence.transaction_sequence
+    with pytest.raises(TypeError):
+        committed.entries["other"] = committed.generation_head_entry
+
+
+def test_executor_rejects_changed_state_and_duplicate_publication():
+    _, store, prepared = _state()
+    condition_key = next(iter(prepared.lifecycle_fence.conditions))
+    condition_entry = store.get(condition_key)
+    assert condition_entry is not None
+    store.compare_set(
+        condition_key,
+        expected_revision=condition_entry.revision,
+        value=condition_entry.value,
+    )
+
+    with pytest.raises(RestartPlanPublicationExecutionConflict, match="state changed"):
+        RestartPlanPublicationExecutor(store, run_id=RUN_ID).execute(prepared)
+
+    _, store, prepared = _state()
+    executor = RestartPlanPublicationExecutor(store, run_id=RUN_ID)
+    executor.execute(prepared)
+    with pytest.raises(RestartPlanPublicationExecutionConflict):
+        executor.execute(prepared)
+
+
+def test_executor_rejects_changed_registration():
+    _, store, prepared = _state()
+    registration_key = next(iter(prepared.authority.records.registration_keys.values()))
+    registration_entry = store.get(registration_key)
+    assert registration_entry is not None
+    store.compare_set(
+        registration_key,
+        expected_revision=registration_entry.revision,
+        value=registration_entry.value,
+    )
+
+    with pytest.raises(
+        RestartPlanPublicationExecutionRegistrationLost,
+        match="registration changed",
+    ):
+        RestartPlanPublicationExecutor(store, run_id=RUN_ID).execute(prepared)
+
+
+def test_executor_rejects_changed_or_expired_lease():
+    clock, store, prepared = _state()
+    guard_entry = store.get(prepared.guard_key)
+    assert guard_entry is not None
+    clock.set(1_150)
+    store.compare_set_in_window(
+        prepared.guard_key,
+        expected_revision=guard_entry.revision,
+        not_before_unix_ms=1_150,
+        deadline_unix_ms=1_400,
+        value=guard_entry.value,
+    )
+
+    with pytest.raises(RestartPlanPublicationExecutionLeaseLost, match="changed"):
+        RestartPlanPublicationExecutor(store, run_id=RUN_ID).execute(prepared)
+
+    clock, store, prepared = _state()
+    prepared.authority.deadline_unix_ms = 1_400
+    for (
+        history
+    ) in prepared.authority.records.candidate.placement_state.registration_histories.values():
+        history.current.expires_at_unix_ms = 1_500
+    clock.set(1_400)
+    with pytest.raises(RestartPlanPublicationExecutionLeaseLost, match="expired"):
+        RestartPlanPublicationExecutor(store, run_id=RUN_ID).execute(prepared)
+
+
+def test_executor_classifies_registration_and_plan_deadlines():
+    clock, store, prepared = _state()
+    clock.set(1_300)
+    with pytest.raises(RestartPlanPublicationExecutionRegistrationLost, match="expired"):
+        RestartPlanPublicationExecutor(store, run_id=RUN_ID).execute(prepared)
+
+    clock, store, prepared = _state()
+    prepared.authority.deadline_unix_ms = 1_250
+    clock.set(1_250)
+    with pytest.raises(RestartPlanPublicationExecutionDeadlineElapsed, match="deadline"):
+        RestartPlanPublicationExecutor(store, run_id=RUN_ID).execute(prepared)
+
+
+def test_executor_rejects_store_time_before_preparation():
+    clock, store, prepared = _state()
+    clock.set(999)
+
+    with pytest.raises(RestartPlanPublicationExecutionClockError, match="contradicts"):
+        RestartPlanPublicationExecutor(store, run_id=RUN_ID).execute(prepared)
+
+
+@pytest.mark.parametrize(
+    "tamper",
+    [
+        "missing",
+        "unexpected",
+        "value",
+        "transaction",
+        "guard",
+        "head_lineage",
+        "immutable_lineage",
+        "time",
+        "order",
+    ],
+)
+def test_executor_rejects_tampered_results(tamper: str):
+    _, store, prepared = _state(tamper=tamper)
+
+    with pytest.raises(RestartPlanPublicationExecutionCorrupt):
+        RestartPlanPublicationExecutor(store, run_id=RUN_ID).execute(prepared)
+
+
+def test_executor_requires_exact_inputs():
+    _, store, prepared = _state()
+    executor = RestartPlanPublicationExecutor(store, run_id=RUN_ID)
+
+    with pytest.raises(TypeError, match="PreparedRestartPlanPublication"):
+        executor.execute(prepared.authority)
+    with pytest.raises(ValueError, match="another run"):
+        RestartPlanPublicationExecutor(store, run_id="other-run").execute(prepared)
+    with pytest.raises(ValueError, match="non-empty"):
+        RestartPlanPublicationExecutor(store, run_id="")

--- a/tests/unit/test_torchrun_restart_plan_publication_execution.py
+++ b/tests/unit/test_torchrun_restart_plan_publication_execution.py
@@ -114,6 +114,11 @@ class TamperedPublicationResultStore(InMemoryControlStore):
                 mutation_sequence=4,
                 value_sequence=4,
             )
+        elif self._tamper == "head_revision":
+            committed[generation_head_key] = replace(
+                committed[generation_head_key],
+                revision=2,
+            )
         elif self._tamper == "immutable_lineage":
             committed[immutable_key] = replace(
                 committed[immutable_key],
@@ -442,6 +447,7 @@ def test_executor_rejects_store_time_before_preparation():
         "transaction",
         "guard",
         "head_lineage",
+        "head_revision",
         "immutable_lineage",
         "time",
         "order",


### PR DESCRIPTION
## Problem

Restart-plan publication has authenticated, lifecycle-fenced transaction inputs, but no guarded mutation boundary or fail-closed verification of the committed response.

## Implementation

- add `RestartPlanPublicationExecutor` with classified lifecycle/generation, registration, lease, deadline, and clock failures
- add immutable `CommittedRestartPlanPublication` verification for exact values, target lineage, shared transaction identity, coordinator guard provenance, input ordering, and commit window
- reject a generation-head response that reuses the prepared opaque revision
- add focused conflict, expiry, duplicate, and response-tampering regressions
- document the execution boundary

## Compatibility

Internal torchrun integration only. No public API or runtime entry point is enabled.

## Validation

- 253 focused tests passed
- 2,275 full CPU tests passed with CUDA hidden
- repository-wide Ruff check and format check passed
- targeted mypy passed
- `git diff --check` passed