### PR TITLE
[Feature][Torchrun] Persist restart-plan recovery evidence

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -764,12 +764,19 @@ class RestartPlan(TypedDict):
 ```
 
 The persisted `RestartPlanRecord` contains the canonical plan; digests for the
-selected recovery-manifest record, closed-intent lifecycle record, source
-generation, and successor generation; the exact node-to-quarantine-record
-digest map; and the coordinator lease identity that authorized publication.
-Its quarantine keys must exactly match `quarantined_node_ids`. The envelope is
-strict and immutable, but it is not a substitute for `validate_restart_plan()`
-or for the later atomic publication transaction.
+selected recovery-manifest record, checkpoint-evidence record, closed-intent
+lifecycle record, source generation, and successor generation; the exact
+node-to-quarantine-record digest map; and the coordinator lease identity that
+authorized publication. Its quarantine keys must exactly match
+`quarantined_node_ids`. The envelope is strict and immutable, but it is not a
+substitute for `validate_restart_plan()` or for the later atomic publication
+transaction.
+`RestartPlanEvidenceRecord` preserves the canonical inventory events and
+trusted certification records used to admit that plan. The record is bound to
+one run, plan ID, and manifest ID and exposes its own digest for the plan
+envelope. Construction proves only canonical durable evidence identity; later
+state validation must still match the events and certifications to the plan,
+manifest, acknowledgements, source generation, and copy eligibility.
 `RestartPlanGenerationState` binds that envelope to the exact closed intent,
 current generation, successor generation, successor assignment, and shared
 coordinator publication authority. Manifest and quarantine resolution remain

--- a/lm_resiliency/integrations/torchrun/_restart_plan_records.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_records.py
@@ -13,6 +13,8 @@ from lm_resiliency.integrations.torchrun._coordinator_lease import (
     CoordinatorLeaseRecord,
 )
 from lm_resiliency.integrations.torchrun._protocol import (
+    CheckpointCertification,
+    CheckpointInventoryEvent,
     ProtocolValidationError,
     RecoveryManifest,
     RestartPlan,
@@ -90,13 +92,182 @@ class RecoveryManifestRecord:
 
 
 @dataclass(frozen=True, slots=True)
-class RestartPlanRecord:
-    """One immutable plan envelope for atomic restart publication."""
+class RestartPlanEvidenceRecord:
+    """Immutable checkpoint evidence retained with one restart plan."""
 
     SCHEMA_VERSION: ClassVar[int] = 1
 
+    plan_id: str
+    run_id: str
+    manifest_id: str
+    inventory_events: Mapping[str, CheckpointInventoryEvent]
+    certifications: tuple[CheckpointCertification, ...]
+
+    def __post_init__(self) -> None:
+        _nonempty_string(self.plan_id, "RestartPlanEvidenceRecord.plan_id")
+        _nonempty_string(self.run_id, "RestartPlanEvidenceRecord.run_id")
+        _nonempty_string(self.manifest_id, "RestartPlanEvidenceRecord.manifest_id")
+        if not isinstance(self.inventory_events, Mapping):
+            raise TypeError("RestartPlanEvidenceRecord.inventory_events must be a mapping")
+        events: dict[str, CheckpointInventoryEvent] = {}
+        for event_id, event in self.inventory_events.items():
+            normalized_event_id = _nonempty_string(
+                event_id,
+                "RestartPlanEvidenceRecord.inventory_events key",
+            )
+            if not isinstance(event, CheckpointInventoryEvent):
+                raise TypeError(
+                    "RestartPlanEvidenceRecord.inventory_events values "
+                    "must be CheckpointInventoryEvent"
+                )
+            if event.event_id != normalized_event_id or event.run_id != self.run_id:
+                raise ValueError(
+                    "RestartPlanEvidenceRecord inventory event identity does not match its key/run"
+                )
+            events[normalized_event_id] = event
+        if not events:
+            raise ValueError("RestartPlanEvidenceRecord requires at least one inventory event")
+        if not isinstance(self.certifications, tuple):
+            raise TypeError("RestartPlanEvidenceRecord.certifications must be a tuple")
+        certification_ids: set[str] = set()
+        certifications: list[CheckpointCertification] = []
+        for certification in self.certifications:
+            if not isinstance(certification, CheckpointCertification):
+                raise TypeError(
+                    "RestartPlanEvidenceRecord.certifications values "
+                    "must be CheckpointCertification"
+                )
+            if certification.run_id != self.run_id:
+                raise ValueError("RestartPlanEvidenceRecord certification belongs to another run")
+            if certification.certification_id in certification_ids:
+                raise ValueError("RestartPlanEvidenceRecord certification IDs must be unique")
+            certification_ids.add(certification.certification_id)
+            certifications.append(certification)
+        object.__setattr__(
+            self,
+            "inventory_events",
+            MappingProxyType(dict(sorted(events.items()))),
+        )
+        object.__setattr__(
+            self,
+            "certifications",
+            tuple(sorted(certifications, key=lambda value: value.certification_id)),
+        )
+
+    @property
+    def digest(self) -> str:
+        return hashlib.sha256(self.to_json()).hexdigest()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "plan_id": self.plan_id,
+            "run_id": self.run_id,
+            "manifest_id": self.manifest_id,
+            "inventory_events": {
+                event_id: event.to_dict() for event_id, event in self.inventory_events.items()
+            },
+            "certifications": [certification.to_dict() for certification in self.certifications],
+        }
+
+    def to_json(self) -> bytes:
+        return _canonical_json(self.to_dict())
+
+    @classmethod
+    def from_json(cls, encoded: bytes) -> RestartPlanEvidenceRecord:
+        value = _json_object(encoded, cls.__name__)
+        _fields(
+            value,
+            path=cls.__name__,
+            required={
+                "schema_version",
+                "plan_id",
+                "run_id",
+                "manifest_id",
+                "inventory_events",
+                "certifications",
+            },
+        )
+        _schema_version(
+            value["schema_version"],
+            cls.__name__,
+            expected=cls.SCHEMA_VERSION,
+        )
+        inventory_values = _mapping(
+            value["inventory_events"],
+            "RestartPlanEvidenceRecord.inventory_events",
+        )
+        inventory_events: dict[str, CheckpointInventoryEvent] = {}
+        for event_id, event_value in inventory_values.items():
+            normalized_event_id = _nonempty_string(
+                event_id,
+                "RestartPlanEvidenceRecord.inventory_events key",
+            )
+            event_mapping = _mapping(
+                event_value,
+                f"RestartPlanEvidenceRecord.inventory_events[{normalized_event_id!r}]",
+            )
+            _schema_version(
+                event_mapping.get("schema_version"),
+                f"RestartPlanEvidenceRecord.inventory_events[{normalized_event_id!r}]",
+                expected=CheckpointInventoryEvent.SCHEMA_VERSION,
+            )
+            try:
+                inventory_events[normalized_event_id] = CheckpointInventoryEvent.from_dict(
+                    event_mapping
+                )
+            except ProtocolValidationError as error:
+                raise ValueError(
+                    "RestartPlanEvidenceRecord contains an invalid inventory event"
+                ) from error
+        certification_values = _array(
+            value["certifications"],
+            "RestartPlanEvidenceRecord.certifications",
+        )
+        certifications: list[CheckpointCertification] = []
+        for index, certification_value in enumerate(certification_values):
+            certification_mapping = _mapping(
+                certification_value,
+                f"RestartPlanEvidenceRecord.certifications[{index}]",
+            )
+            _schema_version(
+                certification_mapping.get("schema_version"),
+                f"RestartPlanEvidenceRecord.certifications[{index}]",
+                expected=CheckpointCertification.SCHEMA_VERSION,
+            )
+            try:
+                certifications.append(CheckpointCertification.from_dict(certification_mapping))
+            except ProtocolValidationError as error:
+                raise ValueError(
+                    "RestartPlanEvidenceRecord contains an invalid certification"
+                ) from error
+        return cls(
+            plan_id=_nonempty_string(
+                value["plan_id"],
+                "RestartPlanEvidenceRecord.plan_id",
+            ),
+            run_id=_nonempty_string(
+                value["run_id"],
+                "RestartPlanEvidenceRecord.run_id",
+            ),
+            manifest_id=_nonempty_string(
+                value["manifest_id"],
+                "RestartPlanEvidenceRecord.manifest_id",
+            ),
+            inventory_events=inventory_events,
+            certifications=tuple(certifications),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RestartPlanRecord:
+    """One immutable plan envelope for atomic restart publication."""
+
+    SCHEMA_VERSION: ClassVar[int] = 2
+
     plan: RestartPlan
     recovery_manifest_record_digest: str
+    recovery_evidence_record_digest: str
     intent_lifecycle_record_digest: str
     from_generation_snapshot_digest: str
     to_generation_snapshot_digest: str
@@ -113,6 +284,10 @@ class RestartPlanRecord:
             (
                 self.recovery_manifest_record_digest,
                 "RestartPlanRecord.recovery_manifest_record_digest",
+            ),
+            (
+                self.recovery_evidence_record_digest,
+                "RestartPlanRecord.recovery_evidence_record_digest",
             ),
             (
                 self.intent_lifecycle_record_digest,
@@ -173,6 +348,7 @@ class RestartPlanRecord:
             "schema_version": self.SCHEMA_VERSION,
             "plan": self.plan.to_dict(),
             "recovery_manifest_record_digest": self.recovery_manifest_record_digest,
+            "recovery_evidence_record_digest": self.recovery_evidence_record_digest,
             "intent_lifecycle_record_digest": self.intent_lifecycle_record_digest,
             "from_generation_snapshot_digest": self.from_generation_snapshot_digest,
             "to_generation_snapshot_digest": self.to_generation_snapshot_digest,
@@ -196,6 +372,7 @@ class RestartPlanRecord:
                 "schema_version",
                 "plan",
                 "recovery_manifest_record_digest",
+                "recovery_evidence_record_digest",
                 "intent_lifecycle_record_digest",
                 "from_generation_snapshot_digest",
                 "to_generation_snapshot_digest",
@@ -226,6 +403,10 @@ class RestartPlanRecord:
             recovery_manifest_record_digest=_digest(
                 value["recovery_manifest_record_digest"],
                 "RestartPlanRecord.recovery_manifest_record_digest",
+            ),
+            recovery_evidence_record_digest=_digest(
+                value["recovery_evidence_record_digest"],
+                "RestartPlanRecord.recovery_evidence_record_digest",
             ),
             intent_lifecycle_record_digest=_digest(
                 value["intent_lifecycle_record_digest"],
@@ -289,6 +470,12 @@ def _json_object(encoded: bytes, path: str) -> Mapping[str, object]:
 def _mapping(value: object, path: str) -> Mapping[str, object]:
     if not isinstance(value, Mapping) or not all(isinstance(key, str) for key in value):
         raise ValueError(f"{path}: expected a JSON object")
+    return value
+
+
+def _array(value: object, path: str) -> list[object]:
+    if not isinstance(value, list):
+        raise ValueError(f"{path}: expected a JSON array")
     return value
 
 
@@ -360,5 +547,6 @@ def _reject_duplicate_object_fields(
 
 __all__ = [
     "RecoveryManifestRecord",
+    "RestartPlanEvidenceRecord",
     "RestartPlanRecord",
 ]

--- a/lm_resiliency/integrations/torchrun/_restart_plan_records.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_records.py
@@ -18,6 +18,7 @@ from lm_resiliency.integrations.torchrun._protocol import (
     ProtocolValidationError,
     RecoveryManifest,
     RestartPlan,
+    WorkerIdentity,
 )
 
 
@@ -211,6 +212,15 @@ class RestartPlanEvidenceRecord:
                 event_mapping.get("schema_version"),
                 f"RestartPlanEvidenceRecord.inventory_events[{normalized_event_id!r}]",
                 expected=CheckpointInventoryEvent.SCHEMA_VERSION,
+            )
+            reporter_mapping = _mapping(
+                event_mapping.get("reporter"),
+                (f"RestartPlanEvidenceRecord.inventory_events[{normalized_event_id!r}].reporter"),
+            )
+            _schema_version(
+                reporter_mapping.get("schema_version"),
+                (f"RestartPlanEvidenceRecord.inventory_events[{normalized_event_id!r}].reporter"),
+                expected=WorkerIdentity.SCHEMA_VERSION,
             )
             try:
                 inventory_events[normalized_event_id] = CheckpointInventoryEvent.from_dict(

--- a/tests/unit/test_torchrun_restart_ack_evidence.py
+++ b/tests/unit/test_torchrun_restart_ack_evidence.py
@@ -325,6 +325,7 @@ def _latest_inventory_state(
     plan_record = RestartPlanRecord(
         plan=plan,
         recovery_manifest_record_digest=manifest_record.digest,
+        recovery_evidence_record_digest="a" * 64,
         intent_lifecycle_record_digest=lifecycle.digest,
         from_generation_snapshot_digest=from_snapshot.digest,
         to_generation_snapshot_digest=to_snapshot.digest,

--- a/tests/unit/test_torchrun_restart_plan_records.py
+++ b/tests/unit/test_torchrun_restart_plan_records.py
@@ -410,6 +410,25 @@ def test_restart_plan_evidence_record_requires_exact_nested_schema(
         )
 
 
+@pytest.mark.parametrize("schema_version", [1.0, "1", None, False])
+def test_restart_plan_evidence_record_requires_exact_reporter_schema(
+    schema_version,
+):
+    value = _evidence_record().to_dict()
+    events = dict(value["inventory_events"])
+    event = dict(events["inventory-0"])
+    reporter = dict(event["reporter"])
+    reporter["schema_version"] = schema_version
+    event["reporter"] = reporter
+    events["inventory-0"] = event
+    value["inventory_events"] = events
+
+    with pytest.raises(ValueError, match="reporter.schema_version"):
+        RestartPlanEvidenceRecord.from_json(
+            json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+        )
+
+
 def test_restart_plan_record_round_trips_as_canonical_json():
     record = _plan_record()
 

--- a/tests/unit/test_torchrun_restart_plan_records.py
+++ b/tests/unit/test_torchrun_restart_plan_records.py
@@ -9,20 +9,26 @@ from dataclasses import replace
 import pytest
 
 from lm_resiliency.integrations.torchrun._protocol import (
+    CheckpointCertification,
     CheckpointCopy,
+    CheckpointInventoryEvent,
     RankCheckpointCopies,
     RecoveryManifest,
     RestartPlan,
     SlotAssignment,
+    WorkerIdentity,
+    checkpoint_inventory_digest,
 )
 from lm_resiliency.integrations.torchrun._restart_plan_records import (
     RecoveryManifestRecord,
+    RestartPlanEvidenceRecord,
     RestartPlanRecord,
 )
 
 RUN_ID = "training-run"
 SOURCE_SNAPSHOT_DIGEST = "a" * 64
 MANIFEST_RECORD_DIGEST = "b" * 64
+EVIDENCE_RECORD_DIGEST = "1" * 64
 LIFECYCLE_RECORD_DIGEST = "c" * 64
 FROM_SNAPSHOT_DIGEST = "d" * 64
 TO_SNAPSHOT_DIGEST = "e" * 64
@@ -69,6 +75,65 @@ def _record() -> RecoveryManifestRecord:
     )
 
 
+def _inventory_events() -> dict[str, CheckpointInventoryEvent]:
+    events: dict[str, CheckpointInventoryEvent] = {}
+    for rank in range(4):
+        event_id = f"inventory-{rank}"
+        node_id = "node-a" if rank < 2 else "node-b"
+        local_rank = rank % 2
+        events[event_id] = CheckpointInventoryEvent(
+            event_id=event_id,
+            run_id=RUN_ID,
+            generation=4,
+            reporter=WorkerIdentity(
+                run_id=RUN_ID,
+                generation=4,
+                node_id=node_id,
+                agent_id=f"agent-{node_id}",
+                logical_node_slot=rank // 2,
+                global_rank=rank,
+                local_rank=local_rank,
+                local_world_size=2,
+                hostname=f"host-{node_id}",
+                gpu_uuid=f"gpu-{node_id}-{local_rank}",
+                topology_digest="topology-v1",
+            ),
+            step=40,
+            trust="recovery_verified",
+            topology_digest="topology-v1",
+            copies=(_copy(rank),),
+        )
+    return events
+
+
+def _certification() -> CheckpointCertification:
+    events = _inventory_events()
+    return CheckpointCertification(
+        certification_id="certification-40",
+        run_id=RUN_ID,
+        source_generation=4,
+        step=40,
+        topology_digest="topology-v1",
+        checkpoint_source="gemini",
+        checkpoint_id=None,
+        expected_world_size=4,
+        certification_kind="dense_consensus",
+        inventory_event_digests={
+            event_id: checkpoint_inventory_digest(event) for event_id, event in events.items()
+        },
+    )
+
+
+def _evidence_record() -> RestartPlanEvidenceRecord:
+    return RestartPlanEvidenceRecord(
+        plan_id="plan-5",
+        run_id=RUN_ID,
+        manifest_id="manifest-40",
+        inventory_events=_inventory_events(),
+        certifications=(_certification(),),
+    )
+
+
 def _plan() -> RestartPlan:
     return RestartPlan(
         plan_id="plan-5",
@@ -108,6 +173,7 @@ def _plan_record() -> RestartPlanRecord:
     return RestartPlanRecord(
         plan=_plan(),
         recovery_manifest_record_digest=MANIFEST_RECORD_DIGEST,
+        recovery_evidence_record_digest=EVIDENCE_RECORD_DIGEST,
         intent_lifecycle_record_digest=LIFECYCLE_RECORD_DIGEST,
         from_generation_snapshot_digest=FROM_SNAPSHOT_DIGEST,
         to_generation_snapshot_digest=TO_SNAPSHOT_DIGEST,
@@ -234,6 +300,116 @@ def test_recovery_manifest_record_requires_encoded_bytes():
         RecoveryManifestRecord.from_json(_record().to_json().decode())
 
 
+def test_restart_plan_evidence_record_round_trips_as_canonical_json():
+    record = _evidence_record()
+
+    assert RestartPlanEvidenceRecord.from_json(record.to_json()) == record
+    assert json.loads(record.to_json()) == record.to_dict()
+    assert record.digest == hashlib.sha256(record.to_json()).hexdigest()
+    assert tuple(record.inventory_events) == tuple(sorted(record.inventory_events))
+
+
+def test_restart_plan_evidence_record_freezes_and_sorts_evidence():
+    events = dict(reversed(tuple(_inventory_events().items())))
+    certification = _certification()
+    record = RestartPlanEvidenceRecord(
+        plan_id="plan-5",
+        run_id=RUN_ID,
+        manifest_id="manifest-40",
+        inventory_events=events,
+        certifications=(certification,),
+    )
+    events.clear()
+
+    assert len(record.inventory_events) == 4
+    with pytest.raises(TypeError):
+        record.inventory_events["other"] = next(iter(record.inventory_events.values()))
+    with pytest.raises(AttributeError):
+        record.certifications = ()
+
+
+def test_restart_plan_evidence_record_requires_bound_event_and_certification_identity():
+    events = _inventory_events()
+    event = events.pop("inventory-0")
+    events["other"] = event
+    with pytest.raises(ValueError, match="identity"):
+        replace(_evidence_record(), inventory_events=events)
+
+    foreign = replace(_certification(), run_id="other-run")
+    with pytest.raises(ValueError, match="another run"):
+        replace(_evidence_record(), certifications=(foreign,))
+
+    with pytest.raises(ValueError, match="unique"):
+        replace(
+            _evidence_record(),
+            certifications=(_certification(), _certification()),
+        )
+
+
+def test_restart_plan_evidence_record_rejects_duplicate_fields_at_any_depth():
+    duplicate = (
+        _evidence_record()
+        .to_json()
+        .decode()
+        .replace(
+            '"plan_id":"plan-5"',
+            '"plan_id":"plan-5","plan_id":"other"',
+            1,
+        )
+    )
+
+    with pytest.raises(ValueError, match="duplicate field 'plan_id'"):
+        RestartPlanEvidenceRecord.from_json(duplicate.encode())
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value.pop("plan_id"),
+        lambda value: value.pop("inventory_events"),
+        lambda value: value.pop("certifications"),
+        lambda value: value.update({"unknown": "field"}),
+        lambda value: value.update({"schema_version": 2}),
+        lambda value: value.update({"inventory_events": []}),
+        lambda value: value.update({"certifications": {}}),
+    ],
+)
+def test_restart_plan_evidence_record_rejects_invalid_wire_shapes(mutation):
+    value = _evidence_record().to_dict()
+    mutation(value)
+
+    with pytest.raises(ValueError):
+        RestartPlanEvidenceRecord.from_json(
+            json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+        )
+
+
+@pytest.mark.parametrize("path", ["inventory", "certification"])
+@pytest.mark.parametrize("schema_version", [1.0, "1", None, False])
+def test_restart_plan_evidence_record_requires_exact_nested_schema(
+    path: str,
+    schema_version,
+):
+    value = _evidence_record().to_dict()
+    if path == "inventory":
+        events = dict(value["inventory_events"])
+        event = dict(events["inventory-0"])
+        event["schema_version"] = schema_version
+        events["inventory-0"] = event
+        value["inventory_events"] = events
+    else:
+        certifications = list(value["certifications"])
+        certification = dict(certifications[0])
+        certification["schema_version"] = schema_version
+        certifications[0] = certification
+        value["certifications"] = certifications
+
+    with pytest.raises(ValueError, match="schema_version"):
+        RestartPlanEvidenceRecord.from_json(
+            json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+        )
+
+
 def test_restart_plan_record_round_trips_as_canonical_json():
     record = _plan_record()
 
@@ -296,6 +472,9 @@ def test_restart_plan_record_requires_exact_types():
     with pytest.raises(ValueError, match="lowercase SHA-256"):
         replace(_plan_record(), recovery_manifest_record_digest="B" * 64)
 
+    with pytest.raises(ValueError, match="lowercase SHA-256"):
+        replace(_plan_record(), recovery_evidence_record_digest="not-a-digest")
+
 
 def test_restart_plan_record_rejects_duplicate_fields_at_any_depth():
     outer_duplicate = (
@@ -303,8 +482,8 @@ def test_restart_plan_record_rejects_duplicate_fields_at_any_depth():
         .to_json()
         .decode()
         .replace(
-            '"schema_version":1',
-            '"schema_version":1,"schema_version":1',
+            '"schema_version":2',
+            '"schema_version":2,"schema_version":2',
             1,
         )
     )
@@ -341,6 +520,7 @@ def test_restart_plan_record_rejects_duplicate_fields_at_any_depth():
     [
         lambda value: value.pop("plan"),
         lambda value: value.pop("recovery_manifest_record_digest"),
+        lambda value: value.pop("recovery_evidence_record_digest"),
         lambda value: value.pop("intent_lifecycle_record_digest"),
         lambda value: value.pop("from_generation_snapshot_digest"),
         lambda value: value.pop("to_generation_snapshot_digest"),
@@ -350,7 +530,7 @@ def test_restart_plan_record_rejects_duplicate_fields_at_any_depth():
         lambda value: value.pop("coordinator_lease_duration_ms"),
         lambda value: value.pop("coordinator_fencing_token"),
         lambda value: value.update({"unknown": "field"}),
-        lambda value: value.update({"schema_version": 2}),
+        lambda value: value.update({"schema_version": 3}),
         lambda value: value.update({"schema_version": True}),
         lambda value: value.update({"plan": []}),
         lambda value: value.update({"quarantine_record_digests": []}),

--- a/tests/unit/test_torchrun_restart_plan_state.py
+++ b/tests/unit/test_torchrun_restart_plan_state.py
@@ -457,6 +457,7 @@ def _generation_state() -> RestartPlanGenerationState:
     record = RestartPlanRecord(
         plan=_plan(),
         recovery_manifest_record_digest="b" * 64,
+        recovery_evidence_record_digest="a" * 64,
         intent_lifecycle_record_digest=lifecycle.digest,
         from_generation_snapshot_digest=from_snapshot.digest,
         to_generation_snapshot_digest=to_snapshot.digest,


### PR DESCRIPTION
## Summary
- add a strict immutable restart-plan evidence record for inventory events and trusted certifications
- bind the evidence digest into schema-v2 restart-plan envelopes
- reject duplicate, malformed, cross-run, and noncanonical nested evidence
- keep policy validation, atomic publication, and readback out of this records-only PR

## Why
The admitted checkpoint inventory and certification evidence was not preserved by plan publication, so a coordinator failover could not reauthorize recovery safety from durable state.

## Validation
- 271 focused restart-plan/acknowledgement tests
- 2,329 full CPU tests
- Ruff check and format
- targeted mypy
- git diff --check