### PR TITLE
[Feature][Torchrun] Read restart acknowledgements after intent closure

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -920,9 +920,10 @@ signed publication, and requires the publication transaction and commit time
 to follow lifecycle closure, before returning the reauthorized recovery state.
 Repeated lifecycle, generation, or lease-history movement remains a retryable
 conflict; missing, mixed, causally impossible, or unsafe recovery evidence
-fails closed. For `latest`, the caller must supply the exact stable
-restart-acknowledgement evidence until historical acknowledgement collection
-is exposed directly to readback.
+fails closed. For `latest`, the caller supplies the exact stable
+restart-acknowledgement evidence reconstructed from the authenticated closed
+intent; the following readback integration wires that historical collection
+directly into this method.
 
 Before commit, the coordinator validates:
 
@@ -1161,9 +1162,12 @@ membership, causal transaction order, and a commit inside all three authority
 windows. It performs no store reads; a following stable reader supplies the
 durable dependencies before acknowledgement collection or quorum logic.
 
-The per-node receipt reader double-collects the current open intent, the
+The per-node receipt reader double-collects the restart-intent opening, the
 create-once acknowledgement key, complete agent-registration history, and
-complete coordinator-lease history. A never-created receipt key returns no
+complete coordinator-lease history. For the active preparation path it reads
+the current opening. After closure it can instead consume the durable opening
+retained by the authenticated lifecycle record, without reconstructing lost
+preparation revisions or time bounds. A never-created receipt key returns no
 acknowledgement. Deleted, rewritten, malformed, or orphaned receipts fail
 closed. Renewed registrations and coordinator leases do not invalidate an
 already committed receipt because the reader resolves the exact historical
@@ -1177,8 +1181,11 @@ separately exposes received, missing, successful, and explicitly failed node
 sets without making a quorum or restart-policy decision.
 
 A read-only collector obtains two identical full active-node observations while
-the durable restart-intent opening remains unchanged. Because acknowledgement
-keys are immutable create-once records, this double collect yields one stable
+the durable restart-intent opening remains unchanged. Before closure it also
+stabilizes the current opening. After closure it accepts an authenticated
+lifecycle value and reconstructs the same durable opening from the retained
+immutable intent and open-head entries. Because acknowledgement keys are
+immutable create-once records, this double collect yields one stable
 receipt-or-absence snapshot without requiring a store-wide read transaction.
 Repeated changes are retryable conflicts; contradictory per-node state fails
 closed as corruption. The collector still makes no quorum or restart decision.

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -922,8 +922,9 @@ Repeated lifecycle, generation, or lease-history movement remains a retryable
 conflict; missing, mixed, causally impossible, or unsafe recovery evidence
 fails closed. For `latest`, the caller supplies the exact stable
 restart-acknowledgement evidence reconstructed from the authenticated closed
-intent; the following readback integration wires that historical collection
-directly into this method.
+intent by calling the historical acknowledgement collector and passing the
+resulting evidence to `read_recovery_state()`. Direct collector wiring remains
+a following integration step.
 
 Before commit, the coordinator validates:
 

--- a/lm_resiliency/integrations/torchrun/_restart_ack_collection.py
+++ b/lm_resiliency/integrations/torchrun/_restart_ack_collection.py
@@ -17,6 +17,8 @@ from lm_resiliency.integrations.torchrun._restart_ack_persisted import (
 )
 from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
     CommittedInitialRestartIntentOpen,
+    PersistedInitialRestartIntentOpen,
+    RestartIntentOpening,
 )
 
 
@@ -24,12 +26,15 @@ from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
 class RestartAckCollection:
     """One exact active-node acknowledgement observation."""
 
-    opened: CommittedInitialRestartIntentOpen
+    opened: RestartIntentOpening
     receipts_by_node_id: Mapping[str, PersistedRestartAck | None]
 
     def __post_init__(self) -> None:
-        if not isinstance(self.opened, CommittedInitialRestartIntentOpen):
-            raise TypeError("RestartAckCollection.opened must be CommittedInitialRestartIntentOpen")
+        if not isinstance(
+            self.opened,
+            (CommittedInitialRestartIntentOpen, PersistedInitialRestartIntentOpen),
+        ):
+            raise TypeError("RestartAckCollection.opened must be a restart-intent opening")
         if not isinstance(self.receipts_by_node_id, Mapping):
             raise TypeError("RestartAckCollection.receipts_by_node_id must be a mapping")
         normalized: dict[str, PersistedRestartAck | None] = {}
@@ -67,7 +72,7 @@ class RestartAckCollection:
 
     @property
     def active_node_ids(self) -> tuple[str, ...]:
-        slot_to_node_id = self.opened.prepared.current.snapshot.record.assignment.slot_to_node_id
+        slot_to_node_id = self.opened.generation_snapshot.record.assignment.slot_to_node_id
         return tuple(dict.fromkeys(slot_to_node_id[slot_id] for slot_id in sorted(slot_to_node_id)))
 
     @property
@@ -123,7 +128,7 @@ class RestartAckEvidence:
             raise TypeError("event must be CheckpointInventoryEvent")
         if event.trust != "latest":
             return False
-        assignment = self.collection.opened.prepared.current.snapshot.record.assignment
+        assignment = self.collection.opened.generation_snapshot.record.assignment
         try:
             validate_worker_identity(event.reporter, assignment)
         except ProtocolValidationError:
@@ -148,13 +153,13 @@ def _nonempty_string(value: object, path: str) -> str:
 
 
 def _same_committed_opening(
-    left: CommittedInitialRestartIntentOpen,
-    right: CommittedInitialRestartIntentOpen,
+    left: RestartIntentOpening,
+    right: RestartIntentOpening,
 ) -> bool:
     return (
-        left.prepared.intent_key == right.prepared.intent_key
+        left.intent_key == right.intent_key
         and left.intent_entry == right.intent_entry
-        and left.prepared.intent_head_key == right.prepared.intent_head_key
+        and left.intent_head_key == right.intent_head_key
         and left.head_entry == right.head_entry
     )
 

--- a/lm_resiliency/integrations/torchrun/_restart_ack_persisted.py
+++ b/lm_resiliency/integrations/torchrun/_restart_ack_persisted.py
@@ -17,6 +17,8 @@ from lm_resiliency.integrations.torchrun._restart_ack_records import (
 )
 from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
     CommittedInitialRestartIntentOpen,
+    PersistedInitialRestartIntentOpen,
+    RestartIntentOpening,
 )
 
 
@@ -26,7 +28,7 @@ class PersistedRestartAck:
 
     receipt: RestartAckReceiptRecord
     receipt_entry: ControlStoreEntry
-    opened: CommittedInitialRestartIntentOpen
+    opened: RestartIntentOpening
     registration_authority: AgentRegistrationAuthority
     coordinator_authority: CoordinatorLeaseAuthority
 
@@ -35,8 +37,11 @@ class PersistedRestartAck:
             raise TypeError("PersistedRestartAck.receipt must be RestartAckReceiptRecord")
         if not isinstance(self.receipt_entry, ControlStoreEntry):
             raise TypeError("PersistedRestartAck.receipt_entry must be ControlStoreEntry")
-        if not isinstance(self.opened, CommittedInitialRestartIntentOpen):
-            raise TypeError("PersistedRestartAck.opened must be CommittedInitialRestartIntentOpen")
+        if not isinstance(
+            self.opened,
+            (CommittedInitialRestartIntentOpen, PersistedInitialRestartIntentOpen),
+        ):
+            raise TypeError("PersistedRestartAck.opened must be a restart-intent opening")
         if not isinstance(self.registration_authority, AgentRegistrationAuthority):
             raise TypeError(
                 "PersistedRestartAck.registration_authority must be AgentRegistrationAuthority"
@@ -54,7 +59,7 @@ class PersistedRestartAck:
         *,
         run_id: str,
         receipt_entry: ControlStoreEntry,
-        opened: CommittedInitialRestartIntentOpen,
+        opened: RestartIntentOpening,
         registration_authority: AgentRegistrationAuthority,
         coordinator_authority: CoordinatorLeaseAuthority,
     ) -> PersistedRestartAck:
@@ -90,7 +95,7 @@ class PersistedRestartAck:
         return self.receipt_entry.transaction_sequence
 
     def _validate_records(self) -> None:
-        if self.receipt.intent_record != self.opened.prepared.record:
+        if self.receipt.intent_record != self.opened.record:
             raise ValueError("PersistedRestartAck does not answer its committed restart intent")
         if self.receipt.received_at_unix_ms < self.opened.committed_at_unix_ms:
             raise ValueError("PersistedRestartAck receipt predates its committed restart intent")
@@ -100,7 +105,7 @@ class PersistedRestartAck:
         if self.coordinator_authority.lease.record.run_id != run_id:
             raise ValueError("PersistedRestartAck coordinator authority belongs to another run")
         active_node_ids = set(
-            self.opened.prepared.current.snapshot.record.assignment.slot_to_node_id.values()
+            self.opened.generation_snapshot.record.assignment.slot_to_node_id.values()
         )
         if self.receipt.acknowledgement.node_id not in active_node_ids:
             raise ValueError("PersistedRestartAck acknowledgement node is not active")
