### PR TITLE
[Feature][Torchrun] Authorize restart-plan readback

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -912,8 +912,15 @@ persisted publication without reading or mutating the store. It resolves the
 exact manifest source generation, quarantine records, inventory events, copy
 eligibility, and exactly one trust path: persisted trusted certifications for
 `recovery_verified`, or supplied restart-acknowledgement evidence for `latest`.
-It still does not authenticate the closed lifecycle or make the publication
-visible to rendezvous.
+`RestartPlanPublicationReader.read_recovery_state()` double-collects that
+publication, the authenticated closed restart-intent lifecycle, and the exact
+manifest source snapshot. It requires the lifecycle's source snapshot and
+immediate successor, including authoritative store metadata, to equal the
+signed publication before returning the reauthorized recovery state. Repeated
+dependency movement remains a retryable conflict; missing, mixed, or unsafe
+recovery evidence fails closed. For `latest`, the caller must supply the exact
+stable restart-acknowledgement evidence until historical acknowledgement
+collection is exposed directly to readback.
 
 Before commit, the coordinator validates:
 

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -916,11 +916,13 @@ eligibility, and exactly one trust path: persisted trusted certifications for
 publication, the authenticated closed restart-intent lifecycle, and the exact
 manifest source snapshot. It requires the lifecycle's source snapshot and
 immediate successor, including authoritative store metadata, to equal the
-signed publication before returning the reauthorized recovery state. Repeated
-dependency movement remains a retryable conflict; missing, mixed, or unsafe
-recovery evidence fails closed. For `latest`, the caller must supply the exact
-stable restart-acknowledgement evidence until historical acknowledgement
-collection is exposed directly to readback.
+signed publication, and requires the publication transaction and commit time
+to follow lifecycle closure, before returning the reauthorized recovery state.
+Repeated lifecycle, generation, or lease-history movement remains a retryable
+conflict; missing, mixed, causally impossible, or unsafe recovery evidence
+fails closed. For `latest`, the caller must supply the exact stable
+restart-acknowledgement evidence until historical acknowledgement collection
+is exposed directly to readback.
 
 Before commit, the coordinator validates:
 

--- a/lm_resiliency/integrations/torchrun/_restart_plan_publication.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_publication.py
@@ -24,6 +24,17 @@ from lm_resiliency.integrations.torchrun._generation_reader import (
     StoredGenerationSnapshot,
 )
 from lm_resiliency.integrations.torchrun._quarantine_store import node_quarantine_key
