### PR TITLE
[Feature][Torchrun] Publish restart-plan evidence atomically

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -777,6 +777,9 @@ one run, plan ID, and manifest ID and exposes its own digest for the plan
 envelope. Construction proves only canonical durable evidence identity; later
 state validation must still match the events and certifications to the plan,
 manifest, acknowledgements, source generation, and copy eligibility.
+The publication bundle writes that evidence record create-once beside the
+manifest, plan, quarantine records, successor snapshot, and generation-head
+update. Its digest must already match the signed plan envelope.
 `RestartPlanGenerationState` binds that envelope to the exact closed intent,
 current generation, successor generation, successor assignment, and shared
 coordinator publication authority. Manifest and quarantine resolution remain
@@ -883,15 +886,16 @@ provenance, input ordering, and commit window before the publication is
 accepted. Lifecycle, generation, or registration churn remains a classified
 conflict; substituted store responses fail closed as corruption.
 `PersistedRestartPlanPublication` reconstructs the publication transaction
-from canonical plan, manifest, quarantine, successor-snapshot, and
-generation-head entries for one requested run. It requires exact envelope
-digests, the requested successor generation, an exact plan-derived successor
-assignment and predecessor digest, immutable record lineage, one transaction
-and commit time, canonical coordinator-lease guard provenance, a transaction
-sequence after the generation-head and lease mutations, and a commit inside
-both the lease and restart-deadline windows. Decoding also rejects manifest
-metadata or trust that conflicts with the plan and quarantine records that
-conflict with the plan lifecycle or publication authority.
+from canonical plan, manifest, recovery-evidence, quarantine,
+successor-snapshot, and generation-head entries for one requested run. It
+requires exact envelope digests, the requested successor generation, an exact
+plan-derived successor assignment and predecessor digest, immutable record
+lineage, one transaction and commit time, canonical coordinator-lease guard
+provenance, a transaction sequence after the generation-head and lease
+mutations, and a commit inside both the lease and restart-deadline windows.
+Decoding also rejects manifest metadata or trust that conflicts with the plan,
+evidence metadata that conflicts with the plan or manifest, and quarantine
+records that conflict with the plan lifecycle or publication authority.
 This transaction decoder does not by itself resolve the source generation,
 closed lifecycle, lease history, inventory evidence, or currently committed
 generation; the stable publication reader performs those checks before

--- a/lm_resiliency/integrations/torchrun/_restart_plan_publication.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_publication.py
@@ -34,6 +34,7 @@ from lm_resiliency.integrations.torchrun._restart_plan_publication_records impor
     PreparedRestartPlanPublication,
     RestartPlanPublicationAuthority,
     RestartPlanPublicationRecords,
+    recovery_evidence_key,
     recovery_manifest_key,
     restart_plan_key,
 )
@@ -229,6 +230,7 @@ class RestartPlanPublicationReadCorrupt(RestartPlanPublicationReadError):
 class _PublicationEntries:
     plan: ControlStoreEntry
     manifest: ControlStoreEntry
+    evidence: ControlStoreEntry
     successor_snapshot: ControlStoreEntry
     generation_head: ControlStoreEntry
     quarantines: tuple[tuple[str, ControlStoreEntry], ...]
@@ -310,6 +312,10 @@ class RestartPlanPublicationReader:
                 recovery_manifest_key(self._run_id, generation),
                 "recovery manifest",
             ),
