### PR TITLE
[Feature][torchrun] Add runtime configuration and restart context

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1778,7 +1778,29 @@ framework durable checkpoint.
 The custom rendezvous backend makes replacement-only semantics explicit without
 changing torchrun's default behavior:
 
+```toml
+# /shared/lm-resiliency/torchrun.toml
+schema_version = 1
+control_endpoint = "control.internal:443"
+replacement_only = true
+max_replacement_generations = 2
+registration_lease_duration_ms = 30000
+poll_interval_ms = 1000
+join_timeout_ms = 300000
+```
+
+The shared policy file contains no node identity or credentials. Every agent
+loads the file, applies any explicitly supplied shared `--rdzv-conf`
+overrides, and registers the canonical resolved-policy digest so drift in
+whitespace does not matter but drift in effective settings fails closed.
+Node-specific `node_id` and `restart_context_path` values come from
+`--rdzv-conf` or `LM_RESILIENCY_NODE_ID` and
+`LM_RESILIENCY_RESTART_CONTEXT`; conflicting sources are rejected. Credentials
+and other secrets remain in deployment-provided environment or credential
+providers and are not included in the policy file or digest.
+
 ```bash
+export LM_RESILIENCY_NODE_ID="${SCHEDULER_NODE_ID}"
 export LM_RESILIENCY_RESTART_CONTEXT="/run/lm-resiliency/${JOB_ID}/restart-context.json"
 
 torchrun \
@@ -1787,7 +1809,7 @@ torchrun \
   --rdzv-backend=lm_resiliency \
   --rdzv-endpoint="${RDZV_ENDPOINT}" \
   --rdzv-id="${JOB_ID}" \
-  --rdzv-conf="control_endpoint=${CONTROL_ENDPOINT},replacement_only=true,max_replacement_generations=2" \
+  --rdzv-conf="config=/shared/lm-resiliency/torchrun.toml" \
   --module torchtitan.train ...
 ```
 

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1791,8 +1791,10 @@ join_timeout_ms = 300000
 
 The shared policy file contains no node identity or credentials. Every agent
 loads the file, applies any explicitly supplied shared `--rdzv-conf`
-overrides, and registers the canonical resolved-policy digest so drift in
-whitespace does not matter but drift in effective settings fails closed.
+overrides, and registers the canonical runtime digest over the resolved policy,
+run ID, rendezvous endpoint, and `min_nodes`/`max_nodes` range. Drift in
+whitespace or node-local settings does not matter, while drift in effective
+shared settings or fleet-size semantics fails closed.
 Node-specific `node_id` and `restart_context_path` values come from
 `--rdzv-conf` or `LM_RESILIENCY_NODE_ID` and
 `LM_RESILIENCY_RESTART_CONTEXT`; conflicting sources are rejected. Credentials

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -224,6 +224,8 @@ class RestartContextFile:
         parent = self._prepare_parent()
         self._reject_existing_symlink()
         encoded = (context.to_json() + "\n").encode("utf-8")
