### PR TITLE
[Feature][torchrun] Add initial slot-aware rendezvous handler

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1488,9 +1488,11 @@ wakes parked standbys and releases registrations. It also clears any stale
 node-local restart context before the initial generation starts. The join
 timeout bounds initial generation formation and worker bootstrap only; after
 generation zero exists, passive standbys remain parked until assignment,
-closure, cancellation, or registration failure. Registration heartbeats
-schedule each renewal from the returned lease's remaining lifetime rather than
-from a fixed interval. An assigned node ID is admitted only when its retained
+explicit shared closure, local shutdown, cancellation, or registration failure.
+Local `shutdown()` releases only that handler's resources; only `set_closed()`
+publishes the run-scoped terminal closure. Registration heartbeats schedule
+each renewal from the returned lease's remaining lifetime rather than from a
+fixed interval. An assigned node ID is admitted only when its retained
 registration history has the same local worker count and environment digest as
 the current handler, so an incompatible process cannot reuse an expired node
 registration. Replacement generation admission, restart-context publication,
@@ -1498,11 +1500,15 @@ and the positive
 `num_nodes_waiting()` restart edge are enabled only after authoritative
 restart-plan readback is integrated in the following slice.
 
-Every `next_rendezvous()` invocation uses an attempt-scoped `PrefixStore` for
-PyTorch's worker bootstrap keys. Bootstrap reads are bounded by the remaining
-join deadline, so a missing slot-zero publisher cannot strand other agents on
-the underlying store timeout and a retry cannot consume address/port values
-from a previous attempt.
+All handler incarnations use one immutable generation-scoped `PrefixStore` for
+PyTorch's worker bootstrap keys. Slot zero publishes one address/port pair and
+later retries or replacement agent incarnations reuse it, so no process-local
+attempt counter can split the worker group across namespaces. Bootstrap reads
+are bounded by the remaining join deadline, so a missing slot-zero publisher
+cannot strand other agents on the underlying store timeout. When the deployment
+supplies an already running agent-owned bootstrap endpoint, the handler reports
+`use_agent_store=True`; a generated endpoint reports `False` so the stock agent
+creates the worker-side TCP store.
 
 Passive standbys are not reported by `num_nodes_waiting()`. After a plan
 commits, the selected replacement becomes the only newly waiting node visible

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -339,6 +339,15 @@ store-time-guarded mutation. Expiry takeover creates a new registration ID and
 fencing token. Registration keys are independently scoped by hashed run and node
 identity, so agents on different nodes do not contend.
 
+Equivalent heartbeat renewals use a store refresh operation that compacts
+unreferenced intermediate values. The retained history keeps the initial and
+current values of each registration lifetime plus every revision consumed by a
+successful guarded transaction condition. Acknowledgements and plan commits
+therefore retain the exact registration authority they used, while long-running
+active and standby agents do not accumulate one durable history entry per
+heartbeat. History readers accept compacted same-registration mutation gaps only
+when the skipped renewals could all have completed before lease expiry.
+
 The coordinator does not enumerate arbitrary control-store keys. A registration
 reader receives the trusted scheduler node-ID set explicitly, derives the same
 hashed keys as the agents, and reads only those registrations. After completing
@@ -1129,11 +1138,12 @@ expected run and node, requires an authoritative commit time, rejects guarded
 registration writes, and preserves the store transaction, mutation, value, and
 lifetime sequences. It also rejects impossible per-entry sequence lineage. The
 following stable reader validates that the retained history begins at the
-initial sequences and contains every renewal, replacement, and recreated-key
-transition. It rejects overlapping registrations, expired renewals, recurrent
-registration identities or fencing tokens, and a current value that is not the
-retained tail. A released registration remains visible in the immutable history
-while the current value is absent.
+initial sequences and contains every replacement and recreated-key transition,
+plus the compacted same-registration renewal boundaries needed to prove lease
+continuity. It rejects overlapping registrations, expired renewal spans,
+recurrent registration identities or fencing tokens, and a current value that
+is not the retained tail. A released registration remains visible in the
+immutable history while the current value is absent.
 
 The restart-acknowledgement state reader double-collects the current open
 intent, verified agent-registration history, and durable coordinator-lease
@@ -1164,12 +1174,12 @@ windows. It performs no store reads; a following stable reader supplies the
 durable dependencies before acknowledgement collection or quorum logic.
 
 The per-node receipt reader double-collects the restart-intent opening, the
-create-once acknowledgement key, complete agent-registration history, and
-complete coordinator-lease history. For the active preparation path it reads
-the current opening. After closure it can instead consume the durable opening
-retained by the authenticated lifecycle record, without reconstructing lost
-preparation revisions or time bounds. A never-created receipt key returns no
-acknowledgement. Deleted, rewritten, malformed, or orphaned receipts fail
+create-once acknowledgement key, verified retained agent-registration history,
+and complete coordinator-lease history. For the active preparation path it
+reads the current opening. After closure it can instead consume the durable
+opening retained by the authenticated lifecycle record, without reconstructing
+lost preparation revisions or time bounds. A never-created receipt key returns
+no acknowledgement. Deleted, rewritten, malformed, or orphaned receipts fail
 closed. Renewed registrations and coordinator leases do not invalidate an
 already committed receipt because the reader resolves the exact historical
 authorities stamped into that receipt.
@@ -1501,6 +1511,10 @@ standbys cannot create or replace that record. Initial registration backend I/O
 does not hold the handler's ownership lock, so local shutdown remains bounded
 while registration is stalled. A registration response arriving after local
 shutdown is not installed or heartbeated and expires conservatively.
+Before any assigned handler returns generation zero, it publishes a
+generation-scoped arrival tied to its live registration and waits until every
+committed slot has a live matching arrival. Missing assigned nodes therefore
+fail at the formation deadline instead of launching a partial worker group.
 Replacement generation admission, restart-context publication, and the positive
 `num_nodes_waiting()` restart edge are enabled only after authoritative
 restart-plan readback is integrated in the following slice.
@@ -1513,7 +1527,9 @@ are bounded by the remaining join deadline, so a missing slot-zero publisher
 cannot strand other agents on the underlying store timeout. When the deployment
 supplies an already running agent-owned bootstrap endpoint, the handler reports
 `use_agent_store=True`; a generated endpoint reports `False` so the stock agent
-creates the worker-side TCP store.
+creates the worker-side TCP store. After bounded bootstrap reads complete, every
+returned store is restored to the shared configured join timeout so later stock
+agent coordination does not inherit rank-specific remaining-deadline values.
 
 Passive standbys are not reported by `num_nodes_waiting()`. After a plan
 commits, the selected replacement becomes the only newly waiting node visible

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1512,7 +1512,9 @@ does not hold the handler's ownership lock, so local shutdown remains bounded
 while registration is stalled. A registration response arriving after local
 shutdown is not installed or heartbeated; a daemon performs an explicit
 best-effort release, with lease expiry as the conservative fallback. Initial
-registration itself is bounded by the formation deadline.
+registration and the initial closure-state observation are bounded by the
+formation deadline. A stalled closure backend cannot defeat that timeout, and
+local shutdown interrupts a handler waiting on the daemonized closure read.
 
 Before publishing readiness, each assigned handler clears its stale node-local
 restart context. Slot zero owns one durable, generation-scoped attempt head,
@@ -1524,17 +1526,22 @@ that proof instead of rereading every registration history, keeping control
 store work linear in the active node count. Slot zero reloads its current
 renewed registration immediately before each guarded completion attempt, so
 heartbeat renewal cannot strand an otherwise complete barrier on a stale
-fencing token. After bootstrap and final generation revalidation, every
-assigned handler publishes one immutable, registration-guarded consumption
-record for the completed attempt. An incomplete attempt remains usable when a
-handler incarnation is replaced. A completed attempt advances only after every
-slot has a durable consumption record, so a replacement for a handler that
-failed after completion but before returning joins the completed attempt
-instead of splitting the worker group. Guarded barrier transactions pin their
-registration revision in retained history. Missing or unprepared assigned
-nodes therefore fail at the formation deadline instead of launching a partial
-worker group. After bootstrap completes, every handler revalidates the
-generation head before returning its slot.
+fencing token. After bootstrap and generation revalidation, every assigned
+handler publishes one immutable, registration-incarnation-scoped consumption
+record for the completed attempt. The guarded publication reloads the current
+registration after heartbeat renewal and atomically conditions on the
+completion proof, generation head, immutable generation snapshot, and absence
+of terminal closure. An incomplete attempt remains usable when a handler
+incarnation is replaced. A stale consumption from an incarnation that failed
+before returning does not satisfy its replacement; the replacement publishes
+its own consumption for the same completed attempt. A completed attempt
+advances only after every slot's current registration has a durable consumption
+record, so a replacement joins the completed attempt instead of splitting the
+worker group. Guarded barrier transactions pin their registration revision in
+retained history. Missing or unprepared assigned nodes therefore fail at the
+formation deadline instead of launching a partial worker group. After
+consumption completes, every handler performs one final closure and generation
+check before returning its slot.
 
 Registration release is best effort and bounded during local shutdown. If the
 backend remains unavailable, cleanup returns without waiting indefinitely and

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1510,14 +1510,24 @@ compatibility identity, and every other assigned node must match it; unassigned
 standbys cannot create or replace that record. Initial registration backend I/O
 does not hold the handler's ownership lock, so local shutdown remains bounded
 while registration is stalled. A registration response arriving after local
-shutdown is not installed or heartbeated and expires conservatively.
-Before any assigned handler returns generation zero, it publishes a
-generation- and attempt-scoped arrival tied to its live registration and waits
-until every committed slot has a live matching arrival for the same attempt.
-Each slot claims its next attempt through durable control-store state, so a
-surviving or replacement handler cannot reuse an arrival from a prior worker
-launch. Missing assigned nodes therefore fail at the formation deadline instead
-of launching a partial worker group.
+shutdown is not installed or heartbeated; a daemon performs an explicit
+best-effort release, with lease expiry as the conservative fallback. Initial
+registration itself is bounded by the formation deadline.
+
+Before publishing readiness, each assigned handler clears its stale node-local
+restart context. Slot zero owns one durable, generation-scoped attempt head,
+while all assigned slots publish attempt-scoped arrivals tied to their live
+registration. Slot zero validates the complete registration set once and
+atomically publishes one immutable completion proof conditioned on the shared
+attempt head plus every arrival and registration revision. Other slots wait on
+that proof instead of rereading every registration history, keeping control
+store work linear in the active node count. An incomplete attempt remains
+usable when a handler incarnation is replaced; a completed attempt advances
+the shared head before the next worker launch. Missing or unprepared assigned
+nodes therefore fail at the formation deadline instead of launching a partial
+worker group. After bootstrap completes, every handler revalidates the
+generation head before returning its slot.
+
 Registration release is best effort and bounded during local shutdown. If the
 backend remains unavailable, cleanup returns without waiting indefinitely and
 the registration expires under its existing lease.

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1485,10 +1485,24 @@ It registers every agent, renews that registration while the handler is alive,
 returns active nodes by logical slot, keeps unassigned agents blocked without
 reporting them as waiting, and propagates one immutable run-scoped closure that
 wakes parked standbys and releases registrations. It also clears any stale
-node-local restart context before the initial generation starts. Replacement
-generation admission, restart-context publication, and the positive
+node-local restart context before the initial generation starts. The join
+timeout bounds initial generation formation and worker bootstrap only; after
+generation zero exists, passive standbys remain parked until assignment,
+closure, cancellation, or registration failure. Registration heartbeats
+schedule each renewal from the returned lease's remaining lifetime rather than
+from a fixed interval. An assigned node ID is admitted only when its retained
+registration history has the same local worker count and environment digest as
+the current handler, so an incompatible process cannot reuse an expired node
+registration. Replacement generation admission, restart-context publication,
+and the positive
 `num_nodes_waiting()` restart edge are enabled only after authoritative
 restart-plan readback is integrated in the following slice.
+
+Every `next_rendezvous()` invocation uses an attempt-scoped `PrefixStore` for
+PyTorch's worker bootstrap keys. Bootstrap reads are bounded by the remaining
+join deadline, so a missing slot-zero publisher cannot strand other agents on
+the underlying store timeout and a retry cannot consume address/port values
+from a previous attempt.
 
 Passive standbys are not reported by `num_nodes_waiting()`. After a plan
 commits, the selected replacement becomes the only newly waiting node visible

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1521,16 +1521,21 @@ registration. Slot zero validates the complete registration set once and
 atomically publishes one immutable completion proof conditioned on the shared
 attempt head plus every arrival and registration revision. Other slots wait on
 that proof instead of rereading every registration history, keeping control
-store work linear in the active node count. An incomplete attempt remains
-usable when a handler incarnation is replaced; a completed attempt advances
-the shared head before the next worker launch. Missing or unprepared assigned
-nodes therefore fail at the formation deadline instead of launching a partial
-worker group. After bootstrap completes, every handler revalidates the
-generation head before returning its slot.
+store work linear in the active node count. Slot zero reloads its current
+renewed registration immediately before each guarded completion attempt, so
+heartbeat renewal cannot strand an otherwise complete barrier on a stale
+fencing token. An incomplete attempt remains usable when a handler incarnation
+is replaced; a completed attempt advances the shared head before the next
+worker launch. Missing or unprepared assigned nodes therefore fail at the
+formation deadline instead of launching a partial worker group. After
+bootstrap completes, every handler revalidates the generation head before
+returning its slot.
 
 Registration release is best effort and bounded during local shutdown. If the
 backend remains unavailable, cleanup returns without waiting indefinitely and
-the registration expires under its existing lease.
+the registration expires under its existing lease. Global closure publication
+also runs through a bounded daemon operation; local heartbeat and registration
+cleanup still proceeds when the control store is unavailable.
 Replacement generation admission, restart-context publication, and the positive
 `num_nodes_waiting()` restart edge are enabled only after authoritative
 restart-plan readback is integrated in the following slice.

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1524,12 +1524,17 @@ that proof instead of rereading every registration history, keeping control
 store work linear in the active node count. Slot zero reloads its current
 renewed registration immediately before each guarded completion attempt, so
 heartbeat renewal cannot strand an otherwise complete barrier on a stale
-fencing token. An incomplete attempt remains usable when a handler incarnation
-is replaced; a completed attempt advances the shared head before the next
-worker launch. Missing or unprepared assigned nodes therefore fail at the
-formation deadline instead of launching a partial worker group. After
-bootstrap completes, every handler revalidates the generation head before
-returning its slot.
+fencing token. After bootstrap and final generation revalidation, every
+assigned handler publishes one immutable, registration-guarded consumption
+record for the completed attempt. An incomplete attempt remains usable when a
+handler incarnation is replaced. A completed attempt advances only after every
+slot has a durable consumption record, so a replacement for a handler that
+failed after completion but before returning joins the completed attempt
+instead of splitting the worker group. Guarded barrier transactions pin their
+registration revision in retained history. Missing or unprepared assigned
+nodes therefore fail at the formation deadline instead of launching a partial
+worker group. After bootstrap completes, every handler revalidates the
+generation head before returning its slot.
 
 Registration release is best effort and bounded during local shutdown. If the
 backend remains unavailable, cleanup returns without waiting indefinitely and

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1480,6 +1480,16 @@ named by the committed plan:
 - exactly `min_nodes` slots complete the rendezvous; and
 - returned group rank is derived from logical slot, not arrival order.
 
+The first runtime slice admits only the immutable generation-zero assignment.
+It registers every agent, renews that registration while the handler is alive,
+returns active nodes by logical slot, keeps unassigned agents blocked without
+reporting them as waiting, and propagates one immutable run-scoped closure that
+wakes parked standbys and releases registrations. It also clears any stale
+node-local restart context before the initial generation starts. Replacement
+generation admission, restart-context publication, and the positive
+`num_nodes_waiting()` restart edge are enabled only after authoritative
+restart-plan readback is integrated in the following slice.
+
 Passive standbys are not reported by `num_nodes_waiting()`. After a plan
 commits, the selected replacement becomes the only newly waiting node visible
 to active agents. This is the restart edge: a random late node must not trigger

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1495,8 +1495,13 @@ each renewal from the returned lease's remaining lifetime rather than from a
 fixed interval. An assigned node ID is admitted only when its retained
 registration history has the same local worker count and environment digest as
 the current handler, so an incompatible process cannot reuse an expired node
-registration. Replacement generation admission, restart-context publication,
-and the positive
+registration. The first assigned node commits one immutable run-scoped workload
+compatibility identity, and every other assigned node must match it; unassigned
+standbys cannot create or replace that record. Initial registration backend I/O
+does not hold the handler's ownership lock, so local shutdown remains bounded
+while registration is stalled. A registration response arriving after local
+shutdown is not installed or heartbeated and expires conservatively.
+Replacement generation admission, restart-context publication, and the positive
 `num_nodes_waiting()` restart edge are enabled only after authoritative
 restart-plan readback is integrated in the following slice.
 

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1512,9 +1512,15 @@ does not hold the handler's ownership lock, so local shutdown remains bounded
 while registration is stalled. A registration response arriving after local
 shutdown is not installed or heartbeated and expires conservatively.
 Before any assigned handler returns generation zero, it publishes a
-generation-scoped arrival tied to its live registration and waits until every
-committed slot has a live matching arrival. Missing assigned nodes therefore
-fail at the formation deadline instead of launching a partial worker group.
+generation- and attempt-scoped arrival tied to its live registration and waits
+until every committed slot has a live matching arrival for the same attempt.
+Each slot claims its next attempt through durable control-store state, so a
+surviving or replacement handler cannot reuse an arrival from a prior worker
+launch. Missing assigned nodes therefore fail at the formation deadline instead
+of launching a partial worker group.
+Registration release is best effort and bounded during local shutdown. If the
+backend remains unavailable, cleanup returns without waiting indefinitely and
+the registration expires under its existing lease.
 Replacement generation admission, restart-context publication, and the positive
 `num_nodes_waiting()` restart edge are enabled only after authoritative
 restart-plan readback is integrated in the following slice.

--- a/lm_resiliency/integrations/torchrun/_agent_registration.py
+++ b/lm_resiliency/integrations/torchrun/_agent_registration.py
@@ -211,7 +211,7 @@ class AgentRegistrationManager:
                         "active agent registration uses a different lease duration"
                     )
                 try:
