### PR TITLE
[Feature][torchrun] Add runtime agent identity configuration

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1800,9 +1800,19 @@ Node-specific `node_id` and `restart_context_path` values come from
 `LM_RESILIENCY_RESTART_CONTEXT`; conflicting sources are rejected. Credentials
 and other secrets remain in deployment-provided environment or credential
 providers and are not included in the policy file or digest.
+Because PyTorch does not include `nproc_per_node` in
+`RendezvousParameters`, the agent also requires `local_world_size` and the
+deployment-generated workload `environment_digest` through `--rdzv-conf` or
+`LM_RESILIENCY_LOCAL_WORLD_SIZE` and
+`LM_RESILIENCY_ENVIRONMENT_DIGEST`. The registered runtime digest includes the
+local worker count. The immutable agent environment digest combines that
+runtime digest with the deployment workload digest, so either runtime or
+software/capability drift produces a different agent identity.
 
 ```bash
 export LM_RESILIENCY_NODE_ID="${SCHEDULER_NODE_ID}"
+export LM_RESILIENCY_LOCAL_WORLD_SIZE=8
+export LM_RESILIENCY_ENVIRONMENT_DIGEST="${WORKLOAD_ENVIRONMENT_DIGEST}"
 export LM_RESILIENCY_RESTART_CONTEXT="/run/lm-resiliency/${JOB_ID}/restart-context.json"
 
 torchrun \

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1804,15 +1804,22 @@ Because PyTorch does not include `nproc_per_node` in
 `RendezvousParameters`, the agent also requires `local_world_size` and the
 deployment-generated workload `environment_digest` through `--rdzv-conf` or
 `LM_RESILIENCY_LOCAL_WORLD_SIZE` and
-`LM_RESILIENCY_ENVIRONMENT_DIGEST`. The registered runtime digest includes the
-local worker count. The immutable agent environment digest combines that
-runtime digest with the deployment workload digest, so either runtime or
-software/capability drift produces a different agent identity.
+`LM_RESILIENCY_ENVIRONMENT_DIGEST`. The scheduler or deployment integration
+must also provide the node's trusted GPU, NIC, HCA, and link identifiers as a
+semicolon-delimited `resource_ids` value or `LM_RESILIENCY_RESOURCE_IDS`; use
+`[]` for an explicitly empty inventory. These per-node IDs are stored in the
+immutable `AgentIdentity` used to authenticate SCOUT hardware reports, but are
+excluded from the shared compatibility digest because each node owns different
+resources. The registered runtime digest includes the local worker count. The
+immutable agent environment digest combines that runtime digest with the
+deployment workload digest, so either runtime or software/capability drift
+produces a different agent identity.
 
 ```bash
 export LM_RESILIENCY_NODE_ID="${SCHEDULER_NODE_ID}"
 export LM_RESILIENCY_LOCAL_WORLD_SIZE=8
 export LM_RESILIENCY_ENVIRONMENT_DIGEST="${WORKLOAD_ENVIRONMENT_DIGEST}"
+export LM_RESILIENCY_RESOURCE_IDS="${GPU_UUIDS_SEMICOLON_DELIMITED}"
 export LM_RESILIENCY_RESTART_CONTEXT="/run/lm-resiliency/${JOB_ID}/restart-context.json"
 
 torchrun \

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -21,10 +21,12 @@ except ModuleNotFoundError:  # pragma: no cover - exercised by the Python 3.10 C
 
 from torch.distributed.elastic.rendezvous import RendezvousParameters
 
-from lm_resiliency.integrations.torchrun._protocol import RestartContext
+from lm_resiliency.integrations.torchrun._protocol import AgentIdentity, RestartContext
 
 _BACKEND = "lm_resiliency"
 _NODE_ID_ENV = "LM_RESILIENCY_NODE_ID"
+_LOCAL_WORLD_SIZE_ENV = "LM_RESILIENCY_LOCAL_WORLD_SIZE"
+_ENVIRONMENT_DIGEST_ENV = "LM_RESILIENCY_ENVIRONMENT_DIGEST"
 _RESTART_CONTEXT_ENV = "LM_RESILIENCY_RESTART_CONTEXT"
 _MAX_CONTEXT_BYTES = 64 * 1024
 _MAX_POLICY_BYTES = 64 * 1024