@@ -120,7 +125,7 @@ class PersistedRestartAck:
         authority = self.coordinator_authority
         expected_guard_digest = hashlib.sha256(authority.lease.record.to_json()).hexdigest()
         if (
-            entry.guard_key != self.opened.prepared.coordinator_lease_key
+            entry.guard_key != self.opened.coordinator_lease_key
             or entry.guard_revision != authority.lease.fencing_token
             or entry.guard_value_digest != expected_guard_digest
             or entry.guard_committed_at_unix_ms != authority.lease.granted_at_unix_ms

--- a/lm_resiliency/integrations/torchrun/_restart_ack_reader.py
+++ b/lm_resiliency/integrations/torchrun/_restart_ack_reader.py
@@ -36,8 +36,12 @@ from lm_resiliency.integrations.torchrun._restart_ack_persisted import (
 from lm_resiliency.integrations.torchrun._restart_ack_records import (
     RestartAckReceiptRecord,
 )
+from lm_resiliency.integrations.torchrun._restart_intent_lifecycle_auth import (
+    AuthenticatedInitialRestartIntentClosure,
+)
 from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
     CommittedInitialRestartIntentOpen,
+    PersistedInitialRestartIntentOpen,
 )
 from lm_resiliency.integrations.torchrun._restart_intent_open_reader import (
     RestartIntentOpenStateClosed,
@@ -92,13 +96,13 @@ class RestartAckReader:
         """Return the current intent's receipt for this node, if committed."""
 
         for _ in range(_MAX_READ_ATTEMPTS):
-            opened = self._read_open()
+            opened = PersistedInitialRestartIntentOpen.from_committed(self._read_open())
             acknowledgement_key = _acknowledgement_key(opened, self._node_id)
             receipt_state = self._receipt_state(acknowledgement_key)
             registration_history = self._read_registration_history()
             lease_history = self._read_lease_history()
             if (
-                opened != self._read_open()
+                opened != PersistedInitialRestartIntentOpen.from_committed(self._read_open())
                 or receipt_state != self._receipt_state(acknowledgement_key)
                 or registration_history != self._read_registration_history()
                 or lease_history != self._read_lease_history()
@@ -117,11 +121,45 @@ class RestartAckReader:
             "restart-acknowledgement dependencies changed repeatedly during read"
         )
 
+    def _read_for_opening(
+        self,
+        opened: PersistedInitialRestartIntentOpen,
+    ) -> PersistedRestartAck | None:
+        """Return this node's receipt for one authenticated historical opening."""
+
+        if not isinstance(opened, PersistedInitialRestartIntentOpen):
+            raise TypeError("opened must be PersistedInitialRestartIntentOpen")
+        if opened.run_id != self._run_id:
+            raise ValueError("opened restart intent belongs to another run")
+        acknowledgement_key = _acknowledgement_key(opened, self._node_id)
+        for _ in range(_MAX_READ_ATTEMPTS):
+            receipt_state = self._receipt_state(acknowledgement_key)
+            registration_history = self._read_registration_history()
+            lease_history = self._read_lease_history()
+            if (
+                receipt_state != self._receipt_state(acknowledgement_key)
+                or registration_history != self._read_registration_history()
+                or lease_history != self._read_lease_history()
+            ):
+                continue
+            receipt_entry = _current_receipt(receipt_state)
+            if receipt_entry is None:
+                return None
+            return self._authenticate(
+                receipt_entry,
+                opened=opened,
+                registration_history=registration_history,
+                lease_history=lease_history,
+            )
+        raise RestartAckReadConflict(
+            "historical restart-acknowledgement dependencies changed repeatedly during read"
+        )
+
     def _authenticate(
         self,
         receipt_entry: ControlStoreEntry,
         *,
-        opened: CommittedInitialRestartIntentOpen,
+        opened: PersistedInitialRestartIntentOpen,
         registration_history: AgentRegistrationHistory,
         lease_history: tuple[CoordinatorLeaseAuthority, ...],
     ) -> PersistedRestartAck:
@@ -258,9 +296,41 @@ class RestartAckCollector:
             "restart acknowledgements changed repeatedly during collection"
         )
 
+    def collect_for_closure(
+        self,
+        closure: AuthenticatedInitialRestartIntentClosure,
+    ) -> RestartAckCollection:
+        """Return stable acknowledgements for one authenticated closed intent."""
+
+        if not isinstance(closure, AuthenticatedInitialRestartIntentClosure):
+            raise TypeError("closure must be AuthenticatedInitialRestartIntentClosure")
+        if closure.intent.intent.run_id != self._run_id:
+            raise ValueError("restart-intent closure belongs to another run")
+        opened = _opening_from_closure(closure)
+        node_ids = _active_node_ids(opened)
+        for _ in range(_MAX_READ_ATTEMPTS):
+            first = self._read_receipts(node_ids, opened=opened)
+            second = self._read_receipts(node_ids, opened=opened)
+            if first != second:
+                continue
+            try:
+                return RestartAckCollection(
+                    opened=opened,
+                    receipts_by_node_id=second,
+                )
+            except (TypeError, ValueError) as error:
+                raise RestartAckCollectionReadCorrupt(
+                    "persisted acknowledgements contradict the closed intent"
+                ) from error
+        raise RestartAckCollectionReadConflict(
+            "historical restart acknowledgements changed repeatedly during collection"
+        )
+
     def _read_receipts(
         self,
         node_ids: tuple[str, ...],
+        *,
+        opened: PersistedInitialRestartIntentOpen | None = None,
     ) -> dict[str, PersistedRestartAck | None]:
         receipts: dict[str, PersistedRestartAck | None] = {}
         for node_id in node_ids:
@@ -273,7 +343,9 @@ class RestartAckCollector:
                 )
                 self._receipt_readers[node_id] = reader
             try:
-                receipts[node_id] = reader.read()
+                receipts[node_id] = (
+                    reader.read() if opened is None else reader._read_for_opening(opened)
+                )
             except RestartAckReadCorrupt as error:
                 raise RestartAckCollectionReadCorrupt(
                     f"persisted acknowledgement for node {node_id!r} is corrupt"
@@ -284,7 +356,7 @@ class RestartAckCollector:
                 ) from error
         return receipts
 
-    def _read_open(self) -> CommittedInitialRestartIntentOpen:
+    def _read_open(self) -> PersistedInitialRestartIntentOpen:
         try:
             opened = self._open_reader.read()
         except RestartIntentOpenStateClosed as error:
@@ -309,7 +381,7 @@ class RestartAckCollector:
             ) from error
         if opened is None:
             raise RestartAckCollectionReadConflict("no current restart intent is open")