+            evidence=self._require_entry(
+                recovery_evidence_key(self._run_id, generation),
+                "recovery evidence",
+            ),
             successor_snapshot=self._require_entry(
                 self._generation_reader.snapshot_key(generation),
                 "successor generation snapshot",
@@ -340,6 +346,7 @@ class RestartPlanPublicationReader:
                 to_generation=generation,
                 plan_entry=entries.plan,
                 manifest_entry=entries.manifest,
+                evidence_entry=entries.evidence,
                 successor_snapshot_entry=entries.successor_snapshot,
                 generation_head_entry=entries.generation_head,
                 quarantine_entries=dict(entries.quarantines),

--- a/lm_resiliency/integrations/torchrun/_restart_plan_publication_records.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_publication_records.py
@@ -20,7 +20,13 @@ from lm_resiliency.integrations.torchrun._quarantine_store import node_quarantin
 from lm_resiliency.integrations.torchrun._restart_plan_publication_lifecycle import (
     RestartPlanPublicationLifecycleFence,
 )
-from lm_resiliency.integrations.torchrun._restart_plan_state import RestartPlanCandidateState
+from lm_resiliency.integrations.torchrun._restart_plan_records import (
+    RestartPlanEvidenceRecord,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_state import (
+    RestartPlanCandidateState,
+    RestartPlanCertificationState,
+)
 
 _CONTROL_PREFIX = "lm_resiliency/torchrun/v1"
 
@@ -64,6 +70,11 @@ class RestartPlanPublicationRecords:
             raise ValueError(
                 "RestartPlanPublicationRecords current and manifest source snapshots disagree"
             )
+        plan_record = self.candidate.placement_state.generation_state.record
+        if plan_record.recovery_evidence_record_digest != self.recovery_evidence_record.digest:
+            raise ValueError(
+                "RestartPlanPublicationRecords recovery evidence digest does not match its plan"
+            )
 
     @property
     def run_prefix(self) -> str:
@@ -79,6 +90,13 @@ class RestartPlanPublicationRecords:
     @property
     def recovery_manifest_key(self) -> str:
         return recovery_manifest_key(
+            self.candidate.plan.run_id,
+            self.candidate.plan.to_generation,
+        )
+
+    @property
+    def recovery_evidence_key(self) -> str:
+        return recovery_evidence_key(
             self.candidate.plan.run_id,
             self.candidate.plan.to_generation,
         )
@@ -129,6 +147,24 @@ class RestartPlanPublicationRecords:
         )
 
     @property
+    def recovery_evidence_record(self) -> RestartPlanEvidenceRecord:
+        recovery_state = self.candidate.recovery_state
+        inventory_state = recovery_state.copy_state.inventory_state
+        trust_state = recovery_state.trust_state
+        certifications = (
+            trust_state.certifications
+            if isinstance(trust_state, RestartPlanCertificationState)
+            else ()
+        )
+        return RestartPlanEvidenceRecord(
+            plan_id=self.candidate.plan.plan_id,
+            run_id=self.candidate.plan.run_id,
+            manifest_id=self.candidate.manifest.manifest_id,
+            inventory_events=inventory_state.inventory_events,
+            certifications=certifications,
+        )
+
+    @property
     def deadline_unix_ms(self) -> int:
         registration_expiries = []
         for history in self.candidate.placement_state.registration_histories.values():
@@ -161,6 +197,11 @@ class RestartPlanPublicationRecords:
             self.recovery_manifest_key: ControlStoreWrite(
                 expected_revision=None,
                 value=manifest_state.resolved_manifest.record.to_json(),
+                require_never_created=True,
+            ),
+            self.recovery_evidence_key: ControlStoreWrite(
+                expected_revision=None,
+                value=self.recovery_evidence_record.to_json(),
                 require_never_created=True,
             ),
             self.plan_key: ControlStoreWrite(
@@ -403,10 +444,17 @@ def recovery_manifest_key(run_id: str, to_generation: int) -> str:
     return f"{restart_plan_key(run_id, to_generation)}/recovery-manifest"
 
 
+def recovery_evidence_key(run_id: str, to_generation: int) -> str:
+    """Return the canonical recovery-evidence key beneath one restart plan."""
+
+    return f"{restart_plan_key(run_id, to_generation)}/recovery-evidence"
+
+
 __all__ = [
     "PreparedRestartPlanPublication",
     "RestartPlanPublicationAuthority",
     "RestartPlanPublicationRecords",
+    "recovery_evidence_key",
     "recovery_manifest_key",
     "restart_plan_key",
 ]

--- a/lm_resiliency/integrations/torchrun/_restart_plan_state.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_state.py
@@ -40,6 +40,7 @@ from lm_resiliency.integrations.torchrun._restart_intent_records import (
 )
 from lm_resiliency.integrations.torchrun._restart_plan_records import (
     RecoveryManifestRecord,
+    RestartPlanEvidenceRecord,
     RestartPlanRecord,
 )
 
@@ -52,11 +53,13 @@ class PersistedRestartPlanPublication:
 
     record: RestartPlanRecord
     manifest_record: RecoveryManifestRecord
+    evidence_record: RestartPlanEvidenceRecord
     successor_snapshot: GenerationSnapshotRecord
     generation_head: GenerationHeadRecord
     quarantine_records: Mapping[str, NodeQuarantineRecord]
     plan_entry: ControlStoreEntry
     manifest_entry: ControlStoreEntry
+    evidence_entry: ControlStoreEntry
     successor_snapshot_entry: ControlStoreEntry
     generation_head_entry: ControlStoreEntry
     quarantine_entries: Mapping[str, ControlStoreEntry]
@@ -65,10 +68,12 @@ class PersistedRestartPlanPublication:
         expected_types = (
             ("record", self.record, RestartPlanRecord),
             ("manifest_record", self.manifest_record, RecoveryManifestRecord),
+            ("evidence_record", self.evidence_record, RestartPlanEvidenceRecord),
             ("successor_snapshot", self.successor_snapshot, GenerationSnapshotRecord),
             ("generation_head", self.generation_head, GenerationHeadRecord),
             ("plan_entry", self.plan_entry, ControlStoreEntry),
             ("manifest_entry", self.manifest_entry, ControlStoreEntry),
+            ("evidence_entry", self.evidence_entry, ControlStoreEntry),
             (
                 "successor_snapshot_entry",
                 self.successor_snapshot_entry,
@@ -102,6 +107,7 @@ class PersistedRestartPlanPublication:
         to_generation: int,
         plan_entry: ControlStoreEntry,
         manifest_entry: ControlStoreEntry,
+        evidence_entry: ControlStoreEntry,
         successor_snapshot_entry: ControlStoreEntry,
         generation_head_entry: ControlStoreEntry,
         quarantine_entries: Mapping[str, ControlStoreEntry],
@@ -119,6 +125,7 @@ class PersistedRestartPlanPublication:
         entries = (
             ("plan_entry", plan_entry),
             ("manifest_entry", manifest_entry),
+            ("evidence_entry", evidence_entry),
             ("successor_snapshot_entry", successor_snapshot_entry),
             ("generation_head_entry", generation_head_entry),
         )
@@ -132,6 +139,7 @@ class PersistedRestartPlanPublication:
         try:
             record = RestartPlanRecord.from_json(plan_entry.value)
             manifest_record = RecoveryManifestRecord.from_json(manifest_entry.value)
+            evidence_record = RestartPlanEvidenceRecord.from_json(evidence_entry.value)
             successor_snapshot = GenerationSnapshotRecord.from_json(successor_snapshot_entry.value)
             generation_head = GenerationHeadRecord.from_json(generation_head_entry.value)
             quarantine_records = {
@@ -147,11 +155,13 @@ class PersistedRestartPlanPublication:
         return cls(
             record=record,
             manifest_record=manifest_record,
+            evidence_record=evidence_record,
             successor_snapshot=successor_snapshot,
             generation_head=generation_head,
             quarantine_records=quarantine_records,
             plan_entry=plan_entry,
             manifest_entry=manifest_entry,
+            evidence_entry=evidence_entry,
             successor_snapshot_entry=successor_snapshot_entry,
             generation_head_entry=generation_head_entry,
             quarantine_entries=normalized_quarantine_entries,
@@ -183,6 +193,19 @@ class PersistedRestartPlanPublication:
             self.manifest_record,
             path="PersistedRestartPlanPublication",
         )
+        if self.record.recovery_evidence_record_digest != self.evidence_record.digest:
+            raise ValueError(
+                "PersistedRestartPlanPublication recovery evidence digest does not match its plan"
+            )
+        if (
+            self.evidence_record.plan_id != plan.plan_id
+            or self.evidence_record.run_id != plan.run_id
+            or self.evidence_record.manifest_id != self.manifest_record.manifest.manifest_id
+        ):
+            raise ValueError(
+                "PersistedRestartPlanPublication recovery evidence "
+                "does not match its plan and manifest"
+            )
         if self.record.to_generation_snapshot_digest != self.successor_snapshot.digest:
             raise ValueError(
                 "PersistedRestartPlanPublication successor digest does not match its plan"
@@ -244,6 +267,7 @@ class PersistedRestartPlanPublication:
         entries = {
             "plan": self.plan_entry,
             "manifest": self.manifest_entry,
+            "evidence": self.evidence_entry,
             "successor": self.successor_snapshot_entry,
             "generation head": self.generation_head_entry,
             **{
@@ -254,6 +278,7 @@ class PersistedRestartPlanPublication:
         expected_values = {
             "plan": self.record.to_json(),
             "manifest": self.manifest_record.to_json(),
+            "evidence": self.evidence_record.to_json(),
             "successor": self.successor_snapshot.to_json(),
             "generation head": self.generation_head.to_json(),
             **{

--- a/tests/unit/test_torchrun_restart_plan_state.py
+++ b/tests/unit/test_torchrun_restart_plan_state.py
@@ -84,11 +84,13 @@ from lm_resiliency.integrations.torchrun._restart_plan_publication import (
 from lm_resiliency.integrations.torchrun._restart_plan_publication_records import (
     RestartPlanPublicationAuthority,
     RestartPlanPublicationRecords,
+    recovery_evidence_key,
     recovery_manifest_key,
     restart_plan_key,
 )
 from lm_resiliency.integrations.torchrun._restart_plan_records import (
     RecoveryManifestRecord,
+    RestartPlanEvidenceRecord,
     RestartPlanRecord,
 )
 from lm_resiliency.integrations.torchrun._restart_plan_state import (
@@ -2023,6 +2025,8 @@ def test_restart_plan_candidate_state_rejects_elapsed_restart_deadline():
 def _publication_records() -> RestartPlanPublicationRecords:
     candidate = _candidate_state()
     inventory_state = candidate.recovery_state.copy_state.inventory_state
+    trust_state = candidate.recovery_state.trust_state
+    assert isinstance(trust_state, RestartPlanCertificationState)
     quarantine_state = inventory_state.quarantine_state
     manifest_state = quarantine_state.manifest_state
     source_snapshot = replace(
@@ -2033,11 +2037,19 @@ def _publication_records() -> RestartPlanPublicationRecords:
         manifest_state.resolved_manifest.record,
         source_generation_snapshot_digest=source_snapshot.record.digest,
     )
+    evidence_record = RestartPlanEvidenceRecord(
+        plan_id=candidate.plan.plan_id,
+        run_id=candidate.plan.run_id,
+        manifest_id=manifest_record.manifest.manifest_id,
+        inventory_events=inventory_state.inventory_events,
+        certifications=trust_state.certifications,
+    )
     generation_state = replace(
         manifest_state.generation_state,
         record=replace(
             manifest_state.generation_state.record,
             recovery_manifest_record_digest=manifest_record.digest,
+            recovery_evidence_record_digest=evidence_record.digest,
         ),
     )
     manifest_state = RestartPlanManifestState(
@@ -2056,8 +2068,6 @@ def _publication_records() -> RestartPlanPublicationRecords:
         inventory_events=inventory_state.inventory_events,
     )
     copy_state = RestartPlanCopyEligibilityState(inventory_state)
-    trust_state = candidate.recovery_state.trust_state
-    assert isinstance(trust_state, RestartPlanCertificationState)
     candidate = RestartPlanCandidateState(
         recovery_state=RestartPlanRecoveryEvidenceState(
             copy_state=copy_state,
@@ -2096,6 +2106,7 @@ def _persisted_publication() -> PersistedRestartPlanPublication:
         publication.candidate.recovery_state.copy_state.inventory_state.quarantine_state
     )
     manifest_record = quarantine_state.manifest_state.resolved_manifest.record
+    evidence_record = publication.recovery_evidence_record
     plan_record = generation_state.record
     run_digest = hashlib.sha256(RUN_ID.encode()).hexdigest()
     guard_key = f"lm_resiliency/torchrun/v1/runs/{run_digest}/coordinator-lease"
@@ -2124,9 +2135,10 @@ def _persisted_publication() -> PersistedRestartPlanPublication:
         to_generation=publication.candidate.plan.to_generation,
         plan_entry=immutable_entry(plan_record.to_json(), 21),
         manifest_entry=immutable_entry(manifest_record.to_json(), 22),
+        evidence_entry=immutable_entry(evidence_record.to_json(), 23),
         successor_snapshot_entry=immutable_entry(
             generation_state.to_snapshot.to_json(),
-            23,
+            24,
         ),
         generation_head_entry=replace(
             immutable_entry(publication.generation_head.to_json(), 29),
@@ -2141,6 +2153,7 @@ def test_persisted_restart_plan_publication_decodes_atomic_records():
     state = _persisted_publication()
 
     assert state.record.plan == state.plan
+    assert state.record.recovery_evidence_record_digest == state.evidence_record.digest
     assert state.generation_head.snapshot_digest == state.successor_snapshot.digest
     assert state.committed_at_unix_ms == 1_200
     assert state.transaction_sequence == 30
@@ -2195,6 +2208,10 @@ def _publication_reader(
                 RUN_ID,
                 publication.plan.to_generation,
             ): publication.manifest_entry,
+            recovery_evidence_key(
+                RUN_ID,
+                publication.plan.to_generation,
+            ): publication.evidence_entry,
             snapshot_key: publication.successor_snapshot_entry,
             head_key: publication.generation_head_entry,
             **{
@@ -2226,12 +2243,16 @@ def test_restart_plan_publication_reader_returns_none_without_generation():
     assert reader.read() is None
 
 
-@pytest.mark.parametrize("path", ["plan", "manifest", "snapshot", "head", "quarantine"])
+@pytest.mark.parametrize(
+    "path",
+    ["plan", "manifest", "evidence", "snapshot", "head", "quarantine"],
+)
 def test_restart_plan_publication_reader_rejects_missing_atomic_entry(path: str):
     reader, store, publication, _ = _publication_reader()
     keys = {
         "plan": restart_plan_key(RUN_ID, publication.plan.to_generation),
         "manifest": recovery_manifest_key(RUN_ID, publication.plan.to_generation),
+        "evidence": recovery_evidence_key(RUN_ID, publication.plan.to_generation),
         "snapshot": reader._generation_reader.snapshot_key(publication.plan.to_generation),
         "head": reader._generation_reader.head_key,
         "quarantine": node_quarantine_key(
@@ -2341,6 +2362,7 @@ def test_persisted_restart_plan_publication_rejects_malformed_records():
             to_generation=state.plan.to_generation,
             plan_entry=replace(state.plan_entry, value=b"{}"),
             manifest_entry=state.manifest_entry,
+            evidence_entry=state.evidence_entry,
             successor_snapshot_entry=state.successor_snapshot_entry,
             generation_head_entry=state.generation_head_entry,
             quarantine_entries=state.quarantine_entries,
@@ -2356,6 +2378,7 @@ def test_persisted_restart_plan_publication_binds_the_requested_run():
             to_generation=state.plan.to_generation,
             plan_entry=state.plan_entry,
             manifest_entry=state.manifest_entry,
+            evidence_entry=state.evidence_entry,
             successor_snapshot_entry=state.successor_snapshot_entry,
             generation_head_entry=state.generation_head_entry,
             quarantine_entries=state.quarantine_entries,
@@ -2366,6 +2389,7 @@ def test_persisted_restart_plan_publication_binds_the_requested_run():
             to_generation=state.plan.to_generation,
             plan_entry=state.plan_entry,
             manifest_entry=state.manifest_entry,
+            evidence_entry=state.evidence_entry,
             successor_snapshot_entry=state.successor_snapshot_entry,
             generation_head_entry=state.generation_head_entry,
             quarantine_entries=state.quarantine_entries,
@@ -2376,6 +2400,7 @@ def test_persisted_restart_plan_publication_binds_the_requested_run():
             to_generation=state.plan.to_generation + 1,
             plan_entry=state.plan_entry,
             manifest_entry=state.manifest_entry,
+            evidence_entry=state.evidence_entry,
             successor_snapshot_entry=state.successor_snapshot_entry,
             generation_head_entry=state.generation_head_entry,
             quarantine_entries=state.quarantine_entries,
@@ -2386,6 +2411,7 @@ def test_persisted_restart_plan_publication_binds_the_requested_run():
             to_generation=0,
             plan_entry=state.plan_entry,
             manifest_entry=state.manifest_entry,
+            evidence_entry=state.evidence_entry,
             successor_snapshot_entry=state.successor_snapshot_entry,
             generation_head_entry=state.generation_head_entry,
             quarantine_entries=state.quarantine_entries,
@@ -2401,6 +2427,14 @@ def test_persisted_restart_plan_publication_rejects_digest_substitution():
             manifest_record=replace(
                 state.manifest_record,
                 source_generation_snapshot_digest="f" * 64,
+            ),
+        )
+    with pytest.raises(ValueError, match="recovery evidence digest"):
+        replace(
+            state,
+            evidence_record=replace(
+                state.evidence_record,
+                plan_id="other-plan",
             ),
         )
     with pytest.raises(ValueError, match="successor digest"):
@@ -2438,6 +2472,30 @@ def test_persisted_restart_plan_publication_rejects_manifest_metadata_substituti
             manifest_entry=replace(
                 state.manifest_entry,
                 value=manifest_record.to_json(),
+            ),
+        )
+
+
+def test_persisted_restart_plan_publication_rejects_evidence_metadata_substitution():
+    state = _persisted_publication()
+    evidence_record = replace(
+        state.evidence_record,
+        manifest_id="other-manifest",
+    )
+    plan_record = replace(
+        state.record,
+        recovery_evidence_record_digest=evidence_record.digest,
+    )
+
+    with pytest.raises(ValueError, match="recovery evidence"):
+        replace(
+            state,
+            record=plan_record,
+            evidence_record=evidence_record,
+            plan_entry=replace(state.plan_entry, value=plan_record.to_json()),
+            evidence_entry=replace(
+                state.evidence_entry,
+                value=evidence_record.to_json(),
             ),
         )
 
@@ -2561,6 +2619,11 @@ def test_persisted_restart_plan_publication_requires_the_planned_successor():
             "share one commit time",
         ),
         (
+            "evidence_entry",
+            lambda entry: replace(entry, mutation_sequence=2),
+            "is not immutable",
+        ),
+        (
             "successor_snapshot_entry",
             lambda entry: replace(entry, guard_value_digest="0" * 64),
             "share guard provenance",
@@ -2607,6 +2670,7 @@ def test_persisted_restart_plan_publication_rejects_transaction_that_predates_mu
             state,
             plan_entry=replace(state.plan_entry, transaction_sequence=1),
             manifest_entry=replace(state.manifest_entry, transaction_sequence=1),
+            evidence_entry=replace(state.evidence_entry, transaction_sequence=1),
             successor_snapshot_entry=replace(
                 state.successor_snapshot_entry,
                 transaction_sequence=1,
@@ -2637,6 +2701,7 @@ def test_persisted_restart_plan_publication_rejects_guard_or_time_substitution()
             state,
             plan_entry=replace(state.plan_entry, guard_key=wrong_guard_key),
             manifest_entry=replace(state.manifest_entry, guard_key=wrong_guard_key),
+            evidence_entry=replace(state.evidence_entry, guard_key=wrong_guard_key),
             successor_snapshot_entry=replace(
                 state.successor_snapshot_entry,
                 guard_key=wrong_guard_key,
@@ -2655,6 +2720,7 @@ def test_persisted_restart_plan_publication_rejects_guard_or_time_substitution()
             state,
             plan_entry=replace(state.plan_entry, committed_at_unix_ms=1_400),
             manifest_entry=replace(state.manifest_entry, committed_at_unix_ms=1_400),
+            evidence_entry=replace(state.evidence_entry, committed_at_unix_ms=1_400),
             successor_snapshot_entry=replace(
                 state.successor_snapshot_entry,
                 committed_at_unix_ms=1_400,
@@ -2675,6 +2741,8 @@ def test_persisted_restart_plan_publication_requires_exact_types():
 
     with pytest.raises(TypeError, match="record must be"):
         replace(state, record=state.record.plan)
+    with pytest.raises(TypeError, match="evidence_record must be"):
+        replace(state, evidence_record=state.evidence_record.inventory_events)
     with pytest.raises(TypeError, match="quarantine_entries must be a mapping"):
         replace(state, quarantine_entries=())
 
@@ -2704,6 +2772,11 @@ def test_restart_plan_publication_records_build_canonical_atomic_inputs():
         value=manifest_record.to_json(),
         require_never_created=True,
     )
+    assert records.writes[records.recovery_evidence_key] == ControlStoreWrite(
+        expected_revision=None,
+        value=records.recovery_evidence_record.to_json(),
+        require_never_created=True,
+    )
     assert records.writes[records.plan_key] == ControlStoreWrite(
         expected_revision=None,
         value=generation_state.record.to_json(),
@@ -2730,6 +2803,7 @@ def test_restart_plan_publication_records_derive_run_scoped_keys():
     assert records.run_prefix == f"lm_resiliency/torchrun/v1/runs/{expected_run_digest}"
     assert records.plan_key.endswith("/restart-plans/5")
     assert records.recovery_manifest_key.endswith("/restart-plans/5/recovery-manifest")
+    assert records.recovery_evidence_key.endswith("/restart-plans/5/recovery-evidence")
     assert records.generation_head_key.endswith("/generation-head")
     assert records.source_generation_snapshot_key.endswith("/generations/4")
     assert records.manifest_source_generation_snapshot_key.endswith("/generations/4")


### PR DESCRIPTION
## Summary
- derive the strict recovery-evidence record from the admitted restart-plan inventory and trust state
- publish the evidence create-once in the same guarded transaction as the plan, manifest, quarantine, successor snapshot, and generation head
- require the plan envelope to sign the exact evidence digest
- extend persisted publication decoding and stable readback to require the same immutable evidence entry

## Why
The evidence record was durable after PR #136 but was not yet part of atomic restart-plan publication. Coordinator failover must not observe a committed plan without the exact inventory and certification bytes used to admit it.

## Compatibility
- internal torchrun control-plane contract only
- no new production module; torchrun remains at 39 private modules
- no public API or wire-schema change beyond the already merged plan/evidence records

## Validation
- 293 focused publication/state/record tests
- 2,332 full CPU tests with CUDA hidden
- Ruff check and format
- targeted mypy
- git diff --check