### PR TITLE
[Feature][Torchrun] Read stable restart-plan publications

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -889,6 +889,13 @@ This transaction decoder does not by itself resolve the source generation,
 closed lifecycle, lease history, inventory evidence, or currently committed
 generation; the stable publication reader performs those checks before
 rendezvous may expose the plan.
+`RestartPlanPublicationReader` double-collects the current generation and
+every atomic publication entry, decodes the stable bundle through
+`PersistedRestartPlanPublication`, and requires the successor snapshot and
+generation-head revisions plus store metadata to equal the authoritative
+current generation. Missing, malformed, mixed, or substituted state fails
+closed; repeated head movement remains a retryable read conflict. This first
+readback boundary still does not reauthorize lifecycle or checkpoint evidence.
 
 Before commit, the coordinator validates:
 

--- a/lm_resiliency/integrations/torchrun/_restart_plan_publication.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_publication.py
@@ -4,14 +4,26 @@ from __future__ import annotations
 
 import threading
 from collections.abc import Callable
+from dataclasses import dataclass
 
-from lm_resiliency.integrations.torchrun._control_store import ControlStore
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStore,
+    ControlStoreEntry,
+)
 from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
     CoordinatorLeaseAuthority,
     CoordinatorLeaseHistoryCorrupt,
     CoordinatorLeaseHistoryError,
     CoordinatorLeaseHistoryReader,
 )