+from lm_resiliency.integrations.torchrun._restart_ack_collection import (
+    RestartAckEvidence,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_lifecycle_auth import (
+    AuthenticatedInitialRestartIntentClosure,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_lifecycle_reader import (
+    InitialRestartIntentLifecycleReader,
+    RestartIntentLifecycleReadCorrupt,
+    RestartIntentLifecycleReadError,
+)
 from lm_resiliency.integrations.torchrun._restart_plan_publication_lifecycle import (
     RestartPlanPublicationLifecycleConflict,
     RestartPlanPublicationLifecycleCorrupt,
@@ -41,6 +52,8 @@ from lm_resiliency.integrations.torchrun._restart_plan_publication_records impor
 from lm_resiliency.integrations.torchrun._restart_plan_records import RestartPlanRecord
 from lm_resiliency.integrations.torchrun._restart_plan_state import (
     PersistedRestartPlanPublication,
+    RestartPlanGenerationState,
+    RestartPlanPersistedRecoveryState,
 )
 
 _MAX_READ_ATTEMPTS = 8
@@ -251,6 +264,10 @@ class RestartPlanPublicationReader:
             store,
             run_id=self._run_id,
         )
+        self._lifecycle_reader = InitialRestartIntentLifecycleReader(
+            store,
+            run_id=self._run_id,
+        )
 
     def read(self) -> PersistedRestartPlanPublication | None:
         """Return the stable publication for the current generation, if any."""
@@ -273,6 +290,40 @@ class RestartPlanPublicationReader:
             "restart-plan publication changed repeatedly during read"
         )
 
+    def read_recovery_state(
+        self,
+        *,
+        acknowledgement_evidence: RestartAckEvidence | None = None,
+    ) -> RestartPlanPersistedRecoveryState | None:
+        """Return one stable publication reauthorized for recovery."""
+
+        if acknowledgement_evidence is not None and not isinstance(
+            acknowledgement_evidence,
+            RestartAckEvidence,
+        ):
+            raise TypeError("acknowledgement_evidence must be RestartAckEvidence or None")
+        for _ in range(_MAX_READ_ATTEMPTS):
+            publication = self.read()
+            if publication is None:
+                return None
+            lifecycle = self._read_lifecycle()
+            manifest_source = self._read_manifest_source(publication)
+            if (
+                self.read() != publication
+                or self._read_lifecycle() != lifecycle
+                or self._read_manifest_source(publication) != manifest_source
+            ):
+                continue
+            return self._reauthorize(
+                publication,
+                lifecycle,
+                manifest_source,
+                acknowledgement_evidence,
+            )
+        raise RestartPlanPublicationReadConflict(
+            "restart-plan recovery state changed repeatedly during read"
+        )
+
     def _read_current(self) -> CurrentGeneration | None:
         try:
             return self._generation_reader.current()
@@ -283,6 +334,81 @@ class RestartPlanPublicationReader:
         except GenerationStateError as error:
             raise RestartPlanPublicationReadConflict(
                 "generation state changed repeatedly while reading restart-plan publication"
+            ) from error
+
+    def _read_lifecycle(self) -> AuthenticatedInitialRestartIntentClosure:
+        try:
+            lifecycle = self._lifecycle_reader.read()
+        except RestartIntentLifecycleReadCorrupt as error:
+            raise RestartPlanPublicationReadCorrupt(
+                "restart-intent lifecycle is corrupt while reauthorizing publication"
+            ) from error
+        except RestartIntentLifecycleReadError as error:
+            raise RestartPlanPublicationReadConflict(
+                "restart-intent lifecycle changed repeatedly while reauthorizing publication"
+            ) from error
+        if lifecycle is None:
+            raise RestartPlanPublicationReadCorrupt(
+                "restart-plan publication has no closed restart-intent lifecycle"
+            )
+        return lifecycle
+
+    def _read_manifest_source(
+        self,
+        publication: PersistedRestartPlanPublication,
+    ) -> StoredGenerationSnapshot:
+        generation = publication.manifest_record.manifest.source_generation
+        try:
+            snapshot = self._generation_reader.get(generation)
+        except GenerationStateCorrupt as error:
+            raise RestartPlanPublicationReadCorrupt(
+                "manifest source generation is corrupt while reauthorizing publication"
+            ) from error
+        except GenerationStateError as error:
+            raise RestartPlanPublicationReadConflict(
+                "manifest source generation changed repeatedly while reauthorizing publication"
+            ) from error
+        if snapshot is None:
+            raise RestartPlanPublicationReadCorrupt(
+                "restart-plan publication references a missing manifest source generation"
+            )
+        return snapshot
+
+    def _reauthorize(
+        self,
+        publication: PersistedRestartPlanPublication,
+        lifecycle: AuthenticatedInitialRestartIntentClosure,
+        manifest_source: StoredGenerationSnapshot,
+        acknowledgement_evidence: RestartAckEvidence | None,
+    ) -> RestartPlanPersistedRecoveryState:
+        successor = lifecycle.immediate_successor
+        expected_successor = self._stored_successor(publication)
+        if (
+            lifecycle.lifecycle.digest != publication.record.intent_lifecycle_record_digest
+            or lifecycle.generation_snapshot.record.digest
+            != publication.record.from_generation_snapshot_digest
+            or successor != expected_successor
+        ):
+            raise RestartPlanPublicationReadCorrupt(
+                "restart-plan publication does not match its closed lifecycle"
+            )
+        try:
+            generation_state = RestartPlanGenerationState(
+                record=publication.record,
+                intent_record=lifecycle.intent,
+                lifecycle_record=lifecycle.lifecycle,
+                from_snapshot=lifecycle.generation_snapshot.record,
+                to_snapshot=publication.successor_snapshot,
+            )
+            return RestartPlanPersistedRecoveryState(
+                publication=publication,
+                generation_state=generation_state,
+                manifest_source_snapshot=manifest_source,
+                acknowledgement_evidence=acknowledgement_evidence,
+            )
+        except (TypeError, ValueError) as error:
+            raise RestartPlanPublicationReadCorrupt(
+                "restart-plan publication recovery evidence is not authoritative"
             ) from error
 
     def _read_entries(self, generation: int) -> _PublicationEntries:
@@ -361,6 +487,19 @@ class RestartPlanPublicationReader:
         publication: PersistedRestartPlanPublication,
         current: CurrentGeneration,
     ) -> None:
