### PR TITLE
[Feature][Torchrun] Decode persisted restart-plan publications

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -881,7 +881,9 @@ generation-head entries for one requested run. It requires exact envelope
 digests, an exact plan-derived successor assignment and predecessor digest,
 immutable record lineage, one transaction and commit time, canonical
 coordinator-lease guard provenance, and a commit inside both the lease and
-restart-deadline windows.
+restart-deadline windows. Decoding also rejects manifest metadata or trust
+that conflicts with the plan and quarantine records that conflict with the
+plan lifecycle or publication authority.
 This transaction decoder does not by itself resolve the source generation,
 closed lifecycle, lease history, inventory evidence, or currently committed
 generation; the stable publication reader performs those checks before

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -877,9 +877,11 @@ accepted. Lifecycle, generation, or registration churn remains a classified
 conflict; substituted store responses fail closed as corruption.
 `PersistedRestartPlanPublication` reconstructs the publication transaction
 from canonical plan, manifest, quarantine, successor-snapshot, and
-generation-head entries. It requires exact envelope digests, immutable record
-lineage, one transaction and commit time, canonical coordinator-lease guard
-provenance, and a commit inside both the lease and restart-deadline windows.
+generation-head entries for one requested run. It requires exact envelope
+digests, an exact plan-derived successor assignment and predecessor digest,
+immutable record lineage, one transaction and commit time, canonical
+coordinator-lease guard provenance, and a commit inside both the lease and
+restart-deadline windows.
 This transaction decoder does not by itself resolve the source generation,
 closed lifecycle, lease history, inventory evidence, or currently committed
 generation; the stable publication reader performs those checks before

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -878,12 +878,13 @@ conflict; substituted store responses fail closed as corruption.
 `PersistedRestartPlanPublication` reconstructs the publication transaction
 from canonical plan, manifest, quarantine, successor-snapshot, and
 generation-head entries for one requested run. It requires exact envelope
-digests, an exact plan-derived successor assignment and predecessor digest,
-immutable record lineage, one transaction and commit time, canonical
-coordinator-lease guard provenance, and a commit inside both the lease and
-restart-deadline windows. Decoding also rejects manifest metadata or trust
-that conflicts with the plan and quarantine records that conflict with the
-plan lifecycle or publication authority.
+digests, the requested successor generation, an exact plan-derived successor
+assignment and predecessor digest, immutable record lineage, one transaction
+and commit time, canonical coordinator-lease guard provenance, a transaction
+sequence after the generation-head and lease mutations, and a commit inside
+both the lease and restart-deadline windows. Decoding also rejects manifest
+metadata or trust that conflicts with the plan and quarantine records that
+conflict with the plan lifecycle or publication authority.
 This transaction decoder does not by itself resolve the source generation,
 closed lifecycle, lease history, inventory evidence, or currently committed
 generation; the stable publication reader performs those checks before

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -875,6 +875,15 @@ immutable-record lineage, common transaction identity, coordinator-lease
 provenance, input ordering, and commit window before the publication is
 accepted. Lifecycle, generation, or registration churn remains a classified
 conflict; substituted store responses fail closed as corruption.
+`PersistedRestartPlanPublication` reconstructs the publication transaction
+from canonical plan, manifest, quarantine, successor-snapshot, and
+generation-head entries. It requires exact envelope digests, immutable record
+lineage, one transaction and commit time, canonical coordinator-lease guard
+provenance, and a commit inside both the lease and restart-deadline windows.
+This transaction decoder does not by itself resolve the source generation,
+closed lifecycle, lease history, inventory evidence, or currently committed
+generation; the stable publication reader performs those checks before
+rendezvous may expose the plan.
 
 Before commit, the coordinator validates:
 

--- a/lm_resiliency/integrations/torchrun/_restart_plan_state.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_state.py
@@ -99,6 +99,7 @@ class PersistedRestartPlanPublication:
         cls,
         *,
         run_id: str,
+        to_generation: int,
         plan_entry: ControlStoreEntry,
         manifest_entry: ControlStoreEntry,
         successor_snapshot_entry: ControlStoreEntry,
@@ -109,6 +110,12 @@ class PersistedRestartPlanPublication:
 
         if not isinstance(run_id, str) or not run_id.strip():
             raise ValueError("run_id must be a non-empty string")
