### PR TITLE
[Feature][Torchrun] Reauthorize persisted restart-plan recovery evidence

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -907,6 +907,13 @@ generation-head revisions plus store metadata to equal the authoritative
 current generation. Missing, malformed, mixed, or substituted state fails
 closed; repeated head movement remains a retryable read conflict. This first
 readback boundary still does not reauthorize lifecycle or checkpoint evidence.
+`RestartPlanPersistedRecoveryState` reauthorizes the checkpoint side of one
+persisted publication without reading or mutating the store. It resolves the
+exact manifest source generation, quarantine records, inventory events, copy
+eligibility, and exactly one trust path: persisted trusted certifications for
+`recovery_verified`, or supplied restart-acknowledgement evidence for `latest`.
+It still does not authenticate the closed lifecycle or make the publication
+visible to rendezvous.
 
 Before commit, the coordinator validates:
 

--- a/lm_resiliency/integrations/torchrun/_restart_plan_state.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_state.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import hashlib
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from types import MappingProxyType
 
 from lm_resiliency.integrations.torchrun._agent_registration_history_reader import (
@@ -1073,6 +1073,115 @@ class RestartPlanRecoveryEvidenceState:
 
 
 @dataclass(frozen=True, slots=True)
+class RestartPlanPersistedRecoveryState:
+    """Reauthorize one persisted publication's exact recovery evidence."""
+
+    publication: PersistedRestartPlanPublication
+    generation_state: RestartPlanGenerationState
+    manifest_source_snapshot: StoredGenerationSnapshot
+    acknowledgement_evidence: RestartAckEvidence | None = None
+    resolved_manifest: ResolvedRecoveryManifest = field(init=False)
+    manifest_state: RestartPlanManifestState = field(init=False)
+    quarantine_state: RestartPlanQuarantineState = field(init=False)
+    inventory_state: RestartPlanInventoryState = field(init=False)
+    recovery_state: RestartPlanRecoveryEvidenceState = field(init=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.publication, PersistedRestartPlanPublication):
+            raise TypeError(
+                "RestartPlanPersistedRecoveryState.publication must be "
+                "PersistedRestartPlanPublication"
+            )
+        if not isinstance(self.generation_state, RestartPlanGenerationState):
+            raise TypeError(
+                "RestartPlanPersistedRecoveryState.generation_state must be "
+                "RestartPlanGenerationState"
+            )
+        if not isinstance(self.manifest_source_snapshot, StoredGenerationSnapshot):
+            raise TypeError(
+                "RestartPlanPersistedRecoveryState.manifest_source_snapshot must be "
+                "StoredGenerationSnapshot"
+            )
+        if self.acknowledgement_evidence is not None and not isinstance(
+            self.acknowledgement_evidence,
+            RestartAckEvidence,
+        ):
+            raise TypeError(
+                "RestartPlanPersistedRecoveryState.acknowledgement_evidence must be "
+                "RestartAckEvidence or None"
+            )
+        if (
+            self.publication.record != self.generation_state.record
+            or self.publication.successor_snapshot != self.generation_state.to_snapshot
+        ):
+            raise ValueError(
+                "RestartPlanPersistedRecoveryState publication and generation state differ"
+            )
+
+        resolved_manifest = ResolvedRecoveryManifest(
+            record=self.publication.manifest_record,
+            source_snapshot=self.manifest_source_snapshot,
+        )
+        manifest_state = RestartPlanManifestState(
+            generation_state=self.generation_state,
+            resolved_manifest=resolved_manifest,
+        )
+        quarantine_state = RestartPlanQuarantineState(
+            manifest_state=manifest_state,
+            quarantine_records=self.publication.quarantine_records,
+        )
+        inventory_state = RestartPlanInventoryState(
+            quarantine_state=quarantine_state,
+            inventory_events=self.publication.evidence_record.inventory_events,
+        )
+        copy_state = RestartPlanCopyEligibilityState(inventory_state)
+        if inventory_state.manifest.trust == "recovery_verified":
+            if self.acknowledgement_evidence is not None:
+                raise ValueError(
+                    "RestartPlanPersistedRecoveryState verified recovery cannot use "
+                    "latest acknowledgement evidence"
+                )
+            trust_state: RestartPlanLatestEvidenceState | RestartPlanCertificationState = (
+                RestartPlanCertificationState(
+                    inventory_state=inventory_state,
+                    certifications=self.publication.evidence_record.certifications,
+                )
+            )
+        else:
+            if self.publication.evidence_record.certifications:
+                raise ValueError(
+                    "RestartPlanPersistedRecoveryState latest recovery cannot use "
+                    "trusted certifications"
+                )
+            if self.acknowledgement_evidence is None:
+                raise ValueError(
+                    "RestartPlanPersistedRecoveryState latest recovery requires "
+                    "acknowledgement evidence"
+                )
+            trust_state = RestartPlanLatestEvidenceState(
+                inventory_state=inventory_state,
+                acknowledgement_evidence=self.acknowledgement_evidence,
+            )
+        recovery_state = RestartPlanRecoveryEvidenceState(
+            copy_state=copy_state,
+            trust_state=trust_state,
+        )
+        object.__setattr__(self, "resolved_manifest", resolved_manifest)
+        object.__setattr__(self, "manifest_state", manifest_state)
+        object.__setattr__(self, "quarantine_state", quarantine_state)
+        object.__setattr__(self, "inventory_state", inventory_state)
+        object.__setattr__(self, "recovery_state", recovery_state)
+
+    @property
+    def plan(self) -> RestartPlan:
+        return self.recovery_state.plan
+
+    @property
+    def manifest(self) -> RecoveryManifest:
+        return self.recovery_state.manifest
+
+
+@dataclass(frozen=True, slots=True)
 class RestartPlanPlacementState:
     """One successor placement backed by exact live agent registrations."""
 
@@ -1268,6 +1377,7 @@ __all__ = [
     "RestartPlanInventoryState",
     "RestartPlanLatestEvidenceState",
     "RestartPlanManifestState",
+    "RestartPlanPersistedRecoveryState",
     "RestartPlanPlacementState",
     "RestartPlanQuarantineState",
     "RestartPlanRecoveryEvidenceState",

--- a/tests/unit/test_torchrun_restart_ack_evidence.py
+++ b/tests/unit/test_torchrun_restart_ack_evidence.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import threading
 from dataclasses import replace
 from typing import Any, cast
@@ -11,11 +12,18 @@ import pytest
 from lm_resiliency.integrations.torchrun._agent_registration import (
     AgentRegistrationManager,
 )
-from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStoreEntry,
+    InMemoryControlStore,
+)
 from lm_resiliency.integrations.torchrun._coordinator_lease import (
     CoordinatorLeaseManager,
 )
+from lm_resiliency.integrations.torchrun._generation_reader import (
+    StoredGenerationSnapshot,
+)
 from lm_resiliency.integrations.torchrun._generation_records import (
+    GenerationHeadRecord,
     GenerationSnapshotRecord,
 )
 from lm_resiliency.integrations.torchrun._generation_state import GenerationStateManager
@@ -59,15 +67,18 @@ from lm_resiliency.integrations.torchrun._restart_intent_records import (
 )
 from lm_resiliency.integrations.torchrun._restart_plan_records import (
     RecoveryManifestRecord,
+    RestartPlanEvidenceRecord,
     RestartPlanRecord,
 )
 from lm_resiliency.integrations.torchrun._restart_plan_state import (
+    PersistedRestartPlanPublication,
     ResolvedRecoveryManifest,
     RestartPlanCopyEligibilityState,
     RestartPlanGenerationState,
     RestartPlanInventoryState,
     RestartPlanLatestEvidenceState,
     RestartPlanManifestState,
+    RestartPlanPersistedRecoveryState,
     RestartPlanQuarantineState,
     RestartPlanRecoveryEvidenceState,
 )
@@ -356,6 +367,176 @@ def _latest_inventory_state(
         ),
         inventory_events={event.event_id: event},
     )