@@ -38,6 +40,8 @@ _SHARED_FIELDS = {
 }
 _RUNTIME_FIELDS = _SHARED_FIELDS | {
     "config",
+    "environment_digest",
+    "local_world_size",
     "node_id",
     "restart_context_path",
 }
@@ -116,7 +120,9 @@ class TorchrunRuntimeConfig:
     endpoint: str
     min_nodes: int
     max_nodes: int
+    local_world_size: int
     node_id: str
+    environment_digest: str
     restart_context_path: Path
     local_addr: str | None
     source_path: Path
@@ -132,7 +138,9 @@ class TorchrunRuntimeConfig:
             raise TorchrunRuntimeConfigError(
                 "max_nodes must exceed min_nodes to provide standby capacity"
             )
+        _positive_integer(self.local_world_size, "local_world_size")
         _nonempty_string(self.node_id, "node_id")
+        _nonempty_string(self.environment_digest, "environment_digest")
         if not isinstance(self.restart_context_path, Path):
             raise TypeError("restart_context_path must be pathlib.Path")
         if not self.restart_context_path.is_absolute():
@@ -153,7 +161,37 @@ class TorchrunRuntimeConfig:
                 "endpoint": self.endpoint,
                 "min_nodes": self.min_nodes,
                 "max_nodes": self.max_nodes,
+                "local_world_size": self.local_world_size,
             }
+        )
+
+    @property
+    def agent_environment_digest(self) -> str:
+        """Return the workload and runtime identity recorded for this agent."""
+
+        return _canonical_digest(
+            {
+                "runtime": self.registration_digest,
+                "workload_environment": self.environment_digest,
+            }
+        )
+
+    def build_agent_identity(
+        self,
+        *,
+        agent_id: str,
+        hostname: str,
+    ) -> AgentIdentity:
+        """Build the immutable agent identity for this handler incarnation."""
+
+        return AgentIdentity(
+            run_id=self.run_id,
+            node_id=self.node_id,
+            agent_id=_nonempty_string(agent_id, "agent_id"),
+            hostname=_nonempty_string(hostname, "hostname"),
+            local_world_size=self.local_world_size,
+            resource_ids=(),
+            environment_digest=self.agent_environment_digest,
         )
 
     @classmethod
@@ -194,6 +232,18 @@ class TorchrunRuntimeConfig:
             "node_id",
             _NODE_ID_ENV,
         )
