### PR TITLE
[Feature][Torchrun] Automatically reauthorize latest acknowledgements

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -920,11 +920,11 @@ signed publication, and requires the publication transaction and commit time
 to follow lifecycle closure, before returning the reauthorized recovery state.
 Repeated lifecycle, generation, or lease-history movement remains a retryable
 conflict; missing, mixed, causally impossible, or unsafe recovery evidence
-fails closed. For `latest`, the caller supplies the exact stable
-restart-acknowledgement evidence reconstructed from the authenticated closed
-intent by calling the historical acknowledgement collector and passing the
-resulting evidence to `read_recovery_state()`. Direct collector wiring remains
-a following integration step.
+fails closed. For `latest`, `read_recovery_state()` automatically reconstructs
+the exact stable restart-acknowledgement evidence from the same authenticated
+closed intent when the caller does not supply evidence explicitly. Collector
+contention remains retryable; missing, corrupted, or contradictory historical
+receipts fail closed.
 
 Before commit, the coordinator validates:
 

--- a/lm_resiliency/integrations/torchrun/_restart_plan_publication.py
+++ b/lm_resiliency/integrations/torchrun/_restart_plan_publication.py
@@ -27,6 +27,11 @@ from lm_resiliency.integrations.torchrun._quarantine_store import node_quarantin
 from lm_resiliency.integrations.torchrun._restart_ack_collection import (
     RestartAckEvidence,
 )
+from lm_resiliency.integrations.torchrun._restart_ack_reader import (
+    RestartAckCollectionReadConflict,
+    RestartAckCollectionReadCorrupt,
+    RestartAckCollector,
+)
 from lm_resiliency.integrations.torchrun._restart_intent_lifecycle_auth import (
     AuthenticatedInitialRestartIntentClosure,
 )
@@ -268,6 +273,10 @@ class RestartPlanPublicationReader:
             store,
             run_id=self._run_id,
         )
+        self._ack_collector = RestartAckCollector(
+            store,
+            run_id=self._run_id,
+        )
 
     def read(self) -> PersistedRestartPlanPublication | None:
         """Return the stable publication for the current generation, if any."""
@@ -308,6 +317,12 @@ class RestartPlanPublicationReader:
                 return None
             lifecycle = self._read_lifecycle()
             manifest_source = self._read_manifest_source(publication)
+            resolved_acknowledgement_evidence = acknowledgement_evidence
+            if (
+                publication.manifest_record.manifest.trust == "latest"
+                and resolved_acknowledgement_evidence is None
+            ):
+                resolved_acknowledgement_evidence = self._read_acknowledgement_evidence(lifecycle)
             if (
                 self.read() != publication
                 or self._read_lifecycle() != lifecycle
@@ -318,7 +333,7 @@ class RestartPlanPublicationReader:
                 publication,
                 lifecycle,
                 manifest_source,
-                acknowledgement_evidence,
+                resolved_acknowledgement_evidence,
             )
         raise RestartPlanPublicationReadConflict(
             "restart-plan recovery state changed repeatedly during read"
@@ -381,6 +396,28 @@ class RestartPlanPublicationReader:
                 "restart-plan publication references a missing manifest source generation"
             )
         return snapshot