+        expected_snapshot = self._stored_successor(publication)
+        if (
+            current.snapshot != expected_snapshot
+            or current.head_revision != publication.generation_head_entry.revision
+        ):
+            raise RestartPlanPublicationReadCorrupt(
+                "latest restart-plan publication does not match the current generation"
+            )
+
+    def _stored_successor(
+        self,
+        publication: PersistedRestartPlanPublication,
+    ) -> StoredGenerationSnapshot:
         successor_entry = publication.successor_snapshot_entry
         if (
             successor_entry.committed_at_unix_ms is None
@@ -372,7 +511,7 @@ class RestartPlanPublicationReader:
             raise RestartPlanPublicationReadCorrupt(
                 "latest restart-plan successor lacks authoritative metadata"
             )
-        expected_snapshot = StoredGenerationSnapshot(
+        return StoredGenerationSnapshot(
             record=publication.successor_snapshot,
             revision=successor_entry.revision,
             committed_at_unix_ms=successor_entry.committed_at_unix_ms,
@@ -382,13 +521,6 @@ class RestartPlanPublicationReader:
             guard_lifetime_sequence=successor_entry.guard_lifetime_sequence,
             guard_committed_at_unix_ms=successor_entry.guard_committed_at_unix_ms,
         )
-        if (
-            current.snapshot != expected_snapshot
-            or current.head_revision != publication.generation_head_entry.revision
-        ):
-            raise RestartPlanPublicationReadCorrupt(
-                "latest restart-plan publication does not match the current generation"
-            )
 
 
 class RestartPlanPublicationPreparer:

--- a/lm_resiliency/integrations/torchrun/_restart_plan_publication.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_publication.py
@@ -339,11 +339,19 @@ class RestartPlanPublicationReader:
     def _read_lifecycle(self) -> AuthenticatedInitialRestartIntentClosure:
         try:
             lifecycle = self._lifecycle_reader.read()
-        except RestartIntentLifecycleReadCorrupt as error:
+        except (
+            CoordinatorLeaseHistoryCorrupt,
+            GenerationStateCorrupt,
+            RestartIntentLifecycleReadCorrupt,
+        ) as error:
             raise RestartPlanPublicationReadCorrupt(
                 "restart-intent lifecycle is corrupt while reauthorizing publication"
             ) from error
-        except RestartIntentLifecycleReadError as error:
+        except (
+            CoordinatorLeaseHistoryError,
+            GenerationStateError,
+            RestartIntentLifecycleReadError,
+        ) as error:
             raise RestartPlanPublicationReadConflict(
                 "restart-intent lifecycle changed repeatedly while reauthorizing publication"
             ) from error
@@ -388,6 +396,8 @@ class RestartPlanPublicationReader:
             or lifecycle.generation_snapshot.record.digest
             != publication.record.from_generation_snapshot_digest
             or successor != expected_successor
+            or publication.transaction_sequence <= lifecycle.transaction_sequence
+            or publication.committed_at_unix_ms < lifecycle.closed_at_unix_ms
         ):
             raise RestartPlanPublicationReadCorrupt(
                 "restart-plan publication does not match its closed lifecycle"

--- a/tests/unit/test_torchrun_restart_plan_state.py
+++ b/tests/unit/test_torchrun_restart_plan_state.py
@@ -2469,6 +2469,8 @@ def _recovery_reader() -> tuple[
         lifecycle=_lifecycle_record(),
         generation_snapshot=records.current.snapshot,
         immediate_successor=current.snapshot,
+        transaction_sequence=publication.transaction_sequence - 1,
+        closed_at_unix_ms=publication.committed_at_unix_ms,
     )
     reader._lifecycle_reader = cast(Any, SequenceLifecycleReader([lifecycle]))
     reader._generation_reader = cast(
@@ -2551,6 +2553,36 @@ def test_restart_plan_publication_reader_recovery_requires_exact_successor():
         reader.read_recovery_state()
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("transaction_sequence", 30),
+        ("closed_at_unix_ms", 1_201),
+    ],
+)
+def test_restart_plan_publication_reader_recovery_requires_closure_before_publication(
+    field: str,
+    value: int,
+):
+    reader, _, lifecycle, _ = _recovery_reader()
+    reader._lifecycle_reader = cast(
+        Any,
+        SequenceLifecycleReader(
+            [
+                SimpleNamespace(
+                    **{
+                        **vars(lifecycle),
+                        field: value,
+                    }
+                )
+            ]
+        ),
+    )
+
+    with pytest.raises(RestartPlanPublicationReadCorrupt, match="closed lifecycle"):
+        reader.read_recovery_state()
+
+
 def test_restart_plan_publication_reader_recovery_retries_lifecycle_change():
     reader, publication, lifecycle, _ = _recovery_reader()
     changed = SimpleNamespace(**vars(lifecycle), observation=1)
@@ -2581,7 +2613,23 @@ def test_restart_plan_publication_reader_recovery_rejects_repeated_lifecycle_cha
             RestartPlanPublicationReadConflict,
         ),
         (
+            CoordinatorLeaseHistoryError("busy"),
+            RestartPlanPublicationReadConflict,
+        ),
+        (
+            GenerationStateError("busy"),
+            RestartPlanPublicationReadConflict,
+        ),
+        (
             RestartIntentLifecycleReadCorrupt("bad"),
+            RestartPlanPublicationReadCorrupt,
+        ),
+        (
+            CoordinatorLeaseHistoryCorrupt("bad"),
+            RestartPlanPublicationReadCorrupt,
+        ),
+        (
+            GenerationStateCorrupt("bad"),
             RestartPlanPublicationReadCorrupt,
         ),
     ],