-                    entry = self._store.compare_set_in_window(
+                    entry = self._store.compare_refresh_in_window(
                         self._registration_key,
                         expected_revision=current.fencing_token,
                         not_before_unix_ms=now_unix_ms,
@@ -284,7 +284,7 @@ class AgentRegistrationManager:
         if registration.expires_at_unix_ms <= now_unix_ms:
             raise AgentRegistrationLost("agent registration expired before renewal")
         try:
-            entry = self._store.compare_set_in_window(
+            entry = self._store.compare_refresh_in_window(
                 self._registration_key,
                 expected_revision=registration.fencing_token,
                 not_before_unix_ms=now_unix_ms,

--- a/lm_resiliency/integrations/torchrun/_agent_registration_history_reader.py
+++ b/lm_resiliency/integrations/torchrun/_agent_registration_history_reader.py
@@ -187,9 +187,14 @@ def _validate_transition(
         )
     if lifetime_delta not in (0, 1):
         raise AgentRegistrationHistoryCorrupt("agent-registration history omits a key lifetime")
-    if mutation_delta != (1 if lifetime_delta == 0 else 2):
-        raise AgentRegistrationHistoryCorrupt("agent-registration history omits a key mutation")
     same_record = current_registration.record == previous_registration.record
+    if lifetime_delta == 0 and same_record:
+        if mutation_delta < 1:
+            raise AgentRegistrationHistoryCorrupt(
+                "agent-registration mutation sequence does not advance"
+            )
+    elif mutation_delta != (1 if lifetime_delta == 0 else 2):
+        raise AgentRegistrationHistoryCorrupt("agent-registration history omits a key mutation")
     expected_value_delta = 0 if lifetime_delta == 0 and same_record else 1
     if value_delta != expected_value_delta:
         raise AgentRegistrationHistoryCorrupt(
@@ -200,7 +205,11 @@ def _validate_transition(
             raise AgentRegistrationHistoryCorrupt(
                 "one agent registration crosses a recreated key lifetime"
             )
-        if current_registration.granted_at_unix_ms >= previous_registration.expires_at_unix_ms:
+        latest_valid_grant = (
+            previous_registration.granted_at_unix_ms
+            + mutation_delta * previous_registration.record.lease_duration_ms
+        )
+        if current_registration.granted_at_unix_ms >= latest_valid_grant:
             raise AgentRegistrationHistoryCorrupt(
                 "agent-registration history renews an expired registration"
             )

--- a/lm_resiliency/integrations/torchrun/_control_store.py
+++ b/lm_resiliency/integrations/torchrun/_control_store.py
@@ -622,6 +622,9 @@ class InMemoryControlStore:
             for key, revision in normalized_conditions.items():
                 if revision is not None:
                     self._pinned_revisions.setdefault(key, set()).add(revision)
+            self._pinned_revisions.setdefault(normalized_guard_key, set()).add(
+                normalized_guard_revision
+            )
             return MappingProxyType(committed)
 
     def _compact_equivalent_refreshes(self, key: str) -> None:

--- a/lm_resiliency/integrations/torchrun/_control_store.py
+++ b/lm_resiliency/integrations/torchrun/_control_store.py
@@ -228,11 +228,13 @@ class ControlStore(Protocol):
         ...
 
     def get_history(self, key: str) -> tuple[ControlStoreEntry, ...]:
-        """Return every committed value for ``key`` in mutation order.
+        """Return retained authoritative values for ``key`` in mutation order.
 
         Deletes are represented by revision, mutation, transaction, and
         lifetime gaps between adjacent value entries rather than synthetic
-        values.
+        values. Backends may compact equivalent refreshes while retaining the
+        first value in the lifetime, the current value, and every revision
+        consumed by a successful guarded transaction condition.
         """
         ...
 
@@ -277,6 +279,23 @@ class ControlStore(Protocol):
         """
         ...
 
+    def compare_refresh_in_window(
+        self,
+        key: str,
+        *,
+        expected_revision: int,
+        not_before_unix_ms: int,
+        deadline_unix_ms: int,
+        value: bytes,
+    ) -> ControlStoreEntry:
+        """Refresh one unchanged value and compact unreferenced renewals.
+
+        The current value must equal ``value``. The store retains the first
+        value in the current key lifetime, every revision consumed by a
+        successful guarded transaction condition, and the latest refresh.
+        """
+        ...
+
     def compare_delete_in_window(
         self,
         key: str,
@@ -316,6 +335,7 @@ class InMemoryControlStore:
         self._lock = threading.RLock()
         self._entries: dict[str, ControlStoreEntry] = {}
         self._histories: dict[str, list[ControlStoreEntry]] = {}
+        self._pinned_revisions: dict[str, set[int]] = {}
         self._last_revisions: dict[str, int] = {}
         self._mutation_sequences: dict[str, int] = {}
         self._value_sequences: dict[str, int] = {}
@@ -410,6 +430,55 @@ class InMemoryControlStore:
                 committed_at_unix_ms=now_unix_ms,
                 transaction_sequence=self._next_transaction_sequence(),
             )
+
+    def compare_refresh_in_window(
+        self,
+        key: str,
+        *,
+        expected_revision: int,
+        not_before_unix_ms: int,
+        deadline_unix_ms: int,
+        value: bytes,
+    ) -> ControlStoreEntry:
+        normalized_key = _control_key(key)
+        normalized_revision = _required_revision(expected_revision)
+        normalized_not_before = _positive_integer(
+            not_before_unix_ms,
+            "not_before_unix_ms",
+        )
+        normalized_deadline = _positive_integer(
+            deadline_unix_ms,
+            "deadline_unix_ms",
+        )
+        if normalized_not_before >= normalized_deadline:
+            raise ValueError("not_before_unix_ms must be before deadline_unix_ms")
+        normalized_value = _control_value(value)
+        with self._lock:
+            self._require_revision(normalized_key, normalized_revision)
+            current = self._entries[normalized_key]
+            if current.value != normalized_value:
+                raise ValueError("refresh value must equal the current control-store value")
+            now_unix_ms = self._store_now_unix_ms()
+            if now_unix_ms < normalized_not_before:
+                raise ControlStoreTooEarly(
+                    normalized_key,
+                    normalized_not_before,
+                    now_unix_ms,
+                )
+            if now_unix_ms >= normalized_deadline:
+                raise ControlStoreDeadlineExceeded(
+                    normalized_key,
+                    normalized_deadline,
+                    now_unix_ms,
+                )
+            entry = self._set_entry(
+                normalized_key,
+                normalized_value,
+                committed_at_unix_ms=now_unix_ms,
+                transaction_sequence=self._next_transaction_sequence(),
+            )
+            self._compact_equivalent_refreshes(normalized_key)
+            return entry
 
     def compare_delete_in_window(
         self,
@@ -550,7 +619,30 @@ class InMemoryControlStore:
                 )
                 for key, write in normalized_writes.items()
             }
+            for key, revision in normalized_conditions.items():
+                if revision is not None:
+                    self._pinned_revisions.setdefault(key, set()).add(revision)
             return MappingProxyType(committed)
+
+    def _compact_equivalent_refreshes(self, key: str) -> None:
+        history = self._histories[key]
+        latest = history[-1]
+        start = len(history) - 1
+        while start > 0:
+            previous = history[start - 1]
+            if (
+                previous.value_sequence != latest.value_sequence
+                or previous.lifetime_sequence != latest.lifetime_sequence
+            ):
+                break
+            start -= 1
+        pinned = self._pinned_revisions.get(key, set())
+        compacted_run = [
+            entry
+            for index, entry in enumerate(history[start:])
+            if index == 0 or entry.revision == latest.revision or entry.revision in pinned
+        ]
+        self._histories[key] = [*history[:start], *compacted_run]
 
     def _require_revision(self, key: str, expected_revision: int | None) -> None:
         entry = self._entries.get(key)

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -74,6 +74,7 @@ _MAX_POLICY_BYTES = 64 * 1024
 _CONTROL_PREFIX = "lm_resiliency/torchrun/v1"
 _CLOSED_SCHEMA_VERSION = 1
 _ARRIVAL_SCHEMA_VERSION = 1
+_ARRIVAL_ATTEMPT_SCHEMA_VERSION = 1
 _SHARED_FIELDS = {
     "control_endpoint",
     "replacement_only",
@@ -401,6 +402,8 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         self._heartbeat_thread: threading.Thread | None = None
         self._heartbeat_last_now_unix_ms = 0
         self._stop_heartbeat_event = threading.Event()
+        self._release_thread: threading.Thread | None = None
+        self._release_error: Exception | None = None
         self._state_changed_event = threading.Event()
         self._closed_event = threading.Event()
         self._shutdown_lock = threading.Lock()
@@ -668,27 +671,64 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             registration = self._registration
             if registration is None:
                 return True
-            try:
-                self._registration_manager.release(registration)
-            except (
-                AgentRegistrationClockError,
-                AgentRegistrationCorrupt,
-                AgentRegistrationLost,
-                AgentRegistrationUnavailable,
-            ) as error:
-                if raise_errors:
-                    raise RendezvousConnectionError(
-                        "failed to release the agent registration"
-                    ) from error
-                return False
-            except Exception as error:
-                if raise_errors:
-                    raise RendezvousConnectionError(
-                        "agent registration backend failed during release"
-                    ) from error
-                return False
-            self._registration = None
+            thread = self._release_thread
+            if thread is None:
+                self._release_error = None
+                thread = threading.Thread(
+                    target=self._release_registration_worker,
+                    args=(registration,),
+                    name=f"lm-resiliency-release-{self._config.node_id}",
+                    daemon=True,
+                )
+                self._release_thread = thread
+                thread.start()
+        if thread is not threading.current_thread():
+            thread.join(
+                timeout=max(
+                    self._config.policy.poll_interval_ms / 500,
+                    0.1,
+                )
+            )
+        if thread.is_alive():
+            return False
+        with self._registration_lock:
+            error = self._release_error
+            self._release_thread = None
+            self._release_error = None
+        if error is None:
             return True
+        if raise_errors:
+            if isinstance(
+                error,
+                (
+                    AgentRegistrationClockError,
+                    AgentRegistrationCorrupt,
+                    AgentRegistrationLost,
+                    AgentRegistrationUnavailable,
+                ),
+            ):
+                raise RendezvousConnectionError(
+                    "failed to release the agent registration"
+                ) from error
+            raise RendezvousConnectionError(
+                "agent registration backend failed during release"
+            ) from error
+        return False
+
+    def _release_registration_worker(
+        self,
+        registration: HeldAgentRegistration,
+    ) -> None:
+        error: Exception | None = None
+        try:
+            self._registration_manager.release(registration)
+        except Exception as release_error:
+            error = release_error
+        with self._registration_lock:
+            if error is None and self._registration == registration:
+                self._registration = None
+            self._release_error = error
+        self._state_changed_event.set()
 
     def _raise_heartbeat_error(self) -> None:
         error = self._heartbeat_error
@@ -824,12 +864,22 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             raise RendezvousConnectionError(
                 "assigned node lost its registration before the arrival barrier"
             )
+        attempt = self._claim_arrival_attempt(
+            generation=assignment.generation,
+            slot=slot,
+            deadline=deadline,
+        )
         arrival_value = self._arrival_value(
             generation=assignment.generation,
+            attempt=attempt,
             slot=slot,
             registration=registration,
         )
-        arrival_key = self._arrival_key(assignment.generation, slot)
+        arrival_key = self._arrival_key(
+            assignment.generation,
+            attempt,
+            slot,
+        )
         try:
             entry = self._control_store.get(arrival_key)
             if entry is None:
@@ -846,19 +896,11 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                             "rendezvous arrival changed without a current record"
                         )
             elif entry.value != arrival_value:
-                try:
-                    entry = self._control_store.compare_set(
-                        arrival_key,
-                        expected_revision=entry.revision,
-                        value=arrival_value,
-                    )
-                except ControlStoreConflict as error:
-                    raise RendezvousConnectionError(
-                        "rendezvous arrival changed during agent replacement"
-                    ) from error
+                raise RendezvousStateError("rendezvous attempt slot was claimed by another agent")
             self._validate_arrival_entry(
                 entry,
                 generation=assignment.generation,
+                attempt=attempt,
                 slot=slot,
                 node_id=self._config.node_id,
             )
@@ -875,7 +917,11 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             for assigned_slot, node_id in assignment.slot_to_node_id.items():
                 try:
                     assigned_entry = self._control_store.get(
-                        self._arrival_key(assignment.generation, assigned_slot)
+                        self._arrival_key(
+                            assignment.generation,
+                            attempt,
+                            assigned_slot,
+                        )
                     )
                 except Exception as error:
                     raise RendezvousConnectionError("failed to read rendezvous arrivals") from error
@@ -885,6 +931,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 self._validate_arrival_entry(
                     assigned_entry,
                     generation=assignment.generation,
+                    attempt=attempt,
                     slot=assigned_slot,
                     node_id=node_id,
                 )
@@ -893,22 +940,157 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             if not self._wait_for_change(deadline):
                 raise RendezvousTimeoutError
 
-    def _arrival_key(self, generation: int, slot: int) -> str:
+    def _claim_arrival_attempt(
+        self,
+        *,
+        generation: int,
+        slot: int,
+        deadline: float,
+    ) -> int:
+        key = self._arrival_attempt_key(generation, slot)
+        while True:
+            if self.is_closed():
+                raise RendezvousClosedError
+            self._raise_heartbeat_error()
+            try:
+                entry = self._control_store.get(key)
+                if entry is None:
+                    expected_revision = None
+                    attempt = 1
+                else:
+                    previous_attempt = self._validate_arrival_attempt_entry(
+                        entry,
+                        generation=generation,
+                        slot=slot,
+                    )
+                    expected_revision = entry.revision
+                    attempt = previous_attempt + 1
+                value = self._arrival_attempt_value(
+                    generation=generation,
+                    slot=slot,
+                    attempt=attempt,
+                )
+                try:
+                    committed = self._control_store.compare_set(
+                        key,
+                        expected_revision=expected_revision,
+                        value=value,
+                    )
+                except ControlStoreConflict:
+                    if not self._wait_for_change(deadline):
+                        raise RendezvousTimeoutError
+                    continue
+                self._validate_arrival_attempt_entry(
+                    committed,
+                    generation=generation,
+                    slot=slot,
+                    expected_attempt=attempt,
+                )
+                return attempt
+            except (RendezvousClosedError, RendezvousStateError, RendezvousTimeoutError):
+                raise
+            except Exception as error:
+                raise RendezvousConnectionError(
+                    "failed to claim a rendezvous arrival attempt"
+                ) from error
+
+    def _arrival_attempt_key(self, generation: int, slot: int) -> str:
         return (
             f"{_CONTROL_PREFIX}/runs/{self._run_digest}/rendezvous/"
-            f"generation-{generation}/arrivals/slot-{slot}"
+            f"generation-{generation}/arrival-attempts/slot-{slot}"
+        )
+
+    def _arrival_attempt_value(
+        self,
+        *,
+        generation: int,
+        slot: int,
+        attempt: int,
+    ) -> bytes:
+        return json.dumps(
+            {
+                "attempt": attempt,
+                "generation": generation,
+                "logical_node_slot": slot,
+                "run_id": self._config.run_id,
+                "schema_version": _ARRIVAL_ATTEMPT_SCHEMA_VERSION,
+            },
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+
+    def _validate_arrival_attempt_entry(
+        self,
+        entry: ControlStoreEntry,
+        *,
+        generation: int,
+        slot: int,
+        expected_attempt: int | None = None,
+    ) -> int:
+        try:
+            payload = json.loads(
+                entry.value.decode("utf-8"),
+                object_pairs_hook=_strict_object,
+            )
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as error:
+            raise RendezvousStateError("rendezvous arrival attempt record is malformed") from error
+        expected_fields = {
+            "attempt",
+            "generation",
+            "logical_node_slot",
+            "run_id",
+            "schema_version",
+        }
+        if not isinstance(payload, dict) or set(payload) != expected_fields:
+            raise RendezvousStateError("rendezvous arrival attempt record has invalid fields")
+        attempt = payload["attempt"]
+        if (
+            isinstance(attempt, bool)
+            or not isinstance(attempt, int)
+            or attempt < 1
+            or isinstance(payload["generation"], bool)
+            or not isinstance(payload["generation"], int)
+            or isinstance(payload["logical_node_slot"], bool)
+            or not isinstance(payload["logical_node_slot"], int)
+            or payload["schema_version"] != _ARRIVAL_ATTEMPT_SCHEMA_VERSION
+            or isinstance(payload["schema_version"], bool)
+            or not isinstance(payload["schema_version"], int)
+            or payload["run_id"] != self._config.run_id
+            or payload["generation"] != generation
+            or payload["logical_node_slot"] != slot
+            or (expected_attempt is not None and attempt != expected_attempt)
+        ):
+            raise RendezvousStateError("rendezvous arrival attempt record does not match its slot")
+        if (
+            entry.mutation_sequence != attempt
+            or entry.value_sequence != attempt
+            or entry.lifetime_sequence != 1
+            or entry.guard_key is not None
+        ):
+            raise RendezvousStateError(
+                "rendezvous arrival attempt record has invalid store provenance"
+            )
+        return attempt
+
+    def _arrival_key(self, generation: int, attempt: int, slot: int) -> str:
+        return (
+            f"{_CONTROL_PREFIX}/runs/{self._run_digest}/rendezvous/"
+            f"generation-{generation}/attempt-{attempt}/arrivals/slot-{slot}"
         )
 
     def _arrival_value(
         self,
         *,
         generation: int,
+        attempt: int,
         slot: int,
         registration: HeldAgentRegistration,
     ) -> bytes:
         return json.dumps(
             {
                 "agent_id": registration.record.agent_identity.agent_id,
+                "attempt": attempt,
                 "generation": generation,
                 "logical_node_slot": slot,
                 "node_id": registration.record.agent_identity.node_id,
@@ -926,6 +1108,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         entry: ControlStoreEntry,
         *,
         generation: int,
+        attempt: int,
         slot: int,
         node_id: str,
     ) -> None:
@@ -938,6 +1121,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             raise RendezvousStateError("rendezvous arrival record is malformed") from error
         expected_fields = {
             "agent_id",
+            "attempt",
             "generation",
             "logical_node_slot",
             "node_id",
@@ -950,6 +1134,8 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         if (
             isinstance(payload["generation"], bool)
             or not isinstance(payload["generation"], int)
+            or isinstance(payload["attempt"], bool)
+            or not isinstance(payload["attempt"], int)
             or isinstance(payload["logical_node_slot"], bool)
             or not isinstance(payload["logical_node_slot"], int)
             or payload["schema_version"] != _ARRIVAL_SCHEMA_VERSION
@@ -957,6 +1143,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             or not isinstance(payload["schema_version"], int)
             or payload["run_id"] != self._config.run_id
             or payload["generation"] != generation
+            or payload["attempt"] != attempt
             or payload["logical_node_slot"] != slot
             or payload["node_id"] != node_id
         ):

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -372,6 +372,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         run_digest = hashlib.sha256(config.run_id.encode("utf-8")).hexdigest()
         self._run_digest = run_digest
         self._closure_key = f"{_CONTROL_PREFIX}/runs/{run_digest}/rendezvous-closed"
+        self._compatibility_key = f"{_CONTROL_PREFIX}/runs/{run_digest}/rendezvous-compatibility"
         self._closure_value = json.dumps(
             {
                 "run_id": config.run_id,
@@ -381,8 +382,20 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             separators=(",", ":"),
             sort_keys=True,
         ).encode("utf-8")
+        self._compatibility_value = json.dumps(
+            {
+                "environment_digest": self._agent_identity.environment_digest,
+                "local_world_size": self._agent_identity.local_world_size,
+                "run_id": config.run_id,
+                "schema_version": 1,
+            },
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
         self._registration_lock = threading.RLock()
         self._registration: HeldAgentRegistration | None = None
+        self._registration_inflight = False
         self._heartbeat_error: Exception | None = None
         self._heartbeat_thread: threading.Thread | None = None
         self._heartbeat_last_now_unix_ms = 0
@@ -445,6 +458,9 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                             bootstrap_store,
                             formation_deadline,
                         )
+                        if self.is_closed():
+                            raise RendezvousClosedError
+                        self._raise_heartbeat_error()
                         return RendezvousInfo(
                             bootstrap_store,
                             slot,
@@ -457,8 +473,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 if not self._wait_for_change(wait_deadline):
                     raise RendezvousTimeoutError
         except BaseException:
-            if self._stop_heartbeat():
-                self._release_registration(raise_errors=False)
+            self._cleanup_local_resources()
             raise
 
     def is_closed(self) -> bool:
@@ -499,8 +514,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             raise RendezvousConnectionError("failed to publish rendezvous closure state") from error
         self._closed_event.set()
         self._state_changed_event.set()
-        if self._stop_heartbeat():
-            self._release_registration(raise_errors=False)
+        self._cleanup_local_resources()
 
     def num_nodes_waiting(self) -> int:
         """Hide passive standbys until a committed replacement plan exists."""
@@ -511,46 +525,63 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         return 0
 
     def shutdown(self) -> bool:
+        self._closed_event.set()
+        self._state_changed_event.set()
+        return self._cleanup_local_resources()
+
+    def _cleanup_local_resources(self) -> bool:
         with self._shutdown_lock:
-            succeeded = True
-            self._closed_event.set()
-            self._state_changed_event.set()
             heartbeat_stopped = self._stop_heartbeat()
-            if not heartbeat_stopped:
-                succeeded = False
-            elif not self._release_registration(raise_errors=False):
-                succeeded = False
+            registration_released = heartbeat_stopped and self._release_registration(
+                raise_errors=False
+            )
             thread = self._heartbeat_thread
-            if thread is not None and thread.is_alive():
-                succeeded = False
-            return succeeded
+            return (
+                heartbeat_stopped
+                and registration_released
+                and (thread is None or not thread.is_alive())
+            )
 
     def _ensure_registered(self) -> None:
         self._raise_heartbeat_error()
         with self._registration_lock:
-            if self._registration is None:
-                try:
-                    self._registration = self._registration_manager.register()
-                except AgentRegistrationCorrupt as error:
-                    raise RendezvousStateError("agent registration state is corrupt") from error
-                except (
-                    AgentRegistrationClockError,
-                    AgentRegistrationLost,
-                    AgentRegistrationUnavailable,
-                ) as error:
-                    raise RendezvousConnectionError(
-                        "failed to acquire the agent registration"
-                    ) from error
-                except Exception as error:
-                    raise RendezvousConnectionError("agent registration backend failed") from error
-            thread = self._heartbeat_thread
-            if thread is None or not thread.is_alive():
-                self._heartbeat_thread = threading.Thread(
-                    target=self._heartbeat_loop,
-                    name=f"lm-resiliency-registration-{self._config.node_id}",
-                    daemon=True,
-                )
-                self._heartbeat_thread.start()
+            if self._registration is not None:
+                self._start_heartbeat_locked()
+                return
+            if self._registration_inflight:
+                raise RendezvousConnectionError("agent registration is already in progress")
+            self._registration_inflight = True
+        try:
+            registration = self._registration_manager.register()
+        except AgentRegistrationCorrupt as error:
+            raise RendezvousStateError("agent registration state is corrupt") from error
+        except (
+            AgentRegistrationClockError,
+            AgentRegistrationLost,
+            AgentRegistrationUnavailable,
+        ) as error:
+            raise RendezvousConnectionError("failed to acquire the agent registration") from error
+        except Exception as error:
+            raise RendezvousConnectionError("agent registration backend failed") from error
+        finally:
+            with self._registration_lock:
+                self._registration_inflight = False
+        with self._registration_lock:
+            if self._closed_event.is_set() or self._stop_heartbeat_event.is_set():
+                raise RendezvousClosedError
+            self._registration = registration
+            self._start_heartbeat_locked()
+
+    def _start_heartbeat_locked(self) -> None:
+        thread = self._heartbeat_thread
+        if thread is None or not thread.is_alive():
+            thread = threading.Thread(
+                target=self._heartbeat_loop,
+                name=f"lm-resiliency-registration-{self._config.node_id}",
+                daemon=True,
+            )
+            thread.start()
+            self._heartbeat_thread = thread
 
     def _heartbeat_loop(self) -> None:
         while True:
@@ -786,9 +817,49 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             )
         for slot, node_id in assignment.slot_to_node_id.items():
             if node_id == self._config.node_id:
+                self._ensure_job_compatibility()
                 self._validate_assigned_registration_history()
                 return slot
         return None
+
+    def _ensure_job_compatibility(self) -> None:
+        try:
+            entry = self._control_store.get(self._compatibility_key)
+            if entry is None:
+                if self._control_store.has_history(self._compatibility_key):
+                    entry = self._control_store.get(self._compatibility_key)
+                    if entry is None:
+                        raise RendezvousStateError("rendezvous compatibility record was deleted")
+                else:
+                    try:
+                        entry = self._control_store.compare_set(
+                            self._compatibility_key,
+                            expected_revision=None,
+                            value=self._compatibility_value,
+                        )
+                    except ControlStoreConflict:
+                        entry = self._control_store.get(self._compatibility_key)
+                        if entry is None:
+                            raise RendezvousStateError(
+                                "rendezvous compatibility changed without a current record"
+                            )
+            if entry.value != self._compatibility_value:
+                raise RendezvousStateError(
+                    "assigned node is incompatible with the committed workload environment"
+                )
+            if (
+                entry.mutation_sequence != 1
+                or entry.value_sequence != 1
+                or entry.lifetime_sequence != 1
+                or entry.guard_key is not None
+            ):
+                raise RendezvousStateError("rendezvous compatibility record is not immutable")
+        except RendezvousStateError:
+            raise
+        except Exception as error:
+            raise RendezvousConnectionError(
+                "failed to validate rendezvous workload compatibility"
+            ) from error
 
     def _wait_for_change(self, deadline: float | None) -> bool:
         if deadline is None:

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -41,6 +41,7 @@ from lm_resiliency.integrations.torchrun._agent_registration import (
     AgentRegistrationLost,
     AgentRegistrationManager,
     AgentRegistrationUnavailable,
+    agent_registration_key,
 )
 from lm_resiliency.integrations.torchrun._agent_registration_history_reader import (
     AgentRegistrationHistoryCorrupt,
@@ -54,6 +55,7 @@ from lm_resiliency.integrations.torchrun._control_store import (
     ControlStore,
     ControlStoreConflict,
     ControlStoreEntry,
+    ControlStoreWrite,
 )
 from lm_resiliency.integrations.torchrun._generation_reader import (
     CurrentGeneration,
@@ -61,7 +63,11 @@ from lm_resiliency.integrations.torchrun._generation_reader import (
     GenerationStateError,
     GenerationStateReader,
 )
-from lm_resiliency.integrations.torchrun._protocol import AgentIdentity, RestartContext
+from lm_resiliency.integrations.torchrun._protocol import (
+    AgentIdentity,
+    RankAssignment,
+    RestartContext,
+)
 
 _BACKEND = "lm_resiliency"
 _NODE_ID_ENV = "LM_RESILIENCY_NODE_ID"
@@ -75,6 +81,7 @@ _CONTROL_PREFIX = "lm_resiliency/torchrun/v1"
 _CLOSED_SCHEMA_VERSION = 1
 _ARRIVAL_SCHEMA_VERSION = 1
 _ARRIVAL_ATTEMPT_SCHEMA_VERSION = 1
+_ARRIVAL_COMPLETION_SCHEMA_VERSION = 1
 _SHARED_FIELDS = {
     "control_endpoint",
     "replacement_only",
@@ -398,12 +405,15 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         self._registration_lock = threading.RLock()
         self._registration: HeldAgentRegistration | None = None
         self._registration_inflight = False
+        self._registration_thread: threading.Thread | None = None
+        self._registration_error: Exception | None = None
         self._heartbeat_error: Exception | None = None
         self._heartbeat_thread: threading.Thread | None = None
         self._heartbeat_last_now_unix_ms = 0
         self._stop_heartbeat_event = threading.Event()
         self._release_thread: threading.Thread | None = None
         self._release_error: Exception | None = None
+        self._last_arrival_attempts: dict[int, int] = {}
         self._state_changed_event = threading.Event()
         self._closed_event = threading.Event()
         self._shutdown_lock = threading.Lock()
@@ -439,7 +449,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             raise RendezvousClosedError
         formation_deadline = self._monotonic_clock() + self._config.policy.join_timeout_ms / 1_000
         try:
-            self._ensure_registered()
+            self._ensure_registered(formation_deadline)
             while True:
                 if self.is_closed():
                     raise RendezvousClosedError
@@ -448,17 +458,17 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 if current is not None:
                     slot = self._initial_slot(current)
                     if slot is not None:
-                        self._wait_for_assigned_arrivals(
-                            current,
-                            slot,
-                            formation_deadline,
-                        )
                         try:
                             self._restart_context.clear()
                         except (OSError, RestartContextFileError) as error:
                             raise RendezvousStateError(
                                 "failed to clear stale initial restart context"
                             ) from error
+                        self._wait_for_assigned_arrivals(
+                            current,
+                            slot,
+                            formation_deadline,
+                        )
                         bootstrap_store = self._bootstrap_store(
                             current.snapshot.record.assignment.generation,
                         )
@@ -470,6 +480,8 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                         if self.is_closed():
                             raise RendezvousClosedError
                         self._raise_heartbeat_error()
+                        if self._read_generation() != current:
+                            raise RendezvousConnectionError("generation changed during rendezvous")
                         return RendezvousInfo(
                             bootstrap_store,
                             slot,
@@ -551,35 +563,85 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 and (thread is None or not thread.is_alive())
             )
 
-    def _ensure_registered(self) -> None:
+    def _ensure_registered(self, deadline: float) -> None:
         self._raise_heartbeat_error()
         with self._registration_lock:
             if self._registration is not None:
                 self._start_heartbeat_locked()
                 return
-            if self._registration_inflight:
-                raise RendezvousConnectionError("agent registration is already in progress")
-            self._registration_inflight = True
-        try:
-            registration = self._registration_manager.register()
-        except AgentRegistrationCorrupt as error:
-            raise RendezvousStateError("agent registration state is corrupt") from error
-        except (
-            AgentRegistrationClockError,
-            AgentRegistrationLost,
-            AgentRegistrationUnavailable,
-        ) as error:
-            raise RendezvousConnectionError("failed to acquire the agent registration") from error
-        except Exception as error:
-            raise RendezvousConnectionError("agent registration backend failed") from error
-        finally:
-            with self._registration_lock:
-                self._registration_inflight = False
-        with self._registration_lock:
+            thread = self._registration_thread
+            if thread is None:
+                self._registration_inflight = True
+                self._registration_error = None
+                thread = threading.Thread(
+                    target=self._registration_worker,
+                    name=f"lm-resiliency-register-{self._config.node_id}",
+                    daemon=True,
+                )
+                self._registration_thread = thread
+                thread.start()
+        while thread.is_alive():
             if self._closed_event.is_set() or self._stop_heartbeat_event.is_set():
                 raise RendezvousClosedError
-            self._registration = registration
-            self._start_heartbeat_locked()
+            remaining = deadline - self._monotonic_clock()
+            if remaining <= 0:
+                raise RendezvousTimeoutError
+            thread.join(
+                timeout=min(
+                    remaining,
+                    self._config.policy.poll_interval_ms / 1_000,
+                )
+            )
+        with self._registration_lock:
+            error = self._registration_error
+            registration = self._registration
+        if error is not None:
+            if isinstance(error, AgentRegistrationCorrupt):
+                raise RendezvousStateError("agent registration state is corrupt") from error
+            if isinstance(
+                error,
+                (
+                    AgentRegistrationClockError,
+                    AgentRegistrationLost,
+                    AgentRegistrationUnavailable,
+                ),
+            ):
+                raise RendezvousConnectionError(
+                    "failed to acquire the agent registration"
+                ) from error
+            raise RendezvousConnectionError("agent registration backend failed") from error
+        if registration is None:
+            if self._closed_event.is_set() or self._stop_heartbeat_event.is_set():
+                raise RendezvousClosedError
+            raise RendezvousConnectionError(
+                "agent registration completed without installing ownership"
+            )
+
+    def _registration_worker(self) -> None:
+        registration: HeldAgentRegistration | None = None
+        error: Exception | None = None
+        try:
+            registration = self._registration_manager.register()
+        except Exception as registration_error:
+            error = registration_error
+        release_late_registration = False
+        with self._registration_lock:
+            self._registration_inflight = False
+            self._registration_error = error
+            if registration is not None:
+                if self._closed_event.is_set() or self._stop_heartbeat_event.is_set():
+                    release_late_registration = True
+                else:
+                    self._registration = registration
+                    self._start_heartbeat_locked()
+        self._state_changed_event.set()
+        if release_late_registration and registration is not None:
+            try:
+                self._registration_manager.release(registration)
+            except Exception:
+                # The registration is lease-bounded; a failed best-effort release
+                # must not keep the registration worker or shutdown path alive.
+                pass
 
     def _start_heartbeat_locked(self) -> None:
         thread = self._heartbeat_thread
@@ -864,9 +926,10 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             raise RendezvousConnectionError(
                 "assigned node lost its registration before the arrival barrier"
             )
-        attempt = self._claim_arrival_attempt(
+        attempt = self._claim_shared_arrival_attempt(
             generation=assignment.generation,
             slot=slot,
+            registration=registration,
             deadline=deadline,
         )
         arrival_value = self._arrival_value(
@@ -896,8 +959,26 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                             "rendezvous arrival changed without a current record"
                         )
             elif entry.value != arrival_value:
-                raise RendezvousStateError("rendezvous attempt slot was claimed by another agent")
-            self._validate_arrival_entry(
+                completion = self._read_arrival_completion(
+                    assignment,
+                    attempt,
+                    registration,
+                )
+                if completion is not None:
+                    raise RendezvousConnectionError(
+                        "rendezvous attempt completed before this agent arrived"
+                    )
+                try:
+                    entry = self._control_store.compare_set(
+                        arrival_key,
+                        expected_revision=entry.revision,
+                        value=arrival_value,
+                    )
+                except ControlStoreConflict as error:
+                    raise RendezvousConnectionError(
+                        "rendezvous arrival changed during agent replacement"
+                    ) from error
+            self._validate_arrival_record(
                 entry,
                 generation=assignment.generation,
                 attempt=attempt,
@@ -913,41 +994,32 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             if self.is_closed():
                 raise RendezvousClosedError
             self._raise_heartbeat_error()
-            complete = True
-            for assigned_slot, node_id in assignment.slot_to_node_id.items():
-                try:
-                    assigned_entry = self._control_store.get(
-                        self._arrival_key(
-                            assignment.generation,
-                            attempt,
-                            assigned_slot,
-                        )
-                    )
-                except Exception as error:
-                    raise RendezvousConnectionError("failed to read rendezvous arrivals") from error
-                if assigned_entry is None:
-                    complete = False
-                    continue
-                self._validate_arrival_entry(
-                    assigned_entry,
-                    generation=assignment.generation,
-                    attempt=attempt,
-                    slot=assigned_slot,
-                    node_id=node_id,
-                )
-            if complete:
+            completion = self._read_arrival_completion(
+                assignment,
+                attempt,
+                registration,
+            )
+            if completion is not None:
+                self._last_arrival_attempts[assignment.generation] = attempt
                 return
+            if slot == 0:
+                self._try_complete_arrival_attempt(
+                    assignment,
+                    attempt,
+                    registration,
+                )
             if not self._wait_for_change(deadline):
                 raise RendezvousTimeoutError
 
-    def _claim_arrival_attempt(
+    def _claim_shared_arrival_attempt(
         self,
         *,
         generation: int,
         slot: int,
+        registration: HeldAgentRegistration,
         deadline: float,
     ) -> int:
-        key = self._arrival_attempt_key(generation, slot)
+        key = self._arrival_attempt_key(generation)
         while True:
             if self.is_closed():
                 raise RendezvousClosedError
@@ -955,35 +1027,59 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             try:
                 entry = self._control_store.get(key)
                 if entry is None:
-                    expected_revision = None
+                    if slot != 0:
+                        if not self._wait_for_change(deadline):
+                            raise RendezvousTimeoutError
+                        continue
                     attempt = 1
+                    value = self._arrival_attempt_value(
+                        generation=generation,
+                        attempt=attempt,
+                        registration=registration,
+                    )
+                    try:
+                        committed = self._control_store.compare_set(
+                            key,
+                            expected_revision=None,
+                            value=value,
+                        )
+                    except ControlStoreConflict:
+                        continue
                 else:
-                    previous_attempt = self._validate_arrival_attempt_entry(
+                    attempt, _, _ = self._validate_arrival_attempt_entry(
                         entry,
                         generation=generation,
-                        slot=slot,
                     )
-                    expected_revision = entry.revision
-                    attempt = previous_attempt + 1
-                value = self._arrival_attempt_value(
-                    generation=generation,
-                    slot=slot,
-                    attempt=attempt,
-                )
-                try:
-                    committed = self._control_store.compare_set(
-                        key,
-                        expected_revision=expected_revision,
-                        value=value,
+                    completed = (
+                        self._control_store.get(self._arrival_completion_key(generation, attempt))
+                        is not None
                     )
-                except ControlStoreConflict:
-                    if not self._wait_for_change(deadline):
-                        raise RendezvousTimeoutError
-                    continue
+                    last_attempt = self._last_arrival_attempts.get(generation, 0)
+                    if slot == 0 and (completed or attempt <= last_attempt):
+                        next_attempt = attempt + 1
+                        value = self._arrival_attempt_value(
+                            generation=generation,
+                            attempt=next_attempt,
+                            registration=registration,
+                        )
+                        try:
+                            committed = self._control_store.compare_set(
+                                key,
+                                expected_revision=entry.revision,
+                                value=value,
+                            )
+                        except ControlStoreConflict:
+                            continue
+                        attempt = next_attempt
+                    elif completed or attempt <= last_attempt:
+                        if not self._wait_for_change(deadline):
+                            raise RendezvousTimeoutError
+                        continue
+                    else:
+                        committed = entry
                 self._validate_arrival_attempt_entry(
                     committed,
                     generation=generation,
-                    slot=slot,
                     expected_attempt=attempt,
                 )
                 return attempt
@@ -994,24 +1090,25 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                     "failed to claim a rendezvous arrival attempt"
                 ) from error
 
-    def _arrival_attempt_key(self, generation: int, slot: int) -> str:
+    def _arrival_attempt_key(self, generation: int) -> str:
         return (
             f"{_CONTROL_PREFIX}/runs/{self._run_digest}/rendezvous/"
-            f"generation-{generation}/arrival-attempts/slot-{slot}"
+            f"generation-{generation}/arrival-attempt"
         )
 
     def _arrival_attempt_value(
         self,
         *,
         generation: int,
-        slot: int,
         attempt: int,
+        registration: HeldAgentRegistration,
     ) -> bytes:
         return json.dumps(
             {
                 "attempt": attempt,
                 "generation": generation,
-                "logical_node_slot": slot,
+                "leader_agent_id": registration.record.agent_identity.agent_id,
+                "leader_registration_id": registration.record.registration_id,
                 "run_id": self._config.run_id,
                 "schema_version": _ARRIVAL_ATTEMPT_SCHEMA_VERSION,
             },
@@ -1025,9 +1122,8 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         entry: ControlStoreEntry,
         *,
         generation: int,
-        slot: int,
         expected_attempt: int | None = None,
-    ) -> int:
+    ) -> tuple[int, str, str]:
         try:
             payload = json.loads(
                 entry.value.decode("utf-8"),
@@ -1038,7 +1134,8 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         expected_fields = {
             "attempt",
             "generation",
-            "logical_node_slot",
+            "leader_agent_id",
+            "leader_registration_id",
             "run_id",
             "schema_version",
         }
@@ -1051,17 +1148,19 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             or attempt < 1
             or isinstance(payload["generation"], bool)
             or not isinstance(payload["generation"], int)
-            or isinstance(payload["logical_node_slot"], bool)
-            or not isinstance(payload["logical_node_slot"], int)
             or payload["schema_version"] != _ARRIVAL_ATTEMPT_SCHEMA_VERSION
             or isinstance(payload["schema_version"], bool)
             or not isinstance(payload["schema_version"], int)
             or payload["run_id"] != self._config.run_id
             or payload["generation"] != generation
-            or payload["logical_node_slot"] != slot
             or (expected_attempt is not None and attempt != expected_attempt)
         ):
-            raise RendezvousStateError("rendezvous arrival attempt record does not match its slot")
+            raise RendezvousStateError(
+                "rendezvous arrival attempt record does not match its generation"
+            )
+        for field in ("leader_agent_id", "leader_registration_id"):
+            if not isinstance(payload[field], str) or not payload[field]:
+                raise RendezvousStateError(f"rendezvous arrival attempt record has invalid {field}")
         if (
             entry.mutation_sequence != attempt
             or entry.value_sequence != attempt
@@ -1071,7 +1170,11 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             raise RendezvousStateError(
                 "rendezvous arrival attempt record has invalid store provenance"
             )
-        return attempt
+        return (
+            attempt,
+            payload["leader_registration_id"],
+            payload["leader_agent_id"],
+        )
 
     def _arrival_key(self, generation: int, attempt: int, slot: int) -> str:
         return (
@@ -1103,7 +1206,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             sort_keys=True,
         ).encode("utf-8")
 
-    def _validate_arrival_entry(
+    def _validate_arrival_record(
         self,
         entry: ControlStoreEntry,
         *,
@@ -1111,7 +1214,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         attempt: int,
         slot: int,
         node_id: str,
-    ) -> None:
+    ) -> tuple[str, str]:
         try:
             payload = json.loads(
                 entry.value.decode("utf-8"),
@@ -1153,6 +1256,15 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 raise RendezvousStateError(f"rendezvous arrival record has invalid {field}")
         if entry.lifetime_sequence != 1 or entry.guard_key is not None:
             raise RendezvousStateError("rendezvous arrival record has invalid store provenance")
+        return payload["registration_id"], payload["agent_id"]
+
+    def _validate_arrived_registration(
+        self,
+        *,
+        node_id: str,
+        registration_id: str,
+        agent_id: str,
+    ) -> HeldAgentRegistration:
         try:
             history = AgentRegistrationHistoryReader(
                 self._control_store,
@@ -1169,10 +1281,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         if current is None:
             raise RendezvousConnectionError("arrived agent no longer has a current registration")
         identity = current.record.agent_identity
-        if (
-            current.record.registration_id != payload["registration_id"]
-            or identity.agent_id != payload["agent_id"]
-        ):
+        if current.record.registration_id != registration_id or identity.agent_id != agent_id:
             raise RendezvousStateError(
                 "rendezvous arrival does not match the current agent registration"
             )
@@ -1187,6 +1296,264 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             )
         if current.expires_at_unix_ms <= now_unix_ms:
             raise RendezvousConnectionError("arrived agent registration has expired")
+        return current
+
+    def _try_complete_arrival_attempt(
+        self,
+        assignment: RankAssignment,
+        attempt: int,
+        leader_registration: HeldAgentRegistration,
+    ) -> None:
+        completion_key = self._arrival_completion_key(
+            assignment.generation,
+            attempt,
+        )
+        if self._control_store.get(completion_key) is not None:
+            return
+        arrivals: dict[str, dict[str, Any]] = {}
+        conditions: dict[str, int | None] = {}
+        deadline_unix_ms = leader_registration.expires_at_unix_ms
+        attempt_key = self._arrival_attempt_key(assignment.generation)
+        try:
+            attempt_entry = self._control_store.get(attempt_key)
+        except Exception as error:
+            raise RendezvousConnectionError(
+                "failed to read the rendezvous arrival attempt"
+            ) from error
+        if attempt_entry is None:
+            raise RendezvousStateError("rendezvous arrival attempt disappeared before completion")
+        self._validate_arrival_attempt_entry(
+            attempt_entry,
+            generation=assignment.generation,
+            expected_attempt=attempt,
+        )
+        conditions[attempt_key] = attempt_entry.revision
+        for assigned_slot, node_id in assignment.slot_to_node_id.items():
+            arrival_key = self._arrival_key(
+                assignment.generation,
+                attempt,
+                assigned_slot,
+            )
+            try:
+                entry = self._control_store.get(arrival_key)
+            except Exception as error:
+                raise RendezvousConnectionError("failed to read rendezvous arrivals") from error
+            if entry is None:
+                return
+            registration_id, agent_id = self._validate_arrival_record(
+                entry,
+                generation=assignment.generation,
+                attempt=attempt,
+                slot=assigned_slot,
+                node_id=node_id,
+            )
+            current_registration = self._validate_arrived_registration(
+                node_id=node_id,
+                registration_id=registration_id,
+                agent_id=agent_id,
+            )
+            registration_key = agent_registration_key(
+                self._config.run_id,
+                node_id,
+            )
+            conditions[arrival_key] = entry.revision
+            if registration_key != self._registration_manager.registration_key:
+                conditions[registration_key] = current_registration.fencing_token
+            deadline_unix_ms = min(
+                deadline_unix_ms,
+                current_registration.expires_at_unix_ms,
+            )
+            arrivals[str(assigned_slot)] = {
+                "agent_id": agent_id,
+                "arrival_revision": entry.revision,
+                "node_id": node_id,
+                "registration_id": registration_id,
+                "registration_revision": current_registration.fencing_token,
+            }
+        now_unix_ms = self._clock()
+        if (
+            isinstance(now_unix_ms, bool)
+            or not isinstance(now_unix_ms, int)
+            or now_unix_ms < leader_registration.granted_at_unix_ms
+            or now_unix_ms >= deadline_unix_ms
+        ):
+            raise RendezvousConnectionError(
+                "rendezvous completion clock is outside the registration window"
+            )
+        value = self._arrival_completion_value(
+            generation=assignment.generation,
+            attempt=attempt,
+            arrivals=arrivals,
+        )
+        try:
+            result = self._control_store.compare_set_many_guarded(
+                {
+                    completion_key: ControlStoreWrite(
+                        expected_revision=None,
+                        value=value,
+                        require_never_created=True,
+                    )
+                },
+                guard_key=self._registration_manager.registration_key,
+                expected_guard_revision=leader_registration.fencing_token,
+                not_before_unix_ms=now_unix_ms,
+                deadline_unix_ms=deadline_unix_ms,
+                conditions=conditions,
+            )
+        except ControlStoreConflict:
+            return
+        except Exception as error:
+            raise RendezvousConnectionError(
+                "failed to commit the rendezvous arrival barrier"
+            ) from error
+        self._validate_arrival_completion_entry(
+            result[completion_key],
+            assignment=assignment,
+            attempt=attempt,
+            registration=leader_registration,
+        )
+        self._state_changed_event.set()
+
+    def _read_arrival_completion(
+        self,
+        assignment: RankAssignment,
+        attempt: int,
+        registration: HeldAgentRegistration,
+    ) -> ControlStoreEntry | None:
+        key = self._arrival_completion_key(assignment.generation, attempt)
+        try:
+            entry = self._control_store.get(key)
+        except Exception as error:
+            raise RendezvousConnectionError(
+                "failed to read the rendezvous arrival completion"
+            ) from error
+        if entry is None:
+            return None
+        self._validate_arrival_completion_entry(
+            entry,
+            assignment=assignment,
+            attempt=attempt,
+            registration=registration,
+        )
+        return entry
+
+    def _arrival_completion_key(self, generation: int, attempt: int) -> str:
+        return (
+            f"{_CONTROL_PREFIX}/runs/{self._run_digest}/rendezvous/"
+            f"generation-{generation}/attempt-{attempt}/complete"
+        )
+
+    def _arrival_completion_value(
+        self,
+        *,
+        generation: int,
+        attempt: int,
+        arrivals: Mapping[str, Mapping[str, Any]],
+    ) -> bytes:
+        return json.dumps(
+            {
+                "arrivals": arrivals,
+                "attempt": attempt,
+                "generation": generation,
+                "run_id": self._config.run_id,
+                "schema_version": _ARRIVAL_COMPLETION_SCHEMA_VERSION,
+            },
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+
+    def _validate_arrival_completion_entry(
+        self,
+        entry: ControlStoreEntry,
+        *,
+        assignment: RankAssignment,
+        attempt: int,
+        registration: HeldAgentRegistration,
+    ) -> None:
+        try:
+            payload = json.loads(
+                entry.value.decode("utf-8"),
+                object_pairs_hook=_strict_object,
+            )
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as error:
+            raise RendezvousStateError("rendezvous arrival completion is malformed") from error
+        expected_fields = {
+            "arrivals",
+            "attempt",
+            "generation",
+            "run_id",
+            "schema_version",
+        }
+        if not isinstance(payload, dict) or set(payload) != expected_fields:
+            raise RendezvousStateError("rendezvous arrival completion has invalid fields")
+        if (
+            payload["run_id"] != self._config.run_id
+            or payload["generation"] != assignment.generation
+            or payload["attempt"] != attempt
+            or payload["schema_version"] != _ARRIVAL_COMPLETION_SCHEMA_VERSION
+            or any(
+                isinstance(payload[field], bool) or not isinstance(payload[field], int)
+                for field in ("generation", "attempt", "schema_version")
+            )
+        ):
+            raise RendezvousStateError("rendezvous arrival completion does not match its attempt")
+        arrivals = payload["arrivals"]
+        expected_slots = {
+            str(slot): node_id for slot, node_id in assignment.slot_to_node_id.items()
+        }
+        if not isinstance(arrivals, dict) or set(arrivals) != set(expected_slots):
+            raise RendezvousStateError("rendezvous arrival completion has invalid slot coverage")
+        own_arrival: Mapping[str, Any] | None = None
+        for slot, node_id in expected_slots.items():
+            arrival = arrivals[slot]
+            fields = {
+                "agent_id",
+                "arrival_revision",
+                "node_id",
+                "registration_id",
+                "registration_revision",
+            }
+            if not isinstance(arrival, dict) or set(arrival) != fields:
+                raise RendezvousStateError(
+                    "rendezvous arrival completion has invalid arrival metadata"
+                )
+            if arrival["node_id"] != node_id:
+                raise RendezvousStateError(
+                    "rendezvous arrival completion has invalid node assignment"
+                )
+            for field in ("agent_id", "registration_id"):
+                if not isinstance(arrival[field], str) or not arrival[field]:
+                    raise RendezvousStateError(f"rendezvous arrival completion has invalid {field}")
+            for field in ("arrival_revision", "registration_revision"):
+                if (
+                    isinstance(arrival[field], bool)
+                    or not isinstance(arrival[field], int)
+                    or arrival[field] < 1
+                ):
+                    raise RendezvousStateError(f"rendezvous arrival completion has invalid {field}")
+            if node_id == self._config.node_id:
+                own_arrival = arrival
+        if own_arrival is None or (
+            own_arrival["registration_id"] != registration.record.registration_id
+            or own_arrival["agent_id"] != registration.record.agent_identity.agent_id
+        ):
+            raise RendezvousConnectionError(
+                "rendezvous completion does not include this agent registration"
+            )
+        slot_zero = arrivals["0"]
+        if (
+            entry.mutation_sequence != 1
+            or entry.value_sequence != 1
+            or entry.lifetime_sequence != 1
+            or entry.guard_key
+            != agent_registration_key(
+                self._config.run_id,
+                expected_slots["0"],
+            )
+            or entry.guard_revision != slot_zero["registration_revision"]
+        ):
+            raise RendezvousStateError("rendezvous arrival completion has invalid store provenance")
 
     def _initial_slot(self, current: CurrentGeneration) -> int | None:
         assignment = current.snapshot.record.assignment

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -7,20 +7,54 @@ import importlib
 import json
 import os
 import secrets
+import socket
 import stat
+import threading
+import time
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any, ClassVar
+from typing import Any, Callable, ClassVar
 
 try:
     _toml = importlib.import_module("tomllib")
 except ModuleNotFoundError:  # pragma: no cover - exercised by the Python 3.10 CI job.
     _toml = importlib.import_module("tomli")
 
-from torch.distributed.elastic.rendezvous import RendezvousParameters
+from torch.distributed import Store
+from torch.distributed.elastic.rendezvous import (
+    RendezvousClosedError,
+    RendezvousConnectionError,
+    RendezvousHandler,
+    RendezvousInfo,
+    RendezvousParameters,
+    RendezvousStateError,
+    RendezvousStoreInfo,
+    RendezvousTimeoutError,
+)
 
+from lm_resiliency.integrations.torchrun._agent_registration import (
+    AgentRegistrationClockError,
+    AgentRegistrationCorrupt,
+    AgentRegistrationLost,
+    AgentRegistrationManager,
+    AgentRegistrationUnavailable,
+)
+from lm_resiliency.integrations.torchrun._agent_registration_records import (
+    HeldAgentRegistration,
+)
+from lm_resiliency.integrations.torchrun._control_store import (
+    ControlStore,
+    ControlStoreConflict,
+    ControlStoreEntry,
+)
+from lm_resiliency.integrations.torchrun._generation_reader import (
+    CurrentGeneration,
+    GenerationStateCorrupt,
+    GenerationStateError,
+    GenerationStateReader,
+)
 from lm_resiliency.integrations.torchrun._protocol import AgentIdentity, RestartContext
 
 _BACKEND = "lm_resiliency"
@@ -31,6 +65,8 @@ _RESOURCE_IDS_ENV = "LM_RESILIENCY_RESOURCE_IDS"
 _RESTART_CONTEXT_ENV = "LM_RESILIENCY_RESTART_CONTEXT"
 _MAX_CONTEXT_BYTES = 64 * 1024
 _MAX_POLICY_BYTES = 64 * 1024
+_CONTROL_PREFIX = "lm_resiliency/torchrun/v1"
+_CLOSED_SCHEMA_VERSION = 1
 _SHARED_FIELDS = {
     "control_endpoint",
     "replacement_only",
@@ -278,6 +314,381 @@ class TorchrunRuntimeConfig:
             local_addr=params.local_addr,
             source_path=source_path,
         )
+
+
+class SlotAwareRendezvousHandler(RendezvousHandler):
+    """Admit the initial fixed-size worker group and park passive standbys."""
+
+    use_agent_store = True
+
+    def __init__(
+        self,
+        config: TorchrunRuntimeConfig,
+        *,
+        control_store: ControlStore,
+        rendezvous_store: Store,
+        clock: Callable[[], int],
+        agent_id: str | None = None,
+        hostname: str | None = None,
+        bootstrap_store_info: RendezvousStoreInfo | None = None,
+        monotonic_clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if not isinstance(config, TorchrunRuntimeConfig):
+            raise TypeError("config must be TorchrunRuntimeConfig")
+        if not callable(clock):
+            raise TypeError("clock must be callable")
+        if not callable(monotonic_clock):
+            raise TypeError("monotonic_clock must be callable")
+        if bootstrap_store_info is not None and not isinstance(
+            bootstrap_store_info,
+            RendezvousStoreInfo,
+        ):
+            raise TypeError("bootstrap_store_info must be RendezvousStoreInfo or None")
+        self._config = config
+        self._control_store = control_store
+        self._rendezvous_store = rendezvous_store
+        self._bootstrap_store_info = bootstrap_store_info
+        self._monotonic_clock = monotonic_clock
+        self._agent_identity = config.build_agent_identity(
+            agent_id=agent_id or secrets.token_hex(16),
+            hostname=hostname or socket.getfqdn(),
+        )
+        self._registration_manager = AgentRegistrationManager(
+            control_store,
+            agent_identity=self._agent_identity,
+            lease_duration_ms=config.policy.registration_lease_duration_ms,
+            clock=clock,
+        )
+        self._generation_reader = GenerationStateReader(
+            control_store,
+            run_id=config.run_id,
+        )
+        self._restart_context = RestartContextFile(config.restart_context_path)
+        run_digest = hashlib.sha256(config.run_id.encode("utf-8")).hexdigest()
+        self._closure_key = f"{_CONTROL_PREFIX}/runs/{run_digest}/rendezvous-closed"
+        self._closure_value = json.dumps(
+            {
+                "run_id": config.run_id,
+                "schema_version": _CLOSED_SCHEMA_VERSION,
+            },
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        self._registration_lock = threading.RLock()
+        self._registration: HeldAgentRegistration | None = None
+        self._heartbeat_error: Exception | None = None
+        self._heartbeat_thread: threading.Thread | None = None
+        self._stop_heartbeat_event = threading.Event()
+        self._state_changed_event = threading.Event()
+        self._closed_event = threading.Event()
+        self._shutdown_lock = threading.Lock()
+
+    @property
+    def agent_identity(self) -> AgentIdentity:
+        """Return the immutable identity registered by this handler."""
+
+        return self._agent_identity
+
+    @property
+    def closure_key(self) -> str:
+        """Return the run-scoped immutable closure key."""
+
+        return self._closure_key
+
+    def get_backend(self) -> str:
+        return _BACKEND
+
+    def get_run_id(self) -> str:
+        return self._config.run_id
+
+    def next_rendezvous(self) -> RendezvousInfo:
+        """Block passive standbys and admit only the initial committed assignment."""
+
+        if self.is_closed():
+            raise RendezvousClosedError
+        self._ensure_registered()
+        deadline = self._monotonic_clock() + self._config.policy.join_timeout_ms / 1_000
+        try:
+            while True:
+                if self.is_closed():
+                    raise RendezvousClosedError
+                self._raise_heartbeat_error()
+                current = self._read_generation()
+                if current is not None:
+                    slot = self._initial_slot(current)
+                    if slot is not None:
+                        try:
+                            self._restart_context.clear()
+                        except (OSError, RestartContextFileError) as error:
+                            raise RendezvousStateError(
+                                "failed to clear stale initial restart context"
+                            ) from error
+                        bootstrap = self._bootstrap_store_info
+                        if bootstrap is None:
+                            try:
+                                bootstrap = RendezvousStoreInfo.build(
+                                    slot,
+                                    self._rendezvous_store,
+                                    self._config.local_addr,
+                                )
+                            except Exception as error:
+                                raise RendezvousConnectionError(
+                                    "failed to publish rendezvous bootstrap information"
+                                ) from error
+                        return RendezvousInfo(
+                            self._rendezvous_store,
+                            slot,
+                            self._config.min_nodes,
+                            bootstrap,
+                        )
+                if not self._wait_for_change(deadline):
+                    raise RendezvousTimeoutError
+        except (
+            RendezvousClosedError,
+            RendezvousConnectionError,
+            RendezvousStateError,
+            RendezvousTimeoutError,
+        ):
+            if self._stop_heartbeat():
+                self._release_registration(raise_errors=False)
+            raise
+
+    def is_closed(self) -> bool:
+        if self._closed_event.is_set():
+            return True
+        try:
+            entry = self._control_store.get(self._closure_key)
+            if entry is None:
+                if self._control_store.has_history(self._closure_key):
+                    raise RendezvousStateError(
+                        "rendezvous closure record was deleted after publication"
+                    )
+                return False
+            self._validate_closure_entry(entry)
+        except RendezvousStateError:
+            raise
+        except Exception as error:
+            raise RendezvousConnectionError("failed to read rendezvous closure state") from error
+        self._closed_event.set()
+        self._state_changed_event.set()
+        return True
+
+    def set_closed(self) -> None:
+        try:
+            entry = self._control_store.get(self._closure_key)
+            if entry is None:
+                if self._control_store.has_history(self._closure_key):
+                    raise RendezvousStateError(
+                        "rendezvous closure record was deleted after publication"
+                    )
+                try:
+                    entry = self._control_store.compare_set(
+                        self._closure_key,
+                        expected_revision=None,
+                        value=self._closure_value,
+                    )
+                except ControlStoreConflict:
+                    entry = self._control_store.get(self._closure_key)
+                    if entry is None:
+                        raise RendezvousStateError(
+                            "rendezvous closure changed without a current record"
+                        )
+            self._validate_closure_entry(entry)
+        except RendezvousStateError:
+            raise
+        except Exception as error:
+            raise RendezvousConnectionError("failed to publish rendezvous closure state") from error
+        self._closed_event.set()
+        self._state_changed_event.set()
+        if self._stop_heartbeat():
+            self._release_registration(raise_errors=False)
+
+    def num_nodes_waiting(self) -> int:
+        """Hide passive standbys until a committed replacement plan exists."""
+
+        if self.is_closed():
+            return 0
+        self._raise_heartbeat_error()
+        return 0
+
+    def shutdown(self) -> bool:
+        with self._shutdown_lock:
+            succeeded = True
+            try:
+                self.set_closed()
+            except (RendezvousConnectionError, RendezvousStateError):
+                succeeded = False
+                self._closed_event.set()
+                self._state_changed_event.set()
+            heartbeat_stopped = self._stop_heartbeat()
+            if not heartbeat_stopped:
+                succeeded = False
+            elif not self._release_registration(raise_errors=False):
+                succeeded = False
+            thread = self._heartbeat_thread
+            if thread is not None and thread.is_alive():
+                succeeded = False
+            return succeeded
+
+    def _ensure_registered(self) -> None:
+        self._raise_heartbeat_error()
+        with self._registration_lock:
+            if self._registration is None:
+                try:
+                    self._registration = self._registration_manager.register()
+                except AgentRegistrationCorrupt as error:
+                    raise RendezvousStateError("agent registration state is corrupt") from error
+                except (
+                    AgentRegistrationClockError,
+                    AgentRegistrationLost,
+                    AgentRegistrationUnavailable,
+                ) as error:
+                    raise RendezvousConnectionError(
+                        "failed to acquire the agent registration"
+                    ) from error
+                except Exception as error:
+                    raise RendezvousConnectionError("agent registration backend failed") from error
+            thread = self._heartbeat_thread
+            if thread is None or not thread.is_alive():
+                self._heartbeat_thread = threading.Thread(
+                    target=self._heartbeat_loop,
+                    name=f"lm-resiliency-registration-{self._config.node_id}",
+                    daemon=True,
+                )
+                self._heartbeat_thread.start()
+
+    def _heartbeat_loop(self) -> None:
+        interval_seconds = max(
+            self._config.policy.registration_lease_duration_ms / 3_000,
+            0.001,
+        )
+        while not self._stop_heartbeat_event.wait(interval_seconds):
+            with self._registration_lock:
+                registration = self._registration
+                if registration is None:
+                    return
+                try:
+                    self._registration = self._registration_manager.renew(registration)
+                except (
+                    AgentRegistrationClockError,
+                    AgentRegistrationCorrupt,
+                    AgentRegistrationLost,
+                    AgentRegistrationUnavailable,
+                ) as error:
+                    self._heartbeat_error = error
+                    self._state_changed_event.set()
+                    return
+                except Exception as error:
+                    self._heartbeat_error = error
+                    self._state_changed_event.set()
+                    return
+
+    def _stop_heartbeat(self) -> bool:
+        self._stop_heartbeat_event.set()
+        self._state_changed_event.set()
+        thread = self._heartbeat_thread
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(
+                timeout=max(
+                    self._config.policy.poll_interval_ms / 500,
+                    0.1,
+                )
+            )
+        return thread is None or not thread.is_alive()
+
+    def _release_registration(self, *, raise_errors: bool) -> bool:
+        with self._registration_lock:
+            registration = self._registration
+            if registration is None:
+                return True
+            try:
+                self._registration_manager.release(registration)
+            except (
+                AgentRegistrationClockError,
+                AgentRegistrationCorrupt,
+                AgentRegistrationLost,
+                AgentRegistrationUnavailable,
+            ) as error:
+                if raise_errors:
+                    raise RendezvousConnectionError(
+                        "failed to release the agent registration"
+                    ) from error
+                return False
+            except Exception as error:
+                if raise_errors:
+                    raise RendezvousConnectionError(
+                        "agent registration backend failed during release"
+                    ) from error
+                return False
+            self._registration = None
+            return True
+
+    def _raise_heartbeat_error(self) -> None:
+        error = self._heartbeat_error
+        if error is None:
+            return
+        if isinstance(error, AgentRegistrationCorrupt):
+            raise RendezvousStateError(
+                "agent registration heartbeat found corrupt state"
+            ) from error
+        raise RendezvousConnectionError("agent registration heartbeat failed") from error
+
+    def _read_generation(self) -> CurrentGeneration | None:
+        try:
+            return self._generation_reader.current()
+        except GenerationStateCorrupt as error:
+            raise RendezvousStateError("generation state is corrupt") from error
+        except GenerationStateError as error:
+            raise RendezvousConnectionError(
+                "generation state changed repeatedly during rendezvous"
+            ) from error
+        except Exception as error:
+            raise RendezvousConnectionError("generation backend failed") from error
+
+    def _initial_slot(self, current: CurrentGeneration) -> int | None:
+        assignment = current.snapshot.record.assignment
+        if assignment.generation != 0:
+            raise RendezvousStateError(
+                "replacement generations are not supported by this handler revision"
+            )
+        if assignment.active_nodes != self._config.min_nodes:
+            raise RendezvousStateError(
+                "initial assignment active node count does not match min_nodes"
+            )
+        if assignment.local_world_size != self._config.local_world_size:
+            raise RendezvousStateError(
+                "initial assignment local world size does not match runtime configuration"
+            )
+        for slot, node_id in assignment.slot_to_node_id.items():
+            if node_id == self._config.node_id:
+                return slot
+        return None
+
+    def _wait_for_change(self, deadline: float) -> bool:
+        remaining = deadline - self._monotonic_clock()
+        if remaining <= 0:
+            return False
+        self._state_changed_event.wait(
+            min(
+                remaining,
+                self._config.policy.poll_interval_ms / 1_000,
+            )
+        )
+        self._state_changed_event.clear()
+        return self._monotonic_clock() < deadline
+
+    def _validate_closure_entry(self, entry: ControlStoreEntry) -> None:
+        if entry.value != self._closure_value:
+            raise RendezvousStateError("rendezvous closure record is malformed")
+        if (
+            entry.mutation_sequence != 1
+            or entry.value_sequence != 1
+            or entry.lifetime_sequence != 1
+        ):
+            raise RendezvousStateError("rendezvous closure record is not immutable")
+        if entry.guard_key is not None:
+            raise RendezvousStateError("rendezvous closure record must be unguarded")
 
 
 @dataclass(frozen=True, slots=True)
@@ -758,6 +1169,7 @@ def _boolean(value: object, path: str) -> bool:
 __all__ = [
     "RestartContextFile",
     "RestartContextFileError",
+    "SlotAwareRendezvousHandler",
     "TorchrunRendezvousPolicy",
     "TorchrunRuntimeConfig",
     "TorchrunRuntimeConfigError",

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -325,8 +325,6 @@ class TorchrunRuntimeConfig:
 class SlotAwareRendezvousHandler(RendezvousHandler):
     """Admit the initial fixed-size worker group and park passive standbys."""
 
-    use_agent_store = True
-
     def __init__(
         self,
         config: TorchrunRuntimeConfig,
@@ -392,14 +390,18 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         self._state_changed_event = threading.Event()
         self._closed_event = threading.Event()
         self._shutdown_lock = threading.Lock()
-        self._attempt_lock = threading.Lock()
-        self._next_attempt = 0
 
     @property
     def agent_identity(self) -> AgentIdentity:
         """Return the immutable identity registered by this handler."""
 
         return self._agent_identity
+
+    @property
+    def use_agent_store(self) -> bool:
+        """Return whether the supplied bootstrap endpoint is agent-owned."""
+
+        return self._bootstrap_store_info is not None
 
     @property
     def closure_key(self) -> str:
@@ -435,18 +437,16 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                             raise RendezvousStateError(
                                 "failed to clear stale initial restart context"
                             ) from error
-                        attempt = self._claim_attempt()
-                        attempt_store = self._attempt_store(
+                        bootstrap_store = self._bootstrap_store(
                             current.snapshot.record.assignment.generation,
-                            attempt,
                         )
                         bootstrap = self._build_bootstrap(
                             slot,
-                            attempt_store,
+                            bootstrap_store,
                             formation_deadline,
                         )
                         return RendezvousInfo(
-                            attempt_store,
+                            bootstrap_store,
                             slot,
                             self._config.min_nodes,
                             bootstrap,
@@ -465,14 +465,9 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         if self._closed_event.is_set():
             return True
         try:
-            entry = self._control_store.get(self._closure_key)
+            entry = self._read_closure_entry()
             if entry is None:
-                if self._control_store.has_history(self._closure_key):
-                    raise RendezvousStateError(
-                        "rendezvous closure record was deleted after publication"
-                    )
                 return False
-            self._validate_closure_entry(entry)
         except RendezvousStateError:
             raise
         except Exception as error:
@@ -483,12 +478,8 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
 
     def set_closed(self) -> None:
         try:
-            entry = self._control_store.get(self._closure_key)
+            entry = self._read_closure_entry()
             if entry is None:
-                if self._control_store.has_history(self._closure_key):
-                    raise RendezvousStateError(
-                        "rendezvous closure record was deleted after publication"
-                    )
                 try:
                     entry = self._control_store.compare_set(
                         self._closure_key,
@@ -522,12 +513,8 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
     def shutdown(self) -> bool:
         with self._shutdown_lock:
             succeeded = True
-            try:
-                self.set_closed()
-            except (RendezvousConnectionError, RendezvousStateError):
-                succeeded = False
-                self._closed_event.set()
-                self._state_changed_event.set()
+            self._closed_event.set()
+            self._state_changed_event.set()
             heartbeat_stopped = self._stop_heartbeat()
             if not heartbeat_stopped:
                 succeeded = False
@@ -628,12 +615,15 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         self._state_changed_event.set()
         thread = self._heartbeat_thread
         if thread is not None and thread is not threading.current_thread():
-            thread.join(
-                timeout=max(
-                    self._config.policy.poll_interval_ms / 500,
-                    0.1,
+            try:
+                thread.join(
+                    timeout=max(
+                        self._config.policy.poll_interval_ms / 500,
+                        0.1,
+                    )
                 )
-            )
+            except RuntimeError:
+                return False
         return thread is None or not thread.is_alive()
 
     def _release_registration(self, *, raise_errors: bool) -> bool:
@@ -685,16 +675,10 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         except Exception as error:
             raise RendezvousConnectionError("generation backend failed") from error
 
-    def _claim_attempt(self) -> int:
-        with self._attempt_lock:
-            attempt = self._next_attempt
-            self._next_attempt += 1
-            return attempt
-
-    def _attempt_store(self, generation: int, attempt: int) -> Store:
+    def _bootstrap_store(self, generation: int) -> Store:
         prefix = (
             f"{_CONTROL_PREFIX}/runs/{self._run_digest}/rendezvous/"
-            f"generation-{generation}/attempt-{attempt}/"
+            f"generation-{generation}/bootstrap/"
         )
         return PrefixStore(prefix, self._rendezvous_store)
 
@@ -712,10 +696,19 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             raise RendezvousTimeoutError
         try:
             store.set_timeout(timedelta(seconds=max(remaining, 0.001)))
-            return RendezvousStoreInfo.build(
-                slot,
-                store,
-                self._config.local_addr,
+            keys = [
+                RendezvousStoreInfo.MASTER_ADDR_KEY,
+                RendezvousStoreInfo.MASTER_PORT_KEY,
+            ]
+            if slot == 0 and not store.check(keys):
+                return RendezvousStoreInfo.build(
+                    slot,
+                    store,
+                    self._config.local_addr,
+                )
+            return RendezvousStoreInfo(
+                store.get(RendezvousStoreInfo.MASTER_ADDR_KEY).decode("utf-8"),
+                int(store.get(RendezvousStoreInfo.MASTER_PORT_KEY).decode("utf-8")),
             )
         except DistStoreError as error:
             raise RendezvousTimeoutError from error
@@ -725,6 +718,19 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             raise RendezvousConnectionError(
                 "failed to publish rendezvous bootstrap information"
             ) from error
+
+    def _read_closure_entry(self) -> ControlStoreEntry | None:
+        entry = self._control_store.get(self._closure_key)
+        if entry is not None:
+            self._validate_closure_entry(entry)
+            return entry
+        if not self._control_store.has_history(self._closure_key):
+            return None
+        entry = self._control_store.get(self._closure_key)
+        if entry is None:
+            raise RendezvousStateError("rendezvous closure record was deleted after publication")
+        self._validate_closure_entry(entry)
+        return entry
 
     def _validate_assigned_registration_history(self) -> None:
         try:

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -13,6 +13,7 @@ import threading
 import time
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from datetime import timedelta
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any, Callable, ClassVar
@@ -22,7 +23,7 @@ try:
 except ModuleNotFoundError:  # pragma: no cover - exercised by the Python 3.10 CI job.
     _toml = importlib.import_module("tomli")
 
-from torch.distributed import Store
+from torch.distributed import DistStoreError, PrefixStore, Store
 from torch.distributed.elastic.rendezvous import (
     RendezvousClosedError,
     RendezvousConnectionError,
@@ -40,6 +41,11 @@ from lm_resiliency.integrations.torchrun._agent_registration import (
     AgentRegistrationLost,
     AgentRegistrationManager,
     AgentRegistrationUnavailable,
+)
+from lm_resiliency.integrations.torchrun._agent_registration_history_reader import (
+    AgentRegistrationHistoryCorrupt,
+    AgentRegistrationHistoryError,
+    AgentRegistrationHistoryReader,
 )
 from lm_resiliency.integrations.torchrun._agent_registration_records import (
     HeldAgentRegistration,
@@ -349,6 +355,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         self._rendezvous_store = rendezvous_store
         self._bootstrap_store_info = bootstrap_store_info
         self._monotonic_clock = monotonic_clock
+        self._clock = clock
         self._agent_identity = config.build_agent_identity(
             agent_id=agent_id or secrets.token_hex(16),
             hostname=hostname or socket.getfqdn(),
@@ -365,6 +372,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         )
         self._restart_context = RestartContextFile(config.restart_context_path)
         run_digest = hashlib.sha256(config.run_id.encode("utf-8")).hexdigest()
+        self._run_digest = run_digest
         self._closure_key = f"{_CONTROL_PREFIX}/runs/{run_digest}/rendezvous-closed"
         self._closure_value = json.dumps(
             {
@@ -379,10 +387,13 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         self._registration: HeldAgentRegistration | None = None
         self._heartbeat_error: Exception | None = None
         self._heartbeat_thread: threading.Thread | None = None
+        self._heartbeat_last_now_unix_ms = 0
         self._stop_heartbeat_event = threading.Event()
         self._state_changed_event = threading.Event()
         self._closed_event = threading.Event()
         self._shutdown_lock = threading.Lock()
+        self._attempt_lock = threading.Lock()
+        self._next_attempt = 0
 
     @property
     def agent_identity(self) -> AgentIdentity:
@@ -407,9 +418,9 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
 
         if self.is_closed():
             raise RendezvousClosedError
-        self._ensure_registered()
-        deadline = self._monotonic_clock() + self._config.policy.join_timeout_ms / 1_000
+        formation_deadline = self._monotonic_clock() + self._config.policy.join_timeout_ms / 1_000
         try:
+            self._ensure_registered()
             while True:
                 if self.is_closed():
                     raise RendezvousClosedError
@@ -424,32 +435,28 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                             raise RendezvousStateError(
                                 "failed to clear stale initial restart context"
                             ) from error
-                        bootstrap = self._bootstrap_store_info
-                        if bootstrap is None:
-                            try:
-                                bootstrap = RendezvousStoreInfo.build(
-                                    slot,
-                                    self._rendezvous_store,
-                                    self._config.local_addr,
-                                )
-                            except Exception as error:
-                                raise RendezvousConnectionError(
-                                    "failed to publish rendezvous bootstrap information"
-                                ) from error
+                        attempt = self._claim_attempt()
+                        attempt_store = self._attempt_store(
+                            current.snapshot.record.assignment.generation,
+                            attempt,
+                        )
+                        bootstrap = self._build_bootstrap(
+                            slot,
+                            attempt_store,
+                            formation_deadline,
+                        )
                         return RendezvousInfo(
-                            self._rendezvous_store,
+                            attempt_store,
                             slot,
                             self._config.min_nodes,
                             bootstrap,
                         )
-                if not self._wait_for_change(deadline):
+                    wait_deadline = None
+                else:
+                    wait_deadline = formation_deadline
+                if not self._wait_for_change(wait_deadline):
                     raise RendezvousTimeoutError
-        except (
-            RendezvousClosedError,
-            RendezvousConnectionError,
-            RendezvousStateError,
-            RendezvousTimeoutError,
-        ):
+        except BaseException:
             if self._stop_heartbeat():
                 self._release_registration(raise_errors=False)
             raise
@@ -559,11 +566,22 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 self._heartbeat_thread.start()
 
     def _heartbeat_loop(self) -> None:
-        interval_seconds = max(
-            self._config.policy.registration_lease_duration_ms / 3_000,
-            0.001,
-        )
-        while not self._stop_heartbeat_event.wait(interval_seconds):
+        while True:
+            with self._registration_lock:
+                registration = self._registration
+                if registration is None:
+                    return
+                try:
+                    delay_seconds = self._renewal_delay_seconds(registration)
+                except (
+                    AgentRegistrationClockError,
+                    AgentRegistrationLost,
+                ) as error:
+                    self._heartbeat_error = error
+                    self._state_changed_event.set()
+                    return
+            if self._stop_heartbeat_event.wait(delay_seconds):
+                return
             with self._registration_lock:
                 registration = self._registration
                 if registration is None:
@@ -583,6 +601,27 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                     self._heartbeat_error = error
                     self._state_changed_event.set()
                     return
+
+    def _renewal_delay_seconds(
+        self,
+        registration: HeldAgentRegistration,
+    ) -> float:
+        now_unix_ms = self._clock()
+        if isinstance(now_unix_ms, bool) or not isinstance(now_unix_ms, int) or now_unix_ms < 1:
+            raise AgentRegistrationClockError(
+                "agent registration heartbeat clock returned an invalid time"
+            )
+        if now_unix_ms < self._heartbeat_last_now_unix_ms:
+            raise AgentRegistrationClockError("agent registration heartbeat clock moved backward")
+        self._heartbeat_last_now_unix_ms = now_unix_ms
+        if now_unix_ms < registration.granted_at_unix_ms:
+            raise AgentRegistrationClockError(
+                "agent registration heartbeat clock precedes the authoritative grant"
+            )
+        remaining_ms = registration.expires_at_unix_ms - now_unix_ms
+        if remaining_ms <= 0:
+            raise AgentRegistrationLost("agent registration expired before the next heartbeat")
+        return remaining_ms / 3_000
 
     def _stop_heartbeat(self) -> bool:
         self._stop_heartbeat_event.set()
@@ -646,6 +685,85 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         except Exception as error:
             raise RendezvousConnectionError("generation backend failed") from error
 
+    def _claim_attempt(self) -> int:
+        with self._attempt_lock:
+            attempt = self._next_attempt
+            self._next_attempt += 1
+            return attempt
+
+    def _attempt_store(self, generation: int, attempt: int) -> Store:
+        prefix = (
+            f"{_CONTROL_PREFIX}/runs/{self._run_digest}/rendezvous/"
+            f"generation-{generation}/attempt-{attempt}/"
+        )
+        return PrefixStore(prefix, self._rendezvous_store)
+
+    def _build_bootstrap(
+        self,
+        slot: int,
+        store: Store,
+        deadline: float,
+    ) -> RendezvousStoreInfo:
+        bootstrap = self._bootstrap_store_info
+        if bootstrap is not None:
+            return bootstrap
+        remaining = deadline - self._monotonic_clock()
+        if remaining <= 0:
+            raise RendezvousTimeoutError
+        try:
+            store.set_timeout(timedelta(seconds=max(remaining, 0.001)))
+            return RendezvousStoreInfo.build(
+                slot,
+                store,
+                self._config.local_addr,
+            )
+        except DistStoreError as error:
+            raise RendezvousTimeoutError from error
+        except Exception as error:
+            if self._monotonic_clock() >= deadline:
+                raise RendezvousTimeoutError from error
+            raise RendezvousConnectionError(
+                "failed to publish rendezvous bootstrap information"
+            ) from error
+
+    def _validate_assigned_registration_history(self) -> None:
+        try:
+            history = AgentRegistrationHistoryReader(
+                self._control_store,
+                run_id=self._config.run_id,
+                node_id=self._config.node_id,
+            ).read()
+        except AgentRegistrationHistoryCorrupt as error:
+            raise RendezvousStateError("assigned agent registration history is corrupt") from error
+        except AgentRegistrationHistoryError as error:
+            raise RendezvousConnectionError(
+                "assigned agent registration history changed repeatedly"
+            ) from error
+        except Exception as error:
+            raise RendezvousConnectionError(
+                "failed to read assigned agent registration history"
+            ) from error
+        with self._registration_lock:
+            registration = self._registration
+        if (
+            registration is None
+            or history.current is None
+            or history.current.record != registration.record
+        ):
+            raise RendezvousConnectionError(
+                "assigned node registration no longer belongs to this handler"
+            )
+        for authority in history.authorities:
+            identity = authority.registration.record.agent_identity
+            if (
+                identity.environment_digest != self._agent_identity.environment_digest
+                or identity.local_world_size != self._agent_identity.local_world_size
+            ):
+                raise RendezvousStateError(
+                    "assigned node registration history is incompatible with "
+                    "the committed workload environment"
+                )
+
     def _initial_slot(self, current: CurrentGeneration) -> int | None:
         assignment = current.snapshot.record.assignment
         if assignment.generation != 0:
@@ -662,21 +780,24 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             )
         for slot, node_id in assignment.slot_to_node_id.items():
             if node_id == self._config.node_id:
+                self._validate_assigned_registration_history()
                 return slot
         return None
 
-    def _wait_for_change(self, deadline: float) -> bool:
-        remaining = deadline - self._monotonic_clock()
-        if remaining <= 0:
-            return False
-        self._state_changed_event.wait(
-            min(
+    def _wait_for_change(self, deadline: float | None) -> bool:
+        if deadline is None:
+            timeout = self._config.policy.poll_interval_ms / 1_000
+        else:
+            remaining = deadline - self._monotonic_clock()
+            if remaining <= 0:
+                return False
+            timeout = min(
                 remaining,
                 self._config.policy.poll_interval_ms / 1_000,
             )
-        )
+        self._state_changed_event.wait(timeout)
         self._state_changed_event.clear()
-        return self._monotonic_clock() < deadline
+        return deadline is None or self._monotonic_clock() < deadline
 
     def _validate_closure_entry(self, entry: ControlStoreEntry) -> None:
         if entry.value != self._closure_value:

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -73,6 +73,7 @@ _MAX_CONTEXT_BYTES = 64 * 1024
 _MAX_POLICY_BYTES = 64 * 1024
 _CONTROL_PREFIX = "lm_resiliency/torchrun/v1"
 _CLOSED_SCHEMA_VERSION = 1
+_ARRIVAL_SCHEMA_VERSION = 1
 _SHARED_FIELDS = {
     "control_endpoint",
     "replacement_only",
@@ -444,6 +445,11 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 if current is not None:
                     slot = self._initial_slot(current)
                     if slot is not None:
+                        self._wait_for_assigned_arrivals(
+                            current,
+                            slot,
+                            formation_deadline,
+                        )
                         try:
                             self._restart_context.clear()
                         except (OSError, RestartContextFileError) as error:
@@ -721,6 +727,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
     ) -> RendezvousStoreInfo:
         bootstrap = self._bootstrap_store_info
         if bootstrap is not None:
+            store.set_timeout(timedelta(milliseconds=self._config.policy.join_timeout_ms))
             return bootstrap
         remaining = deadline - self._monotonic_clock()
         if remaining <= 0:
@@ -732,15 +739,18 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 RendezvousStoreInfo.MASTER_PORT_KEY,
             ]
             if slot == 0 and not store.check(keys):
-                return RendezvousStoreInfo.build(
+                bootstrap = RendezvousStoreInfo.build(
                     slot,
                     store,
                     self._config.local_addr,
                 )
-            return RendezvousStoreInfo(
-                store.get(RendezvousStoreInfo.MASTER_ADDR_KEY).decode("utf-8"),
-                int(store.get(RendezvousStoreInfo.MASTER_PORT_KEY).decode("utf-8")),
-            )
+            else:
+                bootstrap = RendezvousStoreInfo(
+                    store.get(RendezvousStoreInfo.MASTER_ADDR_KEY).decode("utf-8"),
+                    int(store.get(RendezvousStoreInfo.MASTER_PORT_KEY).decode("utf-8")),
+                )
+            store.set_timeout(timedelta(milliseconds=self._config.policy.join_timeout_ms))
+            return bootstrap
         except DistStoreError as error:
             raise RendezvousTimeoutError from error
         except Exception as error:
@@ -800,6 +810,196 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                     "assigned node registration history is incompatible with "
                     "the committed workload environment"
                 )
+
+    def _wait_for_assigned_arrivals(
+        self,
+        current: CurrentGeneration,
+        slot: int,
+        deadline: float,
+    ) -> None:
+        assignment = current.snapshot.record.assignment
+        with self._registration_lock:
+            registration = self._registration
+        if registration is None:
+            raise RendezvousConnectionError(
+                "assigned node lost its registration before the arrival barrier"
+            )
+        arrival_value = self._arrival_value(
+            generation=assignment.generation,
+            slot=slot,
+            registration=registration,
+        )
+        arrival_key = self._arrival_key(assignment.generation, slot)
+        try:
+            entry = self._control_store.get(arrival_key)
+            if entry is None:
+                try:
+                    entry = self._control_store.compare_set(
+                        arrival_key,
+                        expected_revision=None,
+                        value=arrival_value,
+                    )
+                except ControlStoreConflict:
+                    entry = self._control_store.get(arrival_key)
+                    if entry is None:
+                        raise RendezvousStateError(
+                            "rendezvous arrival changed without a current record"
+                        )
+            elif entry.value != arrival_value:
+                try:
+                    entry = self._control_store.compare_set(
+                        arrival_key,
+                        expected_revision=entry.revision,
+                        value=arrival_value,
+                    )
+                except ControlStoreConflict as error:
+                    raise RendezvousConnectionError(
+                        "rendezvous arrival changed during agent replacement"
+                    ) from error
+            self._validate_arrival_entry(
+                entry,
+                generation=assignment.generation,
+                slot=slot,
+                node_id=self._config.node_id,
+            )
+        except RendezvousStateError:
+            raise
+        except Exception as error:
+            raise RendezvousConnectionError("failed to publish rendezvous arrival") from error
+
+        while True:
+            if self.is_closed():
+                raise RendezvousClosedError
+            self._raise_heartbeat_error()
+            complete = True
+            for assigned_slot, node_id in assignment.slot_to_node_id.items():
+                try:
+                    assigned_entry = self._control_store.get(
+                        self._arrival_key(assignment.generation, assigned_slot)
+                    )
+                except Exception as error:
+                    raise RendezvousConnectionError("failed to read rendezvous arrivals") from error
+                if assigned_entry is None:
+                    complete = False
+                    continue
+                self._validate_arrival_entry(
+                    assigned_entry,
+                    generation=assignment.generation,
+                    slot=assigned_slot,
+                    node_id=node_id,
+                )
+            if complete:
+                return
+            if not self._wait_for_change(deadline):
+                raise RendezvousTimeoutError
+
+    def _arrival_key(self, generation: int, slot: int) -> str:
+        return (
+            f"{_CONTROL_PREFIX}/runs/{self._run_digest}/rendezvous/"
+            f"generation-{generation}/arrivals/slot-{slot}"
+        )
+
+    def _arrival_value(
+        self,
+        *,
+        generation: int,
+        slot: int,
+        registration: HeldAgentRegistration,
+    ) -> bytes:
+        return json.dumps(
+            {
+                "agent_id": registration.record.agent_identity.agent_id,
+                "generation": generation,
+                "logical_node_slot": slot,
+                "node_id": registration.record.agent_identity.node_id,
+                "registration_id": registration.record.registration_id,
+                "run_id": self._config.run_id,
+                "schema_version": _ARRIVAL_SCHEMA_VERSION,
+            },
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+
+    def _validate_arrival_entry(
+        self,
+        entry: ControlStoreEntry,
+        *,
+        generation: int,
+        slot: int,
+        node_id: str,
+    ) -> None:
+        try:
+            payload = json.loads(
+                entry.value.decode("utf-8"),
+                object_pairs_hook=_strict_object,
+            )
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as error:
+            raise RendezvousStateError("rendezvous arrival record is malformed") from error
+        expected_fields = {
+            "agent_id",
+            "generation",
+            "logical_node_slot",
+            "node_id",
+            "registration_id",
+            "run_id",
+            "schema_version",
+        }
+        if not isinstance(payload, dict) or set(payload) != expected_fields:
+            raise RendezvousStateError("rendezvous arrival record has invalid fields")
+        if (
+            isinstance(payload["generation"], bool)
+            or not isinstance(payload["generation"], int)
+            or isinstance(payload["logical_node_slot"], bool)
+            or not isinstance(payload["logical_node_slot"], int)
+            or payload["schema_version"] != _ARRIVAL_SCHEMA_VERSION
+            or isinstance(payload["schema_version"], bool)
+            or not isinstance(payload["schema_version"], int)
+            or payload["run_id"] != self._config.run_id
+            or payload["generation"] != generation
+            or payload["logical_node_slot"] != slot
+            or payload["node_id"] != node_id
+        ):
+            raise RendezvousStateError("rendezvous arrival record does not match its assigned slot")
+        for field in ("agent_id", "registration_id"):
+            if not isinstance(payload[field], str) or not payload[field]:
+                raise RendezvousStateError(f"rendezvous arrival record has invalid {field}")
+        if entry.lifetime_sequence != 1 or entry.guard_key is not None:
+            raise RendezvousStateError("rendezvous arrival record has invalid store provenance")
+        try:
+            history = AgentRegistrationHistoryReader(
+                self._control_store,
+                run_id=self._config.run_id,
+                node_id=node_id,
+            ).read()
+        except AgentRegistrationHistoryCorrupt as error:
+            raise RendezvousStateError("arrived agent registration history is corrupt") from error
+        except AgentRegistrationHistoryError as error:
+            raise RendezvousConnectionError(
+                "arrived agent registration history changed repeatedly"
+            ) from error
+        current = history.current
+        if current is None:
+            raise RendezvousConnectionError("arrived agent no longer has a current registration")
+        identity = current.record.agent_identity
+        if (
+            current.record.registration_id != payload["registration_id"]
+            or identity.agent_id != payload["agent_id"]
+        ):
+            raise RendezvousStateError(
+                "rendezvous arrival does not match the current agent registration"
+            )
+        now_unix_ms = self._clock()
+        if (
+            isinstance(now_unix_ms, bool)
+            or not isinstance(now_unix_ms, int)
+            or now_unix_ms < current.granted_at_unix_ms
+        ):
+            raise RendezvousConnectionError(
+                "rendezvous arrival clock is invalid for its registration"
+            )
+        if current.expires_at_unix_ms <= now_unix_ms:
+            raise RendezvousConnectionError("arrived agent registration has expired")
 
     def _initial_slot(self, current: CurrentGeneration) -> int | None:
         assignment = current.snapshot.record.assignment

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -82,6 +82,7 @@ _CLOSED_SCHEMA_VERSION = 1
 _ARRIVAL_SCHEMA_VERSION = 1
 _ARRIVAL_ATTEMPT_SCHEMA_VERSION = 1
 _ARRIVAL_COMPLETION_SCHEMA_VERSION = 1
+_ARRIVAL_CONSUMPTION_SCHEMA_VERSION = 1
 _SHARED_FIELDS = {
     "control_endpoint",
     "replacement_only",
@@ -419,7 +420,6 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         self._release_error: Exception | None = None
         self._closure_thread: threading.Thread | None = None
         self._closure_error: Exception | None = None
-        self._last_arrival_attempts: dict[int, int] = {}
         self._state_changed_event = threading.Event()
         self._closed_event = threading.Event()
         self._closure_lock = threading.Lock()
@@ -471,7 +471,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                             raise RendezvousStateError(
                                 "failed to clear stale initial restart context"
                             ) from error
-                        self._wait_for_assigned_arrivals(
+                        attempt, completion = self._wait_for_assigned_arrivals(
                             current,
                             slot,
                             formation_deadline,
@@ -489,6 +489,12 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                         self._raise_heartbeat_error()
                         if self._read_generation() != current:
                             raise RendezvousConnectionError("generation changed during rendezvous")
+                        self._publish_arrival_consumption(
+                            current.snapshot.record.assignment,
+                            attempt,
+                            slot,
+                            completion,
+                        )
                         return RendezvousInfo(
                             bootstrap_store,
                             slot,
@@ -953,7 +959,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         current: CurrentGeneration,
         slot: int,
         deadline: float,
-    ) -> None:
+    ) -> tuple[int, ControlStoreEntry]:
         assignment = current.snapshot.record.assignment
         with self._registration_lock:
             registration = self._registration
@@ -962,11 +968,18 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 "assigned node lost its registration before the arrival barrier"
             )
         attempt = self._claim_shared_arrival_attempt(
-            generation=assignment.generation,
+            assignment=assignment,
             slot=slot,
             registration=registration,
             deadline=deadline,
         )
+        completion = self._read_arrival_completion(
+            assignment,
+            attempt,
+            None,
+        )
+        if completion is not None:
+            return attempt, completion
         arrival_value = self._arrival_value(
             generation=assignment.generation,
             attempt=attempt,
@@ -997,7 +1010,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 completion = self._read_arrival_completion(
                     assignment,
                     attempt,
-                    registration,
+                    None,
                 )
                 if completion is not None:
                     raise RendezvousConnectionError(
@@ -1032,11 +1045,10 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             completion = self._read_arrival_completion(
                 assignment,
                 attempt,
-                registration,
+                None,
             )
             if completion is not None:
-                self._last_arrival_attempts[assignment.generation] = attempt
-                return
+                return attempt, completion
             if slot == 0:
                 self._try_complete_arrival_attempt(
                     assignment,
@@ -1049,11 +1061,12 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
     def _claim_shared_arrival_attempt(
         self,
         *,
-        generation: int,
+        assignment: RankAssignment,
         slot: int,
         registration: HeldAgentRegistration,
         deadline: float,
     ) -> int:
+        generation = assignment.generation
         key = self._arrival_attempt_key(generation)
         while True:
             if self.is_closed():
@@ -1084,29 +1097,53 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                     attempt, _, _ = self._validate_arrival_attempt_entry(
                         entry,
                         generation=generation,
+                        leader_node_id=assignment.slot_to_node_id[0],
                     )
-                    completed = (
-                        self._control_store.get(self._arrival_completion_key(generation, attempt))
+                    completion = self._read_arrival_completion(
+                        assignment,
+                        attempt,
+                        None,
+                    )
+                    own_consumption = None
+                    if completion is not None:
+                        own_consumption = self._read_arrival_consumption(
+                            assignment,
+                            attempt,
+                            slot,
+                            completion,
+                        )
+                    if completion is not None and own_consumption is None:
+                        committed = entry
+                    elif (
+                        slot == 0
+                        and completion is not None
+                        and self._arrival_consumption_conditions(
+                            assignment,
+                            attempt,
+                            completion,
+                        )
                         is not None
-                    )
-                    last_attempt = self._last_arrival_attempts.get(generation, 0)
-                    if slot == 0 and (completed or attempt <= last_attempt):
+                    ):
                         next_attempt = attempt + 1
                         value = self._arrival_attempt_value(
                             generation=generation,
                             attempt=next_attempt,
                             registration=registration,
                         )
-                        try:
-                            committed = self._control_store.compare_set(
-                                key,
-                                expected_revision=entry.revision,
-                                value=value,
-                            )
-                        except ControlStoreConflict:
+                        advanced = self._advance_arrival_attempt(
+                            assignment,
+                            entry,
+                            attempt,
+                            next_attempt,
+                            value,
+                            registration,
+                            completion,
+                        )
+                        if advanced is None:
                             continue
+                        committed = advanced
                         attempt = next_attempt
-                    elif completed or attempt <= last_attempt:
+                    elif completion is not None:
                         if not self._wait_for_change(deadline):
                             raise RendezvousTimeoutError
                         continue
@@ -1116,6 +1153,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                     committed,
                     generation=generation,
                     expected_attempt=attempt,
+                    leader_node_id=assignment.slot_to_node_id[0],
                 )
                 return attempt
             except (RendezvousClosedError, RendezvousStateError, RendezvousTimeoutError):
@@ -1124,6 +1162,73 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 raise RendezvousConnectionError(
                     "failed to claim a rendezvous arrival attempt"
                 ) from error
+
+    def _advance_arrival_attempt(
+        self,
+        assignment: RankAssignment,
+        current_entry: ControlStoreEntry,
+        current_attempt: int,
+        next_attempt: int,
+        value: bytes,
+        registration: HeldAgentRegistration,
+        completion: ControlStoreEntry,
+    ) -> ControlStoreEntry | None:
+        conditions = self._arrival_consumption_conditions(
+            assignment,
+            current_attempt,
+            completion,
+        )
+        if conditions is None:
+            return None
+        completion_key = self._arrival_completion_key(
+            assignment.generation,
+            current_attempt,
+        )
+        conditions[completion_key] = completion.revision
+        with self._registration_lock:
+            current_registration = self._registration
+        if current_registration is None or current_registration.record != registration.record:
+            raise RendezvousConnectionError("arrival leader no longer owns its agent registration")
+        now_unix_ms = self._clock()
+        if (
+            isinstance(now_unix_ms, bool)
+            or not isinstance(now_unix_ms, int)
+            or now_unix_ms < current_registration.granted_at_unix_ms
+            or now_unix_ms >= current_registration.expires_at_unix_ms
+        ):
+            raise RendezvousConnectionError(
+                "rendezvous attempt advance is outside the registration window"
+            )
+        attempt_key = self._arrival_attempt_key(assignment.generation)
+        try:
+            result = self._control_store.compare_set_many_guarded(
+                {
+                    attempt_key: ControlStoreWrite(
+                        expected_revision=current_entry.revision,
+                        value=value,
+                    )
+                },
+                guard_key=self._registration_manager.registration_key,
+                expected_guard_revision=current_registration.fencing_token,
+                not_before_unix_ms=now_unix_ms,
+                deadline_unix_ms=current_registration.expires_at_unix_ms,
+                conditions=conditions,
+            )
+        except ControlStoreConflict:
+            return None
+        except Exception as error:
+            raise RendezvousConnectionError(
+                "failed to advance the rendezvous arrival attempt"
+            ) from error
+        committed = result[attempt_key]
+        self._validate_arrival_attempt_entry(
+            committed,
+            generation=assignment.generation,
+            expected_attempt=next_attempt,
+            leader_node_id=assignment.slot_to_node_id[0],
+        )
+        self._state_changed_event.set()
+        return committed
 
     def _arrival_attempt_key(self, generation: int) -> str:
         return (
@@ -1158,6 +1263,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         *,
         generation: int,
         expected_attempt: int | None = None,
+        leader_node_id: str | None = None,
     ) -> tuple[int, str, str]:
         try:
             payload = json.loads(
@@ -1196,11 +1302,19 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         for field in ("leader_agent_id", "leader_registration_id"):
             if not isinstance(payload[field], str) or not payload[field]:
                 raise RendezvousStateError(f"rendezvous arrival attempt record has invalid {field}")
+        expected_guard_key = (
+            None
+            if attempt == 1 or leader_node_id is None
+            else agent_registration_key(self._config.run_id, leader_node_id)
+        )
         if (
             entry.mutation_sequence != attempt
             or entry.value_sequence != attempt
             or entry.lifetime_sequence != 1
-            or entry.guard_key is not None
+            or (attempt == 1 and entry.guard_key is not None)
+            or (
+                attempt > 1 and leader_node_id is not None and entry.guard_key != expected_guard_key
+            )
         ):
             raise RendezvousStateError(
                 "rendezvous arrival attempt record has invalid store provenance"
@@ -1369,6 +1483,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             attempt_entry,
             generation=assignment.generation,
             expected_attempt=attempt,
+            leader_node_id=assignment.slot_to_node_id[0],
         )
         conditions[attempt_key] = attempt_entry.revision
         for assigned_slot, node_id in assignment.slot_to_node_id.items():
@@ -1461,7 +1576,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         self,
         assignment: RankAssignment,
         attempt: int,
-        registration: HeldAgentRegistration,
+        registration: HeldAgentRegistration | None,
     ) -> ControlStoreEntry | None:
         key = self._arrival_completion_key(assignment.generation, attempt)
         try:
@@ -1512,8 +1627,8 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         *,
         assignment: RankAssignment,
         attempt: int,
-        registration: HeldAgentRegistration,
-    ) -> None:
+        registration: HeldAgentRegistration | None,
+    ) -> Mapping[str, Mapping[str, Any]]:
         try:
             payload = json.loads(
                 entry.value.decode("utf-8"),
@@ -1577,8 +1692,9 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                     raise RendezvousStateError(f"rendezvous arrival completion has invalid {field}")
             if node_id == self._config.node_id:
                 own_arrival = arrival
-        if own_arrival is None or (
-            own_arrival["registration_id"] != registration.record.registration_id
+        if registration is not None and (
+            own_arrival is None
+            or own_arrival["registration_id"] != registration.record.registration_id
             or own_arrival["agent_id"] != registration.record.agent_identity.agent_id
         ):
             raise RendezvousConnectionError(
@@ -1597,6 +1713,284 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             or entry.guard_revision != slot_zero["registration_revision"]
         ):
             raise RendezvousStateError("rendezvous arrival completion has invalid store provenance")
+        return arrivals
+
+    def _publish_arrival_consumption(
+        self,
+        assignment: RankAssignment,
+        attempt: int,
+        slot: int,
+        completion: ControlStoreEntry,
+    ) -> None:
+        with self._registration_lock:
+            registration = self._registration
+        if registration is None:
+            raise RendezvousConnectionError(
+                "assigned node lost its registration before consuming rendezvous"
+            )
+        key = self._arrival_consumption_key(
+            assignment.generation,
+            attempt,
+            slot,
+        )
+        value = self._arrival_consumption_value(
+            generation=assignment.generation,
+            attempt=attempt,
+            slot=slot,
+            registration=registration,
+            completion=completion,
+        )
+        try:
+            existing = self._control_store.get(key)
+        except Exception as error:
+            raise RendezvousConnectionError("failed to read rendezvous consumption") from error
+        if existing is not None:
+            self._validate_arrival_consumption_entry(
+                existing,
+                assignment=assignment,
+                attempt=attempt,
+                slot=slot,
+                completion=completion,
+                registration=registration,
+            )
+            return
+        now_unix_ms = self._clock()
+        if (
+            isinstance(now_unix_ms, bool)
+            or not isinstance(now_unix_ms, int)
+            or now_unix_ms < registration.granted_at_unix_ms
+            or now_unix_ms >= registration.expires_at_unix_ms
+        ):
+            raise RendezvousConnectionError(
+                "rendezvous consumption is outside the registration window"
+            )
+        completion_key = self._arrival_completion_key(
+            assignment.generation,
+            attempt,
+        )
+        try:
+            result = self._control_store.compare_set_many_guarded(
+                {
+                    key: ControlStoreWrite(
+                        expected_revision=None,
+                        value=value,
+                        require_never_created=True,
+                    )
+                },
+                guard_key=self._registration_manager.registration_key,
+                expected_guard_revision=registration.fencing_token,
+                not_before_unix_ms=now_unix_ms,
+                deadline_unix_ms=registration.expires_at_unix_ms,
+                conditions={completion_key: completion.revision},
+            )
+        except ControlStoreConflict:
+            try:
+                existing = self._control_store.get(key)
+            except Exception as error:
+                raise RendezvousConnectionError(
+                    "failed to resolve concurrent rendezvous consumption"
+                ) from error
+            if existing is None:
+                raise RendezvousConnectionError(
+                    "rendezvous consumption changed without a current record"
+                )
+            self._validate_arrival_consumption_entry(
+                existing,
+                assignment=assignment,
+                attempt=attempt,
+                slot=slot,
+                completion=completion,
+                registration=registration,
+            )
+            return
+        except Exception as error:
+            raise RendezvousConnectionError("failed to publish rendezvous consumption") from error
+        self._validate_arrival_consumption_entry(
+            result[key],
+            assignment=assignment,
+            attempt=attempt,
+            slot=slot,
+            completion=completion,
+            registration=registration,
+        )
+        self._state_changed_event.set()
+
+    def _arrival_consumption_conditions(
+        self,
+        assignment: RankAssignment,
+        attempt: int,
+        completion: ControlStoreEntry,
+    ) -> dict[str, int] | None:
+        conditions: dict[str, int] = {}
+        for slot in assignment.slot_to_node_id:
+            entry = self._read_arrival_consumption(
+                assignment,
+                attempt,
+                slot,
+                completion,
+            )
+            if entry is None:
+                return None
+            conditions[
+                self._arrival_consumption_key(
+                    assignment.generation,
+                    attempt,
+                    slot,
+                )
+            ] = entry.revision
+        return conditions
+
+    def _read_arrival_consumption(
+        self,
+        assignment: RankAssignment,
+        attempt: int,
+        slot: int,
+        completion: ControlStoreEntry,
+    ) -> ControlStoreEntry | None:
+        key = self._arrival_consumption_key(
+            assignment.generation,
+            attempt,
+            slot,
+        )
+        try:
+            entry = self._control_store.get(key)
+        except Exception as error:
+            raise RendezvousConnectionError("failed to read rendezvous consumption") from error
+        if entry is None:
+            return None
+        self._validate_arrival_consumption_entry(
+            entry,
+            assignment=assignment,
+            attempt=attempt,
+            slot=slot,
+            completion=completion,
+            registration=None,
+        )
+        return entry
+
+    def _arrival_consumption_key(
+        self,
+        generation: int,
+        attempt: int,
+        slot: int,
+    ) -> str:
+        return (
+            f"{_CONTROL_PREFIX}/runs/{self._run_digest}/rendezvous/"
+            f"generation-{generation}/attempt-{attempt}/consumed/slot-{slot}"
+        )
+
+    def _arrival_consumption_value(
+        self,
+        *,
+        generation: int,
+        attempt: int,
+        slot: int,
+        registration: HeldAgentRegistration,
+        completion: ControlStoreEntry,
+    ) -> bytes:
+        return json.dumps(
+            {
+                "agent_id": registration.record.agent_identity.agent_id,
+                "attempt": attempt,
+                "completion_digest": hashlib.sha256(completion.value).hexdigest(),
+                "generation": generation,
+                "logical_node_slot": slot,
+                "node_id": registration.record.agent_identity.node_id,
+                "registration_id": registration.record.registration_id,
+                "registration_revision": registration.fencing_token,
+                "run_id": self._config.run_id,
+                "schema_version": _ARRIVAL_CONSUMPTION_SCHEMA_VERSION,
+            },
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+
+    def _validate_arrival_consumption_entry(
+        self,
+        entry: ControlStoreEntry,
+        *,
+        assignment: RankAssignment,
+        attempt: int,
+        slot: int,
+        completion: ControlStoreEntry,
+        registration: HeldAgentRegistration | None,
+    ) -> None:
+        try:
+            payload = json.loads(
+                entry.value.decode("utf-8"),
+                object_pairs_hook=_strict_object,
+            )
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as error:
+            raise RendezvousStateError("rendezvous consumption is malformed") from error
+        expected_fields = {
+            "agent_id",
+            "attempt",
+            "completion_digest",
+            "generation",
+            "logical_node_slot",
+            "node_id",
+            "registration_id",
+            "registration_revision",
+            "run_id",
+            "schema_version",
+        }
+        if not isinstance(payload, dict) or set(payload) != expected_fields:
+            raise RendezvousStateError("rendezvous consumption has invalid fields")
+        expected_node_id = assignment.slot_to_node_id.get(slot)
+        expected_digest = hashlib.sha256(completion.value).hexdigest()
+        if (
+            expected_node_id is None
+            or payload["run_id"] != self._config.run_id
+            or payload["generation"] != assignment.generation
+            or payload["attempt"] != attempt
+            or payload["logical_node_slot"] != slot
+            or payload["node_id"] != expected_node_id
+            or payload["completion_digest"] != expected_digest
+            or payload["schema_version"] != _ARRIVAL_CONSUMPTION_SCHEMA_VERSION
+            or any(
+                isinstance(payload[field], bool) or not isinstance(payload[field], int)
+                for field in (
+                    "generation",
+                    "attempt",
+                    "logical_node_slot",
+                    "registration_revision",
+                    "schema_version",
+                )
+            )
+            or payload["registration_revision"] < 1
+        ):
+            raise RendezvousStateError(
+                "rendezvous consumption does not match its completed attempt"
+            )
+        for field in ("agent_id", "registration_id"):
+            if not isinstance(payload[field], str) or not payload[field]:
+                raise RendezvousStateError(f"rendezvous consumption has invalid {field}")
+        if (
+            not isinstance(payload["completion_digest"], str)
+            or len(payload["completion_digest"]) != 64
+        ):
+            raise RendezvousStateError("rendezvous consumption has invalid completion digest")
+        if registration is not None and (
+            payload["registration_id"] != registration.record.registration_id
+            or payload["agent_id"] != registration.record.agent_identity.agent_id
+            or payload["registration_revision"] != registration.fencing_token
+        ):
+            raise RendezvousConnectionError(
+                "rendezvous attempt was consumed by another agent registration"
+            )
+        if (
+            entry.mutation_sequence != 1
+            or entry.value_sequence != 1
+            or entry.lifetime_sequence != 1
+            or entry.guard_key
+            != agent_registration_key(
+                self._config.run_id,
+                expected_node_id,
+            )
+            or entry.guard_revision != payload["registration_revision"]
+        ):
+            raise RendezvousStateError("rendezvous consumption has invalid store provenance")
 
     def _initial_slot(self, current: CurrentGeneration) -> int | None:
         assignment = current.snapshot.record.assignment

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -420,9 +420,13 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         self._release_error: Exception | None = None
         self._closure_thread: threading.Thread | None = None
         self._closure_error: Exception | None = None
+        self._closure_read_thread: threading.Thread | None = None
+        self._closure_read_entry: ControlStoreEntry | None = None
+        self._closure_read_error: Exception | None = None
         self._state_changed_event = threading.Event()
         self._closed_event = threading.Event()
         self._closure_lock = threading.Lock()
+        self._closure_read_lock = threading.Lock()
         self._shutdown_lock = threading.Lock()
 
     @property
@@ -452,18 +456,20 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
     def next_rendezvous(self) -> RendezvousInfo:
         """Block passive standbys and admit only the initial committed assignment."""
 
-        if self.is_closed():
-            raise RendezvousClosedError
         formation_deadline = self._monotonic_clock() + self._config.policy.join_timeout_ms / 1_000
         try:
+            if self._is_closed_bounded(formation_deadline):
+                raise RendezvousClosedError
             self._ensure_registered(formation_deadline)
             while True:
-                if self.is_closed():
+                current = self._read_generation()
+                slot = None if current is None else self._initial_slot(current)
+                if self._is_closed_bounded(
+                    formation_deadline if current is None or slot is not None else None
+                ):
                     raise RendezvousClosedError
                 self._raise_heartbeat_error()
-                current = self._read_generation()
                 if current is not None:
-                    slot = self._initial_slot(current)
                     if slot is not None:
                         try:
                             self._restart_context.clear()
@@ -490,11 +496,14 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                         if self._read_generation() != current:
                             raise RendezvousConnectionError("generation changed during rendezvous")
                         self._publish_arrival_consumption(
+                            current,
                             current.snapshot.record.assignment,
                             attempt,
                             slot,
                             completion,
+                            formation_deadline,
                         )
+                        self._validate_final_admission_state(current)
                         return RendezvousInfo(
                             bootstrap_store,
                             slot,
@@ -524,6 +533,71 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         self._closed_event.set()
         self._state_changed_event.set()
         return True
+
+    def _is_closed_bounded(self, deadline: float | None) -> bool:
+        if self._closed_event.is_set():
+            return True
+        with self._closure_read_lock:
+            thread = self._closure_read_thread
+            if thread is None:
+                self._closure_read_entry = None
+                self._closure_read_error = None
+                thread = threading.Thread(
+                    target=self._read_closure_worker,
+                    name=f"lm-resiliency-read-close-{self._config.node_id}",
+                    daemon=True,
+                )
+                self._closure_read_thread = thread
+                thread.start()
+        while thread.is_alive():
+            if self._closed_event.is_set():
+                return True
+            if deadline is not None:
+                remaining = deadline - self._monotonic_clock()
+                if remaining <= 0:
+                    raise RendezvousTimeoutError
+            else:
+                remaining = self._config.policy.poll_interval_ms / 1_000
+            thread.join(
+                timeout=min(
+                    remaining,
+                    self._config.policy.poll_interval_ms / 1_000,
+                )
+            )
+        with self._closure_read_lock:
+            entry = self._closure_read_entry
+            error = self._closure_read_error
+            self._closure_read_thread = None
+            self._closure_read_entry = None
+            self._closure_read_error = None
+        if (
+            entry is None
+            and error is None
+            and deadline is not None
+            and self._monotonic_clock() >= deadline
+        ):
+            raise RendezvousTimeoutError
+        if error is not None:
+            if isinstance(error, RendezvousStateError):
+                raise error
+            raise RendezvousConnectionError("failed to read rendezvous closure state") from error
+        if entry is None:
+            return False
+        self._closed_event.set()
+        self._state_changed_event.set()
+        return True
+
+    def _read_closure_worker(self) -> None:
+        entry: ControlStoreEntry | None = None
+        error: Exception | None = None
+        try:
+            entry = self._read_closure_entry()
+        except Exception as closure_error:
+            error = closure_error
+        with self._closure_read_lock:
+            self._closure_read_entry = entry
+            self._closure_read_error = error
+        self._state_changed_event.set()
 
     def set_closed(self) -> None:
         self._closed_event.set()
@@ -1111,6 +1185,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                             attempt,
                             slot,
                             completion,
+                            registration,
                         )
                     if completion is not None and own_consumption is None:
                         committed = entry
@@ -1414,6 +1489,18 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         registration_id: str,
         agent_id: str,
     ) -> HeldAgentRegistration:
+        current = self._current_assigned_registration(node_id)
+        identity = current.record.agent_identity
+        if current.record.registration_id != registration_id or identity.agent_id != agent_id:
+            raise RendezvousStateError(
+                "rendezvous arrival does not match the current agent registration"
+            )
+        return current
+
+    def _current_assigned_registration(
+        self,
+        node_id: str,
+    ) -> HeldAgentRegistration:
         try:
             history = AgentRegistrationHistoryReader(
                 self._control_store,
@@ -1429,11 +1516,6 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         current = history.current
         if current is None:
             raise RendezvousConnectionError("arrived agent no longer has a current registration")
-        identity = current.record.agent_identity
-        if current.record.registration_id != registration_id or identity.agent_id != agent_id:
-            raise RendezvousStateError(
-                "rendezvous arrival does not match the current agent registration"
-            )
         now_unix_ms = self._clock()
         if (
             isinstance(now_unix_ms, bool)
@@ -1446,6 +1528,15 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         if current.expires_at_unix_ms <= now_unix_ms:
             raise RendezvousConnectionError("arrived agent registration has expired")
         return current
+
+    def _validate_final_admission_state(
+        self,
+        current: CurrentGeneration,
+    ) -> None:
+        if self._is_closed_bounded(None):
+            raise RendezvousClosedError
+        if self._read_generation() != current:
+            raise RendezvousConnectionError("generation changed before rendezvous admission")
 
     def _try_complete_arrival_attempt(
         self,
@@ -1717,103 +1808,119 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
 
     def _publish_arrival_consumption(
         self,
+        current: CurrentGeneration,
         assignment: RankAssignment,
         attempt: int,
         slot: int,
         completion: ControlStoreEntry,
+        deadline: float,
     ) -> None:
-        with self._registration_lock:
-            registration = self._registration
-        if registration is None:
-            raise RendezvousConnectionError(
-                "assigned node lost its registration before consuming rendezvous"
+        completion_key = self._arrival_completion_key(assignment.generation, attempt)
+        generation_snapshot_key = self._generation_reader.snapshot_key(assignment.generation)
+        while True:
+            with self._registration_lock:
+                registration = self._registration
+            if registration is None:
+                raise RendezvousConnectionError(
+                    "assigned node lost its registration before consuming rendezvous"
+                )
+            key = self._arrival_consumption_key(
+                assignment.generation,
+                attempt,
+                slot,
+                registration.record.registration_id,
             )
-        key = self._arrival_consumption_key(
-            assignment.generation,
-            attempt,
-            slot,
-        )
-        value = self._arrival_consumption_value(
-            generation=assignment.generation,
-            attempt=attempt,
-            slot=slot,
-            registration=registration,
-            completion=completion,
-        )
-        try:
-            existing = self._control_store.get(key)
-        except Exception as error:
-            raise RendezvousConnectionError("failed to read rendezvous consumption") from error
-        if existing is not None:
-            self._validate_arrival_consumption_entry(
-                existing,
-                assignment=assignment,
+            value = self._arrival_consumption_value(
+                generation=assignment.generation,
                 attempt=attempt,
                 slot=slot,
-                completion=completion,
                 registration=registration,
+                completion=completion,
             )
-            return
-        now_unix_ms = self._clock()
-        if (
-            isinstance(now_unix_ms, bool)
-            or not isinstance(now_unix_ms, int)
-            or now_unix_ms < registration.granted_at_unix_ms
-            or now_unix_ms >= registration.expires_at_unix_ms
-        ):
-            raise RendezvousConnectionError(
-                "rendezvous consumption is outside the registration window"
-            )
-        completion_key = self._arrival_completion_key(
-            assignment.generation,
-            attempt,
-        )
-        try:
-            result = self._control_store.compare_set_many_guarded(
-                {
-                    key: ControlStoreWrite(
-                        expected_revision=None,
-                        value=value,
-                        require_never_created=True,
-                    )
-                },
-                guard_key=self._registration_manager.registration_key,
-                expected_guard_revision=registration.fencing_token,
-                not_before_unix_ms=now_unix_ms,
-                deadline_unix_ms=registration.expires_at_unix_ms,
-                conditions={completion_key: completion.revision},
-            )
-        except ControlStoreConflict:
             try:
                 existing = self._control_store.get(key)
             except Exception as error:
-                raise RendezvousConnectionError(
-                    "failed to resolve concurrent rendezvous consumption"
-                ) from error
-            if existing is None:
-                raise RendezvousConnectionError(
-                    "rendezvous consumption changed without a current record"
+                raise RendezvousConnectionError("failed to read rendezvous consumption") from error
+            if existing is not None:
+                self._validate_arrival_consumption_entry(
+                    existing,
+                    assignment=assignment,
+                    attempt=attempt,
+                    slot=slot,
+                    completion=completion,
+                    registration=registration,
                 )
+                return
+            now_unix_ms = self._clock()
+            if (
+                isinstance(now_unix_ms, bool)
+                or not isinstance(now_unix_ms, int)
+                or now_unix_ms < registration.granted_at_unix_ms
+                or now_unix_ms >= registration.expires_at_unix_ms
+            ):
+                raise RendezvousConnectionError(
+                    "rendezvous consumption is outside the registration window"
+                )
+            try:
+                result = self._control_store.compare_set_many_guarded(
+                    {
+                        key: ControlStoreWrite(
+                            expected_revision=None,
+                            value=value,
+                            require_never_created=True,
+                        )
+                    },
+                    guard_key=self._registration_manager.registration_key,
+                    expected_guard_revision=registration.fencing_token,
+                    not_before_unix_ms=now_unix_ms,
+                    deadline_unix_ms=registration.expires_at_unix_ms,
+                    conditions={
+                        completion_key: completion.revision,
+                        self._generation_reader.head_key: current.head_revision,
+                        generation_snapshot_key: current.snapshot.revision,
+                        self._closure_key: None,
+                    },
+                )
+            except ControlStoreConflict:
+                try:
+                    existing = self._control_store.get(key)
+                except Exception as error:
+                    raise RendezvousConnectionError(
+                        "failed to resolve concurrent rendezvous consumption"
+                    ) from error
+                if existing is not None:
+                    self._validate_arrival_consumption_entry(
+                        existing,
+                        assignment=assignment,
+                        attempt=attempt,
+                        slot=slot,
+                        completion=completion,
+                        registration=registration,
+                    )
+                    return
+                if self._is_closed_bounded(deadline):
+                    raise RendezvousClosedError
+                if self._read_generation() != current:
+                    raise RendezvousConnectionError(
+                        "generation changed before rendezvous consumption"
+                    )
+                if not self._wait_for_change(deadline):
+                    raise RendezvousTimeoutError
+                continue
+            except Exception as error:
+                raise RendezvousConnectionError(
+                    "failed to publish rendezvous consumption"
+                ) from error
             self._validate_arrival_consumption_entry(
-                existing,
+                result[key],
                 assignment=assignment,
                 attempt=attempt,
                 slot=slot,
                 completion=completion,
                 registration=registration,
             )
+            self._state_changed_event.set()
             return
-        except Exception as error:
-            raise RendezvousConnectionError("failed to publish rendezvous consumption") from error
-        self._validate_arrival_consumption_entry(
-            result[key],
-            assignment=assignment,
-            attempt=attempt,
-            slot=slot,
-            completion=completion,
-            registration=registration,
-        )
-        self._state_changed_event.set()
 
     def _arrival_consumption_conditions(
         self,
@@ -1822,12 +1929,14 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         completion: ControlStoreEntry,
     ) -> dict[str, int] | None:
         conditions: dict[str, int] = {}
-        for slot in assignment.slot_to_node_id:
+        for slot, node_id in assignment.slot_to_node_id.items():
+            registration = self._current_assigned_registration(node_id)
             entry = self._read_arrival_consumption(
                 assignment,
                 attempt,
                 slot,
                 completion,
+                registration,
             )
             if entry is None:
                 return None
@@ -1836,8 +1945,12 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                     assignment.generation,
                     attempt,
                     slot,
+                    registration.record.registration_id,
                 )
             ] = entry.revision
+            registration_key = agent_registration_key(self._config.run_id, node_id)
+            if registration_key != self._registration_manager.registration_key:
+                conditions[registration_key] = registration.fencing_token
         return conditions
 
     def _read_arrival_consumption(
@@ -1846,11 +1959,13 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         attempt: int,
         slot: int,
         completion: ControlStoreEntry,
+        registration: HeldAgentRegistration,
     ) -> ControlStoreEntry | None:
         key = self._arrival_consumption_key(
             assignment.generation,
             attempt,
             slot,
+            registration.record.registration_id,
         )
         try:
             entry = self._control_store.get(key)
@@ -1864,7 +1979,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             attempt=attempt,
             slot=slot,
             completion=completion,
-            registration=None,
+            registration=registration,
         )
         return entry
 
@@ -1873,10 +1988,13 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         generation: int,
         attempt: int,
         slot: int,
+        registration_id: str,
     ) -> str:
+        registration_digest = hashlib.sha256(registration_id.encode("utf-8")).hexdigest()
         return (
             f"{_CONTROL_PREFIX}/runs/{self._run_digest}/rendezvous/"
-            f"generation-{generation}/attempt-{attempt}/consumed/slot-{slot}"
+            f"generation-{generation}/attempt-{attempt}/consumed/"
+            f"slot-{slot}/registration-{registration_digest}"
         )
 
     def _arrival_consumption_value(
@@ -1974,7 +2092,6 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         if registration is not None and (
             payload["registration_id"] != registration.record.registration_id
             or payload["agent_id"] != registration.record.agent_identity.agent_id
-            or payload["registration_revision"] != registration.fencing_token
         ):
             raise RendezvousConnectionError(
                 "rendezvous attempt was consumed by another agent registration"

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -108,6 +108,10 @@ class RestartContextFileError(RuntimeError):
     """Raised when the node-local restart-context file is unsafe or malformed."""
 
 
+class _DuplicateJsonFieldError(ValueError):
+    """Raised when strict JSON decoding observes a duplicate object field."""
+
+
 @dataclass(frozen=True, slots=True)
 class TorchrunRendezvousPolicy:
     """Shared replacement-only policy resolved identically by every agent."""
@@ -413,9 +417,12 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         self._stop_heartbeat_event = threading.Event()
         self._release_thread: threading.Thread | None = None
         self._release_error: Exception | None = None
+        self._closure_thread: threading.Thread | None = None
+        self._closure_error: Exception | None = None
         self._last_arrival_attempts: dict[int, int] = {}
         self._state_changed_event = threading.Event()
         self._closed_event = threading.Event()
+        self._closure_lock = threading.Lock()
         self._shutdown_lock = threading.Lock()
 
     @property
@@ -513,6 +520,40 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         return True
 
     def set_closed(self) -> None:
+        self._closed_event.set()
+        self._state_changed_event.set()
+        try:
+            self._publish_closure_bounded()
+        finally:
+            self._cleanup_local_resources()
+
+    def _publish_closure_bounded(self) -> None:
+        with self._closure_lock:
+            thread = self._closure_thread
+            if thread is None:
+                self._closure_error = None
+                thread = threading.Thread(
+                    target=self._publish_closure_worker,
+                    name=f"lm-resiliency-close-{self._config.node_id}",
+                    daemon=True,
+                )
+                self._closure_thread = thread
+                thread.start()
+        thread.join(timeout=self._bounded_cleanup_timeout_seconds())
+        if thread.is_alive():
+            raise RendezvousConnectionError("timed out while publishing rendezvous closure state")
+        with self._closure_lock:
+            error = self._closure_error
+            self._closure_thread = None
+            self._closure_error = None
+        if error is None:
+            return
+        if isinstance(error, RendezvousStateError):
+            raise error
+        raise RendezvousConnectionError("failed to publish rendezvous closure state") from error
+
+    def _publish_closure_worker(self) -> None:
+        error: Exception | None = None
         try:
             entry = self._read_closure_entry()
             if entry is None:
@@ -529,13 +570,11 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                             "rendezvous closure changed without a current record"
                         )
             self._validate_closure_entry(entry)
-        except RendezvousStateError:
-            raise
-        except Exception as error:
-            raise RendezvousConnectionError("failed to publish rendezvous closure state") from error
-        self._closed_event.set()
+        except Exception as closure_error:
+            error = closure_error
+        with self._closure_lock:
+            self._closure_error = error
         self._state_changed_event.set()
-        self._cleanup_local_resources()
 
     def num_nodes_waiting(self) -> int:
         """Hide passive standbys until a committed replacement plan exists."""
@@ -718,12 +757,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         thread = self._heartbeat_thread
         if thread is not None and thread is not threading.current_thread():
             try:
-                thread.join(
-                    timeout=max(
-                        self._config.policy.poll_interval_ms / 500,
-                        0.1,
-                    )
-                )
+                thread.join(timeout=self._bounded_cleanup_timeout_seconds())
             except RuntimeError:
                 return False
         return thread is None or not thread.is_alive()
@@ -745,12 +779,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 self._release_thread = thread
                 thread.start()
         if thread is not threading.current_thread():
-            thread.join(
-                timeout=max(
-                    self._config.policy.poll_interval_ms / 500,
-                    0.1,
-                )
-            )
+            thread.join(timeout=self._bounded_cleanup_timeout_seconds())
         if thread.is_alive():
             return False
         with self._registration_lock:
@@ -776,6 +805,12 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 "agent registration backend failed during release"
             ) from error
         return False
+
+    def _bounded_cleanup_timeout_seconds(self) -> float:
+        return max(
+            self._config.policy.poll_interval_ms / 500,
+            0.1,
+        )
 
     def _release_registration_worker(
         self,
@@ -1304,6 +1339,14 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         attempt: int,
         leader_registration: HeldAgentRegistration,
     ) -> None:
+        with self._registration_lock:
+            current_leader_registration = self._registration
+        if (
+            current_leader_registration is None
+            or current_leader_registration.record != leader_registration.record
+        ):
+            raise RendezvousConnectionError("arrival leader no longer owns its agent registration")
+        leader_registration = current_leader_registration
         completion_key = self._arrival_completion_key(
             assignment.generation,
             attempt,
@@ -1742,6 +1785,8 @@ class RestartContextFile:
             if not isinstance(value, Mapping):
                 raise RestartContextFileError("restart-context JSON must contain an object")
             return RestartContext.from_dict(value)
+        except _DuplicateJsonFieldError as error:
+            raise RestartContextFileError(str(error)) from error
         except RestartContextFileError:
             raise
         except (TypeError, ValueError, UnicodeDecodeError) as error:
@@ -2075,7 +2120,7 @@ def _strict_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
     value: dict[str, Any] = {}
     for key, item in pairs:
         if key in value:
-            raise RestartContextFileError(f"restart-context JSON contains duplicate field {key!r}")
+            raise _DuplicateJsonFieldError(f"JSON contains duplicate field {key!r}")
         value[key] = item
     return value
 

--- a/tests/unit/test_torchrun_agent_registration.py
+++ b/tests/unit/test_torchrun_agent_registration.py
@@ -67,6 +67,26 @@ class ExpireDuringMutationStore(InMemoryControlStore):
             value=value,
         )
 
+    def compare_refresh_in_window(
+        self,
+        key: str,
+        *,
+        expected_revision: int,
+        not_before_unix_ms: int,
+        deadline_unix_ms: int,
+        value: bytes,
+    ):
+        if self.expire_next_mutation:
+            self._manual_clock.set(deadline_unix_ms)
+            self.expire_next_mutation = False
+        return super().compare_refresh_in_window(
+            key,
+            expected_revision=expected_revision,
+            not_before_unix_ms=not_before_unix_ms,
+            deadline_unix_ms=deadline_unix_ms,
+            value=value,
+        )
+
     def compare_delete_in_window(
         self,
         key: str,
@@ -102,6 +122,27 @@ class DelayResponseStore(InMemoryControlStore):
         value: bytes,
     ):
         entry = super().compare_set_in_window(
+            key,
+            expected_revision=expected_revision,
+            not_before_unix_ms=not_before_unix_ms,
+            deadline_unix_ms=deadline_unix_ms,
+            value=value,
+        )
+        if self.delay_next_response_ms:
+            self._manual_clock.advance(self.delay_next_response_ms)
+            self.delay_next_response_ms = 0
+        return entry
+
+    def compare_refresh_in_window(
+        self,
+        key: str,
+        *,
+        expected_revision: int,
+        not_before_unix_ms: int,
+        deadline_unix_ms: int,
+        value: bytes,
+    ):
+        entry = super().compare_refresh_in_window(
             key,
             expected_revision=expected_revision,
             not_before_unix_ms=not_before_unix_ms,

--- a/tests/unit/test_torchrun_agent_registration_history_reader.py
+++ b/tests/unit/test_torchrun_agent_registration_history_reader.py
@@ -160,6 +160,30 @@ def test_registration_history_reader_verifies_renewal_and_replacement():
     )
 
 
+def test_registration_history_reader_accepts_compacted_equivalent_renewals():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    manager = _manager(store, clock, "agent-a")
+    initial = manager.register()
+    current = initial
+    for now_unix_ms in (1_010, 1_020, 1_030, 1_040):
+        clock.set(now_unix_ms)
+        current = manager.renew(current)
+
+    history = AgentRegistrationHistoryReader(
+        store,
+        run_id=RUN_ID,
+        node_id=NODE_ID,
+    ).read()
+
+    assert tuple(authority.registration for authority in history.authorities) == (
+        initial,
+        current,
+    )
+    assert history.authorities[-1].mutation_sequence == 5
+    assert history.current == current
+
+
 def test_registration_history_reader_preserves_release_and_recreate():
     clock = ManualClock()
     store = InMemoryControlStore(clock=clock)
@@ -289,7 +313,6 @@ def test_registration_history_reader_rejects_current_missing_from_history():
     ),
     [
         (3, 2, 1, 1, 1_010, "transaction sequences"),
-        (4, 3, 1, 1, 1_010, "omits a key mutation"),
         (3, 2, 2, 1, 1_010, "value sequence"),
         (5, 5, 3, 3, 1_010, "key lifetime"),
         (3, 2, 1, 1, 999, "grant times"),

--- a/tests/unit/test_torchrun_control_store.py
+++ b/tests/unit/test_torchrun_control_store.py
@@ -127,6 +127,56 @@ def test_control_store_value_sequence_changes_only_with_value_or_lifetime():
     assert recreated.value_sequence == 3
 
 
+def test_control_store_compacts_equivalent_unpinned_refreshes():
+    clock = ManualClock(100)
+    store = InMemoryControlStore(clock=clock)
+    created = store.compare_set_in_window(
+        "run/registration",
+        expected_revision=None,
+        not_before_unix_ms=100,
+        deadline_unix_ms=None,
+        value=b"same",
+    )
+    current = created
+    for now_unix_ms in (101, 102, 103, 104):
+        clock.now_unix_ms = now_unix_ms
+        current = store.compare_refresh_in_window(
+            "run/registration",
+            expected_revision=current.revision,
+            not_before_unix_ms=now_unix_ms,
+            deadline_unix_ms=200,
+            value=b"same",
+        )
+
+    assert store.get_history("run/registration") == (created, current)
+    assert current.mutation_sequence == 5
+    assert current.value_sequence == 1
+    assert current.lifetime_sequence == 1
+
+
+def test_control_store_refresh_rejects_changed_value():
+    clock = ManualClock(100)
+    store = InMemoryControlStore(clock=clock)
+    created = store.compare_set_in_window(
+        "run/registration",
+        expected_revision=None,
+        not_before_unix_ms=100,
+        deadline_unix_ms=None,
+        value=b"same",
+    )
+
+    with pytest.raises(ValueError, match="equal"):
+        store.compare_refresh_in_window(
+            "run/registration",
+            expected_revision=created.revision,
+            not_before_unix_ms=100,
+            deadline_unix_ms=200,
+            value=b"different",
+        )
+
+    assert store.get("run/registration") == created
+
+
 def test_control_store_rejects_stale_update_and_delete():
     store = InMemoryControlStore()
     created = store.compare_set("run/control", expected_revision=None, value=b"one")

--- a/tests/unit/test_torchrun_guarded_control_store.py
+++ b/tests/unit/test_torchrun_guarded_control_store.py
@@ -303,6 +303,48 @@ def test_guarded_transaction_pins_condition_revision_during_refresh_compaction()
     )
 
 
+def test_guarded_transaction_pins_guard_revision_during_refresh_compaction():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    guard = _guard(store)
+    clock.now_unix_ms = 1_001
+    referenced = store.compare_refresh_in_window(
+        "run/coordinator-lease",
+        expected_revision=guard.revision,
+        not_before_unix_ms=1_001,
+        deadline_unix_ms=1_100,
+        value=b"lease-a",
+    )
+    store.compare_set_many_guarded(
+        {
+            "run/generation-head": ControlStoreWrite(
+                expected_revision=None,
+                value=b"generation-0",
+            )
+        },
+        guard_key="run/coordinator-lease",
+        expected_guard_revision=referenced.revision,
+        not_before_unix_ms=1_001,
+        deadline_unix_ms=1_100,
+    )
+    current = referenced
+    for now_unix_ms in (1_002, 1_003, 1_004):
+        clock.now_unix_ms = now_unix_ms
+        current = store.compare_refresh_in_window(
+            "run/coordinator-lease",
+            expected_revision=current.revision,
+            not_before_unix_ms=now_unix_ms,
+            deadline_unix_ms=1_100,
+            value=b"lease-a",
+        )
+
+    assert store.get_history("run/coordinator-lease") == (
+        guard,
+        referenced,
+        current,
+    )
+
+
 def test_guarded_transaction_rejects_condition_conflict_without_partial_writes():
     clock = ManualClock()
     store = InMemoryControlStore(clock=clock)

--- a/tests/unit/test_torchrun_guarded_control_store.py
+++ b/tests/unit/test_torchrun_guarded_control_store.py
@@ -253,6 +253,56 @@ def test_guarded_transaction_commits_when_revision_conditions_hold():
     assert committed["run/restart-intents/intent-a"].value == b"intent-a"
 
 
+def test_guarded_transaction_pins_condition_revision_during_refresh_compaction():
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    guard = _guard(store)
+    registration = store.compare_set_in_window(
+        "run/registration",
+        expected_revision=None,
+        not_before_unix_ms=1_000,
+        deadline_unix_ms=None,
+        value=b"same-registration",
+    )
+    clock.now_unix_ms = 1_001
+    referenced = store.compare_refresh_in_window(
+        "run/registration",
+        expected_revision=registration.revision,
+        not_before_unix_ms=1_001,
+        deadline_unix_ms=1_100,
+        value=b"same-registration",
+    )
+    store.compare_set_many_guarded(
+        {
+            "run/receipt": ControlStoreWrite(
+                expected_revision=None,
+                value=b"receipt",
+            )
+        },
+        guard_key="run/coordinator-lease",
+        expected_guard_revision=guard.revision,
+        not_before_unix_ms=1_001,
+        deadline_unix_ms=1_100,
+        conditions={"run/registration": referenced.revision},
+    )
+    current = referenced
+    for now_unix_ms in (1_002, 1_003, 1_004):
+        clock.now_unix_ms = now_unix_ms
+        current = store.compare_refresh_in_window(
+            "run/registration",
+            expected_revision=current.revision,
+            not_before_unix_ms=now_unix_ms,
+            deadline_unix_ms=1_100,
+            value=b"same-registration",
+        )
+
+    assert store.get_history("run/registration") == (
+        registration,
+        referenced,
+        current,
+    )
+
+
 def test_guarded_transaction_rejects_condition_conflict_without_partial_writes():
     clock = ManualClock()
     store = InMemoryControlStore(clock=clock)

--- a/tests/unit/test_torchrun_restart_ack_reader.py
+++ b/tests/unit/test_torchrun_restart_ack_reader.py
@@ -190,15 +190,21 @@ def test_restart_ack_reader_accepts_historical_authorities_after_renewal():
     clock, store, lease_manager, lease, registration_manager, registration, _ = _state(
         commit_receipt=True
     )
-    clock.set(1_010)
-    registration_manager.renew(registration)
+    current_registration = registration
+    for now_unix_ms in (1_010, 1_020, 1_030, 1_040):
+        clock.set(now_unix_ms)
+        current_registration = registration_manager.renew(current_registration)
     lease_manager.renew(lease)
 
     persisted = RestartAckReader(store, run_id=RUN_ID, node_id="node-a").read()
+    registration_history = store.get_history(registration_manager.registration_key)
 
     assert persisted is not None
     assert persisted.registration_authority.registration == registration
     assert persisted.coordinator_authority.lease == lease
+    assert registration_history[0].revision == registration.fencing_token
+    assert registration_history[-1].revision == current_registration.fencing_token
+    assert len(registration_history) == 2
 
 
 def test_restart_ack_reader_is_node_scoped():

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -1047,11 +1047,17 @@ def _seed_assigned_arrival(
     with handler._registration_lock:
         registration = handler._registration
     assert registration is not None
+    attempt = handler._claim_arrival_attempt(
+        generation=generation,
+        slot=slot,
+        deadline=time.monotonic() + 1,
+    )
     store.compare_set(
-        handler._arrival_key(generation, slot),
+        handler._arrival_key(generation, attempt, slot),
         expected_revision=None,
         value=handler._arrival_value(
             generation=generation,
+            attempt=attempt,
             slot=slot,
             registration=registration,
         ),
@@ -1232,13 +1238,13 @@ def test_slot_aware_handler_reuses_generation_scoped_bootstrap_store(
         args=(second_outcome,),
     )
     second_thread.start()
+    time.sleep(0.02)
+    assert second_thread.is_alive()
+
+    second_a = handler_a.next_rendezvous()
     second_thread.join(timeout=2)
     assert not second_thread.is_alive()
     second_b = second_outcome.get_nowait()
-    assert isinstance(second_b, type(first_a))
-    assert second_b.bootstrap_store_info == first_a.bootstrap_store_info
-
-    second_a = handler_a.next_rendezvous()
     assert isinstance(second_b, type(second_a))
     assert second_b.bootstrap_store_info == second_a.bootstrap_store_info
     assert handler_a.use_agent_store is False
@@ -1672,6 +1678,51 @@ def test_slot_aware_handler_shutdown_is_bounded_by_stuck_heartbeat(
     _wait_until(
         lambda: handler._heartbeat_thread is not None and not handler._heartbeat_thread.is_alive()
     )
+    assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_shutdown_is_bounded_by_stuck_registration_release(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a",))
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+    handler.next_rendezvous()
+    original_release = handler._registration_manager.release
+    started = threading.Event()
+    unblock = threading.Event()
+
+    def delayed_release(registration: Any) -> int:
+        started.set()
+        unblock.wait(timeout=2)
+        return original_release(registration)
+
+    monkeypatch.setattr(
+        handler._registration_manager,
+        "release",
+        delayed_release,
+    )
+
+    before = time.monotonic()
+    assert handler.shutdown() is False
+    elapsed = time.monotonic() - before
+
+    assert elapsed < 0.5
+    assert started.is_set()
+    unblock.set()
+    _wait_until(lambda: handler._registration is None)
     assert handler.shutdown() is True
 
 

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -8,6 +8,7 @@ import stat
 import threading
 import time
 from dataclasses import replace
+from datetime import timedelta
 from pathlib import Path
 from typing import Any, Callable, cast
 
@@ -16,6 +17,7 @@ from torch.distributed import HashStore
 from torch.distributed.elastic.rendezvous import (
     RendezvousClosedError,
     RendezvousConnectionError,
+    RendezvousInfo,
     RendezvousParameters,
     RendezvousStateError,
     RendezvousStoreInfo,
@@ -1018,6 +1020,44 @@ def _wait_until(predicate: Callable[[], bool], *, timeout: float = 2.0) -> None:
     raise AssertionError("condition did not become true before the timeout")
 
 
+def _start_rendezvous(
+    handler: SlotAwareRendezvousHandler,
+) -> tuple[threading.Thread, queue.Queue[BaseException | object]]:
+    outcome: queue.Queue[BaseException | object] = queue.Queue()
+
+    def rendezvous() -> None:
+        try:
+            outcome.put(handler.next_rendezvous())
+        except BaseException as error:
+            outcome.put(error)
+
+    thread = threading.Thread(target=rendezvous)
+    thread.start()
+    return thread, outcome
+
+
+def _seed_assigned_arrival(
+    handler: SlotAwareRendezvousHandler,
+    store: InMemoryControlStore,
+    *,
+    generation: int,
+    slot: int,
+) -> None:
+    handler._ensure_registered()
+    with handler._registration_lock:
+        registration = handler._registration
+    assert registration is not None
+    store.compare_set(
+        handler._arrival_key(generation, slot),
+        expected_revision=None,
+        value=handler._arrival_value(
+            generation=generation,
+            slot=slot,
+            registration=registration,
+        ),
+    )
+
+
 def test_slot_aware_handler_admits_initial_assignment_with_stable_rank(
     tmp_path: Path,
 ):
@@ -1038,8 +1078,22 @@ def test_slot_aware_handler_admits_initial_assignment_with_stable_rank(
         clock=clock,
         agent_id="agent-b",
     )
+    peer = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=2,
+            max_nodes=3,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+    peer_thread, peer_outcome = _start_rendezvous(peer)
 
     info = handler.next_rendezvous()
+    peer_thread.join(timeout=2)
+    peer_info = peer_outcome.get_nowait()
 
     assert handler.get_backend() == "lm_resiliency"
     assert handler.get_run_id() == RUN_ID
@@ -1047,6 +1101,8 @@ def test_slot_aware_handler_admits_initial_assignment_with_stable_rank(
     assert info.rank == 1
     assert info.world_size == 2
     assert info.bootstrap_store_info == RendezvousStoreInfo("master.example", 29500)
+    assert isinstance(peer_info, RendezvousInfo)
+    assert peer_info.rank == 0
     assert not config.restart_context_path.exists()
     registration = AgentRegistrationReader(
         store,
@@ -1057,6 +1113,7 @@ def test_slot_aware_handler_admits_initial_assignment_with_stable_rank(
     assert registration.record.agent_identity == handler.agent_identity
 
     assert handler.shutdown() is True
+    assert peer.shutdown() is True
     assert handler.shutdown() is True
     assert (
         AgentRegistrationReader(
@@ -1066,6 +1123,33 @@ def test_slot_aware_handler_admits_initial_assignment_with_stable_rank(
         ).get("node-b")
         is None
     )
+
+
+def test_slot_aware_handler_times_out_when_an_assigned_slot_never_arrives(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a", "node-b"))
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=2,
+            max_nodes=3,
+            join_timeout_ms=60,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+
+    before = time.monotonic()
+    with pytest.raises(RendezvousTimeoutError):
+        handler.next_rendezvous()
+
+    assert time.monotonic() - before < 0.5
+    assert handler.shutdown() is True
 
 
 def test_slot_aware_handler_reuses_generation_scoped_bootstrap_store(
@@ -1118,6 +1202,8 @@ def test_slot_aware_handler_reuses_generation_scoped_bootstrap_store(
     first_b = first_outcome.get_nowait()
     assert isinstance(first_b, type(first_a))
     assert first_b.bootstrap_store_info == first_a.bootstrap_store_info
+    assert first_a.store.timeout == timedelta(milliseconds=handler_a._config.policy.join_timeout_ms)
+    assert first_b.store.timeout == first_a.store.timeout
 
     assert handler_b.shutdown() is True
     replacement_b = _handler(
@@ -1185,6 +1271,21 @@ def test_slot_aware_handler_bounds_bootstrap_read_and_ignores_stale_unprefixed_k
         rendezvous_store=rendezvous_store,
         bootstrap_store_info=None,
     )
+    peer = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=2,
+            max_nodes=3,
+            join_timeout_ms=60,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+        rendezvous_store=rendezvous_store,
+        bootstrap_store_info=None,
+    )
+    _seed_assigned_arrival(peer, store, generation=0, slot=0)
 
     before = time.monotonic()
     with pytest.raises(RendezvousTimeoutError):
@@ -1193,6 +1294,7 @@ def test_slot_aware_handler_bounds_bootstrap_read_and_ignores_stale_unprefixed_k
 
     assert elapsed < 0.5
     assert handler.shutdown() is True
+    assert peer.shutdown() is True
 
 
 def test_slot_aware_handler_rechecks_closure_after_bootstrap_wait(
@@ -1215,6 +1317,20 @@ def test_slot_aware_handler_rechecks_closure_after_bootstrap_wait(
         rendezvous_store=rendezvous_store,
         bootstrap_store_info=None,
     )
+    peer = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=2,
+            max_nodes=3,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+        rendezvous_store=rendezvous_store,
+        bootstrap_store_info=None,
+    )
+    _seed_assigned_arrival(peer, store, generation=0, slot=0)
     outcome: queue.Queue[BaseException | object] = queue.Queue()
 
     def rendezvous() -> None:
@@ -1244,6 +1360,7 @@ def test_slot_aware_handler_rechecks_closure_after_bootstrap_wait(
 
     assert isinstance(outcome.get_nowait(), RendezvousClosedError)
     assert handler.shutdown() is True
+    assert peer.shutdown() is True
 
 
 def test_slot_aware_handler_rechecks_heartbeat_after_bootstrap_wait(
@@ -1266,6 +1383,20 @@ def test_slot_aware_handler_rechecks_heartbeat_after_bootstrap_wait(
         rendezvous_store=rendezvous_store,
         bootstrap_store_info=None,
     )
+    peer = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=2,
+            max_nodes=3,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+        rendezvous_store=rendezvous_store,
+        bootstrap_store_info=None,
+    )
+    _seed_assigned_arrival(peer, store, generation=0, slot=0)
     outcome: queue.Queue[BaseException | object] = queue.Queue()
 
     def rendezvous() -> None:
@@ -1295,6 +1426,7 @@ def test_slot_aware_handler_rechecks_heartbeat_after_bootstrap_wait(
 
     assert isinstance(outcome.get_nowait(), RendezvousConnectionError)
     assert handler.shutdown() is True
+    assert peer.shutdown() is True
 
 
 def test_slot_aware_handler_parks_standby_without_reporting_waiting_node(
@@ -1644,7 +1776,10 @@ def test_slot_aware_handler_rejects_job_wide_environment_drift(tmp_path: Path):
         agent_id="agent-b",
     )
 
-    assert first.next_rendezvous().rank == 0
+    first._ensure_registered()
+    current = first._read_generation()
+    assert current is not None
+    assert first._initial_slot(current) == 0
     with pytest.raises(RendezvousStateError, match="committed workload environment"):
         second.next_rendezvous()
 

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -1394,9 +1394,19 @@ def test_slot_aware_handler_reuses_generation_scoped_bootstrap_store(
         args=(second_outcome,),
     )
     second_thread.start()
+    second_thread.join(timeout=2)
+    replacement_first = second_outcome.get_nowait()
+    assert isinstance(replacement_first, RendezvousInfo)
+    assert replacement_first.rank == 1
+
+    second_outcome = queue.Queue()
+    second_thread = threading.Thread(
+        target=replacement_rendezvous_b,
+        args=(second_outcome,),
+    )
+    second_thread.start()
     time.sleep(0.02)
     assert second_thread.is_alive()
-
     second_a = handler_a.next_rendezvous()
     second_thread.join(timeout=2)
     assert not second_thread.is_alive()
@@ -1552,10 +1562,34 @@ def test_slot_aware_handler_replacement_consumes_completed_attempt_before_advanc
     )
     completion = store.get(original_leader._arrival_completion_key(0, attempt))
     assert completion is not None
+    original_leader._publish_arrival_consumption(
+        current,
+        assignment,
+        attempt,
+        0,
+        completion,
+        deadline,
+    )
+    original_consumption = store.get(
+        original_leader._arrival_consumption_key(
+            0,
+            attempt,
+            0,
+            original_registration.record.registration_id,
+        )
+    )
+    assert original_consumption is not None
     assert original_leader.shutdown() is True
 
     peer_info = peer.next_rendezvous()
-    peer_consumption = store.get(peer._arrival_consumption_key(0, attempt, 1))
+    peer_consumption = store.get(
+        peer._arrival_consumption_key(
+            0,
+            attempt,
+            1,
+            peer_registration.record.registration_id,
+        )
+    )
     assert peer_info.rank == 1
     assert peer_consumption is not None
 
@@ -1571,11 +1605,22 @@ def test_slot_aware_handler_replacement_consumes_completed_attempt_before_advanc
         agent_id="agent-a-replacement",
     )
     replacement_info = replacement.next_rendezvous()
-    replacement_consumption = store.get(replacement._arrival_consumption_key(0, attempt, 0))
+    with replacement._registration_lock:
+        replacement_registration = replacement._registration
+    assert replacement_registration is not None
+    replacement_consumption = store.get(
+        replacement._arrival_consumption_key(
+            0,
+            attempt,
+            0,
+            replacement_registration.record.registration_id,
+        )
+    )
     attempt_entry = store.get(replacement._arrival_attempt_key(0))
 
     assert replacement_info.rank == 0
     assert replacement_consumption is not None
+    assert replacement_consumption.value != original_consumption.value
     assert attempt_entry is not None
     current_attempt, _, _ = replacement._validate_arrival_attempt_entry(
         attempt_entry,
@@ -1584,6 +1629,172 @@ def test_slot_aware_handler_replacement_consumes_completed_attempt_before_advanc
     assert current_attempt == attempt
     assert peer.shutdown() is True
     assert replacement.shutdown() is True
+
+
+def test_slot_aware_handler_retries_consumption_after_heartbeat_refresh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a",))
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+    original_compare = store.compare_set_many_guarded
+    refreshed = False
+
+    def refresh_before_consumption(*args: Any, **kwargs: Any) -> Any:
+        nonlocal refreshed
+        writes = args[0]
+        if not refreshed and any("/consumed/" in key for key in writes):
+            refreshed = True
+            with handler._registration_lock:
+                registration = handler._registration
+            assert registration is not None
+            renewed = handler._registration_manager.renew(registration)
+            with handler._registration_lock:
+                handler._registration = renewed
+        return original_compare(*args, **kwargs)
+
+    monkeypatch.setattr(store, "compare_set_many_guarded", refresh_before_consumption)
+
+    info = handler.next_rendezvous()
+
+    assert info.rank == 0
+    assert refreshed
+    assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_fences_closure_during_consumption(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a",))
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+    original_compare = store.compare_set_many_guarded
+    closed = False
+
+    def close_before_consumption(*args: Any, **kwargs: Any) -> Any:
+        nonlocal closed
+        writes = args[0]
+        if not closed and any("/consumed/" in key for key in writes):
+            closed = True
+            store.compare_set(
+                handler.closure_key,
+                expected_revision=None,
+                value=handler._closure_value,
+            )
+        return original_compare(*args, **kwargs)
+
+    monkeypatch.setattr(store, "compare_set_many_guarded", close_before_consumption)
+
+    with pytest.raises(RendezvousClosedError):
+        handler.next_rendezvous()
+
+    assert closed
+    assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_shutdown_interrupts_initial_closure_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=1,
+            max_nodes=2,
+            join_timeout_ms=1_000,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+    started = threading.Event()
+    unblock = threading.Event()
+    original_read = handler._read_closure_entry
+
+    def blocked_read() -> Any:
+        started.set()
+        unblock.wait(timeout=2)
+        return original_read()
+
+    monkeypatch.setattr(handler, "_read_closure_entry", blocked_read)
+    thread, outcome = _start_rendezvous(handler)
+    assert started.wait(timeout=1)
+
+    before = time.monotonic()
+    assert handler.shutdown() is True
+    thread.join(timeout=1)
+    elapsed = time.monotonic() - before
+
+    assert not thread.is_alive()
+    assert elapsed < 0.5
+    assert isinstance(outcome.get_nowait(), RendezvousClosedError)
+    unblock.set()
+
+
+def test_slot_aware_handler_bounds_initial_closure_read_by_formation_deadline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=1,
+            max_nodes=2,
+            join_timeout_ms=60,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+    started = threading.Event()
+    unblock = threading.Event()
+
+    def blocked_read() -> Any:
+        started.set()
+        unblock.wait(timeout=2)
+        return None
+
+    monkeypatch.setattr(handler, "_read_closure_entry", blocked_read)
+
+    before = time.monotonic()
+    with pytest.raises(RendezvousTimeoutError):
+        handler.next_rendezvous()
+    elapsed = time.monotonic() - before
+
+    assert started.is_set()
+    assert elapsed < 0.5
+    unblock.set()
+    assert handler.shutdown() is True
 
 
 def test_slot_aware_handler_bounds_bootstrap_read_and_ignores_stale_unprefixed_keys(

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -1081,6 +1081,145 @@ def _seed_assigned_arrival(
     threading.Thread(target=complete_attempt, daemon=True).start()
 
 
+def test_slot_aware_handler_refreshes_leader_registration_before_completion(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _, _, current = _initialize_generation(store, clock, ("node-a", "node-b"))
+    leader = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=2,
+            max_nodes=3,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+    peer = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=2,
+            max_nodes=3,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+    )
+    deadline = time.monotonic() + 1
+    leader._ensure_registered(deadline)
+    peer._ensure_registered(deadline)
+    with leader._registration_lock:
+        original_leader_registration = leader._registration
+    with peer._registration_lock:
+        peer_registration = peer._registration
+    assert original_leader_registration is not None
+    assert peer_registration is not None
+    attempt = leader._claim_shared_arrival_attempt(
+        generation=0,
+        slot=0,
+        registration=original_leader_registration,
+        deadline=deadline,
+    )
+    for slot, handler, registration in (
+        (0, leader, original_leader_registration),
+        (1, peer, peer_registration),
+    ):
+        store.compare_set(
+            leader._arrival_key(0, attempt, slot),
+            expected_revision=None,
+            value=handler._arrival_value(
+                generation=0,
+                attempt=attempt,
+                slot=slot,
+                registration=registration,
+            ),
+        )
+    renewed = leader._registration_manager.renew(original_leader_registration)
+    with leader._registration_lock:
+        leader._registration = renewed
+
+    leader._try_complete_arrival_attempt(
+        current.snapshot.record.assignment,
+        attempt,
+        original_leader_registration,
+    )
+
+    completion = store.get(leader._arrival_completion_key(0, attempt))
+    assert completion is not None
+    assert completion.guard_revision == renewed.fencing_token
+    assert leader.shutdown() is True
+    assert peer.shutdown() is True
+
+
+def test_slot_aware_handler_classifies_duplicate_completion_fields_as_corruption(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _, _, current = _initialize_generation(store, clock, ("node-a",))
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+    deadline = time.monotonic() + 1
+    handler._ensure_registered(deadline)
+    with handler._registration_lock:
+        registration = handler._registration
+    assert registration is not None
+    attempt = handler._claim_shared_arrival_attempt(
+        generation=0,
+        slot=0,
+        registration=registration,
+        deadline=deadline,
+    )
+    store.compare_set(
+        handler._arrival_key(0, attempt, 0),
+        expected_revision=None,
+        value=handler._arrival_value(
+            generation=0,
+            attempt=attempt,
+            slot=0,
+            registration=registration,
+        ),
+    )
+    handler._try_complete_arrival_attempt(
+        current.snapshot.record.assignment,
+        attempt,
+        registration,
+    )
+    completion = store.get(handler._arrival_completion_key(0, attempt))
+    assert completion is not None
+    corrupted = replace(
+        completion,
+        value=completion.value.replace(
+            b'"attempt":1,',
+            b'"attempt":1,"attempt":1,',
+            1,
+        ),
+    )
+
+    with pytest.raises(RendezvousStateError, match="malformed"):
+        handler._validate_arrival_completion_entry(
+            corrupted,
+            assignment=current.snapshot.record.assignment,
+            attempt=attempt,
+            registration=registration,
+        )
+
+    assert handler.shutdown() is True
+
+
 def test_slot_aware_handler_admits_initial_assignment_with_stable_rank(
     tmp_path: Path,
 ):
@@ -2418,6 +2557,58 @@ def test_slot_aware_handler_rejects_deleted_closure_record(tmp_path: Path):
         second.is_closed()
 
     assert second.shutdown() is True
+
+
+def test_slot_aware_handler_bounds_closure_publication_before_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a",))
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+    handler._ensure_registered(time.monotonic() + 1)
+    original_read = handler._read_closure_entry
+    started = threading.Event()
+    unblock = threading.Event()
+
+    def delayed_read():
+        started.set()
+        unblock.wait(timeout=2)
+        return original_read()
+
+    monkeypatch.setattr(handler, "_read_closure_entry", delayed_read)
+
+    before = time.monotonic()
+    with pytest.raises(RendezvousConnectionError, match="timed out"):
+        handler.set_closed()
+    elapsed = time.monotonic() - before
+
+    assert started.is_set()
+    assert elapsed < 0.5
+    _wait_until(
+        lambda: (
+            AgentRegistrationReader(
+                store,
+                run_id=RUN_ID,
+                clock=clock,
+            ).get("node-a")
+            is None
+        )
+    )
+    unblock.set()
+    _wait_until(lambda: store.get(handler.closure_key) is not None)
+    assert handler.shutdown() is True
 
 
 def test_slot_aware_handler_retries_closure_created_during_read(

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -9,7 +9,7 @@ import threading
 import time
 from dataclasses import replace
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Callable, cast
 
 import pytest
 from torch.distributed import HashStore
@@ -22,6 +22,7 @@ from torch.distributed.elastic.rendezvous import (
 )
 
 from lm_resiliency.integrations.torchrun._agent_registration import (
+    AgentRegistrationManager,
     AgentRegistrationReader,
 )
 from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
@@ -988,19 +989,26 @@ def _handler(
     store: InMemoryControlStore,
     clock: ManualClock,
     agent_id: str,
+    rendezvous_store: HashStore | None = None,
+    bootstrap_store_info: RendezvousStoreInfo | None = RendezvousStoreInfo(
+        "master.example",
+        29500,
+    ),
+    monotonic_clock: Callable[[], float] = time.monotonic,
 ) -> SlotAwareRendezvousHandler:
     return SlotAwareRendezvousHandler(
         config,
         control_store=store,
-        rendezvous_store=HashStore(),
+        rendezvous_store=rendezvous_store or HashStore(),
         clock=clock,
         agent_id=agent_id,
         hostname=f"{config.node_id}.example",
-        bootstrap_store_info=RendezvousStoreInfo("master.example", 29500),
+        bootstrap_store_info=bootstrap_store_info,
+        monotonic_clock=monotonic_clock,
     )
 
 
-def _wait_until(predicate: Any, *, timeout: float = 2.0) -> None:
+def _wait_until(predicate: Callable[[], bool], *, timeout: float = 2.0) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if predicate():
@@ -1059,6 +1067,105 @@ def test_slot_aware_handler_admits_initial_assignment_with_stable_rank(
     )
 
 
+def test_slot_aware_handler_uses_attempt_scoped_bootstrap_store(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a", "node-b"))
+    rendezvous_store = HashStore()
+    handler_a = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=2,
+            max_nodes=3,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+        rendezvous_store=rendezvous_store,
+        bootstrap_store_info=None,
+    )
+    handler_b = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=2,
+            max_nodes=3,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+        rendezvous_store=rendezvous_store,
+        bootstrap_store_info=None,
+    )
+
+    def rendezvous_b(outcome: queue.Queue[BaseException | object]) -> None:
+        try:
+            outcome.put(handler_b.next_rendezvous())
+        except BaseException as error:
+            outcome.put(error)
+
+    first_outcome: queue.Queue[BaseException | object] = queue.Queue()
+    first_thread = threading.Thread(target=rendezvous_b, args=(first_outcome,))
+    first_thread.start()
+    time.sleep(0.02)
+    assert first_thread.is_alive()
+    first_a = handler_a.next_rendezvous()
+    first_thread.join(timeout=2)
+    first_b = first_outcome.get_nowait()
+    assert isinstance(first_b, type(first_a))
+    assert first_b.bootstrap_store_info == first_a.bootstrap_store_info
+
+    second_outcome: queue.Queue[BaseException | object] = queue.Queue()
+    second_thread = threading.Thread(target=rendezvous_b, args=(second_outcome,))
+    second_thread.start()
+    time.sleep(0.02)
+    assert second_thread.is_alive()
+    second_a = handler_a.next_rendezvous()
+    second_thread.join(timeout=2)
+    second_b = second_outcome.get_nowait()
+    assert isinstance(second_b, type(second_a))
+    assert second_b.bootstrap_store_info == second_a.bootstrap_store_info
+
+    assert handler_a.shutdown() is True
+    assert handler_b.shutdown() is True
+
+
+def test_slot_aware_handler_bounds_bootstrap_read_and_ignores_stale_unprefixed_keys(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a", "node-b"))
+    rendezvous_store = HashStore()
+    rendezvous_store.set("MASTER_ADDR", b"stale.example")
+    rendezvous_store.set("MASTER_PORT", b"12345")
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=2,
+            max_nodes=3,
+            join_timeout_ms=60,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+        rendezvous_store=rendezvous_store,
+        bootstrap_store_info=None,
+    )
+
+    before = time.monotonic()
+    with pytest.raises(RendezvousTimeoutError):
+        handler.next_rendezvous()
+    elapsed = time.monotonic() - before
+
+    assert elapsed < 0.5
+    assert handler.shutdown() is True
+
+
 def test_slot_aware_handler_parks_standby_without_reporting_waiting_node(
     tmp_path: Path,
 ):
@@ -1071,6 +1178,7 @@ def test_slot_aware_handler_parks_standby_without_reporting_waiting_node(
             node_id="node-b",
             min_nodes=1,
             max_nodes=2,
+            join_timeout_ms=60,
         ),
         store=store,
         clock=clock,
@@ -1099,6 +1207,7 @@ def test_slot_aware_handler_parks_standby_without_reporting_waiting_node(
     thread.start()
     reader = AgentRegistrationReader(store, run_id=RUN_ID, clock=clock)
     _wait_until(lambda: reader.get("node-b") is not None)
+    time.sleep(0.08)
 
     assert thread.is_alive()
     assert standby.num_nodes_waiting() == 0
@@ -1149,6 +1258,55 @@ def test_slot_aware_handler_renews_active_registration(tmp_path: Path):
     assert handler.shutdown() is True
 
 
+def test_slot_aware_handler_schedules_renewal_from_remaining_lease_lifetime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a",))
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=1,
+            max_nodes=2,
+            registration_lease_duration_ms=90,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+    handler.next_rendezvous()
+    original_renew = handler._registration_manager.renew
+    renew_count = 0
+    second_renewal_succeeded = threading.Event()
+    timer: threading.Timer | None = None
+
+    def delayed_first_response(registration: Any) -> Any:
+        nonlocal renew_count, timer
+        renew_count += 1
+        renewed = original_renew(registration)
+        if renew_count == 1:
+            clock.advance(85)
+            timer = threading.Timer(0.01, lambda: clock.advance(10))
+            timer.start()
+        else:
+            second_renewal_succeeded.set()
+        return renewed
+
+    monkeypatch.setattr(
+        handler._registration_manager,
+        "renew",
+        delayed_first_response,
+    )
+
+    assert second_renewal_succeeded.wait(timeout=1)
+    if timer is not None:
+        timer.join(timeout=1)
+    assert handler.shutdown() is True
+
+
 def test_slot_aware_handler_shutdown_is_bounded_by_stuck_heartbeat(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1196,7 +1354,6 @@ def test_slot_aware_handler_times_out_and_releases_standby_registration(
 ):
     clock = ManualClock()
     store = InMemoryControlStore(clock=clock)
-    _initialize_generation(store, clock, ("node-a",))
     handler = _handler(
         _handler_config(
             tmp_path,
@@ -1211,6 +1368,83 @@ def test_slot_aware_handler_times_out_and_releases_standby_registration(
     )
 
     with pytest.raises(RendezvousTimeoutError):
+        handler.next_rendezvous()
+
+    assert (
+        AgentRegistrationReader(
+            store,
+            run_id=RUN_ID,
+            clock=clock,
+        ).get("node-b")
+        is None
+    )
+    assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_rejects_incompatible_node_id_reuse(tmp_path: Path):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a",))
+    original_config = _handler_config(
+        tmp_path,
+        node_id="node-a",
+        min_nodes=1,
+        max_nodes=2,
+    )
+    original_identity = original_config.build_agent_identity(
+        agent_id="agent-a-original",
+        hostname="node-a.example",
+    )
+    registration_manager = AgentRegistrationManager(
+        store,
+        agent_identity=original_identity,
+        lease_duration_ms=original_config.policy.registration_lease_duration_ms,
+        clock=clock,
+    )
+    original_registration = registration_manager.register()
+    registration_manager.release(original_registration)
+    incompatible_config = replace(
+        original_config,
+        environment_digest="environment-v2",
+    )
+    handler = _handler(
+        incompatible_config,
+        store=store,
+        clock=clock,
+        agent_id="agent-a-replacement",
+    )
+
+    with pytest.raises(RendezvousStateError, match="incompatible"):
+        handler.next_rendezvous()
+
+    assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_cleans_up_registration_on_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a",))
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+    )
+
+    def cancel(_deadline: float | None) -> bool:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(handler, "_wait_for_change", cancel)
+
+    with pytest.raises(KeyboardInterrupt):
         handler.next_rendezvous()
 
     assert (

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -1043,14 +1043,16 @@ def _seed_assigned_arrival(
     generation: int,
     slot: int,
 ) -> None:
-    handler._ensure_registered()
+    deadline = time.monotonic() + 1
+    handler._ensure_registered(deadline)
     with handler._registration_lock:
         registration = handler._registration
     assert registration is not None
-    attempt = handler._claim_arrival_attempt(
+    attempt = handler._claim_shared_arrival_attempt(
         generation=generation,
         slot=slot,
-        deadline=time.monotonic() + 1,
+        registration=registration,
+        deadline=deadline,
     )
     store.compare_set(
         handler._arrival_key(generation, attempt, slot),
@@ -1062,6 +1064,21 @@ def _seed_assigned_arrival(
             registration=registration,
         ),
     )
+    current = handler._read_generation()
+    assert current is not None
+
+    def complete_attempt() -> None:
+        while time.monotonic() < deadline:
+            handler._try_complete_arrival_attempt(
+                current.snapshot.record.assignment,
+                attempt,
+                registration,
+            )
+            if store.get(handler._arrival_completion_key(generation, attempt)) is not None:
+                return
+            time.sleep(0.005)
+
+    threading.Thread(target=complete_attempt, daemon=True).start()
 
 
 def test_slot_aware_handler_admits_initial_assignment_with_stable_rank(
@@ -1254,6 +1271,81 @@ def test_slot_aware_handler_reuses_generation_scoped_bootstrap_store(
     assert replacement_b.shutdown() is True
 
 
+def test_slot_aware_handler_reuses_incomplete_attempt_after_leader_replacement(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a", "node-b"))
+    original_leader = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=2,
+            max_nodes=3,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a-original",
+    )
+    deadline = time.monotonic() + 1
+    original_leader._ensure_registered(deadline)
+    with original_leader._registration_lock:
+        original_registration = original_leader._registration
+    assert original_registration is not None
+    assert (
+        original_leader._claim_shared_arrival_attempt(
+            generation=0,
+            slot=0,
+            registration=original_registration,
+            deadline=deadline,
+        )
+        == 1
+    )
+    assert original_leader.shutdown() is True
+
+    peer = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=2,
+            max_nodes=3,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+    )
+    replacement = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=2,
+            max_nodes=3,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a-replacement",
+    )
+    peer_thread, peer_outcome = _start_rendezvous(peer)
+
+    replacement_info = replacement.next_rendezvous()
+    peer_thread.join(timeout=2)
+    peer_info = peer_outcome.get_nowait()
+
+    assert replacement_info.rank == 0
+    assert isinstance(peer_info, RendezvousInfo)
+    assert peer_info.rank == 1
+    attempt_entry = store.get(replacement._arrival_attempt_key(0))
+    assert attempt_entry is not None
+    attempt, _, _ = replacement._validate_arrival_attempt_entry(
+        attempt_entry,
+        generation=0,
+    )
+    assert attempt == 1
+    assert replacement.shutdown() is True
+    assert peer.shutdown() is True
+
+
 def test_slot_aware_handler_bounds_bootstrap_read_and_ignores_stale_unprefixed_keys(
     tmp_path: Path,
 ):
@@ -1369,6 +1461,66 @@ def test_slot_aware_handler_rechecks_closure_after_bootstrap_wait(
     assert peer.shutdown() is True
 
 
+def test_slot_aware_handler_rejects_generation_change_after_bootstrap_wait(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    manager, lease, current = _initialize_generation(
+        store,
+        clock,
+        ("node-a", "node-b"),
+    )
+    rendezvous_store = HashStore()
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=2,
+            max_nodes=3,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+        rendezvous_store=rendezvous_store,
+        bootstrap_store_info=None,
+    )
+    peer = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=2,
+            max_nodes=3,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+        rendezvous_store=rendezvous_store,
+        bootstrap_store_info=None,
+    )
+    _seed_assigned_arrival(peer, store, generation=0, slot=0)
+    thread, outcome = _start_rendezvous(handler)
+    _wait_until(lambda: store.get(handler._arrival_completion_key(0, 1)) is not None)
+    successor = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=1,
+        assignments=(
+            SlotAssignment(0, "node-a", 0, 2),
+            SlotAssignment(1, "node-b", 2, 2),
+        ),
+        topology_digest="topology-v1",
+    )
+    manager.commit_successor(lease, current, successor)
+    bootstrap_store = handler._bootstrap_store(0)
+    bootstrap_store.set(RendezvousStoreInfo.MASTER_ADDR_KEY, "master.example")
+    bootstrap_store.set(RendezvousStoreInfo.MASTER_PORT_KEY, "29500")
+    thread.join(timeout=2)
+
+    assert isinstance(outcome.get_nowait(), RendezvousConnectionError)
+    assert handler.shutdown() is True
+    assert peer.shutdown() is True
+
+
 def test_slot_aware_handler_rechecks_heartbeat_after_bootstrap_wait(
     tmp_path: Path,
 ):
@@ -1433,6 +1585,129 @@ def test_slot_aware_handler_rechecks_heartbeat_after_bootstrap_wait(
     assert isinstance(outcome.get_nowait(), RendezvousConnectionError)
     assert handler.shutdown() is True
     assert peer.shutdown() is True
+
+
+def test_slot_aware_handler_does_not_publish_arrival_before_context_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a", "node-b"))
+    peer = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=2,
+            max_nodes=3,
+            join_timeout_ms=80,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+    )
+    leader = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=2,
+            max_nodes=3,
+            join_timeout_ms=80,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+    original_clear = RestartContextFile.clear
+
+    def fail_peer_clear(context_file: RestartContextFile) -> None:
+        if context_file.path == peer._config.restart_context_path:
+            raise RestartContextFileError("injected context cleanup failure")
+        original_clear(context_file)
+
+    monkeypatch.setattr(RestartContextFile, "clear", fail_peer_clear)
+    peer_thread, peer_outcome = _start_rendezvous(peer)
+
+    with pytest.raises(RendezvousTimeoutError):
+        leader.next_rendezvous()
+    peer_thread.join(timeout=2)
+
+    assert isinstance(peer_outcome.get_nowait(), RendezvousStateError)
+    attempt_entry = store.get(leader._arrival_attempt_key(0))
+    assert attempt_entry is not None
+    attempt, _, _ = leader._validate_arrival_attempt_entry(
+        attempt_entry,
+        generation=0,
+    )
+    assert store.get(leader._arrival_key(0, attempt, 1)) is None
+    assert leader.shutdown() is True
+    assert peer.shutdown() is True
+
+
+def test_slot_aware_handler_reads_registration_histories_linearly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a", "node-b", "node-c"))
+    handlers = tuple(
+        _handler(
+            _handler_config(
+                tmp_path,
+                node_id=node_id,
+                min_nodes=3,
+                max_nodes=4,
+            ),
+            store=store,
+            clock=clock,
+            agent_id=f"agent-{node_id}",
+        )
+        for node_id in ("node-a", "node-b", "node-c")
+    )
+    history_reads = 0
+    history_lock = threading.Lock()
+    original_get_history = store.get_history
+
+    def count_registration_histories(key: str):
+        nonlocal history_reads
+        if "/agent-registrations/" in key:
+            with history_lock:
+                history_reads += 1
+        return original_get_history(key)
+
+    monkeypatch.setattr(store, "get_history", count_registration_histories)
+    deadline = time.monotonic() + 1
+    handlers[0]._ensure_registered(deadline)
+    with handlers[0]._registration_lock:
+        leader_registration = handlers[0]._registration
+    assert leader_registration is not None
+    attempt = handlers[0]._claim_shared_arrival_attempt(
+        generation=0,
+        slot=0,
+        registration=leader_registration,
+        deadline=deadline,
+    )
+    assert attempt == 1
+    peer_threads = tuple(_start_rendezvous(handler) for handler in handlers[1:])
+    _wait_until(
+        lambda: all(
+            store.get(handlers[0]._arrival_key(0, attempt, slot)) is not None for slot in (1, 2)
+        )
+    )
+
+    leader_info = handlers[0].next_rendezvous()
+    peer_infos: list[RendezvousInfo] = []
+    for thread, outcome in peer_threads:
+        thread.join(timeout=2)
+        info = outcome.get_nowait()
+        assert isinstance(info, RendezvousInfo)
+        peer_infos.append(info)
+
+    assert leader_info.rank == 0
+    assert {info.rank for info in peer_infos} == {1, 2}
+    assert history_reads <= 4 * len(handlers)
+    assert all(handler.shutdown() for handler in handlers)
 
 
 def test_slot_aware_handler_parks_standby_without_reporting_waiting_node(
@@ -1827,7 +2102,7 @@ def test_slot_aware_handler_rejects_job_wide_environment_drift(tmp_path: Path):
         agent_id="agent-b",
     )
 
-    first._ensure_registered()
+    first._ensure_registered(time.monotonic() + 1)
     current = first._read_generation()
     assert current is not None
     assert first._initial_slot(current) == 0
@@ -1951,6 +2226,71 @@ def test_slot_aware_handler_shutdown_is_bounded_during_registration(
     release.set()
     thread.join(timeout=2)
     assert isinstance(outcome.get_nowait(), RendezvousClosedError)
+    _wait_until(
+        lambda: (
+            AgentRegistrationReader(
+                store,
+                run_id=RUN_ID,
+                clock=clock,
+            ).get("node-a")
+            is None
+        )
+    )
+
+
+def test_slot_aware_handler_bounds_initial_registration_by_formation_deadline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a",))
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=1,
+            max_nodes=2,
+            join_timeout_ms=60,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+    original_register = handler._registration_manager.register
+    started = threading.Event()
+    release = threading.Event()
+
+    def delayed_registration() -> Any:
+        registration = original_register()
+        started.set()
+        release.wait(timeout=2)
+        return registration
+
+    monkeypatch.setattr(
+        handler._registration_manager,
+        "register",
+        delayed_registration,
+    )
+
+    before = time.monotonic()
+    with pytest.raises(RendezvousTimeoutError):
+        handler.next_rendezvous()
+
+    assert started.is_set()
+    assert time.monotonic() - before < 0.5
+    release.set()
+    _wait_until(
+        lambda: (
+            AgentRegistrationReader(
+                store,
+                run_id=RUN_ID,
+                clock=clock,
+            ).get("node-a")
+            is None
+        )
+    )
+    assert handler.shutdown() is True
 
 
 def test_slot_aware_handler_cleans_up_registration_on_cancellation(

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -1067,7 +1067,7 @@ def test_slot_aware_handler_admits_initial_assignment_with_stable_rank(
     )
 
 
-def test_slot_aware_handler_uses_attempt_scoped_bootstrap_store(
+def test_slot_aware_handler_reuses_generation_scoped_bootstrap_store(
     tmp_path: Path,
 ):
     clock = ManualClock()
@@ -1118,19 +1118,47 @@ def test_slot_aware_handler_uses_attempt_scoped_bootstrap_store(
     assert isinstance(first_b, type(first_a))
     assert first_b.bootstrap_store_info == first_a.bootstrap_store_info
 
+    assert handler_b.shutdown() is True
+    replacement_b = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=2,
+            max_nodes=3,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-b-replacement",
+        rendezvous_store=rendezvous_store,
+        bootstrap_store_info=None,
+    )
+
+    def replacement_rendezvous_b(outcome: queue.Queue[BaseException | object]) -> None:
+        try:
+            outcome.put(replacement_b.next_rendezvous())
+        except BaseException as error:
+            outcome.put(error)
+
     second_outcome: queue.Queue[BaseException | object] = queue.Queue()
-    second_thread = threading.Thread(target=rendezvous_b, args=(second_outcome,))
+    second_thread = threading.Thread(
+        target=replacement_rendezvous_b,
+        args=(second_outcome,),
+    )
     second_thread.start()
-    time.sleep(0.02)
-    assert second_thread.is_alive()
-    second_a = handler_a.next_rendezvous()
     second_thread.join(timeout=2)
+    assert not second_thread.is_alive()
     second_b = second_outcome.get_nowait()
+    assert isinstance(second_b, type(first_a))
+    assert second_b.bootstrap_store_info == first_a.bootstrap_store_info
+
+    second_a = handler_a.next_rendezvous()
     assert isinstance(second_b, type(second_a))
     assert second_b.bootstrap_store_info == second_a.bootstrap_store_info
+    assert handler_a.use_agent_store is False
+    assert replacement_b.use_agent_store is False
 
     assert handler_a.shutdown() is True
-    assert handler_b.shutdown() is True
+    assert replacement_b.shutdown() is True
 
 
 def test_slot_aware_handler_bounds_bootstrap_read_and_ignores_stale_unprefixed_keys(
@@ -1220,6 +1248,68 @@ def test_slot_aware_handler_parks_standby_without_reporting_waiting_node(
     assert reader.get("node-b") is None
     assert standby.shutdown() is True
     assert closer.shutdown() is True
+
+
+def test_slot_aware_handler_local_shutdown_does_not_close_shared_run(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a",))
+    first = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=1,
+            max_nodes=3,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+    )
+    second = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-c",
+            min_nodes=1,
+            max_nodes=3,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-c",
+    )
+    first_outcome: queue.Queue[BaseException | object] = queue.Queue()
+    second_outcome: queue.Queue[BaseException | object] = queue.Queue()
+
+    def rendezvous(
+        handler: SlotAwareRendezvousHandler,
+        outcome: queue.Queue[BaseException | object],
+    ) -> None:
+        try:
+            outcome.put(handler.next_rendezvous())
+        except BaseException as error:
+            outcome.put(error)
+
+    first_thread = threading.Thread(target=rendezvous, args=(first, first_outcome))
+    second_thread = threading.Thread(target=rendezvous, args=(second, second_outcome))
+    first_thread.start()
+    second_thread.start()
+    reader = AgentRegistrationReader(store, run_id=RUN_ID, clock=clock)
+    _wait_until(lambda: reader.get("node-b") is not None)
+    _wait_until(lambda: reader.get("node-c") is not None)
+
+    assert first.shutdown() is True
+    first_thread.join(timeout=2)
+    assert isinstance(first_outcome.get_nowait(), RendezvousClosedError)
+    assert not store.has_history(first.closure_key)
+    assert not second.is_closed()
+    assert second_thread.is_alive()
+
+    second.set_closed()
+    second_thread.join(timeout=2)
+
+    assert isinstance(second_outcome.get_nowait(), RendezvousClosedError)
+    assert second.shutdown() is True
 
 
 def test_slot_aware_handler_renews_active_registration(tmp_path: Path):
@@ -1544,4 +1634,41 @@ def test_slot_aware_handler_rejects_deleted_closure_record(tmp_path: Path):
     with pytest.raises(RendezvousStateError, match="deleted"):
         second.is_closed()
 
-    assert second.shutdown() is False
+    assert second.shutdown() is True
+
+
+def test_slot_aware_handler_retries_closure_created_during_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+    original_has_history = store.has_history
+    published = False
+
+    def publish_before_history(key: str) -> bool:
+        nonlocal published
+        if key == handler.closure_key and not published:
+            published = True
+            store.compare_set(
+                handler.closure_key,
+                expected_revision=None,
+                value=handler._closure_value,
+            )
+        return original_has_history(key)
+
+    monkeypatch.setattr(store, "has_history", publish_before_history)
+
+    assert handler.is_closed()
+    assert handler.shutdown() is True

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -3,25 +3,45 @@
 from __future__ import annotations
 
 import os
+import queue
 import stat
+import threading
+import time
 from dataclasses import replace
 from pathlib import Path
 from typing import Any, cast
 
 import pytest
-from torch.distributed.elastic.rendezvous import RendezvousParameters
+from torch.distributed import HashStore
+from torch.distributed.elastic.rendezvous import (
+    RendezvousClosedError,
+    RendezvousParameters,
+    RendezvousStateError,
+    RendezvousStoreInfo,
+    RendezvousTimeoutError,
+)
 
+from lm_resiliency.integrations.torchrun._agent_registration import (
+    AgentRegistrationReader,
+)
+from lm_resiliency.integrations.torchrun._control_store import InMemoryControlStore
+from lm_resiliency.integrations.torchrun._coordinator_lease import (
+    CoordinatorLeaseManager,
+)
+from lm_resiliency.integrations.torchrun._generation_state import GenerationStateManager
 from lm_resiliency.integrations.torchrun._protocol import (
     FaultEvent,
     HardwareFaultReport,
     RankAssignment,
     RestartContext,
+    SlotAssignment,
     WorkerIdentity,
     validate_event_reporter,
 )
 from lm_resiliency.integrations.torchrun._runtime import (
     RestartContextFile,
     RestartContextFileError,
+    SlotAwareRendezvousHandler,
     TorchrunRendezvousPolicy,
     TorchrunRuntimeConfig,
     TorchrunRuntimeConfigError,
@@ -37,6 +57,20 @@ registration_lease_duration_ms = 30000
 poll_interval_ms = 1000
 join_timeout_ms = 300000
 """
+
+
+class ManualClock:
+    def __init__(self, now_unix_ms: int = 1_000) -> None:
+        self._now_unix_ms = now_unix_ms
+        self._lock = threading.Lock()
+
+    def __call__(self) -> int:
+        with self._lock:
+            return self._now_unix_ms
+
+    def advance(self, duration_ms: int) -> None:
+        with self._lock:
+            self._now_unix_ms += duration_ms
 
 
 def _write_policy(path: Path, content: str = POLICY) -> Path:
@@ -885,3 +919,395 @@ def test_restart_context_file_validates_path(path: object):
 
     with pytest.raises(expected):
         RestartContextFile(cast(Any, path))
+
+
+def _handler_config(
+    tmp_path: Path,
+    *,
+    node_id: str,
+    min_nodes: int,
+    max_nodes: int,
+    registration_lease_duration_ms: int = 120,
+    poll_interval_ms: int = 10,
+    join_timeout_ms: int = 500,
+) -> TorchrunRuntimeConfig:
+    return TorchrunRuntimeConfig(
+        policy=TorchrunRendezvousPolicy(
+            control_endpoint="control.example:443",
+            registration_lease_duration_ms=registration_lease_duration_ms,
+            poll_interval_ms=poll_interval_ms,
+            join_timeout_ms=join_timeout_ms,
+        ),
+        run_id=RUN_ID,
+        endpoint="rdzv.example:29400",
+        min_nodes=min_nodes,
+        max_nodes=max_nodes,
+        local_world_size=2,
+        node_id=node_id,
+        environment_digest="environment-v1",
+        resource_ids=(f"gpu-{node_id}-0", f"gpu-{node_id}-1"),
+        restart_context_path=tmp_path / node_id / "restart-context.json",
+        local_addr=f"{node_id}.example",
+        source_path=tmp_path / "rendezvous.toml",
+    )
+
+
+def _initialize_generation(
+    store: InMemoryControlStore,
+    clock: ManualClock,
+    node_ids: tuple[str, ...],
+):
+    lease = CoordinatorLeaseManager(
+        store,
+        run_id=RUN_ID,
+        coordinator_id="coordinator-a",
+        lease_duration_ms=10_000,
+        clock=clock,
+    ).acquire()
+    assignment = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=0,
+        assignments=tuple(
+            SlotAssignment(
+                logical_node_slot=slot,
+                node_id=node_id,
+                first_global_rank=slot * 2,
+                local_world_size=2,
+            )
+            for slot, node_id in enumerate(node_ids)
+        ),
+        topology_digest="topology-v1",
+    )
+    manager = GenerationStateManager(store, run_id=RUN_ID)
+    return manager, lease, manager.initialize(lease, assignment)
+
+
+def _handler(
+    config: TorchrunRuntimeConfig,
+    *,
+    store: InMemoryControlStore,
+    clock: ManualClock,
+    agent_id: str,
+) -> SlotAwareRendezvousHandler:
+    return SlotAwareRendezvousHandler(
+        config,
+        control_store=store,
+        rendezvous_store=HashStore(),
+        clock=clock,
+        agent_id=agent_id,
+        hostname=f"{config.node_id}.example",
+        bootstrap_store_info=RendezvousStoreInfo("master.example", 29500),
+    )
+
+
+def _wait_until(predicate: Any, *, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.005)
+    raise AssertionError("condition did not become true before the timeout")
+
+
+def test_slot_aware_handler_admits_initial_assignment_with_stable_rank(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a", "node-b"))
+    config = _handler_config(
+        tmp_path,
+        node_id="node-b",
+        min_nodes=2,
+        max_nodes=3,
+    )
+    context_file = RestartContextFile(config.restart_context_path)
+    context_file.write(_context())
+    handler = _handler(
+        config,
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+    )
+
+    info = handler.next_rendezvous()
+
+    assert handler.get_backend() == "lm_resiliency"
+    assert handler.get_run_id() == RUN_ID
+    assert handler.use_agent_store is True
+    assert info.rank == 1
+    assert info.world_size == 2
+    assert info.bootstrap_store_info == RendezvousStoreInfo("master.example", 29500)
+    assert not config.restart_context_path.exists()
+    registration = AgentRegistrationReader(
+        store,
+        run_id=RUN_ID,
+        clock=clock,
+    ).get("node-b")
+    assert registration is not None
+    assert registration.record.agent_identity == handler.agent_identity
+
+    assert handler.shutdown() is True
+    assert handler.shutdown() is True
+    assert (
+        AgentRegistrationReader(
+            store,
+            run_id=RUN_ID,
+            clock=clock,
+        ).get("node-b")
+        is None
+    )
+
+
+def test_slot_aware_handler_parks_standby_without_reporting_waiting_node(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a",))
+    standby = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+    )
+    closer = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+    outcome: queue.Queue[BaseException | object] = queue.Queue()
+
+    def rendezvous() -> None:
+        try:
+            outcome.put(standby.next_rendezvous())
+        except BaseException as error:
+            outcome.put(error)
+
+    thread = threading.Thread(target=rendezvous)
+    thread.start()
+    reader = AgentRegistrationReader(store, run_id=RUN_ID, clock=clock)
+    _wait_until(lambda: reader.get("node-b") is not None)
+
+    assert thread.is_alive()
+    assert standby.num_nodes_waiting() == 0
+
+    closer.set_closed()
+    thread.join(timeout=2)
+
+    assert not thread.is_alive()
+    assert isinstance(outcome.get_nowait(), RendezvousClosedError)
+    assert reader.get("node-b") is None
+    assert standby.shutdown() is True
+    assert closer.shutdown() is True
+
+
+def test_slot_aware_handler_renews_active_registration(tmp_path: Path):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a",))
+    config = _handler_config(
+        tmp_path,
+        node_id="node-a",
+        min_nodes=1,
+        max_nodes=2,
+        registration_lease_duration_ms=90,
+    )
+    handler = _handler(
+        config,
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+    handler.next_rendezvous()
+    reader = AgentRegistrationReader(store, run_id=RUN_ID, clock=clock)
+    initial = reader.get("node-a")
+    assert initial is not None
+
+    clock.advance(20)
+    _wait_until(
+        lambda: (
+            (renewed := reader.get("node-a")) is not None
+            and renewed.fencing_token != initial.fencing_token
+        )
+    )
+
+    renewed = reader.get("node-a")
+    assert renewed is not None
+    assert renewed.expires_at_unix_ms > initial.expires_at_unix_ms
+    assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_shutdown_is_bounded_by_stuck_heartbeat(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a",))
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+    handler.next_rendezvous()
+    started = threading.Event()
+    release = threading.Event()
+
+    def block_renewal(registration: Any) -> Any:
+        started.set()
+        release.wait(timeout=2)
+        return registration
+
+    monkeypatch.setattr(handler._registration_manager, "renew", block_renewal)
+    assert started.wait(timeout=1)
+
+    before = time.monotonic()
+    assert handler.shutdown() is False
+    elapsed = time.monotonic() - before
+
+    assert elapsed < 0.5
+    release.set()
+    _wait_until(
+        lambda: handler._heartbeat_thread is not None and not handler._heartbeat_thread.is_alive()
+    )
+    assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_times_out_and_releases_standby_registration(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a",))
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=1,
+            max_nodes=2,
+            join_timeout_ms=60,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+    )
+
+    with pytest.raises(RendezvousTimeoutError):
+        handler.next_rendezvous()
+
+    assert (
+        AgentRegistrationReader(
+            store,
+            run_id=RUN_ID,
+            clock=clock,
+        ).get("node-b")
+        is None
+    )
+    assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_rejects_generation_after_initial_assignment(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    manager, lease, current = _initialize_generation(store, clock, ("node-a",))
+    successor = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=1,
+        assignments=(SlotAssignment(0, "node-b", 0, 2),),
+        topology_digest="topology-v1",
+    )
+    manager.commit_successor(lease, current, successor)
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+    )
+
+    with pytest.raises(RendezvousStateError, match="replacement generations"):
+        handler.next_rendezvous()
+
+    assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_rejects_assignment_size_mismatch(tmp_path: Path):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a",))
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=2,
+            max_nodes=3,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+
+    with pytest.raises(RendezvousStateError, match="active node count"):
+        handler.next_rendezvous()
+
+    assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_rejects_deleted_closure_record(tmp_path: Path):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    first = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+    first.set_closed()
+    closure = store.get(first.closure_key)
+    assert closure is not None
+    store.compare_delete(first.closure_key, expected_revision=closure.revision)
+    second = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+    )
+
+    with pytest.raises(RendezvousStateError, match="deleted"):
+        second.is_closed()
+
+    assert second.shutdown() is False

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -15,6 +15,7 @@ import pytest
 from torch.distributed import HashStore
 from torch.distributed.elastic.rendezvous import (
     RendezvousClosedError,
+    RendezvousConnectionError,
     RendezvousParameters,
     RendezvousStateError,
     RendezvousStoreInfo,
@@ -928,7 +929,7 @@ def _handler_config(
     node_id: str,
     min_nodes: int,
     max_nodes: int,
-    registration_lease_duration_ms: int = 120,
+    registration_lease_duration_ms: int = 30_000,
     poll_interval_ms: int = 10,
     join_timeout_ms: int = 500,
 ) -> TorchrunRuntimeConfig:
@@ -1194,6 +1195,108 @@ def test_slot_aware_handler_bounds_bootstrap_read_and_ignores_stale_unprefixed_k
     assert handler.shutdown() is True
 
 
+def test_slot_aware_handler_rechecks_closure_after_bootstrap_wait(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a", "node-b"))
+    rendezvous_store = HashStore()
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=2,
+            max_nodes=3,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+        rendezvous_store=rendezvous_store,
+        bootstrap_store_info=None,
+    )
+    outcome: queue.Queue[BaseException | object] = queue.Queue()
+
+    def rendezvous() -> None:
+        try:
+            outcome.put(handler.next_rendezvous())
+        except BaseException as error:
+            outcome.put(error)
+
+    thread = threading.Thread(target=rendezvous)
+    thread.start()
+    _wait_until(
+        lambda: (
+            AgentRegistrationReader(
+                store,
+                run_id=RUN_ID,
+                clock=clock,
+            ).get("node-b")
+            is not None
+        )
+    )
+
+    handler.set_closed()
+    bootstrap_store = handler._bootstrap_store(0)
+    bootstrap_store.set(RendezvousStoreInfo.MASTER_ADDR_KEY, "master.example")
+    bootstrap_store.set(RendezvousStoreInfo.MASTER_PORT_KEY, "29500")
+    thread.join(timeout=2)
+
+    assert isinstance(outcome.get_nowait(), RendezvousClosedError)
+    assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_rechecks_heartbeat_after_bootstrap_wait(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a", "node-b"))
+    rendezvous_store = HashStore()
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=2,
+            max_nodes=3,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+        rendezvous_store=rendezvous_store,
+        bootstrap_store_info=None,
+    )
+    outcome: queue.Queue[BaseException | object] = queue.Queue()
+
+    def rendezvous() -> None:
+        try:
+            outcome.put(handler.next_rendezvous())
+        except BaseException as error:
+            outcome.put(error)
+
+    thread = threading.Thread(target=rendezvous)
+    thread.start()
+    _wait_until(
+        lambda: (
+            AgentRegistrationReader(
+                store,
+                run_id=RUN_ID,
+                clock=clock,
+            ).get("node-b")
+            is not None
+        )
+    )
+
+    handler._heartbeat_error = RuntimeError("registration lost")
+    bootstrap_store = handler._bootstrap_store(0)
+    bootstrap_store.set(RendezvousStoreInfo.MASTER_ADDR_KEY, "master.example")
+    bootstrap_store.set(RendezvousStoreInfo.MASTER_PORT_KEY, "29500")
+    thread.join(timeout=2)
+
+    assert isinstance(outcome.get_nowait(), RendezvousConnectionError)
+    assert handler.shutdown() is True
+
+
 def test_slot_aware_handler_parks_standby_without_reporting_waiting_node(
     tmp_path: Path,
 ):
@@ -1410,6 +1513,7 @@ def test_slot_aware_handler_shutdown_is_bounded_by_stuck_heartbeat(
             node_id="node-a",
             min_nodes=1,
             max_nodes=2,
+            registration_lease_duration_ms=90,
         ),
         store=store,
         clock=clock,
@@ -1508,6 +1612,159 @@ def test_slot_aware_handler_rejects_incompatible_node_id_reuse(tmp_path: Path):
         handler.next_rendezvous()
 
     assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_rejects_job_wide_environment_drift(tmp_path: Path):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a", "node-b"))
+    first = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=2,
+            max_nodes=3,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+    second = _handler(
+        replace(
+            _handler_config(
+                tmp_path,
+                node_id="node-b",
+                min_nodes=2,
+                max_nodes=3,
+            ),
+            environment_digest="environment-v2",
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+    )
+
+    assert first.next_rendezvous().rank == 0
+    with pytest.raises(RendezvousStateError, match="committed workload environment"):
+        second.next_rendezvous()
+
+    assert first.shutdown() is True
+    assert second.shutdown() is True
+
+
+def test_slot_aware_handler_standby_cannot_commit_job_compatibility(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a",))
+    standby = _handler(
+        replace(
+            _handler_config(
+                tmp_path,
+                node_id="node-b",
+                min_nodes=1,
+                max_nodes=2,
+            ),
+            environment_digest="environment-v2",
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+    )
+    active = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+    standby_outcome: queue.Queue[BaseException | object] = queue.Queue()
+
+    def rendezvous_standby() -> None:
+        try:
+            standby_outcome.put(standby.next_rendezvous())
+        except BaseException as error:
+            standby_outcome.put(error)
+
+    standby_thread = threading.Thread(target=rendezvous_standby)
+    standby_thread.start()
+    _wait_until(
+        lambda: (
+            AgentRegistrationReader(
+                store,
+                run_id=RUN_ID,
+                clock=clock,
+            ).get("node-b")
+            is not None
+        )
+    )
+
+    assert store.get(active._compatibility_key) is None
+    assert active.next_rendezvous().rank == 0
+    assert store.get(active._compatibility_key) is not None
+
+    assert standby.shutdown() is True
+    standby_thread.join(timeout=2)
+    assert isinstance(standby_outcome.get_nowait(), RendezvousClosedError)
+    assert active.shutdown() is True
+
+
+def test_slot_aware_handler_shutdown_is_bounded_during_registration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _initialize_generation(store, clock, ("node-a",))
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+    original_register = handler._registration_manager.register
+    started = threading.Event()
+    release = threading.Event()
+    outcome: queue.Queue[BaseException | object] = queue.Queue()
+
+    def delayed_registration() -> Any:
+        registration = original_register()
+        started.set()
+        release.wait(timeout=2)
+        return registration
+
+    def rendezvous() -> None:
+        try:
+            outcome.put(handler.next_rendezvous())
+        except BaseException as error:
+            outcome.put(error)
+
+    monkeypatch.setattr(
+        handler._registration_manager,
+        "register",
+        delayed_registration,
+    )
+    thread = threading.Thread(target=rendezvous)
+    thread.start()
+    assert started.wait(timeout=1)
+
+    before = time.monotonic()
+    assert handler.shutdown() is True
+    assert time.monotonic() - before < 0.5
+
+    release.set()
+    thread.join(timeout=2)
+    assert isinstance(outcome.get_nowait(), RendezvousClosedError)
 
 
 def test_slot_aware_handler_cleans_up_registration_on_cancellation(

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -1048,8 +1048,10 @@ def _seed_assigned_arrival(
     with handler._registration_lock:
         registration = handler._registration
     assert registration is not None
+    current = handler._read_generation()
+    assert current is not None
     attempt = handler._claim_shared_arrival_attempt(
-        generation=generation,
+        assignment=current.snapshot.record.assignment,
         slot=slot,
         registration=registration,
         deadline=deadline,
@@ -1064,8 +1066,6 @@ def _seed_assigned_arrival(
             registration=registration,
         ),
     )
-    current = handler._read_generation()
-    assert current is not None
 
     def complete_attempt() -> None:
         while time.monotonic() < deadline:
@@ -1119,7 +1119,7 @@ def test_slot_aware_handler_refreshes_leader_registration_before_completion(
     assert original_leader_registration is not None
     assert peer_registration is not None
     attempt = leader._claim_shared_arrival_attempt(
-        generation=0,
+        assignment=current.snapshot.record.assignment,
         slot=0,
         registration=original_leader_registration,
         deadline=deadline,
@@ -1178,7 +1178,7 @@ def test_slot_aware_handler_classifies_duplicate_completion_fields_as_corruption
         registration = handler._registration
     assert registration is not None
     attempt = handler._claim_shared_arrival_attempt(
-        generation=0,
+        assignment=current.snapshot.record.assignment,
         slot=0,
         registration=registration,
         deadline=deadline,
@@ -1432,9 +1432,11 @@ def test_slot_aware_handler_reuses_incomplete_attempt_after_leader_replacement(
     with original_leader._registration_lock:
         original_registration = original_leader._registration
     assert original_registration is not None
+    current = original_leader._read_generation()
+    assert current is not None
     assert (
         original_leader._claim_shared_arrival_attempt(
-            generation=0,
+            assignment=current.snapshot.record.assignment,
             slot=0,
             registration=original_registration,
             deadline=deadline,
@@ -1483,6 +1485,105 @@ def test_slot_aware_handler_reuses_incomplete_attempt_after_leader_replacement(
     assert attempt == 1
     assert replacement.shutdown() is True
     assert peer.shutdown() is True
+
+
+def test_slot_aware_handler_replacement_consumes_completed_attempt_before_advance(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _, _, current = _initialize_generation(store, clock, ("node-a", "node-b"))
+    original_leader = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=2,
+            max_nodes=3,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a-original",
+    )
+    peer = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=2,
+            max_nodes=3,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+    )
+    deadline = time.monotonic() + 1
+    original_leader._ensure_registered(deadline)
+    peer._ensure_registered(deadline)
+    with original_leader._registration_lock:
+        original_registration = original_leader._registration
+    with peer._registration_lock:
+        peer_registration = peer._registration
+    assert original_registration is not None
+    assert peer_registration is not None
+    assignment = current.snapshot.record.assignment
+    attempt = original_leader._claim_shared_arrival_attempt(
+        assignment=assignment,
+        slot=0,
+        registration=original_registration,
+        deadline=deadline,
+    )
+    for slot, handler, registration in (
+        (0, original_leader, original_registration),
+        (1, peer, peer_registration),
+    ):
+        store.compare_set(
+            original_leader._arrival_key(0, attempt, slot),
+            expected_revision=None,
+            value=handler._arrival_value(
+                generation=0,
+                attempt=attempt,
+                slot=slot,
+                registration=registration,
+            ),
+        )
+    original_leader._try_complete_arrival_attempt(
+        assignment,
+        attempt,
+        original_registration,
+    )
+    completion = store.get(original_leader._arrival_completion_key(0, attempt))
+    assert completion is not None
+    assert original_leader.shutdown() is True
+
+    peer_info = peer.next_rendezvous()
+    peer_consumption = store.get(peer._arrival_consumption_key(0, attempt, 1))
+    assert peer_info.rank == 1
+    assert peer_consumption is not None
+
+    replacement = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=2,
+            max_nodes=3,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a-replacement",
+    )
+    replacement_info = replacement.next_rendezvous()
+    replacement_consumption = store.get(replacement._arrival_consumption_key(0, attempt, 0))
+    attempt_entry = store.get(replacement._arrival_attempt_key(0))
+
+    assert replacement_info.rank == 0
+    assert replacement_consumption is not None
+    assert attempt_entry is not None
+    current_attempt, _, _ = replacement._validate_arrival_attempt_entry(
+        attempt_entry,
+        generation=0,
+    )
+    assert current_attempt == attempt
+    assert peer.shutdown() is True
+    assert replacement.shutdown() is True
 
 
 def test_slot_aware_handler_bounds_bootstrap_read_and_ignores_stale_unprefixed_keys(
@@ -1821,8 +1922,10 @@ def test_slot_aware_handler_reads_registration_histories_linearly(
     with handlers[0]._registration_lock:
         leader_registration = handlers[0]._registration
     assert leader_registration is not None
+    current = handlers[0]._read_generation()
+    assert current is not None
     attempt = handlers[0]._claim_shared_arrival_attempt(
-        generation=0,
+        assignment=current.snapshot.record.assignment,
         slot=0,
         registration=leader_registration,
         deadline=deadline,


### PR DESCRIPTION
## Summary

- implement `SlotAwareRendezvousHandler` in the existing consolidated runtime module
- admit generation-zero nodes by stable logical slot and fixed `min_nodes` world size
- park passive standbys for the job lifetime without exposing them through `num_nodes_waiting()`
- maintain agent registration heartbeats scheduled from each lease remaining lifetime
- validate assigned node reuse and every assigned node against one immutable job-wide compatibility identity
- coordinate every assigned generation-zero slot through one durable shared attempt, atomic completion proof, and per-slot final-admission consumption before later attempts advance
- reuse one generation-scoped bootstrap endpoint bounded by the join deadline across handler incarnations
- restore one shared post-rendezvous store timeout after bounded bootstrap reads
- compact unreferenced equivalent registration renewals while pinning every revision consumed by a guarded transaction
- propagate immutable run-scoped closure, release registrations asynchronously with a bounded wait, and bound shutdown when a heartbeat or release stalls
- keep registration backend I/O outside ownership locks, serialize bounded cleanup, and clear stale restart context before initial worker launch

## Scope

This first handler slice deliberately rejects replacement generations. Plan-driven replacement admission, restart-context publication, and positive wait-count signaling remain the next runtime PR. No new production module is added.

## Validation

- `147 passed` focused runtime, registration, and control-store tests
- `2456 passed, 1 warning` complete CPU suite with CUDA hidden
- `ruff check .`
- `ruff format --check .`
- targeted mypy for the changed runtime and test modules
- `git diff --check`