+        local_world_size = _node_integer_value(
+            params.get("local_world_size"),
+            resolved_environment.get(_LOCAL_WORLD_SIZE_ENV),
+            "local_world_size",
+            _LOCAL_WORLD_SIZE_ENV,
+        )
+        environment_digest = _node_value(
+            params.get("environment_digest"),
+            resolved_environment.get(_ENVIRONMENT_DIGEST_ENV),
+            "environment_digest",
+            _ENVIRONMENT_DIGEST_ENV,
+        )
         restart_context_path = Path(
             _node_value(
                 params.get("restart_context_path"),
@@ -208,7 +258,9 @@ class TorchrunRuntimeConfig:
             endpoint=params.endpoint,
             min_nodes=params.min_nodes,
             max_nodes=params.max_nodes,
+            local_world_size=local_world_size,
             node_id=node_id,
+            environment_digest=environment_digest,
             restart_context_path=restart_context_path,
             local_addr=params.local_addr,
             source_path=source_path,
@@ -567,6 +619,28 @@ def _node_value(
     ):
         raise TorchrunRuntimeConfigError(f"{parameter_name} conflicts with {environment_name}")
     value = parameter_value or environment_value
+    if value is None:
+        raise TorchrunRuntimeConfigError(f"{parameter_name} or {environment_name} must be provided")
+    return value
+
+
+def _node_integer_value(
+    parameter: object,
+    environment: object,
+    parameter_name: str,
+    environment_name: str,
+) -> int:
+    parameter_value = None if parameter is None else _positive_integer(parameter, parameter_name)
+    environment_value = (
+        None if environment is None else _positive_integer(environment, environment_name)
+    )
+    if (
+        parameter_value is not None
+        and environment_value is not None
+        and parameter_value != environment_value
+    ):
+        raise TorchrunRuntimeConfigError(f"{parameter_name} conflicts with {environment_name}")
+    value = parameter_value if parameter_value is not None else environment_value
     if value is None:
         raise TorchrunRuntimeConfigError(f"{parameter_name} or {environment_name} must be provided")
     return value

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -8,7 +8,7 @@ import json
 import os
 import secrets
 import stat
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
@@ -27,6 +27,7 @@ _BACKEND = "lm_resiliency"
 _NODE_ID_ENV = "LM_RESILIENCY_NODE_ID"
 _LOCAL_WORLD_SIZE_ENV = "LM_RESILIENCY_LOCAL_WORLD_SIZE"
 _ENVIRONMENT_DIGEST_ENV = "LM_RESILIENCY_ENVIRONMENT_DIGEST"
+_RESOURCE_IDS_ENV = "LM_RESILIENCY_RESOURCE_IDS"
 _RESTART_CONTEXT_ENV = "LM_RESILIENCY_RESTART_CONTEXT"
 _MAX_CONTEXT_BYTES = 64 * 1024
 _MAX_POLICY_BYTES = 64 * 1024
@@ -43,6 +44,7 @@ _RUNTIME_FIELDS = _SHARED_FIELDS | {
     "environment_digest",
     "local_world_size",
     "node_id",
+    "resource_ids",
     "restart_context_path",
 }
 
@@ -123,6 +125,7 @@ class TorchrunRuntimeConfig:
     local_world_size: int
     node_id: str
     environment_digest: str
+    resource_ids: tuple[str, ...]
     restart_context_path: Path
     local_addr: str | None
     source_path: Path
@@ -141,6 +144,11 @@ class TorchrunRuntimeConfig:
         _positive_integer(self.local_world_size, "local_world_size")
         _nonempty_string(self.node_id, "node_id")
         _nonempty_string(self.environment_digest, "environment_digest")
+        object.__setattr__(
+            self,
+            "resource_ids",
+            _resource_ids(self.resource_ids, "resource_ids"),
+        )
         if not isinstance(self.restart_context_path, Path):
             raise TypeError("restart_context_path must be pathlib.Path")
         if not self.restart_context_path.is_absolute():
@@ -190,7 +198,7 @@ class TorchrunRuntimeConfig:
             agent_id=_nonempty_string(agent_id, "agent_id"),
             hostname=_nonempty_string(hostname, "hostname"),
             local_world_size=self.local_world_size,
-            resource_ids=(),
+            resource_ids=self.resource_ids,
             environment_digest=self.agent_environment_digest,
         )
 
@@ -244,6 +252,10 @@ class TorchrunRuntimeConfig:
             "environment_digest",
             _ENVIRONMENT_DIGEST_ENV,
         )