+
+
+def _persisted_latest_recovery_inputs(
+    evidence: RestartAckEvidence,
+    event: CheckpointInventoryEvent,
+) -> tuple[
+    PersistedRestartPlanPublication,
+    RestartPlanGenerationState,
+    StoredGenerationSnapshot,
+]:
+    inventory_state = _latest_inventory_state(evidence, event)
+    manifest_state = inventory_state.quarantine_state.manifest_state
+    evidence_record = RestartPlanEvidenceRecord(
+        plan_id=manifest_state.plan.plan_id,
+        run_id=manifest_state.plan.run_id,
+        manifest_id=manifest_state.manifest.manifest_id,
+        inventory_events=inventory_state.inventory_events,
+        certifications=(),
+    )
+    generation_state = replace(
+        manifest_state.generation_state,
+        record=replace(
+            manifest_state.generation_state.record,
+            recovery_evidence_record_digest=evidence_record.digest,
+        ),
+    )
+    plan_record = generation_state.record
+    manifest_record = manifest_state.resolved_manifest.record
+    generation_head = GenerationHeadRecord(
+        run_id=RUN_ID,
+        generation=generation_state.plan.to_generation,
+        snapshot_digest=generation_state.to_snapshot.digest,
+    )
+    guard_key = (
+        "lm_resiliency/torchrun/v1/runs/"
+        f"{hashlib.sha256(RUN_ID.encode('utf-8')).hexdigest()}/coordinator-lease"
+    )
+
+    def immutable_entry(value: bytes, revision: int) -> ControlStoreEntry:
+        return ControlStoreEntry(
+            value=value,
+            revision=revision,
+            committed_at_unix_ms=1_200,
+            transaction_sequence=30,
+            guard_key=guard_key,
+            guard_revision=plan_record.coordinator_fencing_token,
+            guard_value_digest=plan_record.coordinator_lease_digest,
+            guard_mutation_sequence=9,
+            guard_value_sequence=5,
+            guard_lifetime_sequence=1,
+            guard_committed_at_unix_ms=900,
+        )
+
+    publication = PersistedRestartPlanPublication.from_entries(
+        run_id=RUN_ID,
+        to_generation=generation_state.plan.to_generation,
+        plan_entry=immutable_entry(plan_record.to_json(), 21),
+        manifest_entry=immutable_entry(manifest_record.to_json(), 22),
+        evidence_entry=immutable_entry(evidence_record.to_json(), 23),
+        successor_snapshot_entry=immutable_entry(
+            generation_state.to_snapshot.to_json(),
+            24,
+        ),
+        generation_head_entry=replace(
+            immutable_entry(generation_head.to_json(), 25),
+            mutation_sequence=generation_state.plan.to_generation + 1,
+            value_sequence=generation_state.plan.to_generation + 1,
+        ),
+        quarantine_entries={},
+    )
+    return (
+        publication,
+        generation_state,
+        manifest_state.resolved_manifest.source_snapshot,
+    )
+
+
+def test_persisted_latest_recovery_accepts_matching_acknowledgements():
+    event = _latest_event()
+    evidence, _ = _evidence(event=event)
+    publication, generation_state, source_snapshot = _persisted_latest_recovery_inputs(
+        evidence,
+        event,
+    )
+
+    state = RestartPlanPersistedRecoveryState(
+        publication=publication,
+        generation_state=generation_state,
+        manifest_source_snapshot=source_snapshot,
+        acknowledgement_evidence=evidence,
+    )
+
+    assert isinstance(state.recovery_state.trust_state, RestartPlanLatestEvidenceState)
+    assert state.recovery_state.trust_state.acknowledgement_evidence == evidence
+
+
+@pytest.mark.parametrize("acknowledgement_success", [None, False])
+def test_persisted_latest_recovery_rejects_missing_or_failed_acknowledgements(
+    acknowledgement_success,
+):
+    event = _latest_event()
+    evidence, _ = _evidence(event=event)
+    publication, generation_state, source_snapshot = _persisted_latest_recovery_inputs(
+        evidence,
+        event,
+    )
+    persisted = evidence.collection.receipts_by_node_id["node-a"]
+    assert persisted is not None
+    if acknowledgement_success is None:
+        unavailable_receipt = None
+    else:
+        failed_acknowledgement = replace(
+            persisted.receipt.acknowledgement,
+            flushed_step=-1,
+            inventory_event_digests={},
+            transferred_owner_ranks=(),
+            transferred_peer_ranks=(),
+            success=False,
+            reason="preparation failed",
+        )
+        failed_receipt = replace(
+            persisted.receipt,
+            acknowledgement=failed_acknowledgement,
+        )
+        unavailable_receipt = replace(
+            persisted,
+            receipt=failed_receipt,
+            receipt_entry=replace(
+                persisted.receipt_entry,
+                value=failed_receipt.to_json(),
+            ),
+        )
+    unavailable_evidence = RestartAckEvidence(
+        RestartAckCollection(
+            opened=evidence.collection.opened,
+            receipts_by_node_id={
+                "node-a": unavailable_receipt,
+                "node-b": None,
+            },
+        )
+    )
+
+    with pytest.raises(ValueError, match="not authorized"):
+        RestartPlanPersistedRecoveryState(
+            publication=publication,
+            generation_state=generation_state,
+            manifest_source_snapshot=source_snapshot,
+            acknowledgement_evidence=unavailable_evidence,
+        )
+
+
+def test_persisted_latest_recovery_rejects_acknowledgements_for_another_intent():
+    event = _latest_event()
+    evidence, _ = _evidence(event=event)
+    publication, generation_state, source_snapshot = _persisted_latest_recovery_inputs(
+        evidence,
+        event,
+    )
+    other_evidence, _ = _evidence(
+        event=event,
+        intent_id="intent-other",
+    )
+
+    with pytest.raises(ValueError, match="another restart intent"):
+        RestartPlanPersistedRecoveryState(
+            publication=publication,
+            generation_state=generation_state,
+            manifest_source_snapshot=source_snapshot,
+            acknowledgement_evidence=other_evidence,
+        )
 
 
 def test_restart_ack_collection_authorizes_exact_latest_inventory():