+from lm_resiliency.integrations.torchrun._generation_reader import (
+    CurrentGeneration,
+    GenerationStateCorrupt,
+    GenerationStateError,
+    GenerationStateReader,
+    StoredGenerationSnapshot,
+)
+from lm_resiliency.integrations.torchrun._quarantine_store import node_quarantine_key
 from lm_resiliency.integrations.torchrun._restart_plan_publication_lifecycle import (
     RestartPlanPublicationLifecycleConflict,
     RestartPlanPublicationLifecycleCorrupt,
@@ -22,6 +34,12 @@ from lm_resiliency.integrations.torchrun._restart_plan_publication_records impor
     PreparedRestartPlanPublication,
     RestartPlanPublicationAuthority,
     RestartPlanPublicationRecords,
+    recovery_manifest_key,
+    restart_plan_key,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_records import RestartPlanRecord
+from lm_resiliency.integrations.torchrun._restart_plan_state import (
+    PersistedRestartPlanPublication,
 )
 
 _MAX_READ_ATTEMPTS = 8
@@ -195,6 +213,177 @@ class RestartPlanPublicationCorrupt(RestartPlanPublicationError):
     """Raised when durable publication dependencies are contradictory."""
 
 
+class RestartPlanPublicationReadError(RuntimeError):
+    """Base error for reading the latest committed restart plan."""
+
+
+class RestartPlanPublicationReadConflict(RestartPlanPublicationReadError):
+    """Raised when generation or publication state changes repeatedly."""
+
+
+class RestartPlanPublicationReadCorrupt(RestartPlanPublicationReadError):
+    """Raised when the latest publication is incomplete or contradictory."""
+
+
+@dataclass(frozen=True, slots=True)
+class _PublicationEntries:
+    plan: ControlStoreEntry
+    manifest: ControlStoreEntry
+    successor_snapshot: ControlStoreEntry
+    generation_head: ControlStoreEntry
+    quarantines: tuple[tuple[str, ControlStoreEntry], ...]
+
+
+class RestartPlanPublicationReader:
+    """Read one stable latest restart-plan publication without mutation."""
+
+    def __init__(
+        self,
+        store: ControlStore,
+        *,
+        run_id: str,
+    ) -> None:
+        self._store = store
+        self._run_id = _nonempty_string(run_id, "run_id")
+        self._generation_reader = GenerationStateReader(
+            store,
+            run_id=self._run_id,
+        )
+
+    def read(self) -> PersistedRestartPlanPublication | None:
+        """Return the stable publication for the current generation, if any."""
+
+        for _ in range(_MAX_READ_ATTEMPTS):
+            current = self._read_current()
+            if current is None or current.snapshot.record.assignment.generation == 0:
+                return None
+            generation = current.snapshot.record.assignment.generation
+            first = self._read_entries(generation)
+            if self._read_current() != current:
+                continue
+            second = self._read_entries(generation)
+            if second != first or self._read_current() != current:
+                continue
+            publication = self._decode(first, generation)
+            self._validate_current(publication, current)
+            return publication
+        raise RestartPlanPublicationReadConflict(
+            "restart-plan publication changed repeatedly during read"
+        )
+
+    def _read_current(self) -> CurrentGeneration | None:
+        try:
+            return self._generation_reader.current()
+        except GenerationStateCorrupt as error:
+            raise RestartPlanPublicationReadCorrupt(
+                "generation state is corrupt while reading restart-plan publication"
+            ) from error
+        except GenerationStateError as error:
+            raise RestartPlanPublicationReadConflict(
+                "generation state changed repeatedly while reading restart-plan publication"
+            ) from error
+
+    def _read_entries(self, generation: int) -> _PublicationEntries:
+        plan = self._require_entry(
+            restart_plan_key(self._run_id, generation),
+            "restart plan",
+        )
+        try:
+            plan_record = RestartPlanRecord.from_json(plan.value)
+        except (TypeError, ValueError) as error:
+            raise RestartPlanPublicationReadCorrupt(
+                "restart-plan publication contains a malformed plan record"
+            ) from error
+        quarantines = tuple(
+            (
+                node_id,
+                self._require_entry(
+                    node_quarantine_key(self._run_id, node_id),
+                    f"quarantine record for {node_id!r}",
+                ),
+            )
+            for node_id in sorted(plan_record.plan.quarantined_node_ids)
+        )
+        return _PublicationEntries(
+            plan=plan,
+            manifest=self._require_entry(
+                recovery_manifest_key(self._run_id, generation),
+                "recovery manifest",
+            ),
+            successor_snapshot=self._require_entry(
+                self._generation_reader.snapshot_key(generation),
+                "successor generation snapshot",
+            ),
+            generation_head=self._require_entry(
+                self._generation_reader.head_key,
+                "generation head",
+            ),
+            quarantines=quarantines,
+        )
+
+    def _require_entry(self, key: str, path: str) -> ControlStoreEntry:
+        entry = self._store.get(key)
+        if entry is None:
+            raise RestartPlanPublicationReadCorrupt(
+                f"latest restart-plan publication is missing its {path}"
+            )
+        return entry
+
+    def _decode(
+        self,
+        entries: _PublicationEntries,
+        generation: int,
+    ) -> PersistedRestartPlanPublication:
+        try:
+            return PersistedRestartPlanPublication.from_entries(
+                run_id=self._run_id,
+                to_generation=generation,
+                plan_entry=entries.plan,
+                manifest_entry=entries.manifest,
+                successor_snapshot_entry=entries.successor_snapshot,
+                generation_head_entry=entries.generation_head,
+                quarantine_entries=dict(entries.quarantines),
+            )
+        except (TypeError, ValueError) as error:
+            raise RestartPlanPublicationReadCorrupt(
+                "latest restart-plan publication is corrupt"
+            ) from error
+
+    def _validate_current(
+        self,
+        publication: PersistedRestartPlanPublication,
+        current: CurrentGeneration,
+    ) -> None:
+        successor_entry = publication.successor_snapshot_entry
+        if (
+            successor_entry.committed_at_unix_ms is None
+            or successor_entry.guard_mutation_sequence is None
+            or successor_entry.guard_value_sequence is None
+            or successor_entry.guard_lifetime_sequence is None
+            or successor_entry.guard_committed_at_unix_ms is None
+        ):
+            raise RestartPlanPublicationReadCorrupt(
+                "latest restart-plan successor lacks authoritative metadata"
+            )
+        expected_snapshot = StoredGenerationSnapshot(
+            record=publication.successor_snapshot,
+            revision=successor_entry.revision,
+            committed_at_unix_ms=successor_entry.committed_at_unix_ms,
+            transaction_sequence=successor_entry.transaction_sequence,
+            guard_mutation_sequence=successor_entry.guard_mutation_sequence,
+            guard_value_sequence=successor_entry.guard_value_sequence,
+            guard_lifetime_sequence=successor_entry.guard_lifetime_sequence,
+            guard_committed_at_unix_ms=successor_entry.guard_committed_at_unix_ms,
+        )
+        if (
+            current.snapshot != expected_snapshot
+            or current.head_revision != publication.generation_head_entry.revision
+        ):
+            raise RestartPlanPublicationReadCorrupt(
+                "latest restart-plan publication does not match the current generation"
+            )
+
+
 class RestartPlanPublicationPreparer:
     """Compose authenticated authority and lifecycle state without mutation."""
 
@@ -286,4 +475,8 @@ __all__ = [
     "RestartPlanPublicationPreparationError",
     "RestartPlanPublicationPreparationLeaseLost",
     "RestartPlanPublicationPreparer",
+    "RestartPlanPublicationReadConflict",
+    "RestartPlanPublicationReadCorrupt",
+    "RestartPlanPublicationReadError",
+    "RestartPlanPublicationReader",
 ]

--- a/lm_resiliency/integrations/torchrun/_restart_plan_publication_records.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_publication_records.py
@@ -67,16 +67,21 @@ class RestartPlanPublicationRecords:
 
     @property
     def run_prefix(self) -> str:
-        run_digest = hashlib.sha256(self.candidate.plan.run_id.encode("utf-8")).hexdigest()
-        return f"{_CONTROL_PREFIX}/runs/{run_digest}"
+        return _run_prefix(self.candidate.plan.run_id)
 
     @property
     def plan_key(self) -> str:
-        return f"{self.run_prefix}/restart-plans/{self.candidate.plan.to_generation}"
+        return restart_plan_key(
+            self.candidate.plan.run_id,
+            self.candidate.plan.to_generation,
+        )
 
     @property
     def recovery_manifest_key(self) -> str:
-        return f"{self.plan_key}/recovery-manifest"
+        return recovery_manifest_key(
+            self.candidate.plan.run_id,
+            self.candidate.plan.to_generation,
+        )
 
     @property
     def generation_head_key(self) -> str:
@@ -378,8 +383,30 @@ def _positive_integer(value: object, path: str) -> int:
     return value
 
 
+def _run_prefix(run_id: str) -> str:
+    if not isinstance(run_id, str) or not run_id.strip():
+        raise ValueError("run_id must be a non-empty string")
+    run_digest = hashlib.sha256(run_id.encode("utf-8")).hexdigest()
+    return f"{_CONTROL_PREFIX}/runs/{run_digest}"
+
+
+def restart_plan_key(run_id: str, to_generation: int) -> str:
+    """Return the canonical immutable restart-plan key."""
+
+    generation = _positive_integer(to_generation, "to_generation")
+    return f"{_run_prefix(run_id)}/restart-plans/{generation}"
+
+
+def recovery_manifest_key(run_id: str, to_generation: int) -> str:
+    """Return the canonical manifest key beneath one restart plan."""
+
+    return f"{restart_plan_key(run_id, to_generation)}/recovery-manifest"
+
+
 __all__ = [
     "PreparedRestartPlanPublication",
     "RestartPlanPublicationAuthority",
     "RestartPlanPublicationRecords",
+    "recovery_manifest_key",
+    "restart_plan_key",
 ]

--- a/tests/unit/test_torchrun_restart_plan_state.py
+++ b/tests/unit/test_torchrun_restart_plan_state.py
@@ -40,6 +40,8 @@ from lm_resiliency.integrations.torchrun._coordinator_lease_history import (
 )
 from lm_resiliency.integrations.torchrun._generation_reader import (
     CurrentGeneration,
+    GenerationStateCorrupt,
+    GenerationStateError,
     StoredGenerationSnapshot,
 )
 from lm_resiliency.integrations.torchrun._generation_records import (
@@ -63,6 +65,7 @@ from lm_resiliency.integrations.torchrun._protocol import (
 from lm_resiliency.integrations.torchrun._quarantine_records import (
     NodeQuarantineRecord,
 )
+from lm_resiliency.integrations.torchrun._quarantine_store import node_quarantine_key
 from lm_resiliency.integrations.torchrun._restart_intent_records import (
     RestartIntentHeadRecord,
     RestartIntentLifecycleRecord,
@@ -74,10 +77,15 @@ from lm_resiliency.integrations.torchrun._restart_plan_publication import (
     RestartPlanPublicationPreparationConflict,
     RestartPlanPublicationPreparationCorrupt,
     RestartPlanPublicationPreparationLeaseLost,
+    RestartPlanPublicationReadConflict,
+    RestartPlanPublicationReadCorrupt,
+    RestartPlanPublicationReader,
 )
 from lm_resiliency.integrations.torchrun._restart_plan_publication_records import (
     RestartPlanPublicationAuthority,
     RestartPlanPublicationRecords,
+    recovery_manifest_key,
+    restart_plan_key,
 )
 from lm_resiliency.integrations.torchrun._restart_plan_records import (
     RecoveryManifestRecord,
@@ -120,6 +128,39 @@ class FailingLeaseHistoryReader:
 
     def read(self):
         raise self._error
+
+
+class StaticPublicationStore:
+    def __init__(self, entries: dict[str, ControlStoreEntry]) -> None:
+        self.entries = entries
+
+    def get(self, key: str) -> ControlStoreEntry | None:
+        return self.entries.get(key)
+
+
+class SequenceGenerationReader:
+    def __init__(
+        self,
+        values: list[CurrentGeneration | None | Exception],
+        *,
+        snapshot_key: str,
+        head_key: str,
+    ) -> None:
+        self._values = list(values)
+        self._snapshot_key = snapshot_key
+        self.head_key = head_key
+
+    def current(self) -> CurrentGeneration | None:
+        if len(self._values) > 1:
+            value = self._values.pop(0)
+        else:
+            value = self._values[0]
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    def snapshot_key(self, generation: int) -> str:
+        return self._snapshot_key
 
 
 def _assignment(
@@ -2105,6 +2146,189 @@ def test_persisted_restart_plan_publication_decodes_atomic_records():
     assert set(state.quarantine_records) == set(state.plan.quarantined_node_ids)
     with pytest.raises(TypeError):
         state.quarantine_entries["other"] = state.plan_entry
+
+
+def _publication_reader(
+    *,
+    current_values=None,
+) -> tuple[
+    RestartPlanPublicationReader,
+    StaticPublicationStore,
+    PersistedRestartPlanPublication,
+    CurrentGeneration,
+]:
+    publication = _persisted_publication()
+    current = CurrentGeneration(
+        snapshot=StoredGenerationSnapshot(
+            record=publication.successor_snapshot,
+            revision=publication.successor_snapshot_entry.revision,
+            committed_at_unix_ms=publication.committed_at_unix_ms,
+            transaction_sequence=publication.transaction_sequence,
+            guard_mutation_sequence=cast(
+                int,
+                publication.successor_snapshot_entry.guard_mutation_sequence,
+            ),
+            guard_value_sequence=cast(
+                int,
+                publication.successor_snapshot_entry.guard_value_sequence,
+            ),
+            guard_lifetime_sequence=cast(
+                int,
+                publication.successor_snapshot_entry.guard_lifetime_sequence,
+            ),
+            guard_committed_at_unix_ms=cast(
+                int,
+                publication.successor_snapshot_entry.guard_committed_at_unix_ms,
+            ),
+        ),
+        head_revision=publication.generation_head_entry.revision,
+    )
+    store = StaticPublicationStore({})
+    reader = RestartPlanPublicationReader(cast(Any, store), run_id=RUN_ID)
+    snapshot_key = reader._generation_reader.snapshot_key(publication.plan.to_generation)
+    head_key = reader._generation_reader.head_key
+    store.entries.update(
+        {
+            restart_plan_key(RUN_ID, publication.plan.to_generation): publication.plan_entry,
+            recovery_manifest_key(
+                RUN_ID,
+                publication.plan.to_generation,
+            ): publication.manifest_entry,
+            snapshot_key: publication.successor_snapshot_entry,
+            head_key: publication.generation_head_entry,
+            **{
+                node_quarantine_key(RUN_ID, node_id): entry
+                for node_id, entry in publication.quarantine_entries.items()
+            },
+        }
+    )
+    reader._generation_reader = cast(
+        Any,
+        SequenceGenerationReader(
+            current_values if current_values is not None else [current],
+            snapshot_key=snapshot_key,
+            head_key=head_key,
+        ),
+    )
+    return reader, store, publication, current
+
+
+def test_restart_plan_publication_reader_returns_stable_latest_publication():
+    reader, _, publication, _ = _publication_reader()
+
+    assert reader.read() == publication
+
+
+def test_restart_plan_publication_reader_returns_none_without_generation():
+    reader, _, _, _ = _publication_reader(current_values=[None])
+
+    assert reader.read() is None
+
+
+@pytest.mark.parametrize("path", ["plan", "manifest", "snapshot", "head", "quarantine"])
+def test_restart_plan_publication_reader_rejects_missing_atomic_entry(path: str):
+    reader, store, publication, _ = _publication_reader()
+    keys = {
+        "plan": restart_plan_key(RUN_ID, publication.plan.to_generation),
+        "manifest": recovery_manifest_key(RUN_ID, publication.plan.to_generation),
+        "snapshot": reader._generation_reader.snapshot_key(publication.plan.to_generation),
+        "head": reader._generation_reader.head_key,
+        "quarantine": node_quarantine_key(
+            RUN_ID,
+            publication.plan.quarantined_node_ids[0],
+        ),
+    }
+    del store.entries[keys[path]]
+
+    with pytest.raises(RestartPlanPublicationReadCorrupt, match="missing"):
+        reader.read()
+
+
+def test_restart_plan_publication_reader_rejects_malformed_plan():
+    reader, store, publication, _ = _publication_reader()
+    key = restart_plan_key(RUN_ID, publication.plan.to_generation)
+    store.entries[key] = replace(store.entries[key], value=b"not-json")
+
+    with pytest.raises(RestartPlanPublicationReadCorrupt, match="malformed plan"):
+        reader.read()
+
+
+def test_restart_plan_publication_reader_retries_one_generation_change():
+    reader, _, publication, current = _publication_reader()
+    stale = replace(current, head_revision=current.head_revision - 1)
+    reader._generation_reader = cast(
+        Any,
+        SequenceGenerationReader(
+            [stale, current, current, current, current],
+            snapshot_key=reader._generation_reader.snapshot_key(publication.plan.to_generation),
+            head_key=reader._generation_reader.head_key,
+        ),
+    )
+
+    assert reader.read() == publication
+
+
+def test_restart_plan_publication_reader_rejects_repeated_generation_changes():
+    reader, _, publication, current = _publication_reader()
+    stale = replace(current, head_revision=current.head_revision - 1)
+    reader._generation_reader = cast(
+        Any,
+        SequenceGenerationReader(
+            [stale, current] * 9,
+            snapshot_key=reader._generation_reader.snapshot_key(publication.plan.to_generation),
+            head_key=reader._generation_reader.head_key,
+        ),
+    )
+
+    with pytest.raises(RestartPlanPublicationReadConflict, match="changed repeatedly"):
+        reader.read()
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        (GenerationStateError("busy"), RestartPlanPublicationReadConflict),
+        (GenerationStateCorrupt("bad"), RestartPlanPublicationReadCorrupt),
+    ],
+)
+def test_restart_plan_publication_reader_translates_generation_errors(
+    error: Exception,
+    expected: type[Exception],
+):
+    reader, _, publication, _ = _publication_reader()
+    reader._generation_reader = cast(
+        Any,
+        SequenceGenerationReader(
+            [error],
+            snapshot_key=reader._generation_reader.snapshot_key(publication.plan.to_generation),
+            head_key=reader._generation_reader.head_key,
+        ),
+    )
+
+    with pytest.raises(expected):
+        reader.read()
+
+
+def test_restart_plan_publication_reader_requires_exact_current_snapshot():
+    reader, _, publication, current = _publication_reader()
+    mismatched = replace(
+        current,
+        snapshot=replace(
+            current.snapshot,
+            revision=current.snapshot.revision + 1,
+        ),
+    )
+    reader._generation_reader = cast(
+        Any,
+        SequenceGenerationReader(
+            [mismatched],
+            snapshot_key=reader._generation_reader.snapshot_key(publication.plan.to_generation),
+            head_key=reader._generation_reader.head_key,
+        ),
+    )
+
+    with pytest.raises(RestartPlanPublicationReadCorrupt, match="current generation"):
+        reader.read()
 
 
 def test_persisted_restart_plan_publication_rejects_malformed_records():


### PR DESCRIPTION
## Summary
- add canonical restart-plan and manifest key helpers shared by publication writes and reads
- double-collect the current generation and atomic publication entries without adding another module
- decode the stable bundle and require exact successor/head equality with authoritative generation state
- classify repeated generation movement as retryable conflict and persisted contradictions as corruption

## Scope
This PR adds only stable transaction readback. It does not yet reauthorize the closed lifecycle or checkpoint evidence for rendezvous.

## Validation
- 202 focused restart-plan tests
- 2,305 full CPU tests
- Ruff check and format
- targeted mypy
- git diff --check