+
+    def _read_acknowledgement_evidence(
+        self,
+        lifecycle: AuthenticatedInitialRestartIntentClosure,
+    ) -> RestartAckEvidence:
+        try:
+            collection = self._ack_collector.collect_for_closure(lifecycle)
+        except RestartAckCollectionReadCorrupt as error:
+            raise RestartPlanPublicationReadCorrupt(
+                "historical restart acknowledgements are corrupt while reauthorizing publication"
+            ) from error
+        except RestartAckCollectionReadConflict as error:
+            raise RestartPlanPublicationReadConflict(
+                "historical restart acknowledgements changed repeatedly while "
+                "reauthorizing publication"
+            ) from error
+        try:
+            return RestartAckEvidence(collection)
+        except (TypeError, ValueError) as error:
+            raise RestartPlanPublicationReadCorrupt(
+                "historical restart acknowledgements contradict the publication"
+            ) from error
 
     def _reauthorize(
         self,

--- a/tests/unit/test_torchrun_restart_ack_evidence.py
+++ b/tests/unit/test_torchrun_restart_ack_evidence.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import threading
 from dataclasses import replace
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -52,6 +53,8 @@ from lm_resiliency.integrations.torchrun._restart_ack_preparation import (
     RestartAckPreparer,
 )
 from lm_resiliency.integrations.torchrun._restart_ack_reader import (
+    RestartAckCollectionReadConflict,
+    RestartAckCollectionReadCorrupt,
     RestartAckCollector,
     RestartAckReader,
 )
@@ -76,6 +79,11 @@ from lm_resiliency.integrations.torchrun._restart_intent_open_execution import (
 from lm_resiliency.integrations.torchrun._restart_intent_records import (
     RestartIntentHeadRecord,
     RestartIntentLifecycleRecord,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_publication import (
+    RestartPlanPublicationReadConflict,
+    RestartPlanPublicationReadCorrupt,
+    RestartPlanPublicationReader,
 )
 from lm_resiliency.integrations.torchrun._restart_plan_records import (
     RecoveryManifestRecord,
@@ -106,6 +114,56 @@ class ManualClock:
     def __call__(self) -> int:
         with self._lock:
             return self.now_unix_ms
+
+
+class StaticAckCollector:
+    def __init__(
+        self,
+        result: RestartAckCollection | Exception | object,
+    ) -> None:
+        self.result = result
+        self.closures: list[object] = []
+
+    def collect_for_closure(self, closure: object) -> RestartAckCollection:
+        self.closures.append(closure)
+        if isinstance(self.result, Exception):
+            raise self.result
+        return cast(RestartAckCollection, self.result)
+
+
+class StaticLatestPublicationReader(RestartPlanPublicationReader):
+    def __init__(
+        self,
+        publication: PersistedRestartPlanPublication,
+        generation_state: RestartPlanGenerationState,
+        source_snapshot: StoredGenerationSnapshot,
+        collector: StaticAckCollector,
+    ) -> None:
+        super().__init__(InMemoryControlStore(), run_id=RUN_ID)
+        self._publication = publication
+        self._source_snapshot = source_snapshot
+        self._static_lifecycle = SimpleNamespace(
+            intent=generation_state.intent_record,
+            lifecycle=generation_state.lifecycle_record,
+            generation_snapshot=source_snapshot,
+            immediate_successor=self._stored_successor(publication),
+            transaction_sequence=publication.transaction_sequence - 1,
+            closed_at_unix_ms=publication.committed_at_unix_ms,
+        )
+        self._ack_collector = cast(Any, collector)
+
+    def read(self) -> PersistedRestartPlanPublication:
+        return self._publication
+
+    def _read_lifecycle(self) -> Any:
+        return self._static_lifecycle
+
+    def _read_manifest_source(
+        self,
+        publication: PersistedRestartPlanPublication,
+    ) -> StoredGenerationSnapshot:
+        assert publication == self._publication
+        return self._source_snapshot
 
 
 def _event(
@@ -472,6 +530,104 @@ def _persisted_latest_recovery_inputs(
         generation_state,
         manifest_state.resolved_manifest.source_snapshot,
     )
+
+
+def _automatic_latest_reader(
+    evidence: RestartAckEvidence,
+    event: CheckpointInventoryEvent,
+    *,
+    collector_result: RestartAckCollection | Exception | object | None = None,
+) -> tuple[StaticLatestPublicationReader, StaticAckCollector]:
+    publication, generation_state, source_snapshot = _persisted_latest_recovery_inputs(
+        evidence,
+        event,
+    )
+    collector = StaticAckCollector(
+        evidence.collection if collector_result is None else collector_result
+    )
+    return (
+        StaticLatestPublicationReader(
+            publication,
+            generation_state,
+            source_snapshot,
+            collector,
+        ),
+        collector,
+    )
+
+
+def test_publication_reader_automatically_collects_latest_acknowledgements():
+    event = _latest_event()
+    evidence, _ = _evidence(event=event, close_intent=True)
+    reader, collector = _automatic_latest_reader(evidence, event)
+
+    state = reader.read_recovery_state()
+
+    assert state is not None
+    assert isinstance(state.recovery_state.trust_state, RestartPlanLatestEvidenceState)
+    assert state.recovery_state.trust_state.acknowledgement_evidence == evidence
+    assert collector.closures == [reader._static_lifecycle]
+
+
+def test_publication_reader_explicit_latest_evidence_skips_collection():
+    event = _latest_event()
+    evidence, _ = _evidence(event=event, close_intent=True)
+    reader, collector = _automatic_latest_reader(
+        evidence,
+        event,
+        collector_result=AssertionError("collector should not run"),
+    )
+
+    state = reader.read_recovery_state(acknowledgement_evidence=evidence)
+
+    assert state is not None
+    assert state.recovery_state.trust_state.acknowledgement_evidence == evidence
+    assert collector.closures == []
+
+
+@pytest.mark.parametrize(
+    ("collector_error", "expected"),
+    [
+        (
+            RestartAckCollectionReadConflict("busy"),
+            RestartPlanPublicationReadConflict,
+        ),
+        (
+            RestartAckCollectionReadCorrupt("bad"),
+            RestartPlanPublicationReadCorrupt,
+        ),
+    ],
+)
+def test_publication_reader_translates_automatic_collection_errors(
+    collector_error: Exception,
+    expected: type[Exception],
+):
+    event = _latest_event()
+    evidence, _ = _evidence(event=event, close_intent=True)
+    reader, _ = _automatic_latest_reader(
+        evidence,
+        event,
+        collector_result=collector_error,
+    )
+
+    with pytest.raises(expected):
+        reader.read_recovery_state()
+
+
+def test_publication_reader_rejects_contradictory_collector_output():
+    event = _latest_event()
+    evidence, _ = _evidence(event=event, close_intent=True)
+    reader, _ = _automatic_latest_reader(
+        evidence,
+        event,
+        collector_result=object(),
+    )
+
+    with pytest.raises(
+        RestartPlanPublicationReadCorrupt,
+        match="historical restart acknowledgements contradict",
+    ):
+        reader.read_recovery_state()
 
 
 def test_persisted_latest_recovery_accepts_matching_acknowledgements():


### PR DESCRIPTION
## What changed

- Automatically reconstruct historical restart-acknowledgement evidence for persisted `latest` restart-plan publications.
- Preserve the explicit evidence argument as an internal compatibility override.
- Translate acknowledgement collection contention and corruption into the existing publication read error boundary.
- Document the automatic failover readback behavior.

## Why

Persisted `latest` plans previously required callers to manually collect historical acknowledgements and pass evidence into `read_recovery_state()`. The publication reader already owns the authenticated closed lifecycle, so it can perform that reconstruction safely and keep one retryable/fail-closed read boundary.

## Compatibility

No public API or wire-format change. The optional explicit acknowledgement evidence remains supported. No production module is added; the torchrun package remains at 39 modules.

## Validation

- 246 focused torchrun tests
- 2,364 full CPU tests with CUDA hidden
- Ruff check and format
- Targeted mypy for touched production and test files
- `git diff --check`

Repository-wide mypy continues to report pre-existing `_protocol.py` diagnostics unrelated to this change.