-        return opened
+        return PersistedInitialRestartIntentOpen.from_committed(opened)
 
 
 def _current_receipt(
@@ -370,30 +442,42 @@ def _coordinator_authority(
 
 
 def _acknowledgement_key(
-    opened: CommittedInitialRestartIntentOpen,
+    opened: PersistedInitialRestartIntentOpen,
     node_id: str,
 ) -> str:
     node_digest = hashlib.sha256(node_id.encode("utf-8")).hexdigest()
-    return f"{opened.prepared.intent_key}/acknowledgements/{node_digest}"
+    return f"{opened.intent_key}/acknowledgements/{node_digest}"
 
 
 def _active_node_ids(
-    opened: CommittedInitialRestartIntentOpen,
+    opened: PersistedInitialRestartIntentOpen,
 ) -> tuple[str, ...]:
-    slot_to_node_id = opened.prepared.current.snapshot.record.assignment.slot_to_node_id
+    slot_to_node_id = opened.generation_snapshot.record.assignment.slot_to_node_id
     return tuple(slot_to_node_id[slot_id] for slot_id in sorted(slot_to_node_id))
 
 
 def _same_committed_opening(
-    left: CommittedInitialRestartIntentOpen,
-    right: CommittedInitialRestartIntentOpen,
+    left: PersistedInitialRestartIntentOpen,
+    right: PersistedInitialRestartIntentOpen,
 ) -> bool:
-    return (
-        left.prepared.intent_key == right.prepared.intent_key
-        and left.intent_entry == right.intent_entry
-        and left.prepared.intent_head_key == right.prepared.intent_head_key
-        and left.head_entry == right.head_entry
-    )
+    return left == right
+
+
+def _opening_from_closure(
+    closure: AuthenticatedInitialRestartIntentClosure,
+) -> PersistedInitialRestartIntentOpen:
+    try:
+        return PersistedInitialRestartIntentOpen(
+            record=closure.intent,
+            head=closure.open_head,
+            generation_snapshot=closure.generation_snapshot,
+            intent_entry=closure.state.intent_entry,
+            head_entry=closure.state.open_head_entry,
+        )
+    except (TypeError, ValueError) as error:
+        raise RestartAckCollectionReadCorrupt(
+            "restart-intent closure has contradictory opening state"
+        ) from error
 
 
 def _nonempty_string(value: object, path: str) -> str:

--- a/lm_resiliency/integrations/torchrun/_restart_ack_reader.py
+++ b/lm_resiliency/integrations/torchrun/_restart_ack_reader.py
@@ -39,6 +39,11 @@ from lm_resiliency.integrations.torchrun._restart_ack_records import (
 from lm_resiliency.integrations.torchrun._restart_intent_lifecycle_auth import (
     AuthenticatedInitialRestartIntentClosure,
 )
+from lm_resiliency.integrations.torchrun._restart_intent_lifecycle_reader import (
+    InitialRestartIntentLifecycleReader,
+    RestartIntentLifecycleReadCorrupt,
+    RestartIntentLifecycleReadError,
+)
 from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
     CommittedInitialRestartIntentOpen,
     PersistedInitialRestartIntentOpen,
@@ -268,6 +273,10 @@ class RestartAckCollector:
             store,
             run_id=self._run_id,
         )
+        self._lifecycle_reader = InitialRestartIntentLifecycleReader(
+            store,
+            run_id=self._run_id,
+        )
         self._receipt_readers: dict[str, RestartAckReader] = {}
 
     def collect(self) -> RestartAckCollection:
@@ -306,12 +315,17 @@ class RestartAckCollector:
             raise TypeError("closure must be AuthenticatedInitialRestartIntentClosure")
         if closure.intent.intent.run_id != self._run_id:
             raise ValueError("restart-intent closure belongs to another run")
-        opened = _opening_from_closure(closure)
-        node_ids = _active_node_ids(opened)
         for _ in range(_MAX_READ_ATTEMPTS):
+            current_closure = self._read_closure()
+            if current_closure != closure:
+                continue
+            opened = _opening_from_closure(current_closure)
+            node_ids = _active_node_ids(opened)
             first = self._read_receipts(node_ids, opened=opened)
+            if self._read_closure() != current_closure:
+                continue
             second = self._read_receipts(node_ids, opened=opened)
-            if first != second:
+            if first != second or self._read_closure() != current_closure:
                 continue
             try:
                 return RestartAckCollection(
@@ -382,6 +396,29 @@ class RestartAckCollector:
         if opened is None:
             raise RestartAckCollectionReadConflict("no current restart intent is open")
         return PersistedInitialRestartIntentOpen.from_committed(opened)
+
+    def _read_closure(self) -> AuthenticatedInitialRestartIntentClosure:
+        try:
+            closure = self._lifecycle_reader.read()
+        except RestartIntentLifecycleReadCorrupt as error:
+            raise RestartAckCollectionReadCorrupt(
+                "persisted restart-intent lifecycle is corrupt"
+            ) from error
+        except RestartIntentLifecycleReadError as error:
+            raise RestartAckCollectionReadConflict(
+                "restart-intent lifecycle changed repeatedly during collection"
+            ) from error
+        except (CoordinatorLeaseHistoryCorrupt, GenerationStateCorrupt) as error:
+            raise RestartAckCollectionReadCorrupt(
+                "restart-intent lifecycle dependencies are corrupt"
+            ) from error
+        except (CoordinatorLeaseHistoryError, GenerationStateError) as error:
+            raise RestartAckCollectionReadConflict(
+                "restart-intent lifecycle dependencies changed repeatedly"
+            ) from error
+        if closure is None:
+            raise RestartAckCollectionReadConflict("restart intent is not closed")
+        return closure
 
 
 def _current_receipt(

--- a/lm_resiliency/integrations/torchrun/_restart_intent_open_execution.py
+++ b/lm_resiliency/integrations/torchrun/_restart_intent_open_execution.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass
+from typing import TypeAlias
 
 from lm_resiliency.integrations.torchrun._control_store import (
     ControlStore,
@@ -13,9 +15,18 @@ from lm_resiliency.integrations.torchrun._control_store import (
     ControlStoreHistoryConflict,
     ControlStoreTooEarly,
 )
+from lm_resiliency.integrations.torchrun._generation_reader import (
+    StoredGenerationSnapshot,
+)
 from lm_resiliency.integrations.torchrun._restart_intent_open_records import (
     PreparedInitialRestartIntentOpen,
 )
+from lm_resiliency.integrations.torchrun._restart_intent_records import (
+    RestartIntentHeadRecord,
+    RestartIntentRecord,
+)
+
+_CONTROL_PREFIX = "lm_resiliency/torchrun/v1"
 
 
 class RestartIntentOpenExecutionError(RuntimeError):
@@ -40,6 +51,165 @@ class RestartIntentOpenExecutionClockError(RestartIntentOpenExecutionError):
 
 class RestartIntentOpenExecutionCorrupt(RestartIntentOpenExecutionError):
     """Raised when the transaction returns contradictory committed state."""
+
+
+@dataclass(frozen=True, slots=True)
+class PersistedInitialRestartIntentOpen:
+    """One durable initial opening reconstructed without preparation inputs."""
+
+    record: RestartIntentRecord
+    head: RestartIntentHeadRecord
+    generation_snapshot: StoredGenerationSnapshot
+    intent_entry: ControlStoreEntry
+    head_entry: ControlStoreEntry
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.record, RestartIntentRecord):
+            raise TypeError("PersistedInitialRestartIntentOpen.record must be RestartIntentRecord")
+        if not isinstance(self.head, RestartIntentHeadRecord):
+            raise TypeError(
+                "PersistedInitialRestartIntentOpen.head must be RestartIntentHeadRecord"
+            )
+        if not isinstance(self.generation_snapshot, StoredGenerationSnapshot):
+            raise TypeError(
+                "PersistedInitialRestartIntentOpen.generation_snapshot must be "
+                "StoredGenerationSnapshot"
+            )
+        if not isinstance(self.intent_entry, ControlStoreEntry):
+            raise TypeError(
+                "PersistedInitialRestartIntentOpen.intent_entry must be ControlStoreEntry"
+            )
+        if not isinstance(self.head_entry, ControlStoreEntry):
+            raise TypeError(
+                "PersistedInitialRestartIntentOpen.head_entry must be ControlStoreEntry"
+            )
+        if (
+            self.head.run_id != self.record.intent.run_id
+            or self.head.generation != self.record.intent.generation
+            or self.head.intent_id != self.record.intent.intent_id
+            or self.head.intent_digest != self.record.digest
+        ):
+            raise ValueError("PersistedInitialRestartIntentOpen head does not identify its intent")
+        snapshot_record = self.generation_snapshot.record
+        if (
+            snapshot_record.assignment.run_id != self.record.intent.run_id
+            or snapshot_record.assignment.generation != self.record.intent.generation
+            or snapshot_record.digest != self.record.generation_snapshot_digest
+        ):
+            raise ValueError(
+                "PersistedInitialRestartIntentOpen source generation does not identify its intent"
+            )
+        if self.intent_entry.value != self.record.to_json():
+            raise ValueError("PersistedInitialRestartIntentOpen intent entry is noncanonical")
+        if self.head_entry.value != self.head.to_json():
+            raise ValueError("PersistedInitialRestartIntentOpen head entry is noncanonical")
+        for path, entry in (
+            ("intent_entry", self.intent_entry),
+            ("head_entry", self.head_entry),
+        ):
+            if (
+                entry.mutation_sequence != 1
+                or entry.value_sequence != 1
+                or entry.lifetime_sequence != 1
+            ):
+                raise ValueError(
+                    f"PersistedInitialRestartIntentOpen.{path} is not an immutable creation"
+                )
+            if entry.committed_at_unix_ms is None:
+                raise ValueError(
+                    f"PersistedInitialRestartIntentOpen.{path} has no authoritative commit time"
+                )
+            if (
+                entry.guard_key != self.coordinator_lease_key
+                or entry.guard_revision != self.record.coordinator_fencing_token
+                or entry.guard_value_digest != self.record.coordinator_lease_digest
+                or entry.guard_committed_at_unix_ms is None
+                or entry.guard_mutation_sequence is None
+                or entry.guard_value_sequence is None
+                or entry.guard_lifetime_sequence is None
+            ):
+                raise ValueError(
+                    f"PersistedInitialRestartIntentOpen.{path} has invalid lease provenance"
+                )
+        if (
+            self.intent_entry.transaction_sequence != self.head_entry.transaction_sequence
+            or self.intent_entry.committed_at_unix_ms != self.head_entry.committed_at_unix_ms
+            or self.intent_entry.guard_committed_at_unix_ms
+            != self.head_entry.guard_committed_at_unix_ms
+            or self.intent_entry.guard_mutation_sequence != self.head_entry.guard_mutation_sequence
+            or self.intent_entry.guard_value_sequence != self.head_entry.guard_value_sequence
+            or self.intent_entry.guard_lifetime_sequence != self.head_entry.guard_lifetime_sequence
+        ):
+            raise ValueError(
+                "PersistedInitialRestartIntentOpen entries do not share one transaction"
+            )
+        if self.transaction_sequence <= self.generation_snapshot.transaction_sequence:
+            raise ValueError(
+                "PersistedInitialRestartIntentOpen does not follow its source generation"
+            )
+        lease_granted_at_unix_ms = self.intent_entry.guard_committed_at_unix_ms
+        if lease_granted_at_unix_ms is None:
+            raise AssertionError("validated opening lost its lease grant time")
+        if (
+            self.committed_at_unix_ms < self.generation_snapshot.committed_at_unix_ms
+            or self.committed_at_unix_ms < lease_granted_at_unix_ms
+            or self.committed_at_unix_ms
+            >= min(
+                lease_granted_at_unix_ms + self.record.coordinator_lease_duration_ms,
+                self.record.intent.prepare_deadline_unix_ms,
+            )
+        ):
+            raise ValueError(
+                "PersistedInitialRestartIntentOpen commit is outside its authority window"
+            )
+
+    @classmethod
+    def from_committed(
+        cls,
+        opened: CommittedInitialRestartIntentOpen,
+    ) -> PersistedInitialRestartIntentOpen:
+        """Project one executor result into its durable identity."""
+
+        if not isinstance(opened, CommittedInitialRestartIntentOpen):
+            raise TypeError("opened must be CommittedInitialRestartIntentOpen")
+        return cls(
+            record=opened.prepared.record,
+            head=opened.prepared.head,
+            generation_snapshot=opened.prepared.current.snapshot,
+            intent_entry=opened.intent_entry,
+            head_entry=opened.head_entry,
+        )
+
+    @property
+    def run_id(self) -> str:
+        return self.record.intent.run_id
+
+    @property
+    def intent_key(self) -> str:
+        run_digest = hashlib.sha256(self.run_id.encode("utf-8")).hexdigest()
+        intent_digest = hashlib.sha256(self.record.intent.intent_id.encode("utf-8")).hexdigest()
+        return f"{_CONTROL_PREFIX}/runs/{run_digest}/restart-intents/{intent_digest}"
+
+    @property
+    def intent_head_key(self) -> str:
+        run_digest = hashlib.sha256(self.run_id.encode("utf-8")).hexdigest()
+        return f"{_CONTROL_PREFIX}/runs/{run_digest}/restart-intent-head"
+
+    @property
+    def coordinator_lease_key(self) -> str:
+        run_digest = hashlib.sha256(self.run_id.encode("utf-8")).hexdigest()
+        return f"{_CONTROL_PREFIX}/runs/{run_digest}/coordinator-lease"
+
+    @property
+    def committed_at_unix_ms(self) -> int:
+        committed_at_unix_ms = self.intent_entry.committed_at_unix_ms
+        if committed_at_unix_ms is None:
+            raise AssertionError("validated opening lost its commit time")
+        return committed_at_unix_ms
+
+    @property
+    def transaction_sequence(self) -> int:
+        return self.intent_entry.transaction_sequence
 
 
 @dataclass(frozen=True, slots=True)
@@ -144,6 +314,35 @@ class CommittedInitialRestartIntentOpen:
     def transaction_sequence(self) -> int:
         return self.intent_entry.transaction_sequence
 
+    @property
+    def record(self) -> RestartIntentRecord:
+        return self.prepared.record
+
+    @property
+    def head(self) -> RestartIntentHeadRecord:
+        return self.prepared.head
+
+    @property
+    def generation_snapshot(self) -> StoredGenerationSnapshot:
+        return self.prepared.current.snapshot
+
+    @property
+    def intent_key(self) -> str:
+        return self.prepared.intent_key
+
+    @property
+    def intent_head_key(self) -> str:
+        return self.prepared.intent_head_key
+
+    @property
+    def coordinator_lease_key(self) -> str:
+        return self.prepared.coordinator_lease_key
+
+
+RestartIntentOpening: TypeAlias = (
+    CommittedInitialRestartIntentOpen | PersistedInitialRestartIntentOpen
+)
+
 
 class RestartIntentOpenExecutor:
     """Commit and verify one prepared initial restart-intent opening."""
@@ -219,6 +418,8 @@ def _nonempty_string(value: object, path: str) -> str:
 
 __all__ = [
     "CommittedInitialRestartIntentOpen",
+    "PersistedInitialRestartIntentOpen",
+    "RestartIntentOpening",
     "RestartIntentOpenExecutionClockError",
     "RestartIntentOpenExecutionConflict",
     "RestartIntentOpenExecutionCorrupt",

--- a/lm_resiliency/integrations/torchrun/_restart_plan_state.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_state.py
@@ -937,11 +937,11 @@ class RestartPlanLatestEvidenceState:
                 "the exact current generation snapshot"
             )
         opened = self.acknowledgement_evidence.collection.opened
-        if opened.prepared.record != generation_state.intent_record:
+        if opened.record != generation_state.intent_record:
             raise ValueError(
                 "RestartPlanLatestEvidenceState acknowledgements answer another restart intent"
             )
-        if opened.prepared.current.snapshot.record != generation_state.from_snapshot:
+        if opened.generation_snapshot.record != generation_state.from_snapshot:
             raise ValueError(
                 "RestartPlanLatestEvidenceState acknowledgements belong to another generation"
             )

--- a/tests/unit/test_torchrun_restart_ack_collector.py
+++ b/tests/unit/test_torchrun_restart_ack_collector.py
@@ -231,6 +231,32 @@ def test_restart_ack_collector_reconstructs_historical_receipts_after_closure():
     assert collection.received_node_ids == ("node-a", "node-b")
 
 
+def test_restart_ack_collector_rejects_deleted_closed_opening():
+    store, _, clock, lease = _state_details(
+        committed_node_ids=("node-a", "node-b"),
+    )
+    prepared = RestartIntentClosurePreparer(
+        store,
+        run_id=RUN_ID,
+        clock=clock,
+    ).prepare_initial_closure(lease)
+    RestartIntentClosureExecutor(
+        store,
+        run_id=RUN_ID,
+    ).execute_initial_closure(prepared)
+    lifecycle_reader = InitialRestartIntentLifecycleReader(store, run_id=RUN_ID)
+    closure = lifecycle_reader.read()
+    assert closure is not None
+    intent_entry = closure.state.intent_entry
+    store.compare_delete(
+        lifecycle_reader.intent_key(closure.intent.intent.intent_id),
+        expected_revision=intent_entry.revision,
+    )
+
+    with pytest.raises(RestartAckCollectionReadCorrupt, match="lifecycle"):
+        RestartAckCollector(store, run_id=RUN_ID).collect_for_closure(closure)
+
+
 class SequencedCollector(RestartAckCollector):
     def __init__(
         self,

--- a/tests/unit/test_torchrun_restart_ack_collector.py
+++ b/tests/unit/test_torchrun_restart_ack_collector.py
@@ -42,10 +42,20 @@ from lm_resiliency.integrations.torchrun._restart_ack_reader import (
 from lm_resiliency.integrations.torchrun._restart_ack_records import (
     RestartAckReceiptRecord,
 )
+from lm_resiliency.integrations.torchrun._restart_intent_close_execution import (
+    RestartIntentClosureExecutor,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_close_preparation import (
+    RestartIntentClosurePreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_lifecycle_reader import (
+    InitialRestartIntentLifecycleReader,
+)
 from lm_resiliency.integrations.torchrun._restart_intent_open import (
     RestartIntentOpenPreparer,
 )
 from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
+    PersistedInitialRestartIntentOpen,
     RestartIntentOpenExecutor,
 )
 from lm_resiliency.integrations.torchrun._restart_intent_open_reader import (
@@ -71,6 +81,14 @@ def _state(
     *,
     committed_node_ids: tuple[str, ...],
 ) -> tuple[InMemoryControlStore, dict[str, PersistedRestartAck]]:
+    store, persisted, _, _ = _state_details(committed_node_ids=committed_node_ids)
+    return store, persisted
+
+
+def _state_details(
+    *,
+    committed_node_ids: tuple[str, ...],
+):
     clock = ManualClock()
     store = InMemoryControlStore(clock=clock)
     lease = CoordinatorLeaseManager(
@@ -163,7 +181,7 @@ def _state(
         ).read()
         assert persisted_receipt is not None
         persisted[node_id] = persisted_receipt
-    return store, persisted
+    return store, persisted, clock, lease
 
 
 def test_restart_ack_reader_returns_stable_complete_snapshot():
@@ -185,6 +203,34 @@ def test_restart_ack_reader_preserves_stable_absence():
     assert collection.missing_node_ids == ("node-b",)
 
 
+def test_restart_ack_collector_reconstructs_historical_receipts_after_closure():
+    store, _, clock, lease = _state_details(
+        committed_node_ids=("node-a", "node-b"),
+    )
+    prepared = RestartIntentClosurePreparer(
+        store,
+        run_id=RUN_ID,
+        clock=clock,
+    ).prepare_initial_closure(lease)
+    RestartIntentClosureExecutor(
+        store,
+        run_id=RUN_ID,
+    ).execute_initial_closure(prepared)
+    closure = InitialRestartIntentLifecycleReader(store, run_id=RUN_ID).read()
+    assert closure is not None
+
+    with pytest.raises(RestartAckCollectionReadConflict, match="closed"):
+        RestartAckCollector(store, run_id=RUN_ID).collect()
+
+    collection = RestartAckCollector(store, run_id=RUN_ID).collect_for_closure(closure)
+
+    assert collection.opened.record == closure.intent
+    assert collection.opened.head == closure.open_head
+    assert collection.opened.intent_entry == closure.state.intent_entry
+    assert collection.opened.head_entry == closure.state.open_head_entry
+    assert collection.received_node_ids == ("node-a", "node-b")
+
+
 class SequencedCollector(RestartAckCollector):
     def __init__(
         self,
@@ -199,7 +245,10 @@ class SequencedCollector(RestartAckCollector):
     def _read_receipts(
         self,
         node_ids: tuple[str, ...],
+        *,
+        opened: PersistedInitialRestartIntentOpen | None = None,
     ) -> dict[str, PersistedRestartAck | None]:
+        assert opened is None
         self.read_count += 1
         node_b = None if self.read_count == 1 else self.received["node-b"]
         return {

--- a/tests/unit/test_torchrun_restart_ack_evidence.py
+++ b/tests/unit/test_torchrun_restart_ack_evidence.py
@@ -51,9 +51,21 @@ from lm_resiliency.integrations.torchrun._restart_ack_execution import (
 from lm_resiliency.integrations.torchrun._restart_ack_preparation import (
     RestartAckPreparer,
 )
-from lm_resiliency.integrations.torchrun._restart_ack_reader import RestartAckReader
+from lm_resiliency.integrations.torchrun._restart_ack_reader import (
+    RestartAckCollector,
+    RestartAckReader,
+)
 from lm_resiliency.integrations.torchrun._restart_ack_records import (
     RestartAckReceiptRecord,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_close_execution import (
+    RestartIntentClosureExecutor,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_close_preparation import (
+    RestartIntentClosurePreparer,
+)
+from lm_resiliency.integrations.torchrun._restart_intent_lifecycle_reader import (
+    InitialRestartIntentLifecycleReader,
 )
 from lm_resiliency.integrations.torchrun._restart_intent_open import (
     RestartIntentOpenPreparer,
@@ -139,6 +151,7 @@ def _evidence(
     event: CheckpointInventoryEvent | None = None,
     intent_id: str = "intent-a",
     generation: int = 0,
+    close_intent: bool = False,
 ) -> tuple[RestartAckEvidence, CheckpointInventoryEvent]:
     clock = ManualClock()
     store = InMemoryControlStore(clock=clock)
@@ -228,13 +241,30 @@ def _evidence(
             node_id="node-a",
         ).read()
         assert persisted is not None
-    collection = RestartAckCollection(
-        opened=opened,
-        receipts_by_node_id={
-            "node-a": persisted,
-            "node-b": None,
-        },
-    )
+    if close_intent:
+        prepared_closure = RestartIntentClosurePreparer(
+            store,
+            run_id=RUN_ID,
+            clock=clock,
+        ).prepare_initial_closure(lease)
+        RestartIntentClosureExecutor(
+            store,
+            run_id=RUN_ID,
+        ).execute_initial_closure(prepared_closure)
+        closure = InitialRestartIntentLifecycleReader(store, run_id=RUN_ID).read()
+        assert closure is not None
+        collection = RestartAckCollector(
+            store,
+            run_id=RUN_ID,
+        ).collect_for_closure(closure)
+    else:
+        collection = RestartAckCollection(
+            opened=opened,
+            receipts_by_node_id={
+                "node-a": persisted,
+                "node-b": None,
+            },
+        )
     return RestartAckEvidence(collection), event
 
 
@@ -262,9 +292,9 @@ def _latest_inventory_state(
     event: CheckpointInventoryEvent,
 ) -> RestartPlanInventoryState:
     opened = evidence.collection.opened
-    intent_record = opened.prepared.record
+    intent_record = opened.record
     intent = intent_record.intent
-    from_snapshot = opened.prepared.current.snapshot.record
+    from_snapshot = opened.generation_snapshot.record
     lifecycle = RestartIntentLifecycleRecord(
         closed_intent=RestartIntentHeadRecord(
             run_id=intent.run_id,
@@ -357,7 +387,7 @@ def _latest_inventory_state(
         generation_state=generation_state,
         resolved_manifest=ResolvedRecoveryManifest(
             record=manifest_record,
-            source_snapshot=opened.prepared.current.snapshot,
+            source_snapshot=opened.generation_snapshot,
         ),
     )
     return RestartPlanInventoryState(
@@ -659,6 +689,19 @@ def test_restart_plan_latest_evidence_state_binds_exact_acknowledgements():
 
     assert state.plan == inventory_state.plan
     assert state.manifest == inventory_state.manifest
+    assert state.acknowledgement_evidence.authorizes_latest_inventory(event)
+
+
+def test_restart_plan_latest_evidence_state_accepts_historical_acknowledgements():
+    event = _latest_event()
+    evidence, _ = _evidence(event=event, close_intent=True)
+    inventory_state = _latest_inventory_state(evidence, event)
+
+    state = RestartPlanLatestEvidenceState(
+        inventory_state=inventory_state,
+        acknowledgement_evidence=evidence,
+    )
+
     assert state.acknowledgement_evidence.authorizes_latest_inventory(event)
 
 


### PR DESCRIPTION
## Summary
- add a durable restart-intent opening identity reconstructed from committed immutable records
- allow persisted acknowledgements and collections to use either the live committed opening or its durable projection
- collect historical acknowledgements only through an authenticated closed lifecycle value
- revalidate the authoritative lifecycle before, between, and after receipt scans
- keep the current write/preparation path unchanged and keep the torchrun production module count at 39

## Safety boundary
- historical per-node reading remains private; the public collector requires `AuthenticatedInitialRestartIntentClosure`
- canonical intent/head bytes, immutable entry lineage, generation identity, coordinator guard provenance, transaction order, and authority time windows are revalidated
- deletion or corruption of retained lifecycle/opening state fails closed during collection
- historical collections are exercised through `RestartAckEvidence` and `RestartPlanLatestEvidenceState`

## Validation
- 275 focused tests passed
- 2,359 full CPU tests passed with CUDA hidden
- repository-wide Ruff and formatting checks passed
- targeted mypy checks passed
- `git diff --check` passed

## Out of scope
- direct automatic wiring from restart-plan readback to the historical collector
- rendezvous/runtime activation
- public API exports