+        if len(encoded) > _MAX_CONTEXT_BYTES:
+            raise RestartContextFileError("restart context is too large")
         descriptor, temporary = tempfile.mkstemp(
             prefix=f".{self.path.name}.",
             suffix=".tmp",
@@ -255,7 +257,7 @@ class RestartContextFile:
 
     def read(self) -> RestartContext:
         self._validate_parent()
-        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
         try:
             descriptor = os.open(self.path, flags)
         except OSError as error:
@@ -290,6 +292,7 @@ class RestartContextFile:
         try:
             self.path.unlink()
         except FileNotFoundError:
+            self._fsync_directory(self.path.parent)
             return
         except OSError as error:
             raise RestartContextFileError(

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -1,0 +1,493 @@
+"""Runtime configuration and node-local restart-context handoff for torchrun."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+import os
+import stat
+import tempfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, ClassVar
+
+try:
+    _toml = importlib.import_module("tomllib")
+except ModuleNotFoundError:  # pragma: no cover - exercised by the Python 3.10 CI job.
+    _toml = importlib.import_module("tomli")
+
+from torch.distributed.elastic.rendezvous import RendezvousParameters
+
+from lm_resiliency.integrations.torchrun._protocol import RestartContext
+
+_BACKEND = "lm_resiliency"
+_NODE_ID_ENV = "LM_RESILIENCY_NODE_ID"
+_RESTART_CONTEXT_ENV = "LM_RESILIENCY_RESTART_CONTEXT"
+_MAX_CONTEXT_BYTES = 64 * 1024
+_SHARED_FIELDS = {
+    "control_endpoint",
+    "replacement_only",
+    "max_replacement_generations",
+    "registration_lease_duration_ms",
+    "poll_interval_ms",
+    "join_timeout_ms",
+}
+_RUNTIME_FIELDS = _SHARED_FIELDS | {
+    "config",
+    "node_id",
+    "restart_context_path",
+}
+
+
+class TorchrunRuntimeConfigError(ValueError):
+    """Raised when torchrun runtime configuration is unsafe or contradictory."""
+
+
+class RestartContextFileError(RuntimeError):
+    """Raised when the node-local restart-context file is unsafe or malformed."""
+
+
+@dataclass(frozen=True, slots=True)
+class TorchrunRendezvousPolicy:
+    """Shared replacement-only policy resolved identically by every agent."""
+
+    SCHEMA_VERSION: ClassVar[int] = 1
+
+    control_endpoint: str
+    replacement_only: bool = True
+    max_replacement_generations: int = 2
+    registration_lease_duration_ms: int = 30_000
+    poll_interval_ms: int = 1_000
+    join_timeout_ms: int = 300_000
+
+    def __post_init__(self) -> None:
+        _nonempty_string(self.control_endpoint, "control_endpoint")
+        if not isinstance(self.replacement_only, bool):
+            raise TorchrunRuntimeConfigError("replacement_only must be a boolean")
+        if not self.replacement_only:
+            raise TorchrunRuntimeConfigError(
+                "replacement_only=false is unsupported by the lm_resiliency backend"
+            )
+        _positive_integer(
+            self.max_replacement_generations,
+            "max_replacement_generations",
+        )
+        _positive_integer(
+            self.registration_lease_duration_ms,
+            "registration_lease_duration_ms",
+        )
+        _positive_integer(self.poll_interval_ms, "poll_interval_ms")
+        _positive_integer(self.join_timeout_ms, "join_timeout_ms")
+        if self.registration_lease_duration_ms <= self.poll_interval_ms:
+            raise TorchrunRuntimeConfigError(
+                "registration_lease_duration_ms must exceed poll_interval_ms"
+            )
+        if self.join_timeout_ms <= self.poll_interval_ms:
+            raise TorchrunRuntimeConfigError("join_timeout_ms must exceed poll_interval_ms")
+
+    @property
+    def digest(self) -> str:
+        """Return the canonical digest agents register for drift detection."""
+
+        encoded = json.dumps(
+            self.to_dict(),
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "control_endpoint": self.control_endpoint,
+            "replacement_only": self.replacement_only,
+            "max_replacement_generations": self.max_replacement_generations,
+            "registration_lease_duration_ms": self.registration_lease_duration_ms,
+            "poll_interval_ms": self.poll_interval_ms,
+            "join_timeout_ms": self.join_timeout_ms,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class TorchrunRuntimeConfig:
+    """Resolved shared policy and node-local torchrun inputs."""
+
+    policy: TorchrunRendezvousPolicy
+    run_id: str
+    endpoint: str
+    min_nodes: int
+    max_nodes: int
+    node_id: str
+    restart_context_path: Path
+    local_addr: str | None
+    source_path: Path
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.policy, TorchrunRendezvousPolicy):
+            raise TypeError("policy must be TorchrunRendezvousPolicy")
+        _nonempty_string(self.run_id, "run_id")
+        _nonempty_string(self.endpoint, "endpoint")
+        _positive_integer(self.min_nodes, "min_nodes")
+        _positive_integer(self.max_nodes, "max_nodes")
+        if self.max_nodes <= self.min_nodes:
+            raise TorchrunRuntimeConfigError(
+                "max_nodes must exceed min_nodes to provide standby capacity"
+            )
+        _nonempty_string(self.node_id, "node_id")
+        if not isinstance(self.restart_context_path, Path):
+            raise TypeError("restart_context_path must be pathlib.Path")
+        if not self.restart_context_path.is_absolute():
+            raise TorchrunRuntimeConfigError("restart_context_path must be absolute")
+        if self.local_addr is not None:
+            _nonempty_string(self.local_addr, "local_addr")
+        if not isinstance(self.source_path, Path) or not self.source_path.is_absolute():
+            raise TorchrunRuntimeConfigError("source_path must be an absolute pathlib.Path")
+
+    @classmethod
+    def from_parameters(
+        cls,
+        params: RendezvousParameters,
+        *,
+        environment: Mapping[str, str] | None = None,
+    ) -> TorchrunRuntimeConfig:
+        if not isinstance(params, RendezvousParameters):
+            raise TypeError("params must be RendezvousParameters")
+        if params.backend != _BACKEND:
+            raise TorchrunRuntimeConfigError(
+                f"rendezvous backend must be {_BACKEND!r}, got {params.backend!r}"
+            )
+        unknown = set(params.config) - _RUNTIME_FIELDS
+        if unknown:
+            raise TorchrunRuntimeConfigError(
+                f"unknown rendezvous configuration fields: {sorted(unknown)!r}"
+            )
+        source_path = Path(
+            _nonempty_string(params.get("config"), "rendezvous config path")
+        ).expanduser()
+        if not source_path.is_absolute():
+            raise TorchrunRuntimeConfigError("rendezvous config path must be absolute")
+        policy_values = _load_policy_values(source_path)
+        for field in _SHARED_FIELDS:
+            value = params.get(field)
+            if value is not None:
+                policy_values[field] = value
+        policy = _policy_from_values(policy_values)
+        resolved_environment = MappingProxyType(
+            dict(os.environ if environment is None else environment)
+        )
+        node_id = _node_value(
+            params.get("node_id"),
+            resolved_environment.get(_NODE_ID_ENV),
+            "node_id",
+            _NODE_ID_ENV,
+        )
+        restart_context_path = Path(
+            _node_value(
+                params.get("restart_context_path"),
+                resolved_environment.get(_RESTART_CONTEXT_ENV),
+                "restart_context_path",
+                _RESTART_CONTEXT_ENV,
+            )
+        ).expanduser()
+        return cls(
+            policy=policy,
+            run_id=params.run_id,
+            endpoint=params.endpoint,
+            min_nodes=params.min_nodes,
+            max_nodes=params.max_nodes,
+            node_id=node_id,
+            restart_context_path=restart_context_path,
+            local_addr=params.local_addr,
+            source_path=source_path,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RestartContextFile:
+    """Atomically persist and validate one owner-only restart context."""
+
+    path: Path
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.path, Path):
+            raise TypeError("path must be pathlib.Path")
+        if not self.path.is_absolute():
+            raise RestartContextFileError("restart-context path must be absolute")
+
+    def write(self, context: RestartContext) -> None:
+        if not isinstance(context, RestartContext):
+            raise TypeError("context must be RestartContext")
+        parent = self._prepare_parent()
+        self._reject_existing_symlink()
+        encoded = (context.to_json() + "\n").encode("utf-8")
+        descriptor, temporary = tempfile.mkstemp(
+            prefix=f".{self.path.name}.",
+            suffix=".tmp",
+            dir=parent,
+        )
+        try:
+            os.fchmod(descriptor, 0o600)
+            with os.fdopen(descriptor, "wb") as stream:
+                descriptor = -1
+                stream.write(encoded)
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(temporary, self.path)
+            self._fsync_directory(parent)
+        except OSError as error:
+            raise RestartContextFileError(
+                f"failed to publish restart context at {self.path}"
+            ) from error
+        finally:
+            if descriptor >= 0:
+                try:
+                    os.close(descriptor)
+                except OSError:
+                    pass
+            try:
+                os.unlink(temporary)
+            except OSError:
+                pass
+
+    def read(self) -> RestartContext:
+        self._validate_parent()
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            descriptor = os.open(self.path, flags)
+        except OSError as error:
+            raise RestartContextFileError(
+                f"failed to open restart context at {self.path}"
+            ) from error
+        try:
+            metadata = os.fstat(descriptor)
+            self._validate_owned_private_file(metadata)
+            with os.fdopen(descriptor, "rb", closefd=False) as stream:
+                encoded = stream.read(_MAX_CONTEXT_BYTES + 1)
+            if len(encoded) > _MAX_CONTEXT_BYTES:
+                raise RestartContextFileError("restart-context file is too large")
+        finally:
+            os.close(descriptor)
+        try:
+            value = json.loads(
+                encoded,
+                object_pairs_hook=_strict_object,
+            )
+            if not isinstance(value, Mapping):
+                raise RestartContextFileError("restart-context JSON must contain an object")
+            return RestartContext.from_dict(value)
+        except RestartContextFileError:
+            raise
+        except (TypeError, ValueError, UnicodeDecodeError) as error:
+            raise RestartContextFileError("restart-context file is malformed") from error
+
+    def clear(self) -> None:
+        self._validate_parent()
+        self._reject_existing_symlink()
+        try:
+            self.path.unlink()
+        except FileNotFoundError:
+            return
+        except OSError as error:
+            raise RestartContextFileError(
+                f"failed to remove restart context at {self.path}"
+            ) from error
+        self._fsync_directory(self.path.parent)
+
+    def _prepare_parent(self) -> Path:
+        parent = self.path.parent
+        try:
+            parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        except OSError as error:
+            raise RestartContextFileError(
+                f"failed to create restart-context directory {parent}"
+            ) from error
+        self._validate_parent()
+        return parent
+
+    def _validate_parent(self) -> None:
+        parent = self.path.parent
+        try:
+            metadata = parent.lstat()
+        except OSError as error:
+            raise RestartContextFileError(
+                f"failed to inspect restart-context directory {parent}"
+            ) from error
+        if stat.S_ISLNK(metadata.st_mode):
+            raise RestartContextFileError("restart-context parent directory must not be a symlink")
+        if not stat.S_ISDIR(metadata.st_mode):
+            raise RestartContextFileError("restart-context parent is not a directory")
+        if metadata.st_uid != os.geteuid():
+            raise RestartContextFileError("restart-context directory is owned by another user")
+        if stat.S_IMODE(metadata.st_mode) & 0o077:
+            raise RestartContextFileError(
+                "restart-context directory must not grant group or other permissions"
+            )
+
+    def _reject_existing_symlink(self) -> None:
+        try:
+            metadata = self.path.lstat()
+        except FileNotFoundError:
+            return
+        except OSError as error:
+            raise RestartContextFileError(
+                f"failed to inspect restart context at {self.path}"
+            ) from error
+        if stat.S_ISLNK(metadata.st_mode):
+            raise RestartContextFileError("restart-context path must not be a symlink")
+
+    @staticmethod
+    def _validate_owned_private_file(metadata: os.stat_result) -> None:
+        if not stat.S_ISREG(metadata.st_mode):
+            raise RestartContextFileError("restart-context path is not a regular file")
+        if metadata.st_uid != os.geteuid():
+            raise RestartContextFileError("restart-context file is owned by another user")
+        if stat.S_IMODE(metadata.st_mode) & 0o077:
+            raise RestartContextFileError(
+                "restart-context file must not grant group or other permissions"
+            )
+
+    @staticmethod
+    def _fsync_directory(directory: Path) -> None:
+        descriptor = os.open(
+            directory,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+        )
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+
+
+def _load_policy_values(path: Path) -> dict[str, object]:
+    try:
+        with path.open("rb") as stream:
+            value = _toml.load(stream)
+    except (OSError, _toml.TOMLDecodeError) as error:
+        raise TorchrunRuntimeConfigError(f"failed to load rendezvous config {path}") from error
+    if not isinstance(value, dict):
+        raise TorchrunRuntimeConfigError("rendezvous config must contain a TOML table")
+    actual_schema = value.get("schema_version")
+    if type(actual_schema) is not int or actual_schema != 1:
+        raise TorchrunRuntimeConfigError(
+            f"schema_version must be the integer 1, got {actual_schema!r}"
+        )
+    unknown = set(value) - _SHARED_FIELDS - {"schema_version"}
+    if unknown:
+        raise TorchrunRuntimeConfigError(f"unknown rendezvous config fields: {sorted(unknown)!r}")
+    return {field: value[field] for field in _SHARED_FIELDS if field in value}
+
+
+def _policy_from_values(values: Mapping[str, object]) -> TorchrunRendezvousPolicy:
+    try:
+        return TorchrunRendezvousPolicy(
+            control_endpoint=_nonempty_string(
+                values.get("control_endpoint"),
+                "control_endpoint",
+            ),
+            replacement_only=_boolean(
+                values.get("replacement_only", True),
+                "replacement_only",
+            ),
+            max_replacement_generations=_integer(
+                values.get("max_replacement_generations", 2),
+                "max_replacement_generations",
+            ),
+            registration_lease_duration_ms=_integer(
+                values.get("registration_lease_duration_ms", 30_000),
+                "registration_lease_duration_ms",
+            ),
+            poll_interval_ms=_integer(
+                values.get("poll_interval_ms", 1_000),
+                "poll_interval_ms",
+            ),
+            join_timeout_ms=_integer(
+                values.get("join_timeout_ms", 300_000),
+                "join_timeout_ms",
+            ),
+        )
+    except TorchrunRuntimeConfigError:
+        raise
+    except (TypeError, ValueError) as error:
+        raise TorchrunRuntimeConfigError("rendezvous policy is invalid") from error
+
+
+def _node_value(
+    parameter: object,
+    environment: object,
+    parameter_name: str,
+    environment_name: str,
+) -> str:
+    parameter_value = None if parameter is None else _nonempty_string(parameter, parameter_name)
+    environment_value = (
+        None if environment is None else _nonempty_string(environment, environment_name)
+    )
+    if (
+        parameter_value is not None
+        and environment_value is not None
+        and parameter_value != environment_value
+    ):
+        raise TorchrunRuntimeConfigError(f"{parameter_name} conflicts with {environment_name}")
+    value = parameter_value or environment_value
+    if value is None:
+        raise TorchrunRuntimeConfigError(f"{parameter_name} or {environment_name} must be provided")
+    return value
+
+
+def _strict_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise RestartContextFileError(f"restart-context JSON contains duplicate field {key!r}")
+        value[key] = item
+    return value
+
+
+def _nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise TorchrunRuntimeConfigError(f"{path} must be a non-empty string")
+    return value
+
+
+def _integer(value: object, path: str) -> int:
+    if isinstance(value, bool):
+        raise TorchrunRuntimeConfigError(f"{path} must be an integer")
+    if isinstance(value, int):
+        return value
+    if not isinstance(value, str):
+        raise TorchrunRuntimeConfigError(f"{path} must be an integer")
+    try:
+        return int(value)
+    except ValueError as error:
+        raise TorchrunRuntimeConfigError(f"{path} must be an integer") from error
+
+
+def _positive_integer(value: object, path: str) -> int:
+    parsed = _integer(value, path)
+    if parsed < 1:
+        raise TorchrunRuntimeConfigError(f"{path} must be positive")
+    return parsed
+
+
+def _boolean(value: object, path: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    raise TorchrunRuntimeConfigError(f"{path} must be a boolean")
+
+
+__all__ = [
+    "RestartContextFile",
+    "RestartContextFileError",
+    "TorchrunRendezvousPolicy",
+    "TorchrunRuntimeConfig",
+    "TorchrunRuntimeConfigError",
+]

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -6,8 +6,8 @@ import hashlib
 import importlib
 import json
 import os
+import secrets
 import stat
-import tempfile
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -27,6 +27,7 @@ _BACKEND = "lm_resiliency"
 _NODE_ID_ENV = "LM_RESILIENCY_NODE_ID"
 _RESTART_CONTEXT_ENV = "LM_RESILIENCY_RESTART_CONTEXT"
 _MAX_CONTEXT_BYTES = 64 * 1024
+_MAX_POLICY_BYTES = 64 * 1024
 _SHARED_FIELDS = {
     "control_endpoint",
     "replacement_only",
@@ -90,15 +91,9 @@ class TorchrunRendezvousPolicy:
 
     @property
     def digest(self) -> str:
-        """Return the canonical digest agents register for drift detection."""
+        """Return the canonical digest of the shared policy fields."""
 
-        encoded = json.dumps(
-            self.to_dict(),
-            allow_nan=False,
-            separators=(",", ":"),
-            sort_keys=True,
-        ).encode("utf-8")
-        return hashlib.sha256(encoded).hexdigest()
+        return _canonical_digest(self.to_dict())
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -146,6 +141,20 @@ class TorchrunRuntimeConfig:
             _nonempty_string(self.local_addr, "local_addr")
         if not isinstance(self.source_path, Path) or not self.source_path.is_absolute():
             raise TorchrunRuntimeConfigError("source_path must be an absolute pathlib.Path")
+
+    @property
+    def registration_digest(self) -> str:
+        """Return the shared runtime digest registered by every agent."""
+
+        return _canonical_digest(
+            {
+                "policy": self.policy.to_dict(),
+                "run_id": self.run_id,
+                "endpoint": self.endpoint,
+                "min_nodes": self.min_nodes,
+                "max_nodes": self.max_nodes,
+            }
+        )
 
     @classmethod
     def from_parameters(
@@ -217,29 +226,36 @@ class RestartContextFile:
             raise TypeError("path must be pathlib.Path")
         if not self.path.is_absolute():
             raise RestartContextFileError("restart-context path must be absolute")
+        if self.path.name in {"", ".", ".."}:
+            raise RestartContextFileError("restart-context path must name a file")
 
     def write(self, context: RestartContext) -> None:
         if not isinstance(context, RestartContext):
             raise TypeError("context must be RestartContext")
-        parent = self._prepare_parent()
-        self._reject_existing_symlink()
         encoded = (context.to_json() + "\n").encode("utf-8")
         if len(encoded) > _MAX_CONTEXT_BYTES:
             raise RestartContextFileError("restart context is too large")
-        descriptor, temporary = tempfile.mkstemp(
-            prefix=f".{self.path.name}.",
-            suffix=".tmp",
-            dir=parent,
-        )
+        parent_descriptor = self._open_parent(create=True)
+        assert parent_descriptor is not None
+        descriptor = -1
+        temporary = ""
         try:
+            self._reject_existing_symlink(parent_descriptor)
+            descriptor, temporary = self._create_temporary_file(parent_descriptor)
             os.fchmod(descriptor, 0o600)
             with os.fdopen(descriptor, "wb") as stream:
                 descriptor = -1
                 stream.write(encoded)
                 stream.flush()
                 os.fsync(stream.fileno())
-            os.replace(temporary, self.path)
-            self._fsync_directory(parent)
+            os.replace(
+                temporary,
+                self.path.name,
+                src_dir_fd=parent_descriptor,
+                dst_dir_fd=parent_descriptor,
+            )
+            temporary = ""
+            self._fsync_directory(parent_descriptor)
         except OSError as error:
             raise RestartContextFileError(
                 f"failed to publish restart context at {self.path}"
@@ -250,17 +266,33 @@ class RestartContextFile:
                     os.close(descriptor)
                 except OSError:
                     pass
-            try:
-                os.unlink(temporary)
-            except OSError:
-                pass
+            if temporary:
+                try:
+                    os.unlink(temporary, dir_fd=parent_descriptor)
+                except OSError:
+                    pass
+            os.close(parent_descriptor)
 
     def read(self) -> RestartContext:
-        self._validate_parent()
-        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+        parent_descriptor = self._open_parent(create=False)
+        if parent_descriptor is None:
+            raise RestartContextFileError(
+                f"restart-context directory does not exist for {self.path}"
+            )
+        flags = (
+            os.O_RDONLY
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_NONBLOCK", 0)
+            | getattr(os, "O_CLOEXEC", 0)
+        )
         try:
-            descriptor = os.open(self.path, flags)
+            descriptor = os.open(
+                self.path.name,
+                flags,
+                dir_fd=parent_descriptor,
+            )
         except OSError as error:
+            os.close(parent_descriptor)
             raise RestartContextFileError(
                 f"failed to open restart context at {self.path}"
             ) from error
@@ -273,6 +305,7 @@ class RestartContextFile:
                 raise RestartContextFileError("restart-context file is too large")
         finally:
             os.close(descriptor)
+            os.close(parent_descriptor)
         try:
             value = json.loads(
                 encoded,
@@ -287,40 +320,84 @@ class RestartContextFile:
             raise RestartContextFileError("restart-context file is malformed") from error
 
     def clear(self) -> None:
-        self._validate_parent()
-        self._reject_existing_symlink()
-        try:
-            self.path.unlink()
-        except FileNotFoundError:
-            self._fsync_directory(self.path.parent)
+        parent_descriptor = self._open_parent(create=False)
+        if parent_descriptor is None:
             return
-        except OSError as error:
-            raise RestartContextFileError(
-                f"failed to remove restart context at {self.path}"
-            ) from error
-        self._fsync_directory(self.path.parent)
-
-    def _prepare_parent(self) -> Path:
-        parent = self.path.parent
         try:
-            parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-        except OSError as error:
-            raise RestartContextFileError(
-                f"failed to create restart-context directory {parent}"
-            ) from error
-        self._validate_parent()
-        return parent
+            self._reject_existing_symlink(parent_descriptor)
+            try:
+                os.unlink(self.path.name, dir_fd=parent_descriptor)
+            except FileNotFoundError:
+                self._fsync_directory(parent_descriptor)
+                return
+            except OSError as error:
+                raise RestartContextFileError(
+                    f"failed to remove restart context at {self.path}"
+                ) from error
+            self._fsync_directory(parent_descriptor)
+        finally:
+            os.close(parent_descriptor)
 
-    def _validate_parent(self) -> None:
-        parent = self.path.parent
+    def _open_parent(self, *, create: bool) -> int | None:
+        directory_flags = (
+            os.O_RDONLY
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_CLOEXEC", 0)
+        )
         try:
-            metadata = parent.lstat()
+            current = os.open(os.sep, directory_flags)
         except OSError as error:
             raise RestartContextFileError(
-                f"failed to inspect restart-context directory {parent}"
+                "failed to open the filesystem root for restart-context traversal"
             ) from error
-        if stat.S_ISLNK(metadata.st_mode):
-            raise RestartContextFileError("restart-context parent directory must not be a symlink")
+        try:
+            for component in self.path.parent.parts[1:]:
+                if component in {"", ".", ".."}:
+                    raise RestartContextFileError("restart-context parent path is not canonical")
+                try:
+                    following = os.open(
+                        component,
+                        directory_flags,
+                        dir_fd=current,
+                    )
+                except FileNotFoundError:
+                    if not create:
+                        return None
+                    try:
+                        os.mkdir(component, mode=0o700, dir_fd=current)
+                    except FileExistsError:
+                        pass
+                    except OSError as error:
+                        raise RestartContextFileError(
+                            f"failed to create restart-context directory component {component!r}"
+                        ) from error
+                    try:
+                        following = os.open(
+                            component,
+                            directory_flags,
+                            dir_fd=current,
+                        )
+                    except OSError as error:
+                        raise RestartContextFileError(
+                            "restart-context parent path must contain only real directories"
+                        ) from error
+                except OSError as error:
+                    raise RestartContextFileError(
+                        "restart-context parent path must contain only real directories"
+                    ) from error
+                os.close(current)
+                current = following
+            self._validate_owned_private_directory(os.fstat(current))
+            result = current
+            current = -1
+            return result
+        finally:
+            if current >= 0:
+                os.close(current)
+
+    @staticmethod
+    def _validate_owned_private_directory(metadata: os.stat_result) -> None:
         if not stat.S_ISDIR(metadata.st_mode):
             raise RestartContextFileError("restart-context parent is not a directory")
         if metadata.st_uid != os.geteuid():
@@ -330,9 +407,13 @@ class RestartContextFile:
                 "restart-context directory must not grant group or other permissions"
             )
 
-    def _reject_existing_symlink(self) -> None:
+    def _reject_existing_symlink(self, parent_descriptor: int) -> None:
         try:
-            metadata = self.path.lstat()
+            metadata = os.stat(
+                self.path.name,
+                dir_fd=parent_descriptor,
+                follow_symlinks=False,
+            )
         except FileNotFoundError:
             return
         except OSError as error:
@@ -341,6 +422,34 @@ class RestartContextFile:
             ) from error
         if stat.S_ISLNK(metadata.st_mode):
             raise RestartContextFileError("restart-context path must not be a symlink")
+
+    def _create_temporary_file(self, parent_descriptor: int) -> tuple[int, str]:
+        flags = (
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_CLOEXEC", 0)
+        )
+        for _ in range(128):
+            name = f".{self.path.name}.{secrets.token_hex(16)}.tmp"
+            try:
+                descriptor = os.open(
+                    name,
+                    flags,
+                    0o600,
+                    dir_fd=parent_descriptor,
+                )
+            except FileExistsError:
+                continue
+            except OSError as error:
+                raise RestartContextFileError(
+                    f"failed to create temporary restart context for {self.path}"
+                ) from error
+            return descriptor, name
+        raise RestartContextFileError(
+            f"failed to allocate a temporary restart context for {self.path}"
+        )
 
     @staticmethod
     def _validate_owned_private_file(metadata: os.stat_result) -> None:
@@ -354,23 +463,36 @@ class RestartContextFile:
             )
 
     @staticmethod
-    def _fsync_directory(directory: Path) -> None:
-        descriptor = os.open(
-            directory,
-            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
-        )
-        try:
-            os.fsync(descriptor)
-        finally:
-            os.close(descriptor)
+    def _fsync_directory(descriptor: int) -> None:
+        os.fsync(descriptor)
 
 
 def _load_policy_values(path: Path) -> dict[str, object]:
+    descriptor = -1
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+    )
     try:
-        with path.open("rb") as stream:
-            value = _toml.load(stream)
-    except (OSError, _toml.TOMLDecodeError) as error:
+        descriptor = os.open(path, flags)
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise TorchrunRuntimeConfigError("rendezvous config path must be a regular file")
+        with os.fdopen(descriptor, "rb") as stream:
+            descriptor = -1
+            encoded = stream.read(_MAX_POLICY_BYTES + 1)
+        if len(encoded) > _MAX_POLICY_BYTES:
+            raise TorchrunRuntimeConfigError("rendezvous config file is too large")
+        value = _toml.loads(encoded.decode("utf-8"))
+    except TorchrunRuntimeConfigError:
+        raise
+    except (OSError, UnicodeDecodeError, _toml.TOMLDecodeError) as error:
         raise TorchrunRuntimeConfigError(f"failed to load rendezvous config {path}") from error
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
     if not isinstance(value, dict):
         raise TorchrunRuntimeConfigError("rendezvous config must contain a TOML table")
     actual_schema = value.get("schema_version")
@@ -416,6 +538,16 @@ def _policy_from_values(values: Mapping[str, object]) -> TorchrunRendezvousPolic
         raise
     except (TypeError, ValueError) as error:
         raise TorchrunRuntimeConfigError("rendezvous policy is invalid") from error
+
+
+def _canonical_digest(value: Mapping[str, object]) -> str:
+    encoded = json.dumps(
+        value,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
 
 
 def _node_value(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.26,<3",
+    "tomli>=2,<3; python_version < '3.11'",
     "torch>=2.10,<2.14",
 ]
 

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -37,13 +37,19 @@ def _write_policy(path: Path, content: str = POLICY) -> Path:
     return path
 
 
-def _parameters(path: Path, **config: object) -> RendezvousParameters:
+def _parameters(
+    path: Path,
+    *,
+    min_nodes: int = 2,
+    max_nodes: int = 3,
+    **config: object,
+) -> RendezvousParameters:
     return RendezvousParameters(
         backend="lm_resiliency",
         endpoint="rdzv.example:29400",
         run_id=RUN_ID,
-        min_nodes=2,
-        max_nodes=3,
+        min_nodes=min_nodes,
+        max_nodes=max_nodes,
         local_addr="node-a.example",
         config=str(path),
         **config,
@@ -130,7 +136,27 @@ schema_version=1
 
     assert first_config.policy == second_config.policy
     assert first_config.policy.digest == second_config.policy.digest
+    assert first_config.registration_digest == second_config.registration_digest
     assert first_config.node_id != second_config.node_id
+
+
+def test_runtime_config_registration_digest_includes_node_range(tmp_path: Path):
+    source = _write_policy(tmp_path / "rendezvous.toml")
+    common: Any = {
+        "node_id": "node-a",
+        "restart_context_path": "/run/context.json",
+    }
+    first = TorchrunRuntimeConfig.from_parameters(
+        _parameters(source, max_nodes=3, **common),
+        environment={},
+    )
+    second = TorchrunRuntimeConfig.from_parameters(
+        _parameters(source, max_nodes=4, **common),
+        environment={},
+    )
+
+    assert first.policy.digest == second.policy.digest
+    assert first.registration_digest != second.registration_digest
 
 
 def test_runtime_config_rendezvous_overrides_change_resolved_policy(tmp_path: Path):
@@ -210,6 +236,17 @@ def test_runtime_config_rejects_unknown_rendezvous_option(tmp_path: Path):
         )
 
 
+def test_runtime_config_rejects_fifo_policy_without_blocking(tmp_path: Path):
+    source = tmp_path / "rendezvous.toml"
+    os.mkfifo(source, mode=0o600)
+
+    with pytest.raises(TorchrunRuntimeConfigError, match="regular file"):
+        TorchrunRuntimeConfig.from_parameters(
+            _parameters(source),
+            environment=_environment(tmp_path / "context.json"),
+        )
+
+
 @pytest.mark.parametrize(
     ("parameter_name", "environment_name", "parameter_value", "environment_value"),
     [
@@ -238,7 +275,10 @@ def test_runtime_config_rejects_conflicting_node_inputs(
 
     with pytest.raises(TorchrunRuntimeConfigError, match="conflicts"):
         TorchrunRuntimeConfig.from_parameters(
-            _parameters(source, **{parameter_name: parameter_value}),
+            _parameters(
+                source,
+                **cast(Any, {parameter_name: parameter_value}),
+            ),
             environment=environment,
         )
 
@@ -354,7 +394,11 @@ def test_restart_context_file_preserves_previous_value_when_replace_fails(
     context_file = RestartContextFile(path)
     context_file.write(_context())
 
-    def fail_replace(source: object, destination: object) -> None:
+    def fail_replace(
+        source: object,
+        destination: object,
+        **kwargs: object,
+    ) -> None:
         raise OSError("injected replace failure")
 
     monkeypatch.setattr(os, "replace", fail_replace)
@@ -387,8 +431,11 @@ def test_restart_context_file_closes_descriptor_when_permission_setup_fails(
     context_file = RestartContextFile(path)
     real_close = os.close
     closed: list[int] = []
+    failed_descriptor: int | None = None
 
     def fail_fchmod(descriptor: int, mode: int) -> None:
+        nonlocal failed_descriptor
+        failed_descriptor = descriptor
         raise OSError("injected permission failure")
 
     def record_close(descriptor: int) -> None:
@@ -401,7 +448,7 @@ def test_restart_context_file_closes_descriptor_when_permission_setup_fails(
     with pytest.raises(RestartContextFileError, match="failed to publish"):
         context_file.write(_context())
 
-    assert len(closed) == 1
+    assert failed_descriptor in closed
     assert list(path.parent.glob(f".{path.name}.*.tmp")) == []
 
 
@@ -467,7 +514,18 @@ def test_restart_context_file_rejects_symlink_parent(tmp_path: Path):
     linked.symlink_to(actual, target_is_directory=True)
     context_file = RestartContextFile(linked / "restart-context.json")
 
-    with pytest.raises(RestartContextFileError, match="parent directory.*symlink"):
+    with pytest.raises(RestartContextFileError, match="real directories"):
+        context_file.write(_context())
+
+
+def test_restart_context_file_rejects_symlinked_ancestor(tmp_path: Path):
+    actual = tmp_path / "actual"
+    actual.mkdir(mode=0o700)
+    linked = tmp_path / "linked"
+    linked.symlink_to(actual, target_is_directory=True)
+    context_file = RestartContextFile(linked / "private" / "restart-context.json")
+
+    with pytest.raises(RestartContextFileError, match="real directories"):
         context_file.write(_context())
 
 
@@ -491,12 +549,12 @@ def test_restart_context_file_retries_directory_sync_after_failed_clear(
     original_sync = RestartContextFile._fsync_directory
     calls = 0
 
-    def flaky_sync(directory: Path) -> None:
+    def flaky_sync(descriptor: int) -> None:
         nonlocal calls
         calls += 1
         if calls == 1:
             raise OSError("injected directory sync failure")
-        original_sync(directory)
+        original_sync(descriptor)
 
     monkeypatch.setattr(
         RestartContextFile,
@@ -510,6 +568,14 @@ def test_restart_context_file_retries_directory_sync_after_failed_clear(
     assert not path.exists()
     context_file.clear()
     assert calls == 2
+
+
+def test_restart_context_file_clear_accepts_missing_parent(tmp_path: Path):
+    path = tmp_path / "missing" / "restart-context.json"
+
+    RestartContextFile(path).clear()
+
+    assert not path.parent.exists()
 
 
 @pytest.mark.parametrize("path", [Path("relative.json"), cast(Any, "not-a-path")])

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -1,0 +1,464 @@
+"""Contract tests for torchrun runtime configuration and context handoff."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from torch.distributed.elastic.rendezvous import RendezvousParameters
+
+from lm_resiliency.integrations.torchrun._protocol import RestartContext
+from lm_resiliency.integrations.torchrun._runtime import (
+    RestartContextFile,
+    RestartContextFileError,
+    TorchrunRendezvousPolicy,
+    TorchrunRuntimeConfig,
+    TorchrunRuntimeConfigError,
+)
+
+RUN_ID = "training-run"
+POLICY = """\
+schema_version = 1
+control_endpoint = "control.example:443"
+replacement_only = true
+max_replacement_generations = 2
+registration_lease_duration_ms = 30000
+poll_interval_ms = 1000
+join_timeout_ms = 300000
+"""
+
+
+def _write_policy(path: Path, content: str = POLICY) -> Path:
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _parameters(path: Path, **config: object) -> RendezvousParameters:
+    return RendezvousParameters(
+        backend="lm_resiliency",
+        endpoint="rdzv.example:29400",
+        run_id=RUN_ID,
+        min_nodes=2,
+        max_nodes=3,
+        local_addr="node-a.example",
+        config=str(path),
+        **config,
+    )
+
+
+def _environment(context_path: Path) -> dict[str, str]:
+    return {
+        "LM_RESILIENCY_NODE_ID": "node-a",
+        "LM_RESILIENCY_RESTART_CONTEXT": str(context_path),
+    }
+
+
+def _context(*, plan_id: str = "plan-1") -> RestartContext:
+    return RestartContext(
+        plan_id=plan_id,
+        run_id=RUN_ID,
+        generation=1,
+        node_id="node-a",
+        logical_node_slot=0,
+        first_global_rank=0,
+        local_world_size=2,
+        expected_world_size=4,
+        topology_digest="topology-v1",
+        recovery_mode="latest",
+        checkpoint_source="gemini",
+        checkpoint_step=40,
+        checkpoint_id=None,
+        checkpoint_manifest_id="manifest-40",
+        reason_code="attributed_sdc",
+    )
+
+
+def test_runtime_config_loads_shared_policy_and_node_inputs(tmp_path: Path):
+    source = _write_policy(tmp_path / "rendezvous.toml")
+    context_path = tmp_path / "private" / "restart-context.json"
+
+    config = TorchrunRuntimeConfig.from_parameters(
+        _parameters(source),
+        environment=_environment(context_path),
+    )
+
+    assert config.policy.control_endpoint == "control.example:443"
+    assert config.policy.max_replacement_generations == 2
+    assert (
+        config.policy.digest
+        == TorchrunRendezvousPolicy(
+            control_endpoint="control.example:443",
+        ).digest
+    )
+    assert config.run_id == RUN_ID
+    assert config.endpoint == "rdzv.example:29400"
+    assert config.min_nodes == 2
+    assert config.max_nodes == 3
+    assert config.node_id == "node-a"
+    assert config.restart_context_path == context_path
+    assert config.local_addr == "node-a.example"
+    assert config.source_path == source
+
+
+def test_runtime_config_digest_ignores_toml_formatting_and_node_inputs(tmp_path: Path):
+    first = _write_policy(tmp_path / "first.toml")
+    second = _write_policy(
+        tmp_path / "second.toml",
+        """
+join_timeout_ms=300000
+poll_interval_ms=1000
+registration_lease_duration_ms=30000
+max_replacement_generations=2
+replacement_only=true
+control_endpoint="control.example:443"
+schema_version=1
+""",
+    )
+
+    first_config = TorchrunRuntimeConfig.from_parameters(
+        _parameters(first, node_id="node-a", restart_context_path="/run/a.json"),
+        environment={},
+    )
+    second_config = TorchrunRuntimeConfig.from_parameters(
+        _parameters(second, node_id="node-b", restart_context_path="/run/b.json"),
+        environment={},
+    )
+
+    assert first_config.policy == second_config.policy
+    assert first_config.policy.digest == second_config.policy.digest
+    assert first_config.node_id != second_config.node_id
+
+
+def test_runtime_config_rendezvous_overrides_change_resolved_policy(tmp_path: Path):
+    source = _write_policy(tmp_path / "rendezvous.toml")
+    context_path = tmp_path / "restart-context.json"
+
+    config = TorchrunRuntimeConfig.from_parameters(
+        _parameters(
+            source,
+            control_endpoint="override.example:8443",
+            max_replacement_generations="4",
+            registration_lease_duration_ms="45000",
+            poll_interval_ms="500",
+            join_timeout_ms="120000",
+            replacement_only="true",
+        ),
+        environment=_environment(context_path),
+    )
+
+    assert config.policy.control_endpoint == "override.example:8443"
+    assert config.policy.max_replacement_generations == 4
+    assert config.policy.registration_lease_duration_ms == 45_000
+    assert config.policy.poll_interval_ms == 500
+    assert config.policy.join_timeout_ms == 120_000
+
+
+@pytest.mark.parametrize(
+    ("content", "match"),
+    [
+        ('schema_version = 1.0\ncontrol_endpoint = "control"\n', "schema_version"),
+        ('schema_version = 2\ncontrol_endpoint = "control"\n', "schema_version"),
+        (
+            'schema_version = 1\ncontrol_endpoint = "control"\nunknown = 1\n',
+            "unknown rendezvous config",
+        ),
+        ("schema_version = 1\n", "control_endpoint"),
+        (
+            'schema_version = 1\ncontrol_endpoint = "control"\nreplacement_only = false\n',
+            "replacement_only=false",
+        ),
+        (
+            'schema_version = 1\ncontrol_endpoint = "control"\nreplacement_only = 1\n',
+            "replacement_only",
+        ),
+        (
+            'schema_version = 1\ncontrol_endpoint = "control"\n'
+            "poll_interval_ms = 1000\nregistration_lease_duration_ms = 1000\n",
+            "registration_lease_duration_ms",
+        ),
+        (
+            'schema_version = 1\ncontrol_endpoint = "control"\nmax_replacement_generations = 1.5\n',
+            "max_replacement_generations",
+        ),
+    ],
+)
+def test_runtime_config_rejects_unsafe_policy(
+    tmp_path: Path,
+    content: str,
+    match: str,
+):
+    source = _write_policy(tmp_path / "rendezvous.toml", content)
+
+    with pytest.raises(TorchrunRuntimeConfigError, match=match):
+        TorchrunRuntimeConfig.from_parameters(
+            _parameters(source),
+            environment=_environment(tmp_path / "context.json"),
+        )
+
+
+def test_runtime_config_rejects_unknown_rendezvous_option(tmp_path: Path):
+    source = _write_policy(tmp_path / "rendezvous.toml")
+
+    with pytest.raises(TorchrunRuntimeConfigError, match="unknown rendezvous"):
+        TorchrunRuntimeConfig.from_parameters(
+            _parameters(source, unexpected="value"),
+            environment=_environment(tmp_path / "context.json"),
+        )
+
+
+@pytest.mark.parametrize(
+    ("parameter_name", "environment_name", "parameter_value", "environment_value"),
+    [
+        ("node_id", "LM_RESILIENCY_NODE_ID", "node-a", "node-b"),
+        (
+            "restart_context_path",
+            "LM_RESILIENCY_RESTART_CONTEXT",
+            "/run/a.json",
+            "/run/b.json",
+        ),
+    ],
+)
+def test_runtime_config_rejects_conflicting_node_inputs(
+    tmp_path: Path,
+    parameter_name: str,
+    environment_name: str,
+    parameter_value: str,
+    environment_value: str,
+):
+    source = _write_policy(tmp_path / "rendezvous.toml")
+    environment = {
+        "LM_RESILIENCY_NODE_ID": "node-a",
+        "LM_RESILIENCY_RESTART_CONTEXT": "/run/context.json",
+    }
+    environment[environment_name] = environment_value
+
+    with pytest.raises(TorchrunRuntimeConfigError, match="conflicts"):
+        TorchrunRuntimeConfig.from_parameters(
+            _parameters(source, **{parameter_name: parameter_value}),
+            environment=environment,
+        )
+
+
+@pytest.mark.parametrize(
+    "environment",
+    [
+        {"LM_RESILIENCY_RESTART_CONTEXT": "/run/context.json"},
+        {"LM_RESILIENCY_NODE_ID": "node-a"},
+    ],
+)
+def test_runtime_config_requires_node_inputs(
+    tmp_path: Path,
+    environment: dict[str, str],
+):
+    source = _write_policy(tmp_path / "rendezvous.toml")
+
+    with pytest.raises(TorchrunRuntimeConfigError, match="must be provided"):
+        TorchrunRuntimeConfig.from_parameters(
+            _parameters(source),
+            environment=environment,
+        )
+
+
+def test_runtime_config_respects_explicitly_empty_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    source = _write_policy(tmp_path / "rendezvous.toml")
+    monkeypatch.setenv("LM_RESILIENCY_NODE_ID", "process-node")
+    monkeypatch.setenv(
+        "LM_RESILIENCY_RESTART_CONTEXT",
+        str(tmp_path / "process-context.json"),
+    )
+
+    with pytest.raises(TorchrunRuntimeConfigError, match="must be provided"):
+        TorchrunRuntimeConfig.from_parameters(
+            _parameters(source),
+            environment={},
+        )
+
+
+def test_runtime_config_requires_absolute_paths_and_standby_capacity(tmp_path: Path):
+    source = _write_policy(tmp_path / "rendezvous.toml")
+
+    with pytest.raises(TorchrunRuntimeConfigError, match="config path must be absolute"):
+        TorchrunRuntimeConfig.from_parameters(
+            _parameters(Path("relative.toml")),
+            environment=_environment(tmp_path / "context.json"),
+        )
+    with pytest.raises(TorchrunRuntimeConfigError, match="restart_context_path"):
+        TorchrunRuntimeConfig.from_parameters(
+            _parameters(source, restart_context_path="relative.json"),
+            environment={"LM_RESILIENCY_NODE_ID": "node-a"},
+        )
+    with pytest.raises(TorchrunRuntimeConfigError, match="standby capacity"):
+        TorchrunRuntimeConfig.from_parameters(
+            RendezvousParameters(
+                backend="lm_resiliency",
+                endpoint="rdzv.example:29400",
+                run_id=RUN_ID,
+                min_nodes=2,
+                max_nodes=2,
+                config=str(source),
+            ),
+            environment=_environment(tmp_path / "context.json"),
+        )
+
+
+def test_runtime_config_rejects_wrong_backend_and_type(tmp_path: Path):
+    source = _write_policy(tmp_path / "rendezvous.toml")
+
+    with pytest.raises(TorchrunRuntimeConfigError, match="backend"):
+        TorchrunRuntimeConfig.from_parameters(
+            RendezvousParameters(
+                backend="c10d",
+                endpoint="rdzv.example:29400",
+                run_id=RUN_ID,
+                min_nodes=2,
+                max_nodes=3,
+                config=str(source),
+            ),
+            environment=_environment(tmp_path / "context.json"),
+        )
+    with pytest.raises(TypeError, match="RendezvousParameters"):
+        TorchrunRuntimeConfig.from_parameters(cast(Any, object()))
+
+
+def test_restart_context_file_writes_reads_replaces_and_clears(tmp_path: Path):
+    path = tmp_path / "private" / "restart-context.json"
+    context_file = RestartContextFile(path)
+
+    context_file.write(_context())
+
+    assert context_file.read() == _context()
+    assert stat.S_IMODE(path.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+    context_file.write(_context(plan_id="plan-2"))
+    assert context_file.read() == _context(plan_id="plan-2")
+    assert list(path.parent.glob(f".{path.name}.*.tmp")) == []
+
+    context_file.clear()
+    assert not path.exists()
+    context_file.clear()
+
+
+def test_restart_context_file_preserves_previous_value_when_replace_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    path = tmp_path / "private" / "restart-context.json"
+    context_file = RestartContextFile(path)
+    context_file.write(_context())
+
+    def fail_replace(source: object, destination: object) -> None:
+        raise OSError("injected replace failure")
+
+    monkeypatch.setattr(os, "replace", fail_replace)
+
+    with pytest.raises(RestartContextFileError, match="failed to publish"):
+        context_file.write(_context(plan_id="plan-2"))
+
+    assert context_file.read() == _context()
+    assert list(path.parent.glob(f".{path.name}.*.tmp")) == []
+
+
+def test_restart_context_file_closes_descriptor_when_permission_setup_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    path = tmp_path / "private" / "restart-context.json"
+    context_file = RestartContextFile(path)
+    real_close = os.close
+    closed: list[int] = []
+
+    def fail_fchmod(descriptor: int, mode: int) -> None:
+        raise OSError("injected permission failure")
+
+    def record_close(descriptor: int) -> None:
+        closed.append(descriptor)
+        real_close(descriptor)
+
+    monkeypatch.setattr(os, "fchmod", fail_fchmod)
+    monkeypatch.setattr(os, "close", record_close)
+
+    with pytest.raises(RestartContextFileError, match="failed to publish"):
+        context_file.write(_context())
+
+    assert len(closed) == 1
+    assert list(path.parent.glob(f".{path.name}.*.tmp")) == []
+
+
+def test_restart_context_file_rejects_duplicate_json_fields(tmp_path: Path):
+    path = tmp_path / "private" / "restart-context.json"
+    context_file = RestartContextFile(path)
+    context_file.write(_context())
+    encoded = path.read_text(encoding="utf-8").replace(
+        '"plan_id":"plan-1"',
+        '"plan_id":"plan-1","plan_id":"substituted"',
+        1,
+    )
+    path.write_text(encoded, encoding="utf-8")
+    path.chmod(0o600)
+
+    with pytest.raises(RestartContextFileError, match="duplicate field"):
+        context_file.read()
+
+
+def test_restart_context_file_rejects_insecure_directory(tmp_path: Path):
+    parent = tmp_path / "shared"
+    parent.mkdir(mode=0o755)
+    parent.chmod(0o755)
+    context_file = RestartContextFile(parent / "restart-context.json")
+
+    with pytest.raises(RestartContextFileError, match="group or other"):
+        context_file.write(_context())
+
+
+def test_restart_context_file_rejects_symlink_path(tmp_path: Path):
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    target = parent / "target.json"
+    target.write_text("{}", encoding="utf-8")
+    target.chmod(0o600)
+    path = parent / "restart-context.json"
+    path.symlink_to(target)
+    context_file = RestartContextFile(path)
+
+    with pytest.raises(RestartContextFileError, match="symlink"):
+        context_file.write(_context())
+    with pytest.raises(RestartContextFileError, match="failed to open"):
+        context_file.read()
+    with pytest.raises(RestartContextFileError, match="symlink"):
+        context_file.clear()
+
+
+def test_restart_context_file_rejects_symlink_parent(tmp_path: Path):
+    actual = tmp_path / "actual"
+    actual.mkdir(mode=0o700)
+    linked = tmp_path / "linked"
+    linked.symlink_to(actual, target_is_directory=True)
+    context_file = RestartContextFile(linked / "restart-context.json")
+
+    with pytest.raises(RestartContextFileError, match="parent directory.*symlink"):
+        context_file.write(_context())
+
+
+def test_restart_context_file_rejects_insecure_file_permissions(tmp_path: Path):
+    path = tmp_path / "private" / "restart-context.json"
+    context_file = RestartContextFile(path)
+    context_file.write(_context())
+    path.chmod(0o644)
+
+    with pytest.raises(RestartContextFileError, match="group or other"):
+        context_file.read()
+
+
+@pytest.mark.parametrize("path", [Path("relative.json"), cast(Any, "not-a-path")])
+def test_restart_context_file_validates_path(path: object):
+    expected = TypeError if isinstance(path, str) else RestartContextFileError
+
+    with pytest.raises(expected):
+        RestartContextFile(cast(Any, path))

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import stat
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, cast
 
@@ -365,6 +366,19 @@ def test_restart_context_file_preserves_previous_value_when_replace_fails(
     assert list(path.parent.glob(f".{path.name}.*.tmp")) == []
 
 
+def test_restart_context_file_rejects_oversized_value_before_replace(tmp_path: Path):
+    path = tmp_path / "private" / "restart-context.json"
+    context_file = RestartContextFile(path)
+    context_file.write(_context())
+    oversized = replace(_context(plan_id="oversized"), reason_code="x" * (70 * 1024))
+
+    with pytest.raises(RestartContextFileError, match="too large"):
+        context_file.write(oversized)
+
+    assert context_file.read() == _context()
+    assert list(path.parent.glob(f".{path.name}.*.tmp")) == []
+
+
 def test_restart_context_file_closes_descriptor_when_permission_setup_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -435,6 +449,17 @@ def test_restart_context_file_rejects_symlink_path(tmp_path: Path):
         context_file.clear()
 
 
+def test_restart_context_file_rejects_fifo_without_blocking(tmp_path: Path):
+    parent = tmp_path / "private"
+    parent.mkdir(mode=0o700)
+    path = parent / "restart-context.json"
+    os.mkfifo(path, mode=0o600)
+    context_file = RestartContextFile(path)
+
+    with pytest.raises(RestartContextFileError, match="not a regular file"):
+        context_file.read()
+
+
 def test_restart_context_file_rejects_symlink_parent(tmp_path: Path):
     actual = tmp_path / "actual"
     actual.mkdir(mode=0o700)
@@ -454,6 +479,37 @@ def test_restart_context_file_rejects_insecure_file_permissions(tmp_path: Path):
 
     with pytest.raises(RestartContextFileError, match="group or other"):
         context_file.read()
+
+
+def test_restart_context_file_retries_directory_sync_after_failed_clear(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    path = tmp_path / "private" / "restart-context.json"
+    context_file = RestartContextFile(path)
+    context_file.write(_context())
+    original_sync = RestartContextFile._fsync_directory
+    calls = 0
+
+    def flaky_sync(directory: Path) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError("injected directory sync failure")
+        original_sync(directory)
+
+    monkeypatch.setattr(
+        RestartContextFile,
+        "_fsync_directory",
+        staticmethod(flaky_sync),
+    )
+
+    with pytest.raises(OSError, match="injected directory sync failure"):
+        context_file.clear()
+
+    assert not path.exists()
+    context_file.clear()
+    assert calls == 2
 
 
 @pytest.mark.parametrize("path", [Path("relative.json"), cast(Any, "not-a-path")])


### PR DESCRIPTION
## Summary

- add strict versioned TOML policy loading for the `lm_resiliency` rendezvous backend
- resolve node identity and restart-context paths from `--rdzv-conf` or deployment environment with conflict detection
- compute a canonical shared-policy digest for cross-agent drift detection
- add owner-only atomic restart-context write/read/clear semantics
- reject blocking special files, oversized contexts, and incomplete clear durability
- document the concrete torchrun configuration flow
- add the conditional `tomli` dependency for Python 3.10

## Scope

This is one consolidated runtime prerequisite. It does not register a rendezvous backend, admit standby nodes, poll restart plans, or start workers.

## Compatibility

- supports the repository's Python and PyTorch ranges
- importing `lm_resiliency` remains independent of optional framework packages
- no public package exports are added

## Validation

- 123 focused runtime/protocol tests
- 2,400 full CPU tests with CUDA hidden
- `ruff check .`
- `ruff format --check .`
- targeted mypy for the new runtime module and tests

Local `python -m build` was unavailable because the checkout virtual environment does not contain the `build` module; the GitHub packaging job remains required.