--- a/tests/unit/test_torchrun_restart_plan_state.py
+++ b/tests/unit/test_torchrun_restart_plan_state.py
@@ -102,6 +102,7 @@ from lm_resiliency.integrations.torchrun._restart_plan_state import (
     RestartPlanGenerationState,
     RestartPlanInventoryState,
     RestartPlanManifestState,
+    RestartPlanPersistedRecoveryState,
     RestartPlanPlacementState,
     RestartPlanQuarantineState,
     RestartPlanRecoveryEvidenceState,
@@ -1964,6 +1965,67 @@ def test_restart_plan_recovery_evidence_state_rejects_cross_inventory_evidence()
             copy_state=_copy_eligibility_state(),
             trust_state=_certification_state(),
         )
+
+
+def _persisted_recovery_state() -> RestartPlanPersistedRecoveryState:
+    publication = _persisted_publication()
+    records = _publication_records()
+    inventory_state = records.candidate.recovery_state.copy_state.inventory_state
+    manifest_state = inventory_state.quarantine_state.manifest_state
+    return RestartPlanPersistedRecoveryState(
+        publication=publication,
+        generation_state=manifest_state.generation_state,
+        manifest_source_snapshot=manifest_state.resolved_manifest.source_snapshot,
+    )
+
+
+def test_restart_plan_persisted_recovery_state_reauthorizes_verified_evidence():
+    state = _persisted_recovery_state()
+
+    assert state.plan == state.publication.plan
+    assert state.manifest == state.publication.manifest_record.manifest
+    assert (
+        state.inventory_state.inventory_events == state.publication.evidence_record.inventory_events
+    )
+    assert isinstance(state.recovery_state.trust_state, RestartPlanCertificationState)
+    assert (
+        state.recovery_state.trust_state.certifications
+        == state.publication.evidence_record.certifications
+    )
+
+
+def test_restart_plan_persisted_recovery_state_requires_exact_types():
+    state = _persisted_recovery_state()
+
+    with pytest.raises(TypeError, match="publication must be"):
+        replace(state, publication=state.publication.record)
+    with pytest.raises(TypeError, match="generation_state must be"):
+        replace(state, generation_state=state.generation_state.record)
+    with pytest.raises(TypeError, match="manifest_source_snapshot must be"):
+        replace(state, manifest_source_snapshot=state.manifest_source_snapshot.record)
+    with pytest.raises(TypeError, match="acknowledgement_evidence must be"):
+        replace(state, acknowledgement_evidence=object())
+
+
+def test_restart_plan_persisted_recovery_state_rejects_another_generation_state():
+    state = _persisted_recovery_state()
+
+    with pytest.raises(ValueError, match="publication and generation state differ"):
+        replace(state, generation_state=_generation_state())
+
+
+def test_restart_plan_persisted_recovery_state_rejects_another_manifest_source():
+    state = _persisted_recovery_state()
+    source_snapshot = replace(
+        state.manifest_source_snapshot,
+        record=replace(
+            state.manifest_source_snapshot.record,
+            coordinator_id="coordinator-other",
+        ),
+    )
+
+    with pytest.raises(ValueError, match="source snapshot digest"):
+        replace(state, manifest_source_snapshot=source_snapshot)
 
 
 def _candidate_state() -> RestartPlanCandidateState:


### PR DESCRIPTION
## What changed

- add `RestartPlanPersistedRecoveryState` inside the existing restart-plan state domain
- reconstruct manifest, quarantine, inventory, copy eligibility, and trust evidence from one persisted publication
- require exactly one recovery trust path: persisted certifications for `recovery_verified`, or supplied restart acknowledgements for `latest`
- keep lifecycle authentication, rendezvous visibility, and store mutation out of this PR
- cover matching, missing, failed, and different-intent persisted latest acknowledgements

## Why

Stable publication readback now preserves the exact recovery evidence bytes, but failover code still needs to re-run the existing safety validators before using that state. This value composes those established validators without adding another production module or duplicating checkpoint policy.

## Compatibility

Internal torchrun integration only. No public API, wire format, or persisted schema changes.

## Validation

- `211 passed` across focused restart-plan and acknowledgement-evidence suites
- `2340 passed` in the full CUDA-hidden CPU suite
- `ruff check .`
- `ruff format --check .`
- targeted mypy for `_restart_plan_state.py`
- `git diff --check`