+        if (
+            isinstance(to_generation, bool)
+            or not isinstance(to_generation, int)
+            or to_generation < 1
+        ):
+            raise ValueError("to_generation must be a positive integer")
         entries = (
             ("plan_entry", plan_entry),
             ("manifest_entry", manifest_entry),
@@ -135,6 +142,8 @@ class PersistedRestartPlanPublication:
             raise ValueError("restart-plan publication contains malformed records") from error
         if record.plan.run_id != run_id:
             raise ValueError("restart-plan publication belongs to another run")
+        if record.plan.to_generation != to_generation:
+            raise ValueError("restart-plan publication belongs to another generation")
         return cls(
             record=record,
             manifest_record=manifest_record,
@@ -287,7 +296,19 @@ class PersistedRestartPlanPublication:
             raise ValueError(
                 "PersistedRestartPlanPublication entries do not share guard provenance"
             )
-        self._validate_guard(next(iter(guard_provenance)))
+        provenance = next(iter(guard_provenance))
+        self._validate_guard(provenance)
+        transaction_sequence = next(iter(transaction_sequences))
+        guard_mutation_sequence = provenance[3]
+        if not isinstance(guard_mutation_sequence, int):
+            raise AssertionError("validated guard provenance lost its mutation sequence")
+        if transaction_sequence <= max(
+            self.generation_head_entry.mutation_sequence,
+            guard_mutation_sequence,
+        ):
+            raise ValueError(
+                "PersistedRestartPlanPublication transaction sequence predates its mutations"
+            )
         committed_at_unix_ms = next(iter(commit_times))
         if committed_at_unix_ms is None:
             raise AssertionError("validated publication lost its commit time")

--- a/lm_resiliency/integrations/torchrun/_restart_plan_state.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
@@ -9,10 +10,12 @@ from types import MappingProxyType
 from lm_resiliency.integrations.torchrun._agent_registration_history_reader import (
     AgentRegistrationHistory,
 )
+from lm_resiliency.integrations.torchrun._control_store import ControlStoreEntry
 from lm_resiliency.integrations.torchrun._generation_reader import (
     StoredGenerationSnapshot,
 )
 from lm_resiliency.integrations.torchrun._generation_records import (
+    GenerationHeadRecord,
     GenerationSnapshotRecord,
 )
 from lm_resiliency.integrations.torchrun._protocol import (
@@ -39,6 +42,308 @@ from lm_resiliency.integrations.torchrun._restart_plan_records import (
     RecoveryManifestRecord,
     RestartPlanRecord,
 )
+
+_CONTROL_PREFIX = "lm_resiliency/torchrun/v1"
+
+
+@dataclass(frozen=True, slots=True)
+class PersistedRestartPlanPublication:
+    """One canonical restart-plan publication reconstructed from store entries."""
+
+    record: RestartPlanRecord
+    manifest_record: RecoveryManifestRecord
+    successor_snapshot: GenerationSnapshotRecord
+    generation_head: GenerationHeadRecord
+    quarantine_records: Mapping[str, NodeQuarantineRecord]
+    plan_entry: ControlStoreEntry
+    manifest_entry: ControlStoreEntry
+    successor_snapshot_entry: ControlStoreEntry
+    generation_head_entry: ControlStoreEntry
+    quarantine_entries: Mapping[str, ControlStoreEntry]
+
+    def __post_init__(self) -> None:
+        expected_types = (
+            ("record", self.record, RestartPlanRecord),
+            ("manifest_record", self.manifest_record, RecoveryManifestRecord),
+            ("successor_snapshot", self.successor_snapshot, GenerationSnapshotRecord),
+            ("generation_head", self.generation_head, GenerationHeadRecord),
+            ("plan_entry", self.plan_entry, ControlStoreEntry),
+            ("manifest_entry", self.manifest_entry, ControlStoreEntry),
+            (
+                "successor_snapshot_entry",
+                self.successor_snapshot_entry,
+                ControlStoreEntry,
+            ),
+            ("generation_head_entry", self.generation_head_entry, ControlStoreEntry),
+        )
+        for path, value, expected_type in expected_types:
+            if not isinstance(value, expected_type):
+                raise TypeError(
+                    f"PersistedRestartPlanPublication.{path} must be {expected_type.__name__}"
+                )
+        records = _node_record_mapping(
+            self.quarantine_records,
+            path="PersistedRestartPlanPublication.quarantine_records",
+        )
+        entries = _node_entry_mapping(
+            self.quarantine_entries,
+            path="PersistedRestartPlanPublication.quarantine_entries",
+        )
+        object.__setattr__(self, "quarantine_records", MappingProxyType(records))
+        object.__setattr__(self, "quarantine_entries", MappingProxyType(entries))
+        self._validate_records()
+        self._validate_entries()
+
+    @classmethod
+    def from_entries(
+        cls,
+        *,
+        plan_entry: ControlStoreEntry,
+        manifest_entry: ControlStoreEntry,
+        successor_snapshot_entry: ControlStoreEntry,
+        generation_head_entry: ControlStoreEntry,
+        quarantine_entries: Mapping[str, ControlStoreEntry],
+    ) -> PersistedRestartPlanPublication:
+        """Decode and validate one atomic restart-plan publication."""
+
+        entries = (
+            ("plan_entry", plan_entry),
+            ("manifest_entry", manifest_entry),
+            ("successor_snapshot_entry", successor_snapshot_entry),
+            ("generation_head_entry", generation_head_entry),
+        )
+        for path, entry in entries:
+            if not isinstance(entry, ControlStoreEntry):
+                raise TypeError(f"{path} must be ControlStoreEntry")
+        normalized_quarantine_entries = _node_entry_mapping(
+            quarantine_entries,
+            path="quarantine_entries",
+        )
+        try:
+            record = RestartPlanRecord.from_json(plan_entry.value)
+            manifest_record = RecoveryManifestRecord.from_json(manifest_entry.value)
+            successor_snapshot = GenerationSnapshotRecord.from_json(successor_snapshot_entry.value)
+            generation_head = GenerationHeadRecord.from_json(generation_head_entry.value)
+            quarantine_records = {
+                node_id: NodeQuarantineRecord.from_json(entry.value)
+                for node_id, entry in normalized_quarantine_entries.items()
+            }
+        except (TypeError, ValueError) as error:
+            raise ValueError("restart-plan publication contains malformed records") from error
+        return cls(
+            record=record,
+            manifest_record=manifest_record,
+            successor_snapshot=successor_snapshot,
+            generation_head=generation_head,
+            quarantine_records=quarantine_records,
+            plan_entry=plan_entry,
+            manifest_entry=manifest_entry,
+            successor_snapshot_entry=successor_snapshot_entry,
+            generation_head_entry=generation_head_entry,
+            quarantine_entries=normalized_quarantine_entries,
+        )
+
+    @property
+    def plan(self) -> RestartPlan:
+        return self.record.plan
+
+    @property
+    def committed_at_unix_ms(self) -> int:
+        committed_at_unix_ms = self.plan_entry.committed_at_unix_ms
+        if committed_at_unix_ms is None:
+            raise AssertionError("validated publication lost its commit time")
+        return committed_at_unix_ms
+
+    @property
+    def transaction_sequence(self) -> int:
+        return self.plan_entry.transaction_sequence
+
+    def _validate_records(self) -> None:
+        plan = self.record.plan
+        if self.record.recovery_manifest_record_digest != self.manifest_record.digest:
+            raise ValueError(
+                "PersistedRestartPlanPublication manifest digest does not match its plan"
+            )
+        if self.record.to_generation_snapshot_digest != self.successor_snapshot.digest:
+            raise ValueError(
+                "PersistedRestartPlanPublication successor digest does not match its plan"
+            )
+        if (
+            self.generation_head.run_id != plan.run_id
+            or self.generation_head.generation != plan.to_generation
+            or self.generation_head.snapshot_digest != self.successor_snapshot.digest
+        ):
+            raise ValueError(
+                "PersistedRestartPlanPublication generation head does not identify its successor"
+            )
+        expected_quarantine_digests = self.record.quarantine_record_digests
+        if set(self.quarantine_records) != set(expected_quarantine_digests):
+            raise ValueError(
+                "PersistedRestartPlanPublication quarantine records do not match its plan"
+            )
+        for node_id, record in self.quarantine_records.items():
+            if record.node_id != node_id or record.digest != expected_quarantine_digests[node_id]:
+                raise ValueError(
+                    "PersistedRestartPlanPublication quarantine record does not match its plan"
+                )
+        if set(self.quarantine_entries) != set(self.quarantine_records):
+            raise ValueError(
+                "PersistedRestartPlanPublication quarantine entries do not match its records"
+            )
+        if (
+            self.successor_snapshot.coordinator_id != self.record.coordinator_id
+            or self.successor_snapshot.lease_id != self.record.lease_id
+            or self.successor_snapshot.coordinator_lease_duration_ms
+            != self.record.coordinator_lease_duration_ms
+            or self.successor_snapshot.coordinator_fencing_token
+            != self.record.coordinator_fencing_token
+        ):
+            raise ValueError(
+                "PersistedRestartPlanPublication successor uses different publication authority"
+            )
+
+    def _validate_entries(self) -> None:
+        entries = {
+            "plan": self.plan_entry,
+            "manifest": self.manifest_entry,
+            "successor": self.successor_snapshot_entry,
+            "generation head": self.generation_head_entry,
+            **{
+                f"quarantine[{node_id!r}]": entry
+                for node_id, entry in self.quarantine_entries.items()
+            },
+        }
+        expected_values = {
+            "plan": self.record.to_json(),
+            "manifest": self.manifest_record.to_json(),
+            "successor": self.successor_snapshot.to_json(),
+            "generation head": self.generation_head.to_json(),
+            **{
+                f"quarantine[{node_id!r}]": record.to_json()
+                for node_id, record in self.quarantine_records.items()
+            },
+        }
+        commit_times: set[int | None] = set()
+        transaction_sequences: set[int] = set()
+        guard_provenance: set[tuple[object, ...]] = set()
+        for path, entry in entries.items():
+            if entry.value != expected_values[path]:
+                raise ValueError(
+                    f"PersistedRestartPlanPublication {path} entry does not match its record"
+                )
+            if path == "generation head":
+                expected_sequence = self.plan.to_generation + 1
+                if (
+                    entry.mutation_sequence != expected_sequence
+                    or entry.value_sequence != expected_sequence
+                    or entry.lifetime_sequence != 1
+                ):
+                    raise ValueError(
+                        "PersistedRestartPlanPublication generation head has invalid lineage"
+                    )
+            elif (
+                entry.mutation_sequence != 1
+                or entry.value_sequence != 1
+                or entry.lifetime_sequence != 1
+            ):
+                raise ValueError(f"PersistedRestartPlanPublication {path} entry is not immutable")
+            commit_times.add(entry.committed_at_unix_ms)
+            transaction_sequences.add(entry.transaction_sequence)
+            guard_provenance.add(_guard_provenance(entry))
+        if len(commit_times) != 1 or None in commit_times:
+            raise ValueError("PersistedRestartPlanPublication entries do not share one commit time")
+        if len(transaction_sequences) != 1:
+            raise ValueError("PersistedRestartPlanPublication entries do not share one transaction")
+        if len(guard_provenance) != 1:
+            raise ValueError(
+                "PersistedRestartPlanPublication entries do not share guard provenance"
+            )
+        self._validate_guard(next(iter(guard_provenance)))
+        committed_at_unix_ms = next(iter(commit_times))
+        if committed_at_unix_ms is None:
+            raise AssertionError("validated publication lost its commit time")
+        guard_committed_at_unix_ms = self.plan_entry.guard_committed_at_unix_ms
+        if guard_committed_at_unix_ms is None:
+            raise ValueError(
+                "PersistedRestartPlanPublication guard has no authoritative grant time"
+            )
+        if (
+            committed_at_unix_ms < guard_committed_at_unix_ms
+            or committed_at_unix_ms
+            >= guard_committed_at_unix_ms + self.record.coordinator_lease_duration_ms
+            or committed_at_unix_ms >= self.plan.restart_deadline_unix_ms
+        ):
+            raise ValueError(
+                "PersistedRestartPlanPublication commit is outside its authority window"
+            )
+
+    def _validate_guard(self, provenance: tuple[object, ...]) -> None:
+        run_digest = hashlib.sha256(self.plan.run_id.encode("utf-8")).hexdigest()
+        expected_guard_key = f"{_CONTROL_PREFIX}/runs/{run_digest}/coordinator-lease"
+        if (
+            provenance[0] != expected_guard_key
+            or provenance[1] != self.record.coordinator_fencing_token
+            or provenance[2] != self.record.coordinator_lease_digest
+        ):
+            raise ValueError(
+                "PersistedRestartPlanPublication has invalid coordinator guard provenance"
+            )
+
+
+def _guard_provenance(entry: ControlStoreEntry) -> tuple[object, ...]:
+    if (
+        entry.guard_key is None
+        or entry.guard_revision is None
+        or entry.guard_value_digest is None
+        or entry.guard_mutation_sequence is None
+        or entry.guard_value_sequence is None
+        or entry.guard_lifetime_sequence is None
+        or entry.guard_committed_at_unix_ms is None
+    ):
+        raise ValueError("PersistedRestartPlanPublication entry has incomplete guard provenance")
+    return (
+        entry.guard_key,
+        entry.guard_revision,
+        entry.guard_value_digest,
+        entry.guard_mutation_sequence,
+        entry.guard_value_sequence,
+        entry.guard_lifetime_sequence,
+        entry.guard_committed_at_unix_ms,
+    )
+
+
+def _node_record_mapping(
+    value: object,
+    *,
+    path: str,
+) -> dict[str, NodeQuarantineRecord]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{path} must be a mapping")
+    result: dict[str, NodeQuarantineRecord] = {}
+    for node_id, record in value.items():
+        if not isinstance(node_id, str) or not node_id.strip():
+            raise ValueError(f"{path} keys must be non-empty node IDs")
+        if not isinstance(record, NodeQuarantineRecord):
+            raise TypeError(f"{path} values must be NodeQuarantineRecord")
+        result[node_id] = record
+    return dict(sorted(result.items()))
+
+
+def _node_entry_mapping(
+    value: object,
+    *,
+    path: str,
+) -> dict[str, ControlStoreEntry]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{path} must be a mapping")
+    result: dict[str, ControlStoreEntry] = {}
+    for node_id, entry in value.items():
+        if not isinstance(node_id, str) or not node_id.strip():
+            raise ValueError(f"{path} keys must be non-empty node IDs")
+        if not isinstance(entry, ControlStoreEntry):
+            raise TypeError(f"{path} values must be ControlStoreEntry")
+        result[node_id] = entry
+    return dict(sorted(result.items()))
 
 
 @dataclass(frozen=True, slots=True)
@@ -860,6 +1165,7 @@ class RestartPlanCandidateState:
 
 
 __all__ = [
+    "PersistedRestartPlanPublication",
     "ResolvedRecoveryManifest",
     "RestartPlanCandidateState",
     "RestartPlanCertificationState",

--- a/lm_resiliency/integrations/torchrun/_restart_plan_state.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_state.py
@@ -98,6 +98,7 @@ class PersistedRestartPlanPublication:
     def from_entries(
         cls,
         *,
+        run_id: str,
         plan_entry: ControlStoreEntry,
         manifest_entry: ControlStoreEntry,
         successor_snapshot_entry: ControlStoreEntry,
@@ -106,6 +107,8 @@ class PersistedRestartPlanPublication:
     ) -> PersistedRestartPlanPublication:
         """Decode and validate one atomic restart-plan publication."""
 
+        if not isinstance(run_id, str) or not run_id.strip():
+            raise ValueError("run_id must be a non-empty string")
         entries = (
             ("plan_entry", plan_entry),
             ("manifest_entry", manifest_entry),
@@ -130,6 +133,8 @@ class PersistedRestartPlanPublication:
             }
         except (TypeError, ValueError) as error:
             raise ValueError("restart-plan publication contains malformed records") from error
+        if record.plan.run_id != run_id:
+            raise ValueError("restart-plan publication belongs to another run")
         return cls(
             record=record,
             manifest_record=manifest_record,
@@ -167,6 +172,20 @@ class PersistedRestartPlanPublication:
         if self.record.to_generation_snapshot_digest != self.successor_snapshot.digest:
             raise ValueError(
                 "PersistedRestartPlanPublication successor digest does not match its plan"
+            )
+        expected_assignment = RankAssignment.from_assignments(
+            run_id=plan.run_id,
+            generation=plan.to_generation,
+            assignments=plan.slot_assignments,
+            topology_digest=plan.topology_digest,
+        )
+        if (
+            self.successor_snapshot.assignment != expected_assignment
+            or self.successor_snapshot.previous_snapshot_digest
+            != self.record.from_generation_snapshot_digest
+        ):
+            raise ValueError(
+                "PersistedRestartPlanPublication successor does not implement its plan"
             )
         if (
             self.generation_head.run_id != plan.run_id

--- a/lm_resiliency/integrations/torchrun/_restart_plan_state.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_state.py
@@ -169,6 +169,11 @@ class PersistedRestartPlanPublication:
             raise ValueError(
                 "PersistedRestartPlanPublication manifest digest does not match its plan"
             )
+        _validate_manifest_record_matches_plan(
+            self.record,
+            self.manifest_record,
+            path="PersistedRestartPlanPublication",
+        )
         if self.record.to_generation_snapshot_digest != self.successor_snapshot.digest:
             raise ValueError(
                 "PersistedRestartPlanPublication successor digest does not match its plan"
@@ -205,6 +210,11 @@ class PersistedRestartPlanPublication:
                 raise ValueError(
                     "PersistedRestartPlanPublication quarantine record does not match its plan"
                 )
+            _validate_quarantine_record_matches_plan(
+                self.record,
+                record,
+                path="PersistedRestartPlanPublication",
+            )
         if set(self.quarantine_entries) != set(self.quarantine_records):
             raise ValueError(
                 "PersistedRestartPlanPublication quarantine entries do not match its records"
@@ -363,6 +373,55 @@ def _node_entry_mapping(
             raise TypeError(f"{path} values must be ControlStoreEntry")
         result[node_id] = entry
     return dict(sorted(result.items()))
+
+
+def _validate_manifest_record_matches_plan(
+    plan_record: RestartPlanRecord,
+    manifest_record: RecoveryManifestRecord,
+    *,
+    path: str,
+) -> None:
+    plan = plan_record.plan
+    manifest = manifest_record.manifest
+    if (
+        manifest.manifest_id != plan.checkpoint_manifest_id
+        or manifest.run_id != plan.run_id
+        or manifest.source_generation > plan.from_generation
+        or manifest.step != plan.checkpoint_step
+        or manifest.topology_digest != plan.topology_digest
+    ):
+        raise ValueError(f"{path} manifest metadata does not match its plan")
+    if plan.recovery_mode == "recovery_verified" and manifest.trust != "recovery_verified":
+        raise ValueError(f"{path} verified recovery requires a verified manifest")
+    if plan.checkpoint_source == "durable" and manifest.trust != "recovery_verified":
+        raise ValueError(f"{path} durable recovery requires a verified manifest")
+
+
+def _validate_quarantine_record_matches_plan(
+    plan_record: RestartPlanRecord,
+    quarantine_record: NodeQuarantineRecord,
+    *,
+    path: str,
+) -> None:
+    plan = plan_record.plan
+    if (
+        quarantine_record.run_id != plan.run_id
+        or quarantine_record.plan_id != plan.plan_id
+        or quarantine_record.intent_id != plan.intent_id
+        or quarantine_record.from_generation != plan.from_generation
+        or quarantine_record.effective_generation != plan.to_generation
+        or quarantine_record.incident_ids != plan.incident_ids
+        or quarantine_record.reason_code != plan.reason_code
+    ):
+        raise ValueError(f"{path} quarantine record does not match its plan")
+    if (
+        quarantine_record.coordinator_id != plan_record.coordinator_id
+        or quarantine_record.lease_id != plan_record.lease_id
+        or quarantine_record.coordinator_lease_duration_ms
+        != plan_record.coordinator_lease_duration_ms
+        or quarantine_record.coordinator_fencing_token != plan_record.coordinator_fencing_token
+    ):
+        raise ValueError(f"{path} quarantine record uses different publication authority")
 
 
 @dataclass(frozen=True, slots=True)
@@ -547,19 +606,15 @@ class RestartPlanManifestState:
         plan_record = self.generation_state.record
         plan = plan_record.plan
         manifest_record = self.resolved_manifest.record
-        manifest = manifest_record.manifest
         if plan_record.recovery_manifest_record_digest != manifest_record.digest:
             raise ValueError(
                 "RestartPlanManifestState manifest record digest does not match its plan"
             )
-        if (
-            manifest.manifest_id != plan.checkpoint_manifest_id
-            or manifest.run_id != plan.run_id
-            or manifest.source_generation > plan.from_generation
-            or manifest.step != plan.checkpoint_step
-            or manifest.topology_digest != plan.topology_digest
-        ):
-            raise ValueError("RestartPlanManifestState manifest metadata does not match its plan")
+        _validate_manifest_record_matches_plan(
+            plan_record,
+            manifest_record,
+            path="RestartPlanManifestState",
+        )
         source_assignment = self.resolved_manifest.source_assignment
         source_world_size = source_assignment.active_nodes * source_assignment.local_world_size
         if source_world_size != plan.expected_world_size:
@@ -570,14 +625,6 @@ class RestartPlanManifestState:
         ):
             raise ValueError(
                 "RestartPlanManifestState source assignment conflicts with its current generation"
-            )
-        if plan.recovery_mode == "recovery_verified" and manifest.trust != "recovery_verified":
-            raise ValueError(
-                "RestartPlanManifestState verified recovery requires a verified manifest"
-            )
-        if plan.checkpoint_source == "durable" and manifest.trust != "recovery_verified":
-            raise ValueError(
-                "RestartPlanManifestState durable recovery requires a verified manifest"
             )
 
     @property
@@ -626,34 +673,16 @@ class RestartPlanQuarantineState:
             raise ValueError(
                 "RestartPlanQuarantineState records must exactly cover the plan's quarantined nodes"
             )
-        plan = plan_record.plan
         for node_id, record in records.items():
             if record.digest != expected_digests[node_id]:
                 raise ValueError(
                     "RestartPlanQuarantineState quarantine record digest does not match its plan"
                 )
-            if (
-                record.run_id != plan.run_id
-                or record.plan_id != plan.plan_id
-                or record.intent_id != plan.intent_id
-                or record.from_generation != plan.from_generation
-                or record.effective_generation != plan.to_generation
-                or record.incident_ids != plan.incident_ids
-                or record.reason_code != plan.reason_code
-            ):
-                raise ValueError(
-                    "RestartPlanQuarantineState quarantine record does not match its plan"
-                )
-            if (
-                record.coordinator_id != plan_record.coordinator_id
-                or record.lease_id != plan_record.lease_id
-                or record.coordinator_lease_duration_ms != plan_record.coordinator_lease_duration_ms
-                or record.coordinator_fencing_token != plan_record.coordinator_fencing_token
-            ):
-                raise ValueError(
-                    "RestartPlanQuarantineState quarantine record uses different "
-                    "publication authority"
-                )
+            _validate_quarantine_record_matches_plan(
+                plan_record,
+                record,
+                path="RestartPlanQuarantineState",
+            )
         object.__setattr__(
             self,
             "quarantine_records",

--- a/tests/unit/test_torchrun_restart_plan_state.py
+++ b/tests/unit/test_torchrun_restart_plan_state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import threading
+from collections.abc import Callable
 from dataclasses import replace
 from typing import Any, cast
 
@@ -23,6 +24,7 @@ from lm_resiliency.integrations.torchrun._agent_registration_records import (
     HeldAgentRegistration,
 )
 from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStoreEntry,
     ControlStoreWrite,
     InMemoryControlStore,
 )
@@ -82,6 +84,7 @@ from lm_resiliency.integrations.torchrun._restart_plan_records import (
     RestartPlanRecord,
 )
 from lm_resiliency.integrations.torchrun._restart_plan_state import (
+    PersistedRestartPlanPublication,
     ResolvedRecoveryManifest,
     RestartPlanCandidateState,
     RestartPlanCertificationState,
@@ -2042,6 +2045,209 @@ def _publication_records() -> RestartPlanPublicationRecords:
             head_revision=18,
         ),
     )
+
+
+def _persisted_publication() -> PersistedRestartPlanPublication:
+    publication = _publication_records()
+    generation_state = publication.candidate.placement_state.generation_state
+    quarantine_state = (
+        publication.candidate.recovery_state.copy_state.inventory_state.quarantine_state
+    )
+    manifest_record = quarantine_state.manifest_state.resolved_manifest.record
+    plan_record = generation_state.record
+    run_digest = hashlib.sha256(RUN_ID.encode()).hexdigest()
+    guard_key = f"lm_resiliency/torchrun/v1/runs/{run_digest}/coordinator-lease"
+
+    def immutable_entry(value: bytes, revision: int) -> ControlStoreEntry:
+        return ControlStoreEntry(
+            value=value,
+            revision=revision,
+            committed_at_unix_ms=1_200,
+            transaction_sequence=30,
+            guard_key=guard_key,
+            guard_revision=plan_record.coordinator_fencing_token,
+            guard_value_digest=plan_record.coordinator_lease_digest,
+            guard_mutation_sequence=9,
+            guard_value_sequence=5,
+            guard_lifetime_sequence=1,
+            guard_committed_at_unix_ms=900,
+        )
+
+    quarantine_entries = {
+        node_id: immutable_entry(record.to_json(), 24 + index)
+        for index, (node_id, record) in enumerate(quarantine_state.quarantine_records.items())
+    }
+    return PersistedRestartPlanPublication.from_entries(
+        plan_entry=immutable_entry(plan_record.to_json(), 21),
+        manifest_entry=immutable_entry(manifest_record.to_json(), 22),
+        successor_snapshot_entry=immutable_entry(
+            generation_state.to_snapshot.to_json(),
+            23,
+        ),
+        generation_head_entry=replace(
+            immutable_entry(publication.generation_head.to_json(), 29),
+            mutation_sequence=publication.candidate.plan.to_generation + 1,
+            value_sequence=publication.candidate.plan.to_generation + 1,
+        ),
+        quarantine_entries=quarantine_entries,
+    )
+
+
+def test_persisted_restart_plan_publication_decodes_atomic_records():
+    state = _persisted_publication()
+
+    assert state.record.plan == state.plan
+    assert state.generation_head.snapshot_digest == state.successor_snapshot.digest
+    assert state.committed_at_unix_ms == 1_200
+    assert state.transaction_sequence == 30
+    assert set(state.quarantine_records) == set(state.plan.quarantined_node_ids)
+    with pytest.raises(TypeError):
+        state.quarantine_entries["other"] = state.plan_entry
+
+
+def test_persisted_restart_plan_publication_rejects_malformed_records():
+    state = _persisted_publication()
+
+    with pytest.raises(ValueError, match="malformed records"):
+        PersistedRestartPlanPublication.from_entries(
+            plan_entry=replace(state.plan_entry, value=b"{}"),
+            manifest_entry=state.manifest_entry,
+            successor_snapshot_entry=state.successor_snapshot_entry,
+            generation_head_entry=state.generation_head_entry,
+            quarantine_entries=state.quarantine_entries,
+        )
+
+
+def test_persisted_restart_plan_publication_rejects_digest_substitution():
+    state = _persisted_publication()
+
+    with pytest.raises(ValueError, match="manifest digest"):
+        replace(
+            state,
+            manifest_record=replace(
+                state.manifest_record,
+                source_generation_snapshot_digest="f" * 64,
+            ),
+        )
+    with pytest.raises(ValueError, match="successor digest"):
+        replace(
+            state,
+            successor_snapshot=replace(
+                state.successor_snapshot,
+                coordinator_fencing_token=10,
+            ),
+        )
+    with pytest.raises(ValueError, match="quarantine records"):
+        replace(state, quarantine_records={})
+
+
+@pytest.mark.parametrize(
+    ("entry_name", "change", "message"),
+    [
+        (
+            "plan_entry",
+            lambda entry: replace(entry, transaction_sequence=31),
+            "share one transaction",
+        ),
+        (
+            "manifest_entry",
+            lambda entry: replace(entry, committed_at_unix_ms=1_201),
+            "share one commit time",
+        ),
+        (
+            "successor_snapshot_entry",
+            lambda entry: replace(entry, guard_value_digest="0" * 64),
+            "share guard provenance",
+        ),
+        (
+            "plan_entry",
+            lambda entry: replace(
+                entry,
+                mutation_sequence=2,
+                value_sequence=2,
+            ),
+            "is not immutable",
+        ),
+        (
+            "generation_head_entry",
+            lambda entry: replace(
+                entry,
+                mutation_sequence=7,
+                value_sequence=7,
+            ),
+            "generation head has invalid lineage",
+        ),
+    ],
+)
+def test_persisted_restart_plan_publication_rejects_entry_substitution(
+    entry_name: str,
+    change: Callable[[ControlStoreEntry], ControlStoreEntry],
+    message: str,
+) -> None:
+    state = _persisted_publication()
+
+    with pytest.raises(ValueError, match=message):
+        replace(
+            state,
+            **cast(Any, {entry_name: change(getattr(state, entry_name))}),
+        )
+
+
+def test_persisted_restart_plan_publication_rejects_guard_or_time_substitution():
+    state = _persisted_publication()
+    changed_guard = {
+        node_id: replace(entry, guard_revision=10)
+        for node_id, entry in state.quarantine_entries.items()
+    }
+
+    with pytest.raises(ValueError, match="share guard provenance"):
+        replace(state, quarantine_entries=changed_guard)
+    wrong_guard_key = "lm_resiliency/torchrun/v1/runs/other/coordinator-lease"
+    with pytest.raises(ValueError, match="invalid coordinator guard provenance"):
+        replace(
+            state,
+            plan_entry=replace(state.plan_entry, guard_key=wrong_guard_key),
+            manifest_entry=replace(state.manifest_entry, guard_key=wrong_guard_key),
+            successor_snapshot_entry=replace(
+                state.successor_snapshot_entry,
+                guard_key=wrong_guard_key,
+            ),
+            generation_head_entry=replace(
+                state.generation_head_entry,
+                guard_key=wrong_guard_key,
+            ),
+            quarantine_entries={
+                node_id: replace(entry, guard_key=wrong_guard_key)
+                for node_id, entry in state.quarantine_entries.items()
+            },
+        )
+    with pytest.raises(ValueError, match="authority window"):
+        replace(
+            state,
+            plan_entry=replace(state.plan_entry, committed_at_unix_ms=1_400),
+            manifest_entry=replace(state.manifest_entry, committed_at_unix_ms=1_400),
+            successor_snapshot_entry=replace(
+                state.successor_snapshot_entry,
+                committed_at_unix_ms=1_400,
+            ),
+            generation_head_entry=replace(
+                state.generation_head_entry,
+                committed_at_unix_ms=1_400,
+            ),
+            quarantine_entries={
+                node_id: replace(entry, committed_at_unix_ms=1_400)
+                for node_id, entry in state.quarantine_entries.items()
+            },
+        )
+
+
+def test_persisted_restart_plan_publication_requires_exact_types():
+    state = _persisted_publication()
+
+    with pytest.raises(TypeError, match="record must be"):
+        replace(state, record=state.record.plan)
+    with pytest.raises(TypeError, match="quarantine_entries must be a mapping"):
+        replace(state, quarantine_entries=())
 
 
 def test_restart_plan_publication_records_build_canonical_atomic_inputs():

--- a/tests/unit/test_torchrun_restart_plan_state.py
+++ b/tests/unit/test_torchrun_restart_plan_state.py
@@ -2078,6 +2078,7 @@ def _persisted_publication() -> PersistedRestartPlanPublication:
         for index, (node_id, record) in enumerate(quarantine_state.quarantine_records.items())
     }
     return PersistedRestartPlanPublication.from_entries(
+        run_id=RUN_ID,
         plan_entry=immutable_entry(plan_record.to_json(), 21),
         manifest_entry=immutable_entry(manifest_record.to_json(), 22),
         successor_snapshot_entry=immutable_entry(
@@ -2110,7 +2111,31 @@ def test_persisted_restart_plan_publication_rejects_malformed_records():
 
     with pytest.raises(ValueError, match="malformed records"):
         PersistedRestartPlanPublication.from_entries(
+            run_id=RUN_ID,
             plan_entry=replace(state.plan_entry, value=b"{}"),
+            manifest_entry=state.manifest_entry,
+            successor_snapshot_entry=state.successor_snapshot_entry,
+            generation_head_entry=state.generation_head_entry,
+            quarantine_entries=state.quarantine_entries,
+        )
+
+
+def test_persisted_restart_plan_publication_binds_the_requested_run():
+    state = _persisted_publication()
+
+    with pytest.raises(ValueError, match="another run"):
+        PersistedRestartPlanPublication.from_entries(
+            run_id="other-run",
+            plan_entry=state.plan_entry,
+            manifest_entry=state.manifest_entry,
+            successor_snapshot_entry=state.successor_snapshot_entry,
+            generation_head_entry=state.generation_head_entry,
+            quarantine_entries=state.quarantine_entries,
+        )
+    with pytest.raises(ValueError, match="non-empty"):
+        PersistedRestartPlanPublication.from_entries(
+            run_id="",
+            plan_entry=state.plan_entry,
             manifest_entry=state.manifest_entry,
             successor_snapshot_entry=state.successor_snapshot_entry,
             generation_head_entry=state.generation_head_entry,
@@ -2139,6 +2164,49 @@ def test_persisted_restart_plan_publication_rejects_digest_substitution():
         )
     with pytest.raises(ValueError, match="quarantine records"):
         replace(state, quarantine_records={})
+
+
+def test_persisted_restart_plan_publication_requires_the_planned_successor():
+    state = _persisted_publication()
+    slot_assignments = state.plan.slot_assignments
+    reversed_nodes = tuple(assignment.node_id for assignment in reversed(slot_assignments))
+    changed_assignment = RankAssignment.from_assignments(
+        run_id=state.plan.run_id,
+        generation=state.plan.to_generation,
+        assignments=tuple(
+            replace(assignment, node_id=node_id)
+            for assignment, node_id in zip(
+                slot_assignments,
+                reversed_nodes,
+                strict=True,
+            )
+        ),
+        topology_digest=state.plan.topology_digest,
+    )
+    assert changed_assignment != state.successor_snapshot.assignment
+
+    for successor in (
+        replace(state.successor_snapshot, assignment=changed_assignment),
+        replace(
+            state.successor_snapshot,
+            previous_snapshot_digest="e" * 64,
+        ),
+    ):
+        record = replace(
+            state.record,
+            to_generation_snapshot_digest=successor.digest,
+        )
+        with pytest.raises(ValueError, match="successor does not implement"):
+            replace(
+                state,
+                record=record,
+                successor_snapshot=successor,
+                plan_entry=replace(state.plan_entry, value=record.to_json()),
+                successor_snapshot_entry=replace(
+                    state.successor_snapshot_entry,
+                    value=successor.to_json(),
+                ),
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_torchrun_restart_plan_state.py
+++ b/tests/unit/test_torchrun_restart_plan_state.py
@@ -2166,6 +2166,95 @@ def test_persisted_restart_plan_publication_rejects_digest_substitution():
         replace(state, quarantine_records={})
 
 
+def test_persisted_restart_plan_publication_rejects_manifest_metadata_substitution():
+    state = _persisted_publication()
+    manifest_record = replace(
+        state.manifest_record,
+        manifest=replace(
+            state.manifest_record.manifest,
+            manifest_id="other-manifest",
+        ),
+    )
+    plan_record = replace(
+        state.record,
+        recovery_manifest_record_digest=manifest_record.digest,
+    )
+
+    with pytest.raises(ValueError, match="manifest metadata"):
+        replace(
+            state,
+            record=plan_record,
+            manifest_record=manifest_record,
+            plan_entry=replace(state.plan_entry, value=plan_record.to_json()),
+            manifest_entry=replace(
+                state.manifest_entry,
+                value=manifest_record.to_json(),
+            ),
+        )
+
+
+def test_persisted_restart_plan_publication_rejects_weaker_manifest_trust():
+    state = _persisted_publication()
+    manifest_record = replace(
+        state.manifest_record,
+        manifest=replace(state.manifest_record.manifest, trust="latest"),
+    )
+    plan_record = replace(
+        state.record,
+        plan=replace(state.plan, recovery_mode="recovery_verified"),
+        recovery_manifest_record_digest=manifest_record.digest,
+    )
+
+    with pytest.raises(ValueError, match="verified recovery"):
+        replace(
+            state,
+            record=plan_record,
+            manifest_record=manifest_record,
+            plan_entry=replace(state.plan_entry, value=plan_record.to_json()),
+            manifest_entry=replace(
+                state.manifest_entry,
+                value=manifest_record.to_json(),
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    ("change", "message"),
+    [
+        (lambda record: replace(record, plan_id="other-plan"), "does not match its plan"),
+        (
+            lambda record: replace(record, lease_id="other-lease"),
+            "publication authority",
+        ),
+    ],
+)
+def test_persisted_restart_plan_publication_rejects_quarantine_substitution(
+    change: Callable[[NodeQuarantineRecord], NodeQuarantineRecord],
+    message: str,
+) -> None:
+    state = _persisted_publication()
+    node_id, quarantine_record = next(iter(state.quarantine_records.items()))
+    changed_record = change(quarantine_record)
+    plan_record = replace(
+        state.record,
+        quarantine_record_digests={node_id: changed_record.digest},
+    )
+
+    with pytest.raises(ValueError, match=message):
+        replace(
+            state,
+            record=plan_record,
+            quarantine_records={node_id: changed_record},
+            plan_entry=replace(state.plan_entry, value=plan_record.to_json()),
+            quarantine_entries={
+                node_id: replace(
+                    state.quarantine_entries[node_id],
+                    value=changed_record.to_json(),
+                )
+            },
+        )
+
+
 def test_persisted_restart_plan_publication_requires_the_planned_successor():
     state = _persisted_publication()
     slot_assignments = state.plan.slot_assignments

--- a/tests/unit/test_torchrun_restart_plan_state.py
+++ b/tests/unit/test_torchrun_restart_plan_state.py
@@ -2079,6 +2079,7 @@ def _persisted_publication() -> PersistedRestartPlanPublication:
     }
     return PersistedRestartPlanPublication.from_entries(
         run_id=RUN_ID,
+        to_generation=publication.candidate.plan.to_generation,
         plan_entry=immutable_entry(plan_record.to_json(), 21),
         manifest_entry=immutable_entry(manifest_record.to_json(), 22),
         successor_snapshot_entry=immutable_entry(
@@ -2112,6 +2113,7 @@ def test_persisted_restart_plan_publication_rejects_malformed_records():
     with pytest.raises(ValueError, match="malformed records"):
         PersistedRestartPlanPublication.from_entries(
             run_id=RUN_ID,
+            to_generation=state.plan.to_generation,
             plan_entry=replace(state.plan_entry, value=b"{}"),
             manifest_entry=state.manifest_entry,
             successor_snapshot_entry=state.successor_snapshot_entry,
@@ -2126,6 +2128,7 @@ def test_persisted_restart_plan_publication_binds_the_requested_run():
     with pytest.raises(ValueError, match="another run"):
         PersistedRestartPlanPublication.from_entries(
             run_id="other-run",
+            to_generation=state.plan.to_generation,
             plan_entry=state.plan_entry,
             manifest_entry=state.manifest_entry,
             successor_snapshot_entry=state.successor_snapshot_entry,
@@ -2135,6 +2138,27 @@ def test_persisted_restart_plan_publication_binds_the_requested_run():
     with pytest.raises(ValueError, match="non-empty"):
         PersistedRestartPlanPublication.from_entries(
             run_id="",
+            to_generation=state.plan.to_generation,
+            plan_entry=state.plan_entry,
+            manifest_entry=state.manifest_entry,
+            successor_snapshot_entry=state.successor_snapshot_entry,
+            generation_head_entry=state.generation_head_entry,
+            quarantine_entries=state.quarantine_entries,
+        )
+    with pytest.raises(ValueError, match="another generation"):
+        PersistedRestartPlanPublication.from_entries(
+            run_id=RUN_ID,
+            to_generation=state.plan.to_generation + 1,
+            plan_entry=state.plan_entry,
+            manifest_entry=state.manifest_entry,
+            successor_snapshot_entry=state.successor_snapshot_entry,
+            generation_head_entry=state.generation_head_entry,
+            quarantine_entries=state.quarantine_entries,
+        )
+    with pytest.raises(ValueError, match="positive integer"):
+        PersistedRestartPlanPublication.from_entries(
+            run_id=RUN_ID,
+            to_generation=0,
             plan_entry=state.plan_entry,
             manifest_entry=state.manifest_entry,
             successor_snapshot_entry=state.successor_snapshot_entry,
@@ -2347,6 +2371,29 @@ def test_persisted_restart_plan_publication_rejects_entry_substitution(
         replace(
             state,
             **cast(Any, {entry_name: change(getattr(state, entry_name))}),
+        )
+
+
+def test_persisted_restart_plan_publication_rejects_transaction_that_predates_mutations():
+    state = _persisted_publication()
+
+    with pytest.raises(ValueError, match="transaction sequence predates"):
+        replace(
+            state,
+            plan_entry=replace(state.plan_entry, transaction_sequence=1),
+            manifest_entry=replace(state.manifest_entry, transaction_sequence=1),
+            successor_snapshot_entry=replace(
+                state.successor_snapshot_entry,
+                transaction_sequence=1,
+            ),
+            generation_head_entry=replace(
+                state.generation_head_entry,
+                transaction_sequence=1,
+            ),
+            quarantine_entries={
+                node_id: replace(entry, transaction_sequence=1)
+                for node_id, entry in state.quarantine_entries.items()
+            },
         )
 
 


### PR DESCRIPTION
## Summary

- add `PersistedRestartPlanPublication` to reconstruct one atomic plan publication from canonical store entries
- bind decoding to the caller's requested run and successor generation, and require the snapshot to implement the plan's exact assignment and predecessor digest
- validate exact plan, manifest, quarantine, successor-snapshot, and generation-head digests and lineage
- reject manifest metadata/trust and quarantine lifecycle/authority substitution
- require one causally ordered transaction/commit time, canonical coordinator guard provenance, and lease/restart-deadline bounds
- keep source-generation, lifecycle, lease-history, and recovery-evidence resolution for the subsequent stable reader

## Compatibility

Internal torchrun-only value contract. No public API, wire schema, or runtime behavior changes. No new module is added.

## Validation

- `CUDA_VISIBLE_DEVICES='' .venv/bin/python -m pytest -q` (2292 passed)
- focused restart-plan suites (165 passed)
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `/home/ubuntu/anaconda3/bin/mypy lm_resiliency/integrations/torchrun/_restart_plan_state.py tests/unit/test_torchrun_restart_plan_state.py`
- `git diff --check`