+        resource_ids = _node_resource_ids(
+            params.get("resource_ids"),
+            resolved_environment.get(_RESOURCE_IDS_ENV),
+        )
         restart_context_path = Path(
             _node_value(
                 params.get("restart_context_path"),
@@ -261,6 +273,7 @@ class TorchrunRuntimeConfig:
             local_world_size=local_world_size,
             node_id=node_id,
             environment_digest=environment_digest,
+            resource_ids=resource_ids,
             restart_context_path=restart_context_path,
             local_addr=params.local_addr,
             source_path=source_path,
@@ -644,6 +657,55 @@ def _node_integer_value(
     if value is None:
         raise TorchrunRuntimeConfigError(f"{parameter_name} or {environment_name} must be provided")
     return value
+
+
+def _node_resource_ids(
+    parameter: object,
+    environment: object,
+) -> tuple[str, ...]:
+    parameter_value = None if parameter is None else _resource_ids(parameter, "resource_ids")
+    environment_value = (
+        None if environment is None else _resource_ids(environment, _RESOURCE_IDS_ENV)
+    )
+    if (
+        parameter_value is not None
+        and environment_value is not None
+        and parameter_value != environment_value
+    ):
+        raise TorchrunRuntimeConfigError(f"resource_ids conflicts with {_RESOURCE_IDS_ENV}")
+    value = parameter_value if parameter_value is not None else environment_value
+    if value is None:
+        raise TorchrunRuntimeConfigError(f"resource_ids or {_RESOURCE_IDS_ENV} must be provided")
+    return value
+
+
+def _resource_ids(value: object, path: str) -> tuple[str, ...]:
+    items: Sequence[object]
+    if isinstance(value, str):
+        normalized = value.strip()
+        if normalized == "[]":
+            items = ()
+        else:
+            if normalized.startswith("[") or normalized.endswith("]"):
+                raise TorchrunRuntimeConfigError(
+                    f"{path} must be a semicolon-delimited resource list or []"
+                )
+            items = tuple(normalized.split(";"))
+    elif isinstance(value, Sequence) and not isinstance(
+        value,
+        (bytes, bytearray),
+    ):
+        items = value
+    else:
+        raise TorchrunRuntimeConfigError(
+            f"{path} must be a semicolon-delimited resource list or sequence"
+        )
+    result = tuple(
+        _nonempty_string(item, f"{path}[{index}]").strip() for index, item in enumerate(items)
+    )
+    if len(result) != len(set(result)):
+        raise TorchrunRuntimeConfigError(f"{path} resource IDs must be unique")
+    return tuple(sorted(result))
 
 
 def _strict_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -44,6 +44,11 @@ def _parameters(
     max_nodes: int = 3,
     **config: object,
 ) -> RendezvousParameters:
+    runtime_config = {
+        "local_world_size": "2",
+        "environment_digest": "environment-v1",
+        **config,
+    }
     return RendezvousParameters(
         backend="lm_resiliency",
         endpoint="rdzv.example:29400",
@@ -52,7 +57,7 @@ def _parameters(
         max_nodes=max_nodes,
         local_addr="node-a.example",
         config=str(path),
-        **config,
+        **runtime_config,
     )
 
 
@@ -159,6 +164,100 @@ def test_runtime_config_registration_digest_includes_node_range(tmp_path: Path):
     assert first.registration_digest != second.registration_digest
 
 
+def test_runtime_config_registration_digest_includes_local_world_size(tmp_path: Path):
+    source = _write_policy(tmp_path / "rendezvous.toml")
+    common: Any = {
+        "node_id": "node-a",
+        "restart_context_path": "/run/context.json",
+    }
+    first = TorchrunRuntimeConfig.from_parameters(
+        _parameters(source, local_world_size="2", **common),
+        environment={},
+    )
+    second = TorchrunRuntimeConfig.from_parameters(
+        _parameters(source, local_world_size="4", **common),
+        environment={},
+    )
+
+    assert first.registration_digest != second.registration_digest
+
+
+def test_runtime_config_builds_agent_identity(tmp_path: Path):
+    source = _write_policy(tmp_path / "rendezvous.toml")
+    config = TorchrunRuntimeConfig.from_parameters(
+        _parameters(
+            source,
+            node_id="node-a",
+            restart_context_path="/run/context.json",
+        ),
+        environment={},
+    )
+
+    identity = config.build_agent_identity(
+        agent_id="agent-a",
+        hostname="host-a",
+    )
+
+    assert identity.run_id == RUN_ID
+    assert identity.node_id == "node-a"
+    assert identity.agent_id == "agent-a"
+    assert identity.hostname == "host-a"
+    assert identity.local_world_size == 2
+    assert identity.resource_ids == ()
+    assert identity.environment_digest == config.agent_environment_digest
+
+
+def test_runtime_config_resolves_agent_identity_inputs_from_environment(
+    tmp_path: Path,
+):
+    source = _write_policy(tmp_path / "rendezvous.toml")
+    environment = {
+        "LM_RESILIENCY_NODE_ID": "node-a",
+        "LM_RESILIENCY_LOCAL_WORLD_SIZE": "4",
+        "LM_RESILIENCY_ENVIRONMENT_DIGEST": "environment-v2",
+        "LM_RESILIENCY_RESTART_CONTEXT": "/run/context.json",
+    }
+
+    config = TorchrunRuntimeConfig.from_parameters(
+        _parameters(
+            source,
+            local_world_size=None,
+            environment_digest=None,
+        ),
+        environment=environment,
+    )
+
+    assert config.node_id == "node-a"
+    assert config.local_world_size == 4
+    assert config.environment_digest == "environment-v2"
+    assert config.restart_context_path == Path("/run/context.json")
+
+
+def test_runtime_config_agent_environment_digest_binds_workload_and_runtime(
+    tmp_path: Path,
+):
+    source = _write_policy(tmp_path / "rendezvous.toml")
+    common: Any = {
+        "node_id": "node-a",
+        "restart_context_path": "/run/context.json",
+    }
+    first = TorchrunRuntimeConfig.from_parameters(
+        _parameters(source, environment_digest="environment-v1", **common),
+        environment={},
+    )
+    different_workload = TorchrunRuntimeConfig.from_parameters(
+        _parameters(source, environment_digest="environment-v2", **common),
+        environment={},
+    )
+    different_runtime = TorchrunRuntimeConfig.from_parameters(
+        _parameters(source, max_nodes=4, **common),
+        environment={},
+    )
+
+    assert first.agent_environment_digest != different_workload.agent_environment_digest
+    assert first.agent_environment_digest != different_runtime.agent_environment_digest
+
+
 def test_runtime_config_rendezvous_overrides_change_resolved_policy(tmp_path: Path):
     source = _write_policy(tmp_path / "rendezvous.toml")
     context_path = tmp_path / "restart-context.json"
@@ -251,6 +350,13 @@ def test_runtime_config_rejects_fifo_policy_without_blocking(tmp_path: Path):
     ("parameter_name", "environment_name", "parameter_value", "environment_value"),
     [
         ("node_id", "LM_RESILIENCY_NODE_ID", "node-a", "node-b"),
+        ("local_world_size", "LM_RESILIENCY_LOCAL_WORLD_SIZE", "2", "4"),
+        (
+            "environment_digest",
+            "LM_RESILIENCY_ENVIRONMENT_DIGEST",
+            "environment-v1",
+            "environment-v2",
+        ),
         (
             "restart_context_path",
             "LM_RESILIENCY_RESTART_CONTEXT",
@@ -303,6 +409,46 @@ def test_runtime_config_requires_node_inputs(
         )
 
 
+@pytest.mark.parametrize(
+    ("config", "environment", "match"),
+    [
+        (
+            {"local_world_size": None},
+            {},
+            "LM_RESILIENCY_LOCAL_WORLD_SIZE",
+        ),
+        (
+            {"environment_digest": None},
+            {},
+            "LM_RESILIENCY_ENVIRONMENT_DIGEST",
+        ),
+        (
+            {"local_world_size": "0"},
+            {},
+            "local_world_size must be positive",
+        ),
+    ],
+)
+def test_runtime_config_requires_agent_identity_inputs(
+    tmp_path: Path,
+    config: dict[str, object],
+    environment: dict[str, str],
+    match: str,
+):
+    source = _write_policy(tmp_path / "rendezvous.toml")
+    runtime_config: Any = {
+        "node_id": "node-a",
+        "restart_context_path": "/run/context.json",
+        **config,
+    }
+
+    with pytest.raises(TorchrunRuntimeConfigError, match=match):
+        TorchrunRuntimeConfig.from_parameters(
+            _parameters(source, **runtime_config),
+            environment=environment,
+        )
+
+
 def test_runtime_config_respects_explicitly_empty_environment(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -343,6 +489,8 @@ def test_runtime_config_requires_absolute_paths_and_standby_capacity(tmp_path: P
                 min_nodes=2,
                 max_nodes=2,
                 config=str(source),
+                local_world_size="2",
+                environment_digest="environment-v1",
             ),
             environment=_environment(tmp_path / "context.json"),
         )

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -11,7 +11,14 @@ from typing import Any, cast
 import pytest
 from torch.distributed.elastic.rendezvous import RendezvousParameters
 
-from lm_resiliency.integrations.torchrun._protocol import RestartContext
+from lm_resiliency.integrations.torchrun._protocol import (
+    FaultEvent,
+    HardwareFaultReport,
+    RankAssignment,
+    RestartContext,
+    WorkerIdentity,
+    validate_event_reporter,
+)
 from lm_resiliency.integrations.torchrun._runtime import (
     RestartContextFile,
     RestartContextFileError,
@@ -47,6 +54,7 @@ def _parameters(
     runtime_config = {
         "local_world_size": "2",
         "environment_digest": "environment-v1",
+        "resource_ids": "gpu-node-a-0;gpu-node-a-1",
         **config,
     }
     return RendezvousParameters(
@@ -110,6 +118,7 @@ def test_runtime_config_loads_shared_policy_and_node_inputs(tmp_path: Path):
     assert config.min_nodes == 2
     assert config.max_nodes == 3
     assert config.node_id == "node-a"
+    assert config.resource_ids == ("gpu-node-a-0", "gpu-node-a-1")
     assert config.restart_context_path == context_path
     assert config.local_addr == "node-a.example"
     assert config.source_path == source
@@ -131,11 +140,21 @@ schema_version=1
     )
 
     first_config = TorchrunRuntimeConfig.from_parameters(
-        _parameters(first, node_id="node-a", restart_context_path="/run/a.json"),
+        _parameters(
+            first,
+            node_id="node-a",
+            resource_ids="gpu-node-a-0;gpu-node-a-1",
+            restart_context_path="/run/a.json",
+        ),
         environment={},
     )
     second_config = TorchrunRuntimeConfig.from_parameters(
-        _parameters(second, node_id="node-b", restart_context_path="/run/b.json"),
+        _parameters(
+            second,
+            node_id="node-b",
+            resource_ids="gpu-node-b-0;gpu-node-b-1",
+            restart_context_path="/run/b.json",
+        ),
         environment={},
     )
 
@@ -203,8 +222,83 @@ def test_runtime_config_builds_agent_identity(tmp_path: Path):
     assert identity.agent_id == "agent-a"
     assert identity.hostname == "host-a"
     assert identity.local_world_size == 2
-    assert identity.resource_ids == ()
+    assert identity.resource_ids == ("gpu-node-a-0", "gpu-node-a-1")
     assert identity.environment_digest == config.agent_environment_digest
+
+
+def test_runtime_config_agent_identity_authorizes_registered_hardware_report(
+    tmp_path: Path,
+):
+    source = _write_policy(tmp_path / "rendezvous.toml")
+    config = TorchrunRuntimeConfig.from_parameters(
+        _parameters(
+            source,
+            node_id="node-a",
+            restart_context_path="/run/context.json",
+        ),
+        environment={},
+    )
+    identity = config.build_agent_identity(
+        agent_id="agent-a",
+        hostname="host-a",
+    )
+    assignment = RankAssignment(
+        run_id=RUN_ID,
+        generation=0,
+        active_nodes=1,
+        local_world_size=2,
+        slot_to_node_id={0: "node-a"},
+        slot_to_rank_range={0: (0, 2)},
+        topology_digest="topology-v1",
+    )
+    reporter = WorkerIdentity(
+        run_id=RUN_ID,
+        generation=0,
+        node_id="node-a",
+        agent_id="agent-a",
+        logical_node_slot=0,
+        global_rank=0,
+        local_rank=0,
+        local_world_size=2,
+        hostname="host-a",
+        gpu_uuid="gpu-node-a-0",
+        topology_digest="topology-v1",
+    )
+    event = FaultEvent(
+        event_id="fault-gpu-a0",
+        incident_id="incident-a",
+        run_id=RUN_ID,
+        generation=0,
+        reporter=reporter,
+        optimizer_step=10,
+        report=HardwareFaultReport(
+            kind="hardware",
+            resource_kind="gpu",
+            resource_id="gpu-node-a-0",
+            metric="uncorrectable_ecc",
+            value=1.0,
+            severity="fatal",
+            message="fatal ECC",
+        ),
+    )
+
+    validate_event_reporter(
+        event,
+        assignment,
+        agent_identity=identity,
+        resource_to_node_id={
+            "gpu-node-a-0": "node-a",
+            "gpu-node-a-1": "node-a",
+        },
+        resource_to_kind={
+            "gpu-node-a-0": "gpu",
+            "gpu-node-a-1": "gpu",
+        },
+        resource_to_global_rank={
+            "gpu-node-a-0": 0,
+            "gpu-node-a-1": 1,
+        },
+    )
 
 
 def test_runtime_config_resolves_agent_identity_inputs_from_environment(
@@ -215,6 +309,7 @@ def test_runtime_config_resolves_agent_identity_inputs_from_environment(
         "LM_RESILIENCY_NODE_ID": "node-a",
         "LM_RESILIENCY_LOCAL_WORLD_SIZE": "4",
         "LM_RESILIENCY_ENVIRONMENT_DIGEST": "environment-v2",
+        "LM_RESILIENCY_RESOURCE_IDS": "gpu-node-a-1;gpu-node-a-0",
         "LM_RESILIENCY_RESTART_CONTEXT": "/run/context.json",
     }
 
@@ -223,6 +318,7 @@ def test_runtime_config_resolves_agent_identity_inputs_from_environment(
             source,
             local_world_size=None,
             environment_digest=None,
+            resource_ids=None,
         ),
         environment=environment,
     )
@@ -230,6 +326,7 @@ def test_runtime_config_resolves_agent_identity_inputs_from_environment(
     assert config.node_id == "node-a"
     assert config.local_world_size == 4
     assert config.environment_digest == "environment-v2"
+    assert config.resource_ids == ("gpu-node-a-0", "gpu-node-a-1")
     assert config.restart_context_path == Path("/run/context.json")
 
 
@@ -358,6 +455,12 @@ def test_runtime_config_rejects_fifo_policy_without_blocking(tmp_path: Path):
             "environment-v2",
         ),
         (
+            "resource_ids",
+            "LM_RESILIENCY_RESOURCE_IDS",
+            "gpu-node-a-0;gpu-node-a-1",
+            "gpu-node-a-0;hca-node-a",
+        ),
+        (
             "restart_context_path",
             "LM_RESILIENCY_RESTART_CONTEXT",
             "/run/a.json",
@@ -423,6 +526,11 @@ def test_runtime_config_requires_node_inputs(
             "LM_RESILIENCY_ENVIRONMENT_DIGEST",
         ),
         (
+            {"resource_ids": None},
+            {},
+            "LM_RESILIENCY_RESOURCE_IDS",
+        ),
+        (
             {"local_world_size": "0"},
             {},
             "local_world_size must be positive",
@@ -447,6 +555,50 @@ def test_runtime_config_requires_agent_identity_inputs(
             _parameters(source, **runtime_config),
             environment=environment,
         )
+
+
+@pytest.mark.parametrize(
+    ("resource_ids", "match"),
+    [
+        ("gpu-node-a-0;;gpu-node-a-1", r"resource_ids\[1\]"),
+        ("gpu-node-a-0;gpu-node-a-0", "must be unique"),
+        ('["gpu-node-a-0","gpu-node-a-1"]', "semicolon-delimited"),
+        ({"gpu-node-a-0": True}, "semicolon-delimited"),
+    ],
+)
+def test_runtime_config_rejects_invalid_resource_ids(
+    tmp_path: Path,
+    resource_ids: object,
+    match: str,
+):
+    source = _write_policy(tmp_path / "rendezvous.toml")
+
+    with pytest.raises(TorchrunRuntimeConfigError, match=match):
+        TorchrunRuntimeConfig.from_parameters(
+            _parameters(
+                source,
+                node_id="node-a",
+                resource_ids=resource_ids,
+                restart_context_path="/run/context.json",
+            ),
+            environment={},
+        )
+
+
+def test_runtime_config_accepts_explicit_empty_resource_inventory(tmp_path: Path):
+    source = _write_policy(tmp_path / "rendezvous.toml")
+
+    config = TorchrunRuntimeConfig.from_parameters(
+        _parameters(
+            source,
+            node_id="node-a",
+            resource_ids="[]",
+            restart_context_path="/run/context.json",
+        ),
+        environment={},
+    )
+
+    assert config.resource_ids == ()
 
 
 def test_runtime_config_respects_explicitly_empty_environment(
@@ -491,6 +643,7 @@ def test_runtime_config_requires_absolute_paths_and_standby_capacity(tmp_path: P
                 config=str(source),
                 local_world_size="2",
                 environment_digest="environment-v1",
+                resource_ids="[]",
             ),
             environment=_environment(tmp_path / "context.json"),
         )


### PR DESCRIPTION
## Summary
- require explicit `local_world_size`, deployment `environment_digest`, and trusted per-node `resource_ids` runtime inputs
- build immutable `AgentIdentity` values for rendezvous handler incarnations
- bind local worker count into the registered fleet digest and combine runtime/workload identity
- preserve per-node GPU/NIC/HCA/link IDs in the agent identity used to authenticate SCOUT reports
- document `rdzv-conf` and environment-variable provisioning

## Why
PyTorch does not expose `nproc_per_node` through `RendezvousParameters`. The resilient rendezvous handler must not fabricate the local worker count, environment compatibility identity, or trusted hardware inventory when registering an agent.

## Scope
This PR adds runtime identity configuration only. It does not register a rendezvous backend or implement standby admission.

## Validation
- 140 focused runtime/protocol tests
- 2,417 full CPU tests
- Ruff and formatting checks
- targeted mypy