--- a/tests/unit/test_torchrun_restart_plan_state.py
+++ b/tests/unit/test_torchrun_restart_plan_state.py
@@ -6,6 +6,7 @@ import hashlib
 import threading
 from collections.abc import Callable
 from dataclasses import replace
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -66,6 +67,10 @@ from lm_resiliency.integrations.torchrun._quarantine_records import (
     NodeQuarantineRecord,
 )
 from lm_resiliency.integrations.torchrun._quarantine_store import node_quarantine_key
+from lm_resiliency.integrations.torchrun._restart_intent_lifecycle_reader import (
+    RestartIntentLifecycleReadCorrupt,
+    RestartIntentLifecycleReadError,
+)
 from lm_resiliency.integrations.torchrun._restart_intent_records import (
     RestartIntentHeadRecord,
     RestartIntentLifecycleRecord,
@@ -148,9 +153,11 @@ class SequenceGenerationReader:
         *,
         snapshot_key: str,
         head_key: str,
+        snapshots: dict[int, StoredGenerationSnapshot | None | Exception] | None = None,
     ) -> None:
         self._values = list(values)
         self._snapshot_key = snapshot_key
+        self._snapshots = snapshots or {}
         self.head_key = head_key
 
     def current(self) -> CurrentGeneration | None:
@@ -164,6 +171,39 @@ class SequenceGenerationReader:
 
     def snapshot_key(self, generation: int) -> str:
         return self._snapshot_key
+
+    def get(self, generation: int) -> StoredGenerationSnapshot | None:
+        value = self._snapshots.get(generation)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+
+class SequenceLifecycleReader:
+    def __init__(self, values: list[object | Exception]) -> None:
+        self._values = list(values)
+
+    def read(self):
+        if len(self._values) > 1:
+            value = self._values.pop(0)
+        else:
+            value = self._values[0]
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+
+class ChangingLifecycleReader:
+    def __init__(self, lifecycle: object) -> None:
+        self._lifecycle = lifecycle
+        self._sequence = 0
+
+    def read(self):
+        self._sequence += 1
+        return SimpleNamespace(
+            **vars(self._lifecycle),
+            observation=self._sequence,
+        )
 
 
 def _assignment(
@@ -2413,6 +2453,172 @@ def test_restart_plan_publication_reader_requires_exact_current_snapshot():
 
     with pytest.raises(RestartPlanPublicationReadCorrupt, match="current generation"):
         reader.read()
+
+
+def _recovery_reader() -> tuple[
+    RestartPlanPublicationReader,
+    PersistedRestartPlanPublication,
+    object,
+    StoredGenerationSnapshot,
+]:
+    reader, _, publication, current = _publication_reader()
+    records = _publication_records()
+    source_snapshot = records.candidate.recovery_state.copy_state.inventory_state.quarantine_state.manifest_state.resolved_manifest.source_snapshot
+    lifecycle = SimpleNamespace(
+        intent=_intent_record(),
+        lifecycle=_lifecycle_record(),
+        generation_snapshot=records.current.snapshot,
+        immediate_successor=current.snapshot,
+    )
+    reader._lifecycle_reader = cast(Any, SequenceLifecycleReader([lifecycle]))
+    reader._generation_reader = cast(
+        Any,
+        SequenceGenerationReader(
+            [current],
+            snapshot_key=reader._generation_reader.snapshot_key(publication.plan.to_generation),
+            head_key=reader._generation_reader.head_key,
+            snapshots={source_snapshot.record.assignment.generation: source_snapshot},
+        ),
+    )
+    return reader, publication, lifecycle, source_snapshot
+
+
+def test_restart_plan_publication_reader_reauthorizes_verified_recovery():
+    reader, publication, _, source_snapshot = _recovery_reader()
+
+    state = reader.read_recovery_state()
+
+    assert state is not None
+    assert state.publication == publication
+    assert state.manifest_source_snapshot == source_snapshot
+    assert state.plan == publication.plan
+
+
+def test_restart_plan_publication_reader_recovery_returns_none_without_publication():
+    reader, _, _, _ = _recovery_reader()
+    reader._generation_reader = cast(
+        Any,
+        SequenceGenerationReader(
+            [None],
+            snapshot_key="unused",
+            head_key="unused",
+        ),
+    )
+
+    assert reader.read_recovery_state() is None
+
+
+def test_restart_plan_publication_reader_recovery_requires_exact_lifecycle():
+    reader, _, lifecycle, _ = _recovery_reader()
+    reader._lifecycle_reader = cast(
+        Any,
+        SequenceLifecycleReader(
+            [
+                SimpleNamespace(
+                    **{
+                        **vars(lifecycle),
+                        "lifecycle": replace(
+                            lifecycle.lifecycle,
+                            lease_id="lease-other",
+                        ),
+                    }
+                )
+            ]
+        ),
+    )
+
+    with pytest.raises(RestartPlanPublicationReadCorrupt, match="closed lifecycle"):
+        reader.read_recovery_state()
+
+
+def test_restart_plan_publication_reader_recovery_requires_exact_successor():
+    reader, _, lifecycle, _ = _recovery_reader()
+    reader._lifecycle_reader = cast(
+        Any,
+        SequenceLifecycleReader(
+            [
+                SimpleNamespace(
+                    **{
+                        **vars(lifecycle),
+                        "immediate_successor": None,
+                    }
+                )
+            ]
+        ),
+    )
+
+    with pytest.raises(RestartPlanPublicationReadCorrupt, match="closed lifecycle"):
+        reader.read_recovery_state()
+
+
+def test_restart_plan_publication_reader_recovery_retries_lifecycle_change():
+    reader, publication, lifecycle, _ = _recovery_reader()
+    changed = SimpleNamespace(**vars(lifecycle), observation=1)
+    reader._lifecycle_reader = cast(
+        Any,
+        SequenceLifecycleReader([lifecycle, changed, changed, changed]),
+    )
+
+    state = reader.read_recovery_state()
+
+    assert state is not None
+    assert state.publication == publication
+
+
+def test_restart_plan_publication_reader_recovery_rejects_repeated_lifecycle_changes():
+    reader, _, lifecycle, _ = _recovery_reader()
+    reader._lifecycle_reader = cast(Any, ChangingLifecycleReader(lifecycle))
+
+    with pytest.raises(RestartPlanPublicationReadConflict, match="changed repeatedly"):
+        reader.read_recovery_state()
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        (
+            RestartIntentLifecycleReadError("busy"),
+            RestartPlanPublicationReadConflict,
+        ),
+        (
+            RestartIntentLifecycleReadCorrupt("bad"),
+            RestartPlanPublicationReadCorrupt,
+        ),
+    ],
+)
+def test_restart_plan_publication_reader_recovery_translates_lifecycle_errors(
+    error: Exception,
+    expected: type[Exception],
+):
+    reader, _, _, _ = _recovery_reader()
+    reader._lifecycle_reader = cast(Any, SequenceLifecycleReader([error]))
+
+    with pytest.raises(expected):
+        reader.read_recovery_state()
+
+
+def test_restart_plan_publication_reader_recovery_requires_manifest_source():
+    reader, publication, _, _ = _recovery_reader()
+    current = reader._generation_reader.current()
+    assert current is not None
+    reader._generation_reader = cast(
+        Any,
+        SequenceGenerationReader(
+            [current],
+            snapshot_key=reader._generation_reader.snapshot_key(publication.plan.to_generation),
+            head_key=reader._generation_reader.head_key,
+        ),
+    )
+
+    with pytest.raises(RestartPlanPublicationReadCorrupt, match="missing manifest source"):
+        reader.read_recovery_state()
+
+
+def test_restart_plan_publication_reader_recovery_requires_acknowledgement_type():
+    reader, _, _, _ = _recovery_reader()
+
+    with pytest.raises(TypeError, match="acknowledgement_evidence"):
+        reader.read_recovery_state(acknowledgement_evidence=cast(Any, object()))
 
 
 def test_persisted_restart_plan_publication_rejects_malformed_records():


### PR DESCRIPTION
## What changed

- Extend `RestartPlanPublicationReader` with stable recovery-state readback.
- Double-collect the persisted publication, authenticated closed lifecycle, and manifest source generation.
- Require the lifecycle source and exact successor store metadata to match the signed publication.
- Require lifecycle closure to precede publication in transaction order and commit time.
- Translate lifecycle lease/generation contention into the publication reader retryable error boundary.
- Reuse `RestartPlanGenerationState` and `RestartPlanPersistedRecoveryState` for recovery-evidence validation.

## Why

Stable publication decoding alone did not prove that the committed plan matched the closed restart intent or that its checkpoint evidence remained authoritative. Rendezvous must not expose a plan until those dependencies are observed consistently, the intent was closed before publication, and recovery evidence is revalidated fail closed.

## Compatibility

- Private torchrun integration API only.
- No new production module or persisted schema change.
- `latest` recovery still requires the caller to supply the exact stable acknowledgement evidence; historical acknowledgement reconstruction remains a follow-up.

## Validation

- `227` focused tests passed.
- `2356` full CPU tests passed with CUDA hidden.
- Repository-wide Ruff and formatting checks passed.
- Targeted mypy passed.
