### PR TITLE
[Feature][torchrun] Admit replacement generations

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1588,8 +1588,14 @@ unreadable; every outstanding token has its own fixed-length, digest-named
 durable invalidation marker, so delayed cleanup from an older handler cannot
 revalidate a newer failed context, long valid context basenames cannot overflow
 the filesystem component limit, and a later replacement context with a
-different token remains valid. Context
-publication and cleanup acquire the parent
+different token remains valid. The worker-visible file remains canonical root
+`RestartContext` JSON. The cleanup token and the context digest are stored in a
+hidden owner-only sidecar under the same directory lock, and final admission
+requires the exact token published by that handler incarnation. A normal
+heartbeat renewal may advance the registration fencing token, but admission
+accepts it only when retained authority history proves uninterrupted ownership
+by the same immutable registration and agent incarnation. Context publication
+and cleanup acquire the parent
 directory lock nonblocking under the admission or bounded-cleanup deadline, so
 a stale process cannot strand replacement admission. The replacement deadline
 is derived and revalidated from authoritative, nondecreasing control-store time

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1558,7 +1558,10 @@ registration-history, and attempt-head reads complete, the handler samples
 authoritative control-store time once and uses that observation to recheck both
 the exclusive restart deadline and the exact registration's lease window. The
 shared attempt head must still name the admitted attempt. A completed
-replacement attempt advances only after this proof exists; initial attempts
+replacement attempt advances only after every admitted handler has completed
+its final return validation and durably acknowledged the exact admission,
+registration, and consumption it observed. A descheduled peer therefore keeps
+the shared attempt head fixed until its return check completes; initial attempts
 retain the consumption-only advancement rule. Guarded barrier transactions pin
 their registration revision in retained history. Missing, unprepared, late, or
 superseded assigned nodes therefore fail instead of allowing an early or stale
@@ -1581,9 +1584,11 @@ proof is the final shared decision observed before `next_rendezvous()` returns.
 A failed admission first durably invalidates the exact cryptographic cleanup
 token published by that handler incarnation, then attempts bounded physical
 removal. If the directory lock is unavailable, the stale file remains
-unreadable; every outstanding token has its own durable invalidation marker, so
-delayed cleanup from an older handler cannot revalidate a newer failed context,
-and a later replacement context with a different token remains valid. Context
+unreadable; every outstanding token has its own fixed-length, digest-named
+durable invalidation marker, so delayed cleanup from an older handler cannot
+revalidate a newer failed context, long valid context basenames cannot overflow
+the filesystem component limit, and a later replacement context with a
+different token remains valid. Context
 publication and cleanup acquire the parent
 directory lock nonblocking under the admission or bounded-cleanup deadline, so
 a stale process cannot strand replacement admission. The replacement deadline

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -164,7 +164,11 @@ reference integration does not require that experimental surface.
 The integration must also avoid depending on `--max-restarts` as its only
 replacement budget. Failure retries and membership changes have had different
 accounting behavior across torchrun versions. The coordinator should own an
-explicit `max_replacement_generations` policy.
+explicit `max_replacement_generations` policy. The current runtime admits
+exactly one replacement generation because authoritative lifecycle readback
+currently proves only the first closed intent and successor. Configuration
+values greater than one fail closed until repeated lifecycle readback is
+implemented.
 
 ## Three-Layer Architecture
 
@@ -1876,7 +1880,7 @@ changing torchrun's default behavior:
 schema_version = 1
 control_endpoint = "control.internal:443"
 replacement_only = true
-max_replacement_generations = 2
+max_replacement_generations = 1
 registration_lease_duration_ms = 30000
 poll_interval_ms = 1000
 join_timeout_ms = 300000

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1538,14 +1538,20 @@ completion proof, generation head, immutable generation snapshot, and absence
 of terminal closure. An incomplete attempt remains usable when a handler
 incarnation is replaced. A stale consumption from an incarnation that failed
 before returning does not satisfy its replacement; the replacement publishes
-its own consumption for the same completed attempt. A completed attempt
-advances only after every slot's current registration has a durable consumption
-record, so a replacement joins the completed attempt instead of splitting the
-worker group. Guarded barrier transactions pin their registration revision in
-retained history. Missing or unprepared assigned nodes therefore fail at the
-formation deadline instead of launching a partial worker group. After
-consumption completes, every handler performs one final closure and generation
-check before returning its slot.
+its own consumption for the same completed attempt. For a replacement
+generation, a consumption record is a locally validated readiness claim rather
+than permission to return. Slot zero atomically commits one immutable
+group-admission proof only after every assigned slot has published readiness.
+That guarded transaction conditions on every readiness and live registration
+revision, the attempt and completion records, the generation head and immutable
+snapshot, and absence of terminal closure, and it must commit before the plan's
+exclusive restart deadline. Every replacement handler observes and validates
+the same admission proof before returning. A completed replacement attempt
+advances only after this proof exists; initial attempts retain the
+consumption-only advancement rule. Guarded barrier transactions pin their
+registration revision in retained history. Missing, unprepared, or late
+assigned nodes therefore fail at the shared deadline instead of allowing an
+early node to launch a partial worker group.
 
 Registration release is best effort and bounded during local shutdown. If the
 backend remains unavailable, cleanup returns without waiting indefinitely and
@@ -1558,11 +1564,12 @@ persisted restart-plan publication before admitting any assigned node. It
 requires the plan assignment to equal the committed generation, enforces the
 replacement budget and exclusive restart deadline, and writes the exact
 node-local `RestartContext` before the assigned node participates in the shared
-arrival barrier. The plan, generation, deadline, and persisted context are
-revalidated immediately before `next_rendezvous()` returns. A failed admission
-clears any context written by that attempt. Passive standbys and removed nodes
-remain parked. The positive `num_nodes_waiting()` restart edge remains disabled
-until the following signaling slice.
+arrival barrier. Each assigned node revalidates the plan, generation, deadline,
+and persisted context before publishing readiness; the immutable group-admission
+proof is the final shared decision observed before `next_rendezvous()` returns.
+A failed admission clears any context written by that attempt. Passive standbys
+and removed nodes remain parked. The positive `num_nodes_waiting()` restart edge
+remains disabled until the following signaling slice.
 
 All handler incarnations use one immutable generation-scoped `PrefixStore` for
 PyTorch's worker bootstrap keys. Slot zero publishes one address/port pair and

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1520,8 +1520,10 @@ registration and the initial closure-state observation are bounded by the
 formation deadline. A stalled closure backend cannot defeat that timeout, and
 local shutdown interrupts a handler waiting on the daemonized closure read.
 
-Before publishing readiness, each assigned handler clears its stale node-local
-restart context. Slot zero owns one durable, generation-scoped attempt head,
+Before publishing readiness, each assigned handler clears only a node-local
+restart context from another run. An initial-generation handler refuses to
+remove a current-run replacement context, so a stale incarnation cannot erase
+newer recovery state. Slot zero owns one durable, generation-scoped attempt head,
 while all assigned slots publish attempt-scoped arrivals tied to their live
 registration. Slot zero validates the complete registration set once and
 atomically publishes one immutable completion proof conditioned on the shared
@@ -1546,7 +1548,12 @@ That guarded transaction conditions on every readiness and live registration
 revision, the attempt and completion records, the generation head and immutable
 snapshot, and absence of terminal closure, and it must commit before the plan's
 exclusive restart deadline. Every replacement handler observes and validates
-the same admission proof before returning. After all blocking plan/context,
+the same admission proof before returning. The proof must name that handler's
+exact live registration and its exact consumption entry; a replacement
+incarnation must publish new readiness and cannot reuse the old decision. A
+temporarily absent or expired peer registration remains incomplete readiness
+until the deadline, while corrupt retained registration history still fails
+closed. After all blocking plan/context,
 registration-history, and attempt-head reads complete, the handler samples
 authoritative control-store time once and uses that observation to recheck both
 the exclusive restart deadline and the exact registration's lease window. The
@@ -1574,8 +1581,10 @@ proof is the final shared decision observed before `next_rendezvous()` returns.
 A failed admission first durably invalidates the exact cryptographic cleanup
 token published by that handler incarnation, then attempts bounded physical
 removal. If the directory lock is unavailable, the stale file remains
-unreadable; because invalidation is token-specific, a later replacement
-context remains valid. Context publication and cleanup acquire the parent
+unreadable; every outstanding token has its own durable invalidation marker, so
+delayed cleanup from an older handler cannot revalidate a newer failed context,
+and a later replacement context with a different token remains valid. Context
+publication and cleanup acquire the parent
 directory lock nonblocking under the admission or bounded-cleanup deadline, so
 a stale process cannot strand replacement admission. The replacement deadline
 is derived and revalidated from authoritative, nondecreasing control-store time

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1558,14 +1558,17 @@ registration-history, and attempt-head reads complete, the handler samples
 authoritative control-store time once and uses that observation to recheck both
 the exclusive restart deadline and the exact registration's lease window. The
 shared attempt head must still name the admitted attempt. A completed
-replacement attempt advances only after every admitted handler has completed
-its final return validation and durably acknowledged the exact admission,
-registration, and consumption it observed. A descheduled peer therefore keeps
-the shared attempt head fixed until its return check completes; initial attempts
-retain the consumption-only advancement rule. Guarded barrier transactions pin
-their registration revision in retained history. Missing, unprepared, late, or
-superseded assigned nodes therefore fail instead of allowing an early or stale
-incarnation to launch a partial worker group.
+replacement attempt advances only after every assigned slot enters a subsequent
+`next_rendezvous()` call and durably acknowledges the prior admission and
+consumption. The acknowledgement is slot-scoped and guarded by the entering
+handler's live registration, so a normal heartbeat renewal is retried and a
+replacement incarnation can acknowledge its slot before joining a fresh
+attempt. A descheduled peer that has not re-entered therefore keeps the shared
+attempt head fixed; initial attempts retain the consumption-only advancement
+rule. Guarded barrier transactions pin their registration revision in retained
+history. Missing, unprepared, late, or superseded assigned nodes therefore fail
+instead of allowing an early or stale incarnation to launch a partial worker
+group.
 
 Registration release is best effort and bounded during local shutdown. If the
 backend remains unavailable, cleanup returns without waiting indefinitely and
@@ -1588,7 +1591,9 @@ unreadable; every outstanding token has its own fixed-length, digest-named
 durable invalidation marker, so delayed cleanup from an older handler cannot
 revalidate a newer failed context, long valid context basenames cannot overflow
 the filesystem component limit, and a later replacement context with a
-different token remains valid. The worker-visible file remains canonical root
+different token remains valid. An invalidation marker remains durable after
+physical context deletion, so a crash cannot resurrect a deleted context pair
+without its fence. The worker-visible file remains canonical root
 `RestartContext` JSON. The cleanup token and the context digest are stored in a
 hidden owner-only sidecar under the same directory lock, and final admission
 requires the exact token published by that handler incarnation. A normal

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1569,10 +1569,15 @@ arrival barrier. Each assigned node revalidates the plan, generation, deadline,
 and persisted context before publishing readiness; the immutable group-admission
 proof is the final shared decision observed before `next_rendezvous()` returns.
 A failed admission removes the context only when the current file is the exact
-device/inode version published by that handler incarnation, so an older handler
-cannot delete a replacement incarnation's atomic update. Passive standbys and
-removed nodes remain parked. The positive `num_nodes_waiting()` restart edge
-remains disabled until the following signaling slice.
+cryptographic cleanup token published by that handler incarnation, so an older
+handler cannot delete a replacement incarnation's atomic update even if the
+filesystem reuses an inode. Context publication and cleanup acquire the parent
+directory lock nonblocking under the admission or bounded-cleanup deadline, so
+a stale process cannot strand replacement admission. The replacement deadline
+is derived and revalidated from authoritative, nondecreasing control-store time
+rather than an agent wall clock. Passive standbys and removed nodes remain
+parked. The positive `num_nodes_waiting()` restart edge remains disabled until
+the following signaling slice.
 
 All handler incarnations use one immutable generation-scoped `PrefixStore` for
 PyTorch's worker bootstrap keys. Slot zero publishes one address/port pair and

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1595,12 +1595,16 @@ different token remains valid. An invalidation marker remains durable after
 physical context deletion, so a crash cannot resurrect a deleted context pair
 without its fence. The worker-visible file remains canonical root
 `RestartContext` JSON. The cleanup token and the context digest are stored in a
-hidden owner-only sidecar under the same directory lock, and final admission
-requires the exact token published by that handler incarnation. A normal
-heartbeat renewal may advance the registration fencing token, but admission
-accepts it only when retained authority history proves uninterrupted ownership
-by the same immutable registration and agent incarnation. Context publication
-and cleanup acquire the parent
+hidden owner-only sidecar under the same directory lock. The sidecar also binds
+publication to the writer's verified registration ID and store-stamped
+registration mutation sequence. An older registration cannot overwrite a
+context published by a later registration, while a normal heartbeat renewal of
+the same immutable registration may advance the mutation sequence. Final
+admission requires the exact token published by that handler incarnation. A
+normal heartbeat renewal may advance the registration fencing token, but
+admission accepts it only when retained authority history proves uninterrupted
+ownership by the same immutable registration and agent incarnation. Context
+publication and cleanup acquire the parent
 directory lock nonblocking under the admission or bounded-cleanup deadline, so
 a stale process cannot strand replacement admission. The replacement deadline
 is derived and revalidated from authoritative, nondecreasing control-store time

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1546,13 +1546,16 @@ That guarded transaction conditions on every readiness and live registration
 revision, the attempt and completion records, the generation head and immutable
 snapshot, and absence of terminal closure, and it must commit before the plan's
 exclusive restart deadline. Every replacement handler observes and validates
-the same admission proof before returning, then rechecks the original deadline
-and confirms that its exact agent incarnation still owns one live
-registration. A completed replacement attempt advances only after this proof
-exists; initial attempts retain the consumption-only advancement rule. Guarded
-barrier transactions pin their registration revision in retained history.
-Missing, unprepared, late, or superseded assigned nodes therefore fail instead
-of allowing an early or stale incarnation to launch a partial worker group.
+the same admission proof before returning. After all blocking plan/context,
+registration-history, and attempt-head reads complete, the handler samples
+authoritative control-store time once and uses that observation to recheck both
+the exclusive restart deadline and the exact registration's lease window. The
+shared attempt head must still name the admitted attempt. A completed
+replacement attempt advances only after this proof exists; initial attempts
+retain the consumption-only advancement rule. Guarded barrier transactions pin
+their registration revision in retained history. Missing, unprepared, late, or
+superseded assigned nodes therefore fail instead of allowing an early or stale
+incarnation to launch a partial worker group.
 
 Registration release is best effort and bounded during local shutdown. If the
 backend remains unavailable, cleanup returns without waiting indefinitely and
@@ -1568,10 +1571,11 @@ node-local `RestartContext` before the assigned node participates in the shared
 arrival barrier. Each assigned node revalidates the plan, generation, deadline,
 and persisted context before publishing readiness; the immutable group-admission
 proof is the final shared decision observed before `next_rendezvous()` returns.
-A failed admission removes the context only when the current file is the exact
-cryptographic cleanup token published by that handler incarnation, so an older
-handler cannot delete a replacement incarnation's atomic update even if the
-filesystem reuses an inode. Context publication and cleanup acquire the parent
+A failed admission first durably invalidates the exact cryptographic cleanup
+token published by that handler incarnation, then attempts bounded physical
+removal. If the directory lock is unavailable, the stale file remains
+unreadable; because invalidation is token-specific, a later replacement
+context remains valid. Context publication and cleanup acquire the parent
 directory lock nonblocking under the admission or bounded-cleanup deadline, so
 a stale process cannot strand replacement admission. The replacement deadline
 is derived and revalidated from authoritative, nondecreasing control-store time

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1604,6 +1604,8 @@ admission requires the exact token published by that handler incarnation. A
 normal heartbeat renewal may advance the registration fencing token, but
 admission accepts it only when retained authority history proves uninterrupted
 ownership by the same immutable registration and agent incarnation. Context
+cleanup also removes and directory-syncs an orphaned sidecar when a crash
+leaves metadata without its root context. Context
 publication and cleanup acquire the parent
 directory lock nonblocking under the admission or bounded-cleanup deadline, so
 a stale process cannot strand replacement admission. The replacement deadline

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1546,12 +1546,13 @@ That guarded transaction conditions on every readiness and live registration
 revision, the attempt and completion records, the generation head and immutable
 snapshot, and absence of terminal closure, and it must commit before the plan's
 exclusive restart deadline. Every replacement handler observes and validates
-the same admission proof before returning. A completed replacement attempt
-advances only after this proof exists; initial attempts retain the
-consumption-only advancement rule. Guarded barrier transactions pin their
-registration revision in retained history. Missing, unprepared, or late
-assigned nodes therefore fail at the shared deadline instead of allowing an
-early node to launch a partial worker group.
+the same admission proof before returning, then rechecks the original deadline
+and confirms that its exact agent incarnation still owns one live
+registration. A completed replacement attempt advances only after this proof
+exists; initial attempts retain the consumption-only advancement rule. Guarded
+barrier transactions pin their registration revision in retained history.
+Missing, unprepared, late, or superseded assigned nodes therefore fail instead
+of allowing an early or stale incarnation to launch a partial worker group.
 
 Registration release is best effort and bounded during local shutdown. If the
 backend remains unavailable, cleanup returns without waiting indefinitely and
@@ -1567,8 +1568,10 @@ node-local `RestartContext` before the assigned node participates in the shared
 arrival barrier. Each assigned node revalidates the plan, generation, deadline,
 and persisted context before publishing readiness; the immutable group-admission
 proof is the final shared decision observed before `next_rendezvous()` returns.
-A failed admission clears any context written by that attempt. Passive standbys
-and removed nodes remain parked. The positive `num_nodes_waiting()` restart edge
+A failed admission removes the context only when the current file is the exact
+device/inode version published by that handler incarnation, so an older handler
+cannot delete a replacement incarnation's atomic update. Passive standbys and
+removed nodes remain parked. The positive `num_nodes_waiting()` restart edge
 remains disabled until the following signaling slice.
 
 All handler incarnations use one immutable generation-scoped `PrefixStore` for

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1548,9 +1548,17 @@ backend remains unavailable, cleanup returns without waiting indefinitely and
 the registration expires under its existing lease. Global closure publication
 also runs through a bounded daemon operation; local heartbeat and registration
 cleanup still proceeds when the control store is unavailable.
-Replacement generation admission, restart-context publication, and the positive
-`num_nodes_waiting()` restart edge are enabled only after authoritative
-restart-plan readback is integrated in the following slice.
+
+For a replacement generation, the handler reads and reauthorizes the exact
+persisted restart-plan publication before admitting any assigned node. It
+requires the plan assignment to equal the committed generation, enforces the
+replacement budget and exclusive restart deadline, and writes the exact
+node-local `RestartContext` before the assigned node participates in the shared
+arrival barrier. The plan, generation, deadline, and persisted context are
+revalidated immediately before `next_rendezvous()` returns. A failed admission
+clears any context written by that attempt. Passive standbys and removed nodes
+remain parked. The positive `num_nodes_waiting()` restart edge remains disabled
+until the following signaling slice.
 
 All handler incarnations use one immutable generation-scoped `PrefixStore` for
 PyTorch's worker bootstrap keys. Slot zero publishes one address/port pair and
@@ -1564,11 +1572,12 @@ creates the worker-side TCP store. After bounded bootstrap reads complete, every
 returned store is restored to the shared configured join timeout so later stock
 agent coordination does not inherit rank-specific remaining-deadline values.
 
-Passive standbys are not reported by `num_nodes_waiting()`. After a plan
-commits, the selected replacement becomes the only newly waiting node visible
-to active agents. This is the restart edge: a random late node must not trigger
-scale-up. This mechanism is used only when the next plan admits at least one
-standby; it is not a generic restart signal for unchanged membership.
+Passive standbys are not reported by `num_nodes_waiting()`. In the following
+signaling slice, after a plan commits, the selected replacement becomes the only
+newly waiting node visible to active agents. This is the restart edge: a random
+late node must not trigger scale-up. The mechanism is used only when the next
+plan admits at least one standby; it is not a generic restart signal for
+unchanged membership.
 
 Before returning an admitted node from `next_rendezvous()`, the handler:
 

--- a/lm_resiliency/integrations/torchrun/_control_store.py
+++ b/lm_resiliency/integrations/torchrun/_control_store.py
@@ -223,6 +223,10 @@ class ControlStoreWrite:
 class ControlStore(Protocol):
     """Strongly consistent per-key compare-and-set storage."""
 
+    def observe_time_unix_ms(self) -> int:
+        """Return one authoritative, nondecreasing control-store time sample."""
+        ...
+
     def get(self, key: str) -> ControlStoreEntry | None:
         """Return the current value, or ``None`` when the key is absent."""
         ...
@@ -343,6 +347,10 @@ class InMemoryControlStore:
         self._transaction_sequence = 0
         self._clock = clock or _system_unix_ms
         self._last_now_unix_ms = 0
+
+    def observe_time_unix_ms(self) -> int:
+        with self._lock:
+            return self._store_now_unix_ms()
 
     def get(self, key: str) -> ControlStoreEntry | None:
         normalized_key = _control_key(key)

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -47,6 +47,7 @@ from lm_resiliency.integrations.torchrun._agent_registration import (
     agent_registration_key,
 )
 from lm_resiliency.integrations.torchrun._agent_registration_history_reader import (
+    AgentRegistrationHistory,
     AgentRegistrationHistoryCorrupt,
     AgentRegistrationHistoryError,
     AgentRegistrationHistoryReader,
@@ -90,9 +91,10 @@ _ENVIRONMENT_DIGEST_ENV = "LM_RESILIENCY_ENVIRONMENT_DIGEST"
 _RESOURCE_IDS_ENV = "LM_RESILIENCY_RESOURCE_IDS"
 _RESTART_CONTEXT_ENV = "LM_RESILIENCY_RESTART_CONTEXT"
 _MAX_CONTEXT_BYTES = 64 * 1024
+_MAX_CONTEXT_METADATA_BYTES = 1_024
 _MAX_CONTEXT_INVALIDATION_BYTES = 1_024
 _MAX_POLICY_BYTES = 64 * 1024
-_CONTEXT_FILE_SCHEMA_VERSION = 1
+_CONTEXT_METADATA_SCHEMA_VERSION = 1
 _CONTEXT_INVALIDATION_SCHEMA_VERSION = 1
 _CONTEXT_LOCK_TIMEOUT_SECONDS = 1.0
 _CONTEXT_LOCK_POLL_SECONDS = 0.01
@@ -554,6 +556,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                             current,
                             recovery_state,
                             admission_deadline,
+                            expected_context_token=context_token,
                         )
                         self._publish_arrival_consumption(
                             current,
@@ -573,6 +576,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                                 completion,
                                 recovery_state,
                                 admission_deadline,
+                                context_token,
                             )
                         return RendezvousInfo(
                             bootstrap_store,
@@ -1693,13 +1697,20 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         admission_deadline: float | None = None,
         *,
         validate_deadline: bool = True,
+        expected_context_token: _RestartContextCleanupToken | None = None,
     ) -> None:
         if self._is_closed_bounded(admission_deadline):
             raise RendezvousClosedError
         if self._read_generation() != current:
             raise RendezvousConnectionError("generation changed before rendezvous admission")
         if recovery_state is None:
+            if expected_context_token is not None:
+                raise RendezvousStateError(
+                    "initial rendezvous unexpectedly carries restart-context ownership"
+                )
             return
+        if expected_context_token is None:
+            raise RendezvousStateError("replacement rendezvous lacks restart-context ownership")
         refreshed = self._read_recovery_state()
         if refreshed != recovery_state:
             raise RendezvousConnectionError(
@@ -1713,12 +1724,12 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             self._validate_replacement_deadline(refreshed, admission_deadline)
         expected_context = self._restart_context_for_plan(refreshed.plan)
         try:
-            persisted_context = self._restart_context.read()
+            persisted_token, persisted_context = self._restart_context.read_with_token()
         except (OSError, RestartContextFileError) as error:
             raise RendezvousStateError(
                 "failed to validate the replacement restart context"
             ) from error
-        if persisted_context != expected_context:
+        if persisted_context != expected_context or persisted_token != expected_context_token:
             raise RendezvousStateError(
                 "replacement restart context changed before rendezvous admission"
             )
@@ -2373,7 +2384,10 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         completion: ControlStoreEntry,
         recovery_state: RestartPlanPersistedRecoveryState,
         deadline: float,
+        context_token: _RestartContextCleanupToken | None,
     ) -> ControlStoreEntry:
+        if context_token is None:
+            raise RendezvousStateError("replacement rendezvous lacks restart-context ownership")
         while True:
             admission = self._read_replacement_admission(
                 assignment,
@@ -2391,6 +2405,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                     admission,
                     recovery_state,
                     deadline,
+                    context_token,
                 )
                 return admission
             if slot == 0:
@@ -2418,6 +2433,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                         admission,
                         recovery_state,
                         deadline,
+                        context_token,
                     )
                     return admission
             if not self._wait_for_change(deadline):
@@ -2437,6 +2453,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                         admission,
                         recovery_state,
                         deadline,
+                        context_token,
                     )
                     return admission
                 raise RendezvousTimeoutError
@@ -2451,19 +2468,26 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         admission: ControlStoreEntry,
         recovery_state: RestartPlanPersistedRecoveryState,
         deadline: float,
+        context_token: _RestartContextCleanupToken,
     ) -> None:
         self._validate_final_admission_state(
             current,
             recovery_state,
             deadline,
             validate_deadline=False,
+            expected_context_token=context_token,
         )
         self._raise_heartbeat_error()
         with self._registration_lock:
             registration = self._registration
         if registration is None:
             raise RendezvousConnectionError("replacement agent no longer owns its registration")
-        current_registration = self._read_current_assigned_registration(self._config.node_id)
+        registration_history = self._read_assigned_registration_history(self._config.node_id)
+        current_registration = registration_history.current
+        if current_registration is None:
+            raise RendezvousConnectionError(
+                "replacement agent no longer has a current registration"
+            )
         if current_registration.record != registration.record:
             raise RendezvousConnectionError(
                 "replacement agent registration changed before admission"
@@ -2476,10 +2500,19 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             recovery_state=recovery_state,
         )
         metadata = consumptions[str(slot)]
+        admission_registration = next(
+            (
+                authority.registration
+                for authority in registration_history.authorities
+                if authority.registration.fencing_token == metadata["registration_revision"]
+            ),
+            None,
+        )
         if (
             metadata["registration_id"] != current_registration.record.registration_id
             or metadata["agent_id"] != current_registration.record.agent_identity.agent_id
-            or metadata["registration_revision"] != current_registration.fencing_token
+            or admission_registration is None
+            or admission_registration.record != current_registration.record
         ):
             raise RendezvousConnectionError(
                 "replacement admission does not include this agent registration"
@@ -2520,6 +2553,27 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             recovery_state,
             now_unix_ms=now_unix_ms,
         )
+
+    def _read_assigned_registration_history(
+        self,
+        node_id: str,
+    ) -> AgentRegistrationHistory:
+        try:
+            return AgentRegistrationHistoryReader(
+                self._control_store,
+                run_id=self._config.run_id,
+                node_id=node_id,
+            ).read()
+        except AgentRegistrationHistoryCorrupt as error:
+            raise RendezvousStateError("arrived agent registration history is corrupt") from error
+        except AgentRegistrationHistoryError as error:
+            raise RendezvousConnectionError(
+                "arrived agent registration history changed repeatedly"
+            ) from error
+        except Exception as error:
+            raise RendezvousConnectionError(
+                "failed to read arrived agent registration history"
+            ) from error
 
     def _publish_replacement_return_acknowledgement(
         self,
@@ -3433,56 +3487,70 @@ class RestartContextFile:
         if not isinstance(context, RestartContext):
             raise TypeError("context must be RestartContext")
         cleanup_token = secrets.token_hex(32)
-        encoded = (
-            json.dumps(
-                {
-                    "schema_version": _CONTEXT_FILE_SCHEMA_VERSION,
-                    "cleanup_token": cleanup_token,
-                    "context": context.to_dict(),
-                },
-                allow_nan=False,
-                separators=(",", ":"),
-                sort_keys=True,
-            )
-            + "\n"
-        ).encode("utf-8")
+        encoded = (context.to_json() + "\n").encode("utf-8")
+        metadata = self._encode_metadata(cleanup_token, encoded)
         if len(encoded) > _MAX_CONTEXT_BYTES:
             raise RestartContextFileError("restart context is too large")
         parent_descriptor = self._open_parent(create=True)
         assert parent_descriptor is not None
-        descriptor = -1
-        temporary = ""
+        context_descriptor = -1
+        context_temporary = ""
+        metadata_descriptor = -1
+        metadata_temporary = ""
+        metadata_published = False
         try:
             self._acquire_parent_lock(parent_descriptor, deadline=deadline)
             self._reject_existing_symlink(parent_descriptor)
-            descriptor, temporary = self._create_temporary_file(parent_descriptor)
-            os.fchmod(descriptor, 0o600)
-            with os.fdopen(descriptor, "wb") as stream:
-                descriptor = -1
+            context_descriptor, context_temporary = self._create_temporary_file(parent_descriptor)
+            metadata_descriptor, metadata_temporary = self._create_temporary_file(
+                parent_descriptor,
+                target_name=self._metadata_name(),
+            )
+            os.fchmod(context_descriptor, 0o600)
+            os.fchmod(metadata_descriptor, 0o600)
+            with os.fdopen(context_descriptor, "wb") as stream:
+                context_descriptor = -1
                 stream.write(encoded)
                 stream.flush()
                 os.fsync(stream.fileno())
+            with os.fdopen(metadata_descriptor, "wb") as stream:
+                metadata_descriptor = -1
+                stream.write(metadata)
+                stream.flush()
+                os.fsync(stream.fileno())
             os.replace(
-                temporary,
+                metadata_temporary,
+                self._metadata_name(),
+                src_dir_fd=parent_descriptor,
+                dst_dir_fd=parent_descriptor,
+            )
+            metadata_temporary = ""
+            metadata_published = True
+            os.replace(
+                context_temporary,
                 self.path.name,
                 src_dir_fd=parent_descriptor,
                 dst_dir_fd=parent_descriptor,
             )
-            temporary = ""
+            context_temporary = ""
             self._fsync_directory(parent_descriptor)
             return cleanup_token
         except OSError as error:
             raise RestartContextFileError(
                 f"failed to publish restart context at {self.path}",
-                published_token=cleanup_token if not temporary else None,
+                published_token=cleanup_token if metadata_published else None,
             ) from error
         finally:
-            if descriptor >= 0:
+            for descriptor in (context_descriptor, metadata_descriptor):
+                if descriptor < 0:
+                    continue
                 try:
                     os.close(descriptor)
                 except OSError:
                     pass
-            if temporary:
+            for temporary in (context_temporary, metadata_temporary):
+                if not temporary:
+                    continue
                 try:
                     os.unlink(temporary, dir_fd=parent_descriptor)
                 except OSError:
@@ -3490,18 +3558,31 @@ class RestartContextFile:
             os.close(parent_descriptor)
 
     def read(self) -> RestartContext:
+        return self.read_with_token()[1]
+
+    def read_with_token(
+        self,
+    ) -> tuple[_RestartContextCleanupToken, RestartContext]:
         parent_descriptor = self._open_parent(create=False)
         if parent_descriptor is None:
             raise RestartContextFileError(
                 f"restart-context directory does not exist for {self.path}"
             )
         try:
+            self._acquire_parent_lock(parent_descriptor, deadline=None)
             encoded = self._read_encoded(parent_descriptor)
             assert encoded is not None
-            cleanup_token, context = self._decode_envelope(encoded)
+            metadata = self._read_encoded(
+                parent_descriptor,
+                name=self._metadata_name(),
+                maximum_bytes=_MAX_CONTEXT_METADATA_BYTES,
+            )
+            assert metadata is not None
+            context = self._decode_context(encoded)
+            cleanup_token = self._decode_metadata(metadata, encoded)
             if self._is_invalidated(parent_descriptor, cleanup_token):
                 raise RestartContextFileError("restart context has been invalidated")
-            return context
+            return cleanup_token, context
         finally:
             os.close(parent_descriptor)
 
@@ -3571,15 +3652,7 @@ class RestartContextFile:
         try:
             self._acquire_parent_lock(parent_descriptor, deadline=deadline)
             self._reject_existing_symlink(parent_descriptor)
-            try:
-                os.unlink(self.path.name, dir_fd=parent_descriptor)
-            except FileNotFoundError:
-                self._fsync_directory(parent_descriptor)
-                return
-            except OSError as error:
-                raise RestartContextFileError(
-                    f"failed to remove restart context at {self.path}"
-                ) from error
+            self._unlink_context_pair(parent_descriptor)
             self._fsync_directory(parent_descriptor)
         finally:
             os.close(parent_descriptor)
@@ -3601,19 +3674,12 @@ class RestartContextFile:
             encoded = self._read_encoded(parent_descriptor, missing_ok=True)
             if encoded is None:
                 return False
-            _, context = self._decode_envelope(encoded)
+            context = self._decode_context(encoded)
             if context.run_id == run_id:
                 raise RestartContextFileError(
                     "refusing to remove a restart context for the current run"
                 )
-            try:
-                os.unlink(self.path.name, dir_fd=parent_descriptor)
-            except FileNotFoundError:
-                return False
-            except OSError as error:
-                raise RestartContextFileError(
-                    f"failed to remove restart context at {self.path}"
-                ) from error
+            self._unlink_context_pair(parent_descriptor)
             self._fsync_directory(parent_descriptor)
             return True
         finally:
@@ -3632,20 +3698,18 @@ class RestartContextFile:
         try:
             self._acquire_parent_lock(parent_descriptor, deadline=deadline)
             self._reject_existing_symlink(parent_descriptor)
-            encoded = self._read_encoded(parent_descriptor, missing_ok=True)
-            if encoded is None:
+            metadata = self._read_encoded(
+                parent_descriptor,
+                missing_ok=True,
+                name=self._metadata_name(),
+                maximum_bytes=_MAX_CONTEXT_METADATA_BYTES,
+            )
+            if metadata is None:
                 return False
-            current_token, _ = self._decode_envelope(encoded)
+            current_token, _ = self._decode_metadata_record(metadata)
             if current_token != cleanup_token:
                 return False
-            try:
-                os.unlink(self.path.name, dir_fd=parent_descriptor)
-            except FileNotFoundError:
-                return False
-            except OSError as error:
-                raise RestartContextFileError(
-                    f"failed to remove restart context at {self.path}"
-                ) from error
+            self._unlink_context_pair(parent_descriptor)
             try:
                 os.unlink(
                     self._invalidation_name(cleanup_token),
@@ -3661,6 +3725,17 @@ class RestartContextFile:
             return True
         finally:
             os.close(parent_descriptor)
+
+    def _unlink_context_pair(self, parent_descriptor: int) -> None:
+        for name in (self.path.name, self._metadata_name()):
+            try:
+                os.unlink(name, dir_fd=parent_descriptor)
+            except FileNotFoundError:
+                continue
+            except OSError as error:
+                raise RestartContextFileError(
+                    f"failed to remove restart context at {self.path}"
+                ) from error
 
     def _acquire_parent_lock(
         self,
@@ -3790,11 +3865,8 @@ class RestartContextFile:
                 "restart-context invalidation marker is malformed"
             ) from error
 
-    @classmethod
-    def _decode_envelope(
-        cls,
-        encoded: bytes,
-    ) -> tuple[_RestartContextCleanupToken, RestartContext]:
+    @staticmethod
+    def _decode_context(encoded: bytes) -> RestartContext:
         try:
             value = json.loads(
                 encoded,
@@ -3802,27 +3874,95 @@ class RestartContextFile:
             )
             if not isinstance(value, Mapping):
                 raise RestartContextFileError("restart-context JSON must contain an object")
-            expected = {"schema_version", "cleanup_token", "context"}
-            if set(value) != expected:
-                raise RestartContextFileError("restart-context envelope fields are invalid")
-            if (
-                type(value["schema_version"]) is not int
-                or value["schema_version"] != _CONTEXT_FILE_SCHEMA_VERSION
-            ):
-                raise RestartContextFileError("restart-context envelope schema version is invalid")
-            cleanup_token = cls._validate_cleanup_token(value["cleanup_token"])
-            context_value = value["context"]
-            if not isinstance(context_value, Mapping):
-                raise RestartContextFileError(
-                    "restart-context envelope context must contain an object"
-                )
-            return cleanup_token, RestartContext.from_dict(context_value)
+            return RestartContext.from_dict(value)
         except _DuplicateJsonFieldError as error:
             raise RestartContextFileError(str(error)) from error
         except RestartContextFileError:
             raise
         except (TypeError, ValueError, UnicodeDecodeError) as error:
             raise RestartContextFileError("restart-context file is malformed") from error
+
+    @classmethod
+    def _encode_metadata(
+        cls,
+        cleanup_token: _RestartContextCleanupToken,
+        context: bytes,
+    ) -> bytes:
+        cls._validate_cleanup_token(cleanup_token)
+        encoded = (
+            json.dumps(
+                {
+                    "schema_version": _CONTEXT_METADATA_SCHEMA_VERSION,
+                    "cleanup_token": cleanup_token,
+                    "context_sha256": hashlib.sha256(context).hexdigest(),
+                },
+                allow_nan=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+            + "\n"
+        ).encode("utf-8")
+        if len(encoded) > _MAX_CONTEXT_METADATA_BYTES:
+            raise RestartContextFileError("restart-context metadata is too large")
+        return encoded
+
+    @classmethod
+    def _decode_metadata(
+        cls,
+        encoded: bytes,
+        context: bytes,
+    ) -> _RestartContextCleanupToken:
+        cleanup_token, context_digest = cls._decode_metadata_record(encoded)
+        if not secrets.compare_digest(
+            context_digest,
+            hashlib.sha256(context).hexdigest(),
+        ):
+            raise RestartContextFileError("restart-context metadata does not match the context")
+        return cleanup_token
+
+    @classmethod
+    def _decode_metadata_record(
+        cls,
+        encoded: bytes,
+    ) -> tuple[_RestartContextCleanupToken, str]:
+        try:
+            value = json.loads(
+                encoded,
+                object_pairs_hook=_strict_object,
+            )
+            if not isinstance(value, Mapping):
+                raise RestartContextFileError(
+                    "restart-context metadata JSON must contain an object"
+                )
+            expected = {"schema_version", "cleanup_token", "context_sha256"}
+            if set(value) != expected:
+                raise RestartContextFileError("restart-context metadata fields are invalid")
+            if (
+                type(value["schema_version"]) is not int
+                or value["schema_version"] != _CONTEXT_METADATA_SCHEMA_VERSION
+            ):
+                raise RestartContextFileError("restart-context metadata schema version is invalid")
+            cleanup_token = cls._validate_cleanup_token(value["cleanup_token"])
+            context_digest = value["context_sha256"]
+            if (
+                not isinstance(context_digest, str)
+                or len(context_digest) != 64
+                or context_digest != context_digest.lower()
+            ):
+                raise RestartContextFileError("restart-context metadata digest is invalid")
+            try:
+                int(context_digest, 16)
+            except ValueError as error:
+                raise RestartContextFileError(
+                    "restart-context metadata digest is invalid"
+                ) from error
+            return cleanup_token, context_digest
+        except _DuplicateJsonFieldError as error:
+            raise RestartContextFileError(str(error)) from error
+        except RestartContextFileError:
+            raise
+        except (TypeError, ValueError, UnicodeDecodeError) as error:
+            raise RestartContextFileError("restart-context metadata is malformed") from error
 
     @staticmethod
     def _validate_cleanup_token(value: object) -> _RestartContextCleanupToken:
@@ -3958,6 +4098,10 @@ class RestartContextFile:
         identity = f"{self.path.name}\0{cleanup_token}".encode("utf-8")
         digest = hashlib.sha256(identity).hexdigest()
         return f".restart-context-invalidated-{digest}"
+
+    def _metadata_name(self) -> str:
+        digest = hashlib.sha256(self.path.name.encode("utf-8")).hexdigest()
+        return f".restart-context-metadata-{digest}"
 
     @staticmethod
     def _validate_owned_private_file(metadata: os.stat_result) -> None:

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -105,7 +105,7 @@ _ARRIVAL_ATTEMPT_SCHEMA_VERSION = 1
 _ARRIVAL_COMPLETION_SCHEMA_VERSION = 1
 _ARRIVAL_CONSUMPTION_SCHEMA_VERSION = 1
 _ARRIVAL_ADMISSION_SCHEMA_VERSION = 1
-_ARRIVAL_RETURN_SCHEMA_VERSION = 1
+_ARRIVAL_RETURN_SCHEMA_VERSION = 2
 _SUPPORTED_REPLACEMENT_GENERATIONS = 1
 _SHARED_FIELDS = {
     "control_endpoint",
@@ -529,6 +529,13 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 self._raise_heartbeat_error()
                 if current is not None:
                     if slot is not None:
+                        if recovery_state is not None:
+                            self._acknowledge_prior_replacement_return(
+                                current,
+                                slot,
+                                recovery_state,
+                                admission_deadline,
+                            )
                         context_token = self._prepare_restart_context(
                             current,
                             recovery_state,
@@ -1266,52 +1273,104 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                         attempt,
                         None,
                     )
-                    own_consumption = None
-                    if completion is not None:
-                        own_consumption = self._read_arrival_consumption(
-                            assignment,
-                            attempt,
-                            slot,
-                            completion,
-                            registration,
-                        )
-                    if completion is not None and own_consumption is None:
-                        committed = entry
-                    elif (
-                        slot == 0
-                        and completion is not None
-                        and self._arrival_consumption_conditions(
+                    admission = None
+                    own_return = None
+                    if completion is not None and generation > 0:
+                        admission = self._read_replacement_admission(
                             assignment,
                             attempt,
                             completion,
+                            None,
                         )
-                        is not None
-                    ):
-                        next_attempt = attempt + 1
-                        value = self._arrival_attempt_value(
-                            generation=generation,
-                            attempt=next_attempt,
-                            registration=registration,
-                        )
-                        advanced = self._advance_arrival_attempt(
-                            assignment,
-                            entry,
-                            attempt,
-                            next_attempt,
-                            value,
-                            registration,
-                            completion,
-                        )
-                        if advanced is None:
+                        if admission is not None:
+                            own_return = self._read_arrival_return(
+                                assignment,
+                                attempt,
+                                slot,
+                                admission,
+                            )
+                    if admission is not None and own_return is not None:
+                        assert completion is not None
+                        if (
+                            slot == 0
+                            and self._arrival_return_conditions(
+                                assignment,
+                                attempt,
+                                completion,
+                                admission,
+                            )
+                            is not None
+                        ):
+                            next_attempt = attempt + 1
+                            value = self._arrival_attempt_value(
+                                generation=generation,
+                                attempt=next_attempt,
+                                registration=registration,
+                            )
+                            advanced = self._advance_arrival_attempt(
+                                assignment,
+                                entry,
+                                attempt,
+                                next_attempt,
+                                value,
+                                registration,
+                                completion,
+                            )
+                            if advanced is None:
+                                continue
+                            committed = advanced
+                            attempt = next_attempt
+                        else:
+                            if not self._wait_for_change(deadline):
+                                raise RendezvousTimeoutError
                             continue
-                        committed = advanced
-                        attempt = next_attempt
-                    elif completion is not None:
-                        if not self._wait_for_change(deadline):
-                            raise RendezvousTimeoutError
-                        continue
                     else:
-                        committed = entry
+                        own_consumption = None
+                        if completion is not None:
+                            own_consumption = self._read_arrival_consumption(
+                                assignment,
+                                attempt,
+                                slot,
+                                completion,
+                                registration,
+                            )
+                        if completion is not None and own_consumption is None:
+                            committed = entry
+                        elif (
+                            slot == 0
+                            and completion is not None
+                            and self._arrival_consumption_conditions(
+                                assignment,
+                                attempt,
+                                completion,
+                            )
+                            is not None
+                        ):
+                            next_attempt = attempt + 1
+                            value = self._arrival_attempt_value(
+                                generation=generation,
+                                attempt=next_attempt,
+                                registration=registration,
+                            )
+                            advanced = self._advance_arrival_attempt(
+                                assignment,
+                                entry,
+                                attempt,
+                                next_attempt,
+                                value,
+                                registration,
+                                completion,
+                            )
+                            if advanced is None:
+                                continue
+                            committed = advanced
+                            attempt = next_attempt
+                        elif completion is not None:
+                            if not self._wait_for_change(deadline):
+                                raise RendezvousTimeoutError
+                            continue
+                        else:
+                            committed = entry
                 self._validate_arrival_attempt_entry(
                     committed,
                     generation=generation,
@@ -1336,13 +1395,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         registration: HeldAgentRegistration,
         completion: ControlStoreEntry,
     ) -> ControlStoreEntry | None:
-        conditions = self._arrival_consumption_conditions(
-            assignment,
-            current_attempt,
-            completion,
-        )
-        if conditions is None:
-            return None
+        conditions: dict[str, int]
         if assignment.generation > 0:
             admission = self._read_replacement_admission(
                 assignment,
@@ -1352,12 +1405,12 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             )
             if admission is None:
                 return None
-            conditions[
+            conditions = {
                 self._arrival_admission_key(
                     assignment.generation,
                     current_attempt,
-                )
-            ] = admission.revision
+                ): admission.revision
+            }
             return_conditions = self._arrival_return_conditions(
                 assignment,
                 current_attempt,
@@ -1367,6 +1420,15 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             if return_conditions is None:
                 return None
             conditions.update(return_conditions)
+        else:
+            consumption_conditions = self._arrival_consumption_conditions(
+                assignment,
+                current_attempt,
+                completion,
+            )
+            if consumption_conditions is None:
+                return None
+            conditions = consumption_conditions
         completion_key = self._arrival_completion_key(
             assignment.generation,
             current_attempt,
@@ -2542,17 +2604,6 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             deadline,
             now_unix_ms=now_unix_ms,
         )
-        self._publish_replacement_return_acknowledgement(
-            current,
-            assignment,
-            attempt,
-            slot,
-            admission,
-            consumption,
-            current_registration,
-            recovery_state,
-            now_unix_ms=now_unix_ms,
-        )
 
     def _read_assigned_registration_history(
         self,
@@ -2575,90 +2626,175 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 "failed to read arrived agent registration history"
             ) from error
 
+    def _acknowledge_prior_replacement_return(
+        self,
+        current: CurrentGeneration,
+        slot: int,
+        recovery_state: RestartPlanPersistedRecoveryState,
+        deadline: float,
+    ) -> None:
+        assignment = current.snapshot.record.assignment
+        attempt_entry = self._control_store.get(self._arrival_attempt_key(assignment.generation))
+        if attempt_entry is None:
+            return
+        attempt, _, _ = self._validate_arrival_attempt_entry(
+            attempt_entry,
+            generation=assignment.generation,
+            leader_node_id=assignment.slot_to_node_id[0],
+        )
+        completion = self._read_arrival_completion(
+            assignment,
+            attempt,
+            None,
+        )
+        if completion is None:
+            return
+        admission = self._read_replacement_admission(
+            assignment,
+            attempt,
+            completion,
+            recovery_state,
+        )
+        if admission is None:
+            return
+        self._publish_replacement_return_acknowledgement(
+            current,
+            assignment,
+            attempt,
+            slot,
+            completion,
+            admission,
+            recovery_state,
+            deadline=deadline,
+        )
+
     def _publish_replacement_return_acknowledgement(
         self,
         current: CurrentGeneration,
         assignment: RankAssignment,
         attempt: int,
         slot: int,
+        completion: ControlStoreEntry,
         admission: ControlStoreEntry,
-        consumption: ControlStoreEntry,
-        registration: HeldAgentRegistration,
         recovery_state: RestartPlanPersistedRecoveryState,
         *,
-        now_unix_ms: int,
+        deadline: float,
     ) -> ControlStoreEntry:
+        consumptions = self._validate_replacement_admission_entry(
+            admission,
+            assignment=assignment,
+            attempt=attempt,
+            completion=completion,
+            recovery_state=recovery_state,
+        )
+        metadata = consumptions[str(slot)]
+        consumption_key = self._arrival_consumption_key(
+            assignment.generation,
+            attempt,
+            slot,
+            metadata["registration_id"],
+        )
+        consumption = self._control_store.get(consumption_key)
+        if consumption is None or consumption.revision != metadata["consumption_revision"]:
+            raise RendezvousStateError("replacement admission references a missing consumption")
         key = self._arrival_return_key(
             assignment.generation,
             attempt,
             slot,
-            registration.record.registration_id,
         )
-        value = self._arrival_return_value(
-            generation=assignment.generation,
-            attempt=attempt,
-            slot=slot,
-            admission=admission,
-            consumption=consumption,
-            registration=registration,
-        )
-        existing = self._control_store.get(key)
-        if existing is not None:
-            self._validate_arrival_return_entry(
-                existing,
-                assignment=assignment,
+        while True:
+            existing = self._control_store.get(key)
+            if existing is not None:
+                self._validate_arrival_return_entry(
+                    existing,
+                    assignment=assignment,
+                    attempt=attempt,
+                    slot=slot,
+                    admission=admission,
+                    consumption=consumption,
+                    registration=None,
+                )
+                return existing
+            with self._registration_lock:
+                registration = self._registration
+            if registration is None:
+                raise RendezvousConnectionError(
+                    "replacement agent lost its registration before re-entering rendezvous"
+                )
+            value = self._arrival_return_value(
+                generation=assignment.generation,
                 attempt=attempt,
                 slot=slot,
                 admission=admission,
                 consumption=consumption,
                 registration=registration,
             )
-            return existing
-        deadline_unix_ms = min(
-            registration.expires_at_unix_ms,
-            recovery_state.plan.restart_deadline_unix_ms,
-        )
-        try:
-            result = self._control_store.compare_set_many_guarded(
-                {
-                    key: ControlStoreWrite(
-                        expected_revision=None,
-                        value=value,
-                        require_never_created=True,
-                    )
-                },
-                guard_key=self._registration_manager.registration_key,
-                expected_guard_revision=registration.fencing_token,
-                not_before_unix_ms=now_unix_ms,
-                deadline_unix_ms=deadline_unix_ms,
-                conditions={
-                    self._arrival_admission_key(
-                        assignment.generation,
-                        attempt,
-                    ): admission.revision,
-                    self._arrival_consumption_key(
-                        assignment.generation,
-                        attempt,
-                        slot,
-                        registration.record.registration_id,
-                    ): consumption.revision,
-                    self._generation_reader.head_key: current.head_revision,
-                    self._generation_reader.snapshot_key(
-                        assignment.generation,
-                    ): current.snapshot.revision,
-                    self._closure_key: None,
-                },
+            now_unix_ms = self._replacement_now_unix_ms(recovery_state)
+            deadline_unix_ms = min(
+                registration.expires_at_unix_ms,
+                recovery_state.plan.restart_deadline_unix_ms,
             )
-        except ControlStoreDeadlineExceeded as error:
-            raise RendezvousTimeoutError from error
-        except ControlStoreConflict:
-            existing = self._control_store.get(key)
-            if existing is None:
+            if self._monotonic_clock() >= deadline:
+                raise RendezvousTimeoutError
+            try:
+                result = self._control_store.compare_set_many_guarded(
+                    {
+                        key: ControlStoreWrite(
+                            expected_revision=None,
+                            value=value,
+                            require_never_created=True,
+                        )
+                    },
+                    guard_key=self._registration_manager.registration_key,
+                    expected_guard_revision=registration.fencing_token,
+                    not_before_unix_ms=now_unix_ms,
+                    deadline_unix_ms=deadline_unix_ms,
+                    conditions={
+                        self._arrival_admission_key(
+                            assignment.generation,
+                            attempt,
+                        ): admission.revision,
+                        consumption_key: consumption.revision,
+                        self._generation_reader.head_key: current.head_revision,
+                        self._generation_reader.snapshot_key(
+                            assignment.generation,
+                        ): current.snapshot.revision,
+                        self._closure_key: None,
+                    },
+                )
+            except ControlStoreDeadlineExceeded as error:
+                raise RendezvousTimeoutError from error
+            except ControlStoreConflict:
+                existing = self._control_store.get(key)
+                if existing is not None:
+                    self._validate_arrival_return_entry(
+                        existing,
+                        assignment=assignment,
+                        attempt=attempt,
+                        slot=slot,
+                        admission=admission,
+                        consumption=consumption,
+                        registration=None,
+                    )
+                    return existing
+                with self._registration_lock:
+                    refreshed = self._registration
+                if (
+                    refreshed is not None
+                    and refreshed.record == registration.record
+                    and refreshed.fencing_token != registration.fencing_token
+                ):
+                    continue
                 raise RendezvousConnectionError(
                     "replacement return acknowledgement lost its admission fence"
                 ) from None
+            except Exception as error:
+                raise RendezvousConnectionError(
+                    "failed to publish replacement return acknowledgement"
+                ) from error
+            entry = result[key]
             self._validate_arrival_return_entry(
-                existing,
+                entry,
                 assignment=assignment,
                 attempt=attempt,
                 slot=slot,
@@ -2666,22 +2802,39 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 consumption=consumption,
                 registration=registration,
             )
-            return existing
+            self._state_changed_event.set()
+            return entry
+
+    def _read_arrival_return(
+        self,
+        assignment: RankAssignment,
+        attempt: int,
+        slot: int,
+        admission: ControlStoreEntry,
+    ) -> ControlStoreEntry | None:
+        try:
+            entry = self._control_store.get(
+                self._arrival_return_key(
+                    assignment.generation,
+                    attempt,
+                    slot,
+                )
+            )
         except Exception as error:
             raise RendezvousConnectionError(
-                "failed to publish replacement return acknowledgement"
+                "failed to read replacement return acknowledgement"
             ) from error
-        entry = result[key]
+        if entry is None:
+            return None
         self._validate_arrival_return_entry(
             entry,
             assignment=assignment,
             attempt=attempt,
             slot=slot,
             admission=admission,
-            consumption=consumption,
-            registration=registration,
+            consumption=None,
+            registration=None,
         )
-        self._state_changed_event.set()
         return entry
 
     def _arrival_return_conditions(
@@ -2705,7 +2858,6 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 assignment.generation,
                 attempt,
                 slot,
-                metadata["registration_id"],
             )
             try:
                 entry = self._control_store.get(key)
@@ -2724,12 +2876,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 consumption=None,
                 registration=None,
             )
-            if (
-                payload["agent_id"] != metadata["agent_id"]
-                or payload["registration_id"] != metadata["registration_id"]
-                or payload["registration_revision"] != metadata["registration_revision"]
-                or payload["consumption_revision"] != metadata["consumption_revision"]
-            ):
+            if payload["consumption_revision"] != metadata["consumption_revision"]:
                 raise RendezvousStateError(
                     "replacement return acknowledgement does not match its admission metadata"
                 )
@@ -2748,13 +2895,11 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         generation: int,
         attempt: int,
         slot: int,
-        registration_id: str,
     ) -> str:
-        registration_digest = hashlib.sha256(registration_id.encode("utf-8")).hexdigest()
         return (
             f"{_CONTROL_PREFIX}/runs/{self._run_digest}/rendezvous/"
             f"generation-{generation}/attempt-{attempt}/returned/"
-            f"slot-{slot}/registration-{registration_digest}"
+            f"slot-{slot}"
         )
 
     def _arrival_return_value(
@@ -3710,17 +3855,6 @@ class RestartContextFile:
             if current_token != cleanup_token:
                 return False
             self._unlink_context_pair(parent_descriptor)
-            try:
-                os.unlink(
-                    self._invalidation_name(cleanup_token),
-                    dir_fd=parent_descriptor,
-                )
-            except FileNotFoundError:
-                pass
-            except OSError as error:
-                raise RestartContextFileError(
-                    f"failed to remove restart-context invalidation for {self.path}"
-                ) from error
             self._fsync_directory(parent_descriptor)
             return True
         finally:

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -94,7 +94,7 @@ _MAX_CONTEXT_BYTES = 64 * 1024
 _MAX_CONTEXT_METADATA_BYTES = 1_024
 _MAX_CONTEXT_INVALIDATION_BYTES = 1_024
 _MAX_POLICY_BYTES = 64 * 1024
-_CONTEXT_METADATA_SCHEMA_VERSION = 1
+_CONTEXT_METADATA_SCHEMA_VERSION = 2
 _CONTEXT_INVALIDATION_SCHEMA_VERSION = 1
 _CONTEXT_LOCK_TIMEOUT_SECONDS = 1.0
 _CONTEXT_LOCK_POLL_SECONDS = 0.01
@@ -130,6 +130,22 @@ class TorchrunRuntimeConfigError(ValueError):
 
 
 _RestartContextCleanupToken = str
+
+
+@dataclass(frozen=True, slots=True)
+class _RestartContextOwnership:
+    registration_id: str
+    mutation_sequence: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.registration_id, str) or not self.registration_id:
+            raise TypeError("registration_id must be a non-empty string")
+        if (
+            isinstance(self.mutation_sequence, bool)
+            or not isinstance(self.mutation_sequence, int)
+            or self.mutation_sequence < 1
+        ):
+            raise TypeError("mutation_sequence must be a positive integer")
 
 
 class RestartContextFileError(RuntimeError):
@@ -1086,6 +1102,9 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         return entry
 
     def _validate_assigned_registration_history(self) -> None:
+        self._current_restart_context_ownership()
+
+    def _current_restart_context_ownership(self) -> _RestartContextOwnership:
         try:
             history = AgentRegistrationHistoryReader(
                 self._control_store,
@@ -1108,6 +1127,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             registration is None
             or history.current is None
             or history.current.record != registration.record
+            or not history.authorities
         ):
             raise RendezvousConnectionError(
                 "assigned node registration no longer belongs to this handler"
@@ -1122,6 +1142,15 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                     "assigned node registration history is incompatible with "
                     "the committed workload environment"
                 )
+        current_authority = history.authorities[-1]
+        if current_authority.registration != history.current:
+            raise RendezvousStateError(
+                "assigned node registration history has an invalid current authority"
+            )
+        return _RestartContextOwnership(
+            registration_id=history.current.record.registration_id,
+            mutation_sequence=current_authority.mutation_sequence,
+        )
 
     def _wait_for_assigned_arrivals(
         self,
@@ -3499,8 +3528,13 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         if recovery_state is None:
             raise RendezvousStateError("replacement generation lacks an authoritative restart plan")
         context = self._restart_context_for_plan(recovery_state.plan)
+        ownership = self._current_restart_context_ownership()
         try:
-            return self._restart_context.write(context, deadline=deadline)
+            return self._restart_context.write(
+                context,
+                deadline=deadline,
+                ownership=ownership,
+            )
         except (OSError, RestartContextFileError) as error:
             if isinstance(error, RestartContextFileError) and error.published_token is not None:
                 self._invalidate_and_clear_restart_context(error.published_token)
@@ -3628,12 +3662,15 @@ class RestartContextFile:
         context: RestartContext,
         *,
         deadline: float | None = None,
+        ownership: _RestartContextOwnership | None = None,
     ) -> _RestartContextCleanupToken:
         if not isinstance(context, RestartContext):
             raise TypeError("context must be RestartContext")
+        if ownership is not None and not isinstance(ownership, _RestartContextOwnership):
+            raise TypeError("ownership must be _RestartContextOwnership or None")
         cleanup_token = secrets.token_hex(32)
         encoded = (context.to_json() + "\n").encode("utf-8")
-        metadata = self._encode_metadata(cleanup_token, encoded)
+        metadata = self._encode_metadata(cleanup_token, encoded, ownership)
         if len(encoded) > _MAX_CONTEXT_BYTES:
             raise RestartContextFileError("restart context is too large")
         parent_descriptor = self._open_parent(create=True)
@@ -3646,6 +3683,21 @@ class RestartContextFile:
         try:
             self._acquire_parent_lock(parent_descriptor, deadline=deadline)
             self._reject_existing_symlink(parent_descriptor)
+            existing_metadata = self._read_encoded(
+                parent_descriptor,
+                missing_ok=True,
+                name=self._metadata_name(),
+                maximum_bytes=_MAX_CONTEXT_METADATA_BYTES,
+            )
+            existing_ownership = (
+                None
+                if existing_metadata is None
+                else self._decode_metadata_record(existing_metadata)[2]
+            )
+            self._validate_replacement_ownership(
+                existing=existing_ownership,
+                replacement=ownership,
+            )
             context_descriptor, context_temporary = self._create_temporary_file(parent_descriptor)
             metadata_descriptor, metadata_temporary = self._create_temporary_file(
                 parent_descriptor,
@@ -3851,7 +3903,7 @@ class RestartContextFile:
             )
             if metadata is None:
                 return False
-            current_token, _ = self._decode_metadata_record(metadata)
+            current_token, _, _ = self._decode_metadata_record(metadata)
             if current_token != cleanup_token:
                 return False
             self._unlink_context_pair(parent_descriptor)
@@ -4021,6 +4073,7 @@ class RestartContextFile:
         cls,
         cleanup_token: _RestartContextCleanupToken,
         context: bytes,
+        ownership: _RestartContextOwnership | None,
     ) -> bytes:
         cls._validate_cleanup_token(cleanup_token)
         encoded = (
@@ -4029,6 +4082,10 @@ class RestartContextFile:
                     "schema_version": _CONTEXT_METADATA_SCHEMA_VERSION,
                     "cleanup_token": cleanup_token,
                     "context_sha256": hashlib.sha256(context).hexdigest(),
+                    "registration_id": (None if ownership is None else ownership.registration_id),
+                    "registration_mutation_sequence": (
+                        None if ownership is None else ownership.mutation_sequence
+                    ),
                 },
                 allow_nan=False,
                 separators=(",", ":"),
@@ -4046,7 +4103,7 @@ class RestartContextFile:
         encoded: bytes,
         context: bytes,
     ) -> _RestartContextCleanupToken:
-        cleanup_token, context_digest = cls._decode_metadata_record(encoded)
+        cleanup_token, context_digest, _ = cls._decode_metadata_record(encoded)
         if not secrets.compare_digest(
             context_digest,
             hashlib.sha256(context).hexdigest(),
@@ -4058,7 +4115,7 @@ class RestartContextFile:
     def _decode_metadata_record(
         cls,
         encoded: bytes,
-    ) -> tuple[_RestartContextCleanupToken, str]:
+    ) -> tuple[_RestartContextCleanupToken, str, _RestartContextOwnership | None]:
         try:
             value = json.loads(
                 encoded,
@@ -4068,7 +4125,13 @@ class RestartContextFile:
                 raise RestartContextFileError(
                     "restart-context metadata JSON must contain an object"
                 )
-            expected = {"schema_version", "cleanup_token", "context_sha256"}
+            expected = {
+                "schema_version",
+                "cleanup_token",
+                "context_sha256",
+                "registration_id",
+                "registration_mutation_sequence",
+            }
             if set(value) != expected:
                 raise RestartContextFileError("restart-context metadata fields are invalid")
             if (
@@ -4090,13 +4153,48 @@ class RestartContextFile:
                 raise RestartContextFileError(
                     "restart-context metadata digest is invalid"
                 ) from error
-            return cleanup_token, context_digest
+            registration_id = value["registration_id"]
+            mutation_sequence = value["registration_mutation_sequence"]
+            if registration_id is None and mutation_sequence is None:
+                ownership = None
+            elif (
+                isinstance(registration_id, str)
+                and registration_id
+                and (type(mutation_sequence) is int and mutation_sequence >= 1)
+            ):
+                ownership = _RestartContextOwnership(
+                    registration_id=registration_id,
+                    mutation_sequence=mutation_sequence,
+                )
+            else:
+                raise RestartContextFileError("restart-context metadata ownership is invalid")
+            return cleanup_token, context_digest, ownership
         except _DuplicateJsonFieldError as error:
             raise RestartContextFileError(str(error)) from error
         except RestartContextFileError:
             raise
         except (TypeError, ValueError, UnicodeDecodeError) as error:
             raise RestartContextFileError("restart-context metadata is malformed") from error
+
+    @staticmethod
+    def _validate_replacement_ownership(
+        *,
+        existing: _RestartContextOwnership | None,
+        replacement: _RestartContextOwnership | None,
+    ) -> None:
+        if existing is None:
+            return
+        if replacement is None:
+            raise RestartContextFileError(
+                "unowned restart context cannot replace registration-owned state"
+            )
+        if replacement.mutation_sequence < existing.mutation_sequence or (
+            replacement.mutation_sequence == existing.mutation_sequence
+            and replacement.registration_id != existing.registration_id
+        ):
+            raise RestartContextFileError(
+                "stale registration cannot replace a newer restart context"
+            )
 
     @staticmethod
     def _validate_cleanup_token(value: object) -> _RestartContextCleanupToken:

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -54,6 +54,7 @@ from lm_resiliency.integrations.torchrun._agent_registration_records import (
 from lm_resiliency.integrations.torchrun._control_store import (
     ControlStore,
     ControlStoreConflict,
+    ControlStoreDeadlineExceeded,
     ControlStoreEntry,
     ControlStoreWrite,
 )
@@ -93,6 +94,7 @@ _ARRIVAL_SCHEMA_VERSION = 1
 _ARRIVAL_ATTEMPT_SCHEMA_VERSION = 1
 _ARRIVAL_COMPLETION_SCHEMA_VERSION = 1
 _ARRIVAL_CONSUMPTION_SCHEMA_VERSION = 1
+_ARRIVAL_ADMISSION_SCHEMA_VERSION = 1
 _SUPPORTED_REPLACEMENT_GENERATIONS = 1
 _SHARED_FIELDS = {
     "control_endpoint",
@@ -527,6 +529,11 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                         self._raise_heartbeat_error()
                         if self._read_generation() != current:
                             raise RendezvousConnectionError("generation changed during rendezvous")
+                        self._validate_final_admission_state(
+                            current,
+                            recovery_state,
+                            admission_deadline,
+                        )
                         self._publish_arrival_consumption(
                             current,
                             current.snapshot.record.assignment,
@@ -534,12 +541,18 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                             slot,
                             completion,
                             admission_deadline,
-                        )
-                        self._validate_final_admission_state(
-                            current,
                             recovery_state,
-                            admission_deadline,
                         )
+                        if recovery_state is not None:
+                            self._wait_for_replacement_admission(
+                                current,
+                                current.snapshot.record.assignment,
+                                attempt,
+                                slot,
+                                completion,
+                                recovery_state,
+                                admission_deadline,
+                            )
                         return RendezvousInfo(
                             bootstrap_store,
                             slot,
@@ -1300,6 +1313,21 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         )
         if conditions is None:
             return None
+        if assignment.generation > 0:
+            admission = self._read_replacement_admission(
+                assignment,
+                current_attempt,
+                completion,
+                None,
+            )
+            if admission is None:
+                return None
+            conditions[
+                self._arrival_admission_key(
+                    assignment.generation,
+                    current_attempt,
+                )
+            ] = admission.revision
         completion_key = self._arrival_completion_key(
             assignment.generation,
             current_attempt,
@@ -1580,7 +1608,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         recovery_state: RestartPlanPersistedRecoveryState | None = None,
         admission_deadline: float | None = None,
     ) -> None:
-        if self._is_closed_bounded(None):
+        if self._is_closed_bounded(admission_deadline):
             raise RendezvousClosedError
         if self._read_generation() != current:
             raise RendezvousConnectionError("generation changed before rendezvous admission")
@@ -1884,6 +1912,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         slot: int,
         completion: ControlStoreEntry,
         deadline: float,
+        recovery_state: RestartPlanPersistedRecoveryState | None = None,
     ) -> None:
         completion_key = self._arrival_completion_key(assignment.generation, attempt)
         generation_snapshot_key = self._generation_reader.snapshot_key(assignment.generation)
@@ -1922,15 +1951,22 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 )
                 return
             now_unix_ms = self._clock()
+            store_deadline_unix_ms = registration.expires_at_unix_ms
+            if recovery_state is not None:
+                store_deadline_unix_ms = min(
+                    store_deadline_unix_ms,
+                    recovery_state.plan.restart_deadline_unix_ms,
+                )
             if (
                 isinstance(now_unix_ms, bool)
                 or not isinstance(now_unix_ms, int)
                 or now_unix_ms < registration.granted_at_unix_ms
-                or now_unix_ms >= registration.expires_at_unix_ms
+                or now_unix_ms >= store_deadline_unix_ms
+                or self._monotonic_clock() >= deadline
             ):
-                raise RendezvousConnectionError(
-                    "rendezvous consumption is outside the registration window"
-                )
+                if recovery_state is not None:
+                    raise RendezvousTimeoutError
+                raise RendezvousConnectionError("rendezvous consumption is outside its window")
             try:
                 result = self._control_store.compare_set_many_guarded(
                     {
@@ -1943,7 +1979,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                     guard_key=self._registration_manager.registration_key,
                     expected_guard_revision=registration.fencing_token,
                     not_before_unix_ms=now_unix_ms,
-                    deadline_unix_ms=registration.expires_at_unix_ms,
+                    deadline_unix_ms=store_deadline_unix_ms,
                     conditions={
                         completion_key: completion.revision,
                         self._generation_reader.head_key: current.head_revision,
@@ -1951,6 +1987,12 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                         self._closure_key: None,
                     },
                 )
+            except ControlStoreDeadlineExceeded as error:
+                if recovery_state is not None:
+                    raise RendezvousTimeoutError from error
+                raise RendezvousConnectionError(
+                    "rendezvous consumption missed its registration window"
+                ) from error
             except ControlStoreConflict:
                 try:
                     existing = self._control_store.get(key)
@@ -1998,7 +2040,21 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         attempt: int,
         completion: ControlStoreEntry,
     ) -> dict[str, int] | None:
+        state = self._arrival_consumption_state(
+            assignment,
+            attempt,
+            completion,
+        )
+        return None if state is None else state[0]
+
+    def _arrival_consumption_state(
+        self,
+        assignment: RankAssignment,
+        attempt: int,
+        completion: ControlStoreEntry,
+    ) -> tuple[dict[str, int], dict[str, dict[str, Any]]] | None:
         conditions: dict[str, int] = {}
+        consumptions: dict[str, dict[str, Any]] = {}
         for slot, node_id in assignment.slot_to_node_id.items():
             registration = self._current_assigned_registration(node_id)
             entry = self._read_arrival_consumption(
@@ -2010,6 +2066,14 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             )
             if entry is None:
                 return None
+            payload = self._validate_arrival_consumption_entry(
+                entry,
+                assignment=assignment,
+                attempt=attempt,
+                slot=slot,
+                completion=completion,
+                registration=registration,
+            )
             conditions[
                 self._arrival_consumption_key(
                     assignment.generation,
@@ -2021,7 +2085,15 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             registration_key = agent_registration_key(self._config.run_id, node_id)
             if registration_key != self._registration_manager.registration_key:
                 conditions[registration_key] = registration.fencing_token
-        return conditions
+            consumptions[str(slot)] = {
+                "agent_id": payload["agent_id"],
+                "consumption_revision": entry.revision,
+                "consumption_transaction_sequence": entry.transaction_sequence,
+                "node_id": node_id,
+                "registration_id": payload["registration_id"],
+                "registration_revision": registration.fencing_token,
+            }
+        return conditions, consumptions
 
     def _read_arrival_consumption(
         self,
@@ -2103,7 +2175,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         slot: int,
         completion: ControlStoreEntry,
         registration: HeldAgentRegistration | None,
-    ) -> None:
+    ) -> Mapping[str, Any]:
         try:
             payload = json.loads(
                 entry.value.decode("utf-8"),
@@ -2178,6 +2250,365 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             or entry.guard_revision != payload["registration_revision"]
         ):
             raise RendezvousStateError("rendezvous consumption has invalid store provenance")
+        return payload
+
+    def _wait_for_replacement_admission(
+        self,
+        current: CurrentGeneration,
+        assignment: RankAssignment,
+        attempt: int,
+        slot: int,
+        completion: ControlStoreEntry,
+        recovery_state: RestartPlanPersistedRecoveryState,
+        deadline: float,
+    ) -> ControlStoreEntry:
+        while True:
+            admission = self._read_replacement_admission(
+                assignment,
+                attempt,
+                completion,
+                recovery_state,
+            )
+            if admission is not None:
+                return admission
+            if slot == 0:
+                self._try_commit_replacement_admission(
+                    current,
+                    assignment,
+                    attempt,
+                    completion,
+                    recovery_state,
+                    deadline,
+                )
+                admission = self._read_replacement_admission(
+                    assignment,
+                    attempt,
+                    completion,
+                    recovery_state,
+                )
+                if admission is not None:
+                    return admission
+            if not self._wait_for_change(deadline):
+                admission = self._read_replacement_admission(
+                    assignment,
+                    attempt,
+                    completion,
+                    recovery_state,
+                )
+                if admission is not None:
+                    return admission
+                raise RendezvousTimeoutError
+
+    def _try_commit_replacement_admission(
+        self,
+        current: CurrentGeneration,
+        assignment: RankAssignment,
+        attempt: int,
+        completion: ControlStoreEntry,
+        recovery_state: RestartPlanPersistedRecoveryState,
+        deadline: float,
+    ) -> None:
+        admission_key = self._arrival_admission_key(
+            assignment.generation,
+            attempt,
+        )
+        if self._control_store.get(admission_key) is not None:
+            return
+        state = self._arrival_consumption_state(
+            assignment,
+            attempt,
+            completion,
+        )
+        if state is None:
+            return
+        readiness_conditions, consumptions = state
+        conditions: dict[str, int | None] = dict(readiness_conditions)
+        with self._registration_lock:
+            leader_registration = self._registration
+        if leader_registration is None:
+            raise RendezvousConnectionError(
+                "replacement leader lost its registration before group admission"
+            )
+        slot_zero = consumptions["0"]
+        if (
+            slot_zero["registration_id"] != leader_registration.record.registration_id
+            or slot_zero["agent_id"] != leader_registration.record.agent_identity.agent_id
+        ):
+            raise RendezvousConnectionError(
+                "replacement leader registration changed before group admission"
+            )
+        completion_key = self._arrival_completion_key(
+            assignment.generation,
+            attempt,
+        )
+        attempt_key = self._arrival_attempt_key(assignment.generation)
+        snapshot_key = self._generation_reader.snapshot_key(assignment.generation)
+        attempt_entry = self._control_store.get(attempt_key)
+        if attempt_entry is None:
+            raise RendezvousStateError(
+                "replacement rendezvous attempt disappeared before group admission"
+            )
+        self._validate_arrival_attempt_entry(
+            attempt_entry,
+            generation=assignment.generation,
+            expected_attempt=attempt,
+            leader_node_id=assignment.slot_to_node_id[0],
+        )
+        conditions.update(
+            {
+                attempt_key: attempt_entry.revision,
+                completion_key: completion.revision,
+                self._generation_reader.head_key: current.head_revision,
+                snapshot_key: current.snapshot.revision,
+                self._closure_key: None,
+            }
+        )
+        now_unix_ms = self._replacement_now_unix_ms(recovery_state)
+        store_deadline_unix_ms = recovery_state.plan.restart_deadline_unix_ms
+        for metadata in consumptions.values():
+            registration = self._current_assigned_registration(metadata["node_id"])
+            if (
+                registration.record.registration_id != metadata["registration_id"]
+                or registration.record.agent_identity.agent_id != metadata["agent_id"]
+            ):
+                return
+            metadata["registration_revision"] = registration.fencing_token
+            store_deadline_unix_ms = min(
+                store_deadline_unix_ms,
+                registration.expires_at_unix_ms,
+            )
+            registration_key = agent_registration_key(
+                self._config.run_id,
+                metadata["node_id"],
+            )
+            if registration_key != self._registration_manager.registration_key:
+                conditions[registration_key] = registration.fencing_token
+        if self._monotonic_clock() >= deadline or now_unix_ms >= store_deadline_unix_ms:
+            raise RendezvousTimeoutError
+        value = self._arrival_admission_value(
+            generation=assignment.generation,
+            attempt=attempt,
+            recovery_state=recovery_state,
+            completion=completion,
+            consumptions=consumptions,
+        )
+        try:
+            result = self._control_store.compare_set_many_guarded(
+                {
+                    admission_key: ControlStoreWrite(
+                        expected_revision=None,
+                        value=value,
+                        require_never_created=True,
+                    )
+                },
+                guard_key=self._registration_manager.registration_key,
+                expected_guard_revision=leader_registration.fencing_token,
+                not_before_unix_ms=now_unix_ms,
+                deadline_unix_ms=store_deadline_unix_ms,
+                conditions=conditions,
+            )
+        except ControlStoreDeadlineExceeded as error:
+            raise RendezvousTimeoutError from error
+        except ControlStoreConflict:
+            return
+        except Exception as error:
+            raise RendezvousConnectionError(
+                "failed to commit replacement group admission"
+            ) from error
+        self._validate_replacement_admission_entry(
+            result[admission_key],
+            assignment=assignment,
+            attempt=attempt,
+            completion=completion,
+            recovery_state=recovery_state,
+        )
+        self._state_changed_event.set()
+
+    def _read_replacement_admission(
+        self,
+        assignment: RankAssignment,
+        attempt: int,
+        completion: ControlStoreEntry,
+        recovery_state: RestartPlanPersistedRecoveryState | None,
+    ) -> ControlStoreEntry | None:
+        key = self._arrival_admission_key(
+            assignment.generation,
+            attempt,
+        )
+        try:
+            entry = self._control_store.get(key)
+        except Exception as error:
+            raise RendezvousConnectionError("failed to read replacement group admission") from error
+        if entry is None:
+            return None
+        self._validate_replacement_admission_entry(
+            entry,
+            assignment=assignment,
+            attempt=attempt,
+            completion=completion,
+            recovery_state=recovery_state,
+        )
+        return entry
+
+    def _arrival_admission_key(self, generation: int, attempt: int) -> str:
+        return (
+            f"{_CONTROL_PREFIX}/runs/{self._run_digest}/rendezvous/"
+            f"generation-{generation}/attempt-{attempt}/admitted"
+        )
+
+    def _arrival_admission_value(
+        self,
+        *,
+        generation: int,
+        attempt: int,
+        recovery_state: RestartPlanPersistedRecoveryState,
+        completion: ControlStoreEntry,
+        consumptions: Mapping[str, Mapping[str, Any]],
+    ) -> bytes:
+        return json.dumps(
+            {
+                "attempt": attempt,
+                "completion_digest": hashlib.sha256(completion.value).hexdigest(),
+                "consumptions": consumptions,
+                "generation": generation,
+                "plan_id": recovery_state.plan.plan_id,
+                "restart_deadline_unix_ms": (recovery_state.plan.restart_deadline_unix_ms),
+                "run_id": self._config.run_id,
+                "schema_version": _ARRIVAL_ADMISSION_SCHEMA_VERSION,
+            },
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+
+    def _validate_replacement_admission_entry(
+        self,
+        entry: ControlStoreEntry,
+        *,
+        assignment: RankAssignment,
+        attempt: int,
+        completion: ControlStoreEntry,
+        recovery_state: RestartPlanPersistedRecoveryState | None,
+    ) -> Mapping[str, Mapping[str, Any]]:
+        try:
+            payload = json.loads(
+                entry.value.decode("utf-8"),
+                object_pairs_hook=_strict_object,
+            )
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as error:
+            raise RendezvousStateError("replacement group admission is malformed") from error
+        expected_fields = {
+            "attempt",
+            "completion_digest",
+            "consumptions",
+            "generation",
+            "plan_id",
+            "restart_deadline_unix_ms",
+            "run_id",
+            "schema_version",
+        }
+        integer_fields = (
+            "attempt",
+            "generation",
+            "restart_deadline_unix_ms",
+            "schema_version",
+        )
+        if (
+            not isinstance(payload, dict)
+            or set(payload) != expected_fields
+            or payload["run_id"] != self._config.run_id
+            or payload["generation"] != assignment.generation
+            or payload["attempt"] != attempt
+            or payload["schema_version"] != _ARRIVAL_ADMISSION_SCHEMA_VERSION
+            or any(
+                isinstance(payload[field], bool) or not isinstance(payload[field], int)
+                for field in integer_fields
+            )
+            or payload["restart_deadline_unix_ms"] < 1
+            or payload["completion_digest"] != hashlib.sha256(completion.value).hexdigest()
+            or not isinstance(payload["plan_id"], str)
+            or not payload["plan_id"]
+        ):
+            raise RendezvousStateError(
+                "replacement group admission does not match its rendezvous attempt"
+            )
+        if recovery_state is not None and (
+            payload["plan_id"] != recovery_state.plan.plan_id
+            or payload["restart_deadline_unix_ms"] != recovery_state.plan.restart_deadline_unix_ms
+        ):
+            raise RendezvousStateError(
+                "replacement group admission does not match its restart plan"
+            )
+        if entry.value != json.dumps(
+            payload,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8"):
+            raise RendezvousStateError("replacement group admission contains noncanonical bytes")
+        consumptions = payload["consumptions"]
+        expected_slots = {
+            str(slot): node_id for slot, node_id in assignment.slot_to_node_id.items()
+        }
+        if not isinstance(consumptions, dict) or set(consumptions) != set(expected_slots):
+            raise RendezvousStateError("replacement group admission has invalid slot coverage")
+        for slot, node_id in expected_slots.items():
+            metadata = consumptions[slot]
+            fields = {
+                "agent_id",
+                "consumption_revision",
+                "consumption_transaction_sequence",
+                "node_id",
+                "registration_id",
+                "registration_revision",
+            }
+            if (
+                not isinstance(metadata, dict)
+                or set(metadata) != fields
+                or metadata["node_id"] != node_id
+            ):
+                raise RendezvousStateError(
+                    "replacement group admission has invalid readiness metadata"
+                )
+            for field in ("agent_id", "registration_id"):
+                if not isinstance(metadata[field], str) or not metadata[field]:
+                    raise RendezvousStateError(f"replacement group admission has invalid {field}")
+            for field in (
+                "consumption_revision",
+                "consumption_transaction_sequence",
+                "registration_revision",
+            ):
+                if (
+                    isinstance(metadata[field], bool)
+                    or not isinstance(metadata[field], int)
+                    or metadata[field] < 1
+                ):
+                    raise RendezvousStateError(f"replacement group admission has invalid {field}")
+        slot_zero = consumptions["0"]
+        if (
+            entry.mutation_sequence != 1
+            or entry.value_sequence != 1
+            or entry.lifetime_sequence != 1
+            or entry.guard_key
+            != agent_registration_key(
+                self._config.run_id,
+                expected_slots["0"],
+            )
+            or entry.guard_revision != slot_zero["registration_revision"]
+            or entry.committed_at_unix_ms is None
+            or entry.committed_at_unix_ms >= payload["restart_deadline_unix_ms"]
+            or entry.transaction_sequence <= completion.transaction_sequence
+            or any(
+                entry.transaction_sequence <= metadata["consumption_transaction_sequence"]
+                for metadata in consumptions.values()
+            )
+        ):
+            raise RendezvousStateError("replacement group admission has invalid store provenance")
+        if recovery_state is not None and (
+            entry.committed_at_unix_ms < recovery_state.publication.committed_at_unix_ms
+        ):
+            raise RendezvousStateError("replacement group admission predates its restart plan")
+        return consumptions
 
     def _generation_admission(
         self,

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -103,6 +103,7 @@ _ARRIVAL_ATTEMPT_SCHEMA_VERSION = 1
 _ARRIVAL_COMPLETION_SCHEMA_VERSION = 1
 _ARRIVAL_CONSUMPTION_SCHEMA_VERSION = 1
 _ARRIVAL_ADMISSION_SCHEMA_VERSION = 1
+_ARRIVAL_RETURN_SCHEMA_VERSION = 1
 _SUPPORTED_REPLACEMENT_GENERATIONS = 1
 _SHARED_FIELDS = {
     "control_endpoint",
@@ -1353,6 +1354,15 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                     current_attempt,
                 )
             ] = admission.revision
+            return_conditions = self._arrival_return_conditions(
+                assignment,
+                current_attempt,
+                completion,
+                admission,
+            )
+            if return_conditions is None:
+                return None
+            conditions.update(return_conditions)
         completion_key = self._arrival_completion_key(
             assignment.generation,
             current_attempt,
@@ -2499,6 +2509,331 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             deadline,
             now_unix_ms=now_unix_ms,
         )
+        self._publish_replacement_return_acknowledgement(
+            current,
+            assignment,
+            attempt,
+            slot,
+            admission,
+            consumption,
+            current_registration,
+            recovery_state,
+            now_unix_ms=now_unix_ms,
+        )
+
+    def _publish_replacement_return_acknowledgement(
+        self,
+        current: CurrentGeneration,
+        assignment: RankAssignment,
+        attempt: int,
+        slot: int,
+        admission: ControlStoreEntry,
+        consumption: ControlStoreEntry,
+        registration: HeldAgentRegistration,
+        recovery_state: RestartPlanPersistedRecoveryState,
+        *,
+        now_unix_ms: int,
+    ) -> ControlStoreEntry:
+        key = self._arrival_return_key(
+            assignment.generation,
+            attempt,
+            slot,
+            registration.record.registration_id,
+        )
+        value = self._arrival_return_value(
+            generation=assignment.generation,
+            attempt=attempt,
+            slot=slot,
+            admission=admission,
+            consumption=consumption,
+            registration=registration,
+        )
+        existing = self._control_store.get(key)
+        if existing is not None:
+            self._validate_arrival_return_entry(
+                existing,
+                assignment=assignment,
+                attempt=attempt,
+                slot=slot,
+                admission=admission,
+                consumption=consumption,
+                registration=registration,
+            )
+            return existing
+        deadline_unix_ms = min(
+            registration.expires_at_unix_ms,
+            recovery_state.plan.restart_deadline_unix_ms,
+        )
+        try:
+            result = self._control_store.compare_set_many_guarded(
+                {
+                    key: ControlStoreWrite(
+                        expected_revision=None,
+                        value=value,
+                        require_never_created=True,
+                    )
+                },
+                guard_key=self._registration_manager.registration_key,
+                expected_guard_revision=registration.fencing_token,
+                not_before_unix_ms=now_unix_ms,
+                deadline_unix_ms=deadline_unix_ms,
+                conditions={
+                    self._arrival_admission_key(
+                        assignment.generation,
+                        attempt,
+                    ): admission.revision,
+                    self._arrival_consumption_key(
+                        assignment.generation,
+                        attempt,
+                        slot,
+                        registration.record.registration_id,
+                    ): consumption.revision,
+                    self._generation_reader.head_key: current.head_revision,
+                    self._generation_reader.snapshot_key(
+                        assignment.generation,
+                    ): current.snapshot.revision,
+                    self._closure_key: None,
+                },
+            )
+        except ControlStoreDeadlineExceeded as error:
+            raise RendezvousTimeoutError from error
+        except ControlStoreConflict:
+            existing = self._control_store.get(key)
+            if existing is None:
+                raise RendezvousConnectionError(
+                    "replacement return acknowledgement lost its admission fence"
+                ) from None
+            self._validate_arrival_return_entry(
+                existing,
+                assignment=assignment,
+                attempt=attempt,
+                slot=slot,
+                admission=admission,
+                consumption=consumption,
+                registration=registration,
+            )
+            return existing
+        except Exception as error:
+            raise RendezvousConnectionError(
+                "failed to publish replacement return acknowledgement"
+            ) from error
+        entry = result[key]
+        self._validate_arrival_return_entry(
+            entry,
+            assignment=assignment,
+            attempt=attempt,
+            slot=slot,
+            admission=admission,
+            consumption=consumption,
+            registration=registration,
+        )
+        self._state_changed_event.set()
+        return entry
+
+    def _arrival_return_conditions(
+        self,
+        assignment: RankAssignment,
+        attempt: int,
+        completion: ControlStoreEntry,
+        admission: ControlStoreEntry,
+    ) -> dict[str, int] | None:
+        consumptions = self._validate_replacement_admission_entry(
+            admission,
+            assignment=assignment,
+            attempt=attempt,
+            completion=completion,
+            recovery_state=None,
+        )
+        conditions: dict[str, int] = {}
+        for slot, node_id in assignment.slot_to_node_id.items():
+            metadata = consumptions[str(slot)]
+            key = self._arrival_return_key(
+                assignment.generation,
+                attempt,
+                slot,
+                metadata["registration_id"],
+            )
+            try:
+                entry = self._control_store.get(key)
+            except Exception as error:
+                raise RendezvousConnectionError(
+                    "failed to read replacement return acknowledgement"
+                ) from error
+            if entry is None:
+                return None
+            payload = self._validate_arrival_return_entry(
+                entry,
+                assignment=assignment,
+                attempt=attempt,
+                slot=slot,
+                admission=admission,
+                consumption=None,
+                registration=None,
+            )
+            if (
+                payload["agent_id"] != metadata["agent_id"]
+                or payload["registration_id"] != metadata["registration_id"]
+                or payload["registration_revision"] != metadata["registration_revision"]
+                or payload["consumption_revision"] != metadata["consumption_revision"]
+            ):
+                raise RendezvousStateError(
+                    "replacement return acknowledgement does not match its admission metadata"
+                )
+            if entry.guard_key != agent_registration_key(
+                self._config.run_id,
+                node_id,
+            ):
+                raise RendezvousStateError(
+                    "replacement return acknowledgement has invalid registration provenance"
+                )
+            conditions[key] = entry.revision
+        return conditions
+
+    def _arrival_return_key(
+        self,
+        generation: int,
+        attempt: int,
+        slot: int,
+        registration_id: str,
+    ) -> str:
+        registration_digest = hashlib.sha256(registration_id.encode("utf-8")).hexdigest()
+        return (
+            f"{_CONTROL_PREFIX}/runs/{self._run_digest}/rendezvous/"
+            f"generation-{generation}/attempt-{attempt}/returned/"
+            f"slot-{slot}/registration-{registration_digest}"
+        )
+
+    def _arrival_return_value(
+        self,
+        *,
+        generation: int,
+        attempt: int,
+        slot: int,
+        admission: ControlStoreEntry,
+        consumption: ControlStoreEntry,
+        registration: HeldAgentRegistration,
+    ) -> bytes:
+        return json.dumps(
+            {
+                "admission_digest": hashlib.sha256(admission.value).hexdigest(),
+                "agent_id": registration.record.agent_identity.agent_id,
+                "attempt": attempt,
+                "consumption_revision": consumption.revision,
+                "generation": generation,
+                "logical_node_slot": slot,
+                "node_id": registration.record.agent_identity.node_id,
+                "registration_id": registration.record.registration_id,
+                "registration_revision": registration.fencing_token,
+                "run_id": self._config.run_id,
+                "schema_version": _ARRIVAL_RETURN_SCHEMA_VERSION,
+            },
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+
+    def _validate_arrival_return_entry(
+        self,
+        entry: ControlStoreEntry,
+        *,
+        assignment: RankAssignment,
+        attempt: int,
+        slot: int,
+        admission: ControlStoreEntry,
+        consumption: ControlStoreEntry | None,
+        registration: HeldAgentRegistration | None,
+    ) -> Mapping[str, Any]:
+        try:
+            payload = json.loads(
+                entry.value.decode("utf-8"),
+                object_pairs_hook=_strict_object,
+            )
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as error:
+            raise RendezvousStateError("replacement return acknowledgement is malformed") from error
+        expected_fields = {
+            "admission_digest",
+            "agent_id",
+            "attempt",
+            "consumption_revision",
+            "generation",
+            "logical_node_slot",
+            "node_id",
+            "registration_id",
+            "registration_revision",
+            "run_id",
+            "schema_version",
+        }
+        expected_node_id = assignment.slot_to_node_id.get(slot)
+        integer_fields = (
+            "attempt",
+            "consumption_revision",
+            "generation",
+            "registration_revision",
+            "schema_version",
+        )
+        if (
+            not isinstance(payload, dict)
+            or set(payload) != expected_fields
+            or payload["run_id"] != self._config.run_id
+            or payload["generation"] != assignment.generation
+            or payload["attempt"] != attempt
+            or payload["logical_node_slot"] != slot
+            or payload["node_id"] != expected_node_id
+            or payload["admission_digest"] != hashlib.sha256(admission.value).hexdigest()
+            or payload["schema_version"] != _ARRIVAL_RETURN_SCHEMA_VERSION
+            or isinstance(payload["logical_node_slot"], bool)
+            or not isinstance(payload["logical_node_slot"], int)
+            or payload["logical_node_slot"] < 0
+            or any(
+                isinstance(payload[field], bool)
+                or not isinstance(payload[field], int)
+                or payload[field] < 1
+                for field in integer_fields
+            )
+        ):
+            raise RendezvousStateError(
+                "replacement return acknowledgement does not match its admission"
+            )
+        for field in ("agent_id", "registration_id"):
+            if not isinstance(payload[field], str) or not payload[field]:
+                raise RendezvousStateError(
+                    f"replacement return acknowledgement has invalid {field}"
+                )
+        if consumption is not None and payload["consumption_revision"] != consumption.revision:
+            raise RendezvousStateError(
+                "replacement return acknowledgement does not match its consumption"
+            )
+        if registration is not None and (
+            payload["registration_id"] != registration.record.registration_id
+            or payload["agent_id"] != registration.record.agent_identity.agent_id
+            or payload["registration_revision"] != registration.fencing_token
+        ):
+            raise RendezvousConnectionError(
+                "replacement return acknowledgement belongs to another registration"
+            )
+        if (
+            entry.value
+            != json.dumps(
+                payload,
+                allow_nan=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ).encode("utf-8")
+            or entry.mutation_sequence != 1
+            or entry.value_sequence != 1
+            or entry.lifetime_sequence != 1
+            or entry.guard_key
+            != agent_registration_key(
+                self._config.run_id,
+                expected_node_id,
+            )
+            or entry.guard_revision != payload["registration_revision"]
+            or entry.transaction_sequence <= admission.transaction_sequence
+        ):
+            raise RendezvousStateError(
+                "replacement return acknowledgement has invalid store provenance"
+            )
+        return payload
 
     def _try_commit_replacement_admission(
         self,
@@ -3620,7 +3955,9 @@ class RestartContextFile:
 
     def _invalidation_name(self, cleanup_token: _RestartContextCleanupToken) -> str:
         self._validate_cleanup_token(cleanup_token)
-        return f".{self.path.name}.invalidated-{cleanup_token}"
+        identity = f"{self.path.name}\0{cleanup_token}".encode("utf-8")
+        digest = hashlib.sha256(identity).hexdigest()
+        return f".restart-context-invalidated-{digest}"
 
     @staticmethod
     def _validate_owned_private_file(metadata: os.stat_result) -> None:

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import errno
 import fcntl
 import hashlib
 import importlib
 import json
+import math
 import os
 import secrets
 import socket
@@ -89,6 +91,9 @@ _RESOURCE_IDS_ENV = "LM_RESILIENCY_RESOURCE_IDS"
 _RESTART_CONTEXT_ENV = "LM_RESILIENCY_RESTART_CONTEXT"
 _MAX_CONTEXT_BYTES = 64 * 1024
 _MAX_POLICY_BYTES = 64 * 1024
+_CONTEXT_FILE_SCHEMA_VERSION = 1
+_CONTEXT_LOCK_TIMEOUT_SECONDS = 1.0
+_CONTEXT_LOCK_POLL_SECONDS = 0.01
 _CONTROL_PREFIX = "lm_resiliency/torchrun/v1"
 _CLOSED_SCHEMA_VERSION = 1
 _ARRIVAL_SCHEMA_VERSION = 1
@@ -119,7 +124,7 @@ class TorchrunRuntimeConfigError(ValueError):
     """Raised when torchrun runtime configuration is unsafe or contradictory."""
 
 
-_RestartContextFileVersion = tuple[int, int]
+_RestartContextCleanupToken = str
 
 
 class RestartContextFileError(RuntimeError):
@@ -129,10 +134,10 @@ class RestartContextFileError(RuntimeError):
         self,
         message: str,
         *,
-        published_version: _RestartContextFileVersion | None = None,
+        published_token: _RestartContextCleanupToken | None = None,
     ) -> None:
         super().__init__(message)
-        self.published_version = published_version
+        self.published_token = published_token
 
 
 class _DuplicateJsonFieldError(ValueError):
@@ -416,7 +421,10 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             control_store,
             run_id=config.run_id,
         )
-        self._restart_context = RestartContextFile(config.restart_context_path)
+        self._restart_context = RestartContextFile(
+            config.restart_context_path,
+            monotonic_clock=monotonic_clock,
+        )
         run_digest = hashlib.sha256(config.run_id.encode("utf-8")).hexdigest()
         self._run_digest = run_digest
         self._closure_key = f"{_CONTROL_PREFIX}/runs/{run_digest}/rendezvous-closed"
@@ -493,7 +501,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         """Admit one authoritative fixed-size generation and park passive standbys."""
 
         formation_deadline = self._monotonic_clock() + self._config.policy.join_timeout_ms / 1_000
-        context_version: _RestartContextFileVersion | None = None
+        context_token: _RestartContextCleanupToken | None = None
         try:
             if self._is_closed_bounded(formation_deadline):
                 raise RendezvousClosedError
@@ -516,9 +524,10 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 self._raise_heartbeat_error()
                 if current is not None:
                     if slot is not None:
-                        context_version = self._prepare_restart_context(
+                        context_token = self._prepare_restart_context(
                             current,
                             recovery_state,
+                            admission_deadline,
                         )
                         attempt, completion = self._wait_for_assigned_arrivals(
                             current,
@@ -578,9 +587,12 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                         self._monotonic_clock() + self._config.policy.join_timeout_ms / 1_000
                     )
         except BaseException:
-            if context_version is not None:
+            if context_token is not None:
                 try:
-                    self._restart_context.clear_if_version(context_version)
+                    self._restart_context.clear_if_token(
+                        context_token,
+                        deadline=self._context_cleanup_deadline(),
+                    )
                 except (OSError, RestartContextFileError):
                     pass
             self._cleanup_local_resources()
@@ -2750,9 +2762,16 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         self,
         recovery_state: RestartPlanPersistedRecoveryState,
     ) -> int:
-        now_unix_ms = self._clock()
+        try:
+            now_unix_ms = self._control_store.observe_time_unix_ms()
+        except Exception as error:
+            raise RendezvousConnectionError(
+                "failed to observe authoritative replacement rendezvous time"
+            ) from error
         if isinstance(now_unix_ms, bool) or not isinstance(now_unix_ms, int) or now_unix_ms < 1:
-            raise RendezvousConnectionError("replacement rendezvous clock returned an invalid time")
+            raise RendezvousConnectionError(
+                "control-store replacement rendezvous clock returned an invalid time"
+            )
         publication_time = recovery_state.publication.committed_at_unix_ms
         with self._replacement_clock_lock:
             if now_unix_ms < publication_time or (
@@ -2781,10 +2800,11 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         self,
         current: CurrentGeneration,
         recovery_state: RestartPlanPersistedRecoveryState | None,
-    ) -> _RestartContextFileVersion | None:
+        deadline: float,
+    ) -> _RestartContextCleanupToken | None:
         if current.snapshot.record.assignment.generation == 0:
             try:
-                self._restart_context.clear()
+                self._restart_context.clear(deadline=deadline)
             except (OSError, RestartContextFileError) as error:
                 raise RendezvousStateError(
                     "failed to clear stale initial restart context"
@@ -2794,16 +2814,22 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             raise RendezvousStateError("replacement generation lacks an authoritative restart plan")
         context = self._restart_context_for_plan(recovery_state.plan)
         try:
-            return self._restart_context.write(context)
+            return self._restart_context.write(context, deadline=deadline)
         except (OSError, RestartContextFileError) as error:
-            if isinstance(error, RestartContextFileError) and error.published_version is not None:
+            if isinstance(error, RestartContextFileError) and error.published_token is not None:
                 try:
-                    self._restart_context.clear_if_version(error.published_version)
+                    self._restart_context.clear_if_token(
+                        error.published_token,
+                        deadline=self._context_cleanup_deadline(),
+                    )
                 except (OSError, RestartContextFileError):
                     pass
             raise RendezvousStateError(
                 "failed to publish the replacement restart context"
             ) from error
+
+    def _context_cleanup_deadline(self) -> float:
+        return self._monotonic_clock() + _CONTEXT_LOCK_TIMEOUT_SECONDS
 
     def _restart_context_for_plan(self, plan: RestartPlan) -> RestartContext:
         try:
@@ -2885,33 +2911,51 @@ class RestartContextFile:
     """Atomically persist and validate one owner-only restart context."""
 
     path: Path
+    monotonic_clock: Callable[[], float] = time.monotonic
 
     def __post_init__(self) -> None:
         if not isinstance(self.path, Path):
             raise TypeError("path must be pathlib.Path")
+        if not callable(self.monotonic_clock):
+            raise TypeError("monotonic_clock must be callable")
         if not self.path.is_absolute():
             raise RestartContextFileError("restart-context path must be absolute")
         if self.path.name in {"", ".", ".."}:
             raise RestartContextFileError("restart-context path must name a file")
 
-    def write(self, context: RestartContext) -> _RestartContextFileVersion:
+    def write(
+        self,
+        context: RestartContext,
+        *,
+        deadline: float | None = None,
+    ) -> _RestartContextCleanupToken:
         if not isinstance(context, RestartContext):
             raise TypeError("context must be RestartContext")
-        encoded = (context.to_json() + "\n").encode("utf-8")
+        cleanup_token = secrets.token_hex(32)
+        encoded = (
+            json.dumps(
+                {
+                    "schema_version": _CONTEXT_FILE_SCHEMA_VERSION,
+                    "cleanup_token": cleanup_token,
+                    "context": context.to_dict(),
+                },
+                allow_nan=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+            + "\n"
+        ).encode("utf-8")
         if len(encoded) > _MAX_CONTEXT_BYTES:
             raise RestartContextFileError("restart context is too large")
         parent_descriptor = self._open_parent(create=True)
         assert parent_descriptor is not None
         descriptor = -1
         temporary = ""
-        published_version: _RestartContextFileVersion | None = None
         try:
-            fcntl.flock(parent_descriptor, fcntl.LOCK_EX)
+            self._acquire_parent_lock(parent_descriptor, deadline=deadline)
             self._reject_existing_symlink(parent_descriptor)
             descriptor, temporary = self._create_temporary_file(parent_descriptor)
             os.fchmod(descriptor, 0o600)
-            metadata = os.fstat(descriptor)
-            published_version = (metadata.st_dev, metadata.st_ino)
             with os.fdopen(descriptor, "wb") as stream:
                 descriptor = -1
                 stream.write(encoded)
@@ -2925,11 +2969,11 @@ class RestartContextFile:
             )
             temporary = ""
             self._fsync_directory(parent_descriptor)
-            return published_version
+            return cleanup_token
         except OSError as error:
             raise RestartContextFileError(
                 f"failed to publish restart context at {self.path}",
-                published_version=published_version if not temporary else None,
+                published_token=cleanup_token if not temporary else None,
             ) from error
         finally:
             if descriptor >= 0:
@@ -2950,54 +2994,20 @@ class RestartContextFile:
             raise RestartContextFileError(
                 f"restart-context directory does not exist for {self.path}"
             )
-        flags = (
-            os.O_RDONLY
-            | getattr(os, "O_NOFOLLOW", 0)
-            | getattr(os, "O_NONBLOCK", 0)
-            | getattr(os, "O_CLOEXEC", 0)
-        )
         try:
-            descriptor = os.open(
-                self.path.name,
-                flags,
-                dir_fd=parent_descriptor,
-            )
-        except OSError as error:
-            os.close(parent_descriptor)
-            raise RestartContextFileError(
-                f"failed to open restart context at {self.path}"
-            ) from error
-        try:
-            metadata = os.fstat(descriptor)
-            self._validate_owned_private_file(metadata)
-            with os.fdopen(descriptor, "rb", closefd=False) as stream:
-                encoded = stream.read(_MAX_CONTEXT_BYTES + 1)
-            if len(encoded) > _MAX_CONTEXT_BYTES:
-                raise RestartContextFileError("restart-context file is too large")
+            encoded = self._read_encoded(parent_descriptor)
         finally:
-            os.close(descriptor)
             os.close(parent_descriptor)
-        try:
-            value = json.loads(
-                encoded,
-                object_pairs_hook=_strict_object,
-            )
-            if not isinstance(value, Mapping):
-                raise RestartContextFileError("restart-context JSON must contain an object")
-            return RestartContext.from_dict(value)
-        except _DuplicateJsonFieldError as error:
-            raise RestartContextFileError(str(error)) from error
-        except RestartContextFileError:
-            raise
-        except (TypeError, ValueError, UnicodeDecodeError) as error:
-            raise RestartContextFileError("restart-context file is malformed") from error
+        assert encoded is not None
+        _, context = self._decode_envelope(encoded)
+        return context
 
-    def clear(self) -> None:
+    def clear(self, *, deadline: float | None = None) -> None:
         parent_descriptor = self._open_parent(create=False)
         if parent_descriptor is None:
             return
         try:
-            fcntl.flock(parent_descriptor, fcntl.LOCK_EX)
+            self._acquire_parent_lock(parent_descriptor, deadline=deadline)
             self._reject_existing_symlink(parent_descriptor)
             try:
                 os.unlink(self.path.name, dir_fd=parent_descriptor)
@@ -3012,39 +3022,24 @@ class RestartContextFile:
         finally:
             os.close(parent_descriptor)
 
-    def clear_if_version(
+    def clear_if_token(
         self,
-        version: _RestartContextFileVersion,
+        cleanup_token: _RestartContextCleanupToken,
+        *,
+        deadline: float | None = None,
     ) -> bool:
-        if (
-            not isinstance(version, tuple)
-            or len(version) != 2
-            or any(
-                isinstance(value, bool) or not isinstance(value, int) or value < 0
-                for value in version
-            )
-        ):
-            raise TypeError("version must contain nonnegative device and inode integers")
+        self._validate_cleanup_token(cleanup_token)
         parent_descriptor = self._open_parent(create=False)
         if parent_descriptor is None:
             return False
         try:
-            fcntl.flock(parent_descriptor, fcntl.LOCK_EX)
+            self._acquire_parent_lock(parent_descriptor, deadline=deadline)
             self._reject_existing_symlink(parent_descriptor)
-            try:
-                metadata = os.stat(
-                    self.path.name,
-                    dir_fd=parent_descriptor,
-                    follow_symlinks=False,
-                )
-            except FileNotFoundError:
+            encoded = self._read_encoded(parent_descriptor, missing_ok=True)
+            if encoded is None:
                 return False
-            except OSError as error:
-                raise RestartContextFileError(
-                    f"failed to inspect restart context at {self.path}"
-                ) from error
-            self._validate_owned_private_file(metadata)
-            if (metadata.st_dev, metadata.st_ino) != version:
+            current_token, _ = self._decode_envelope(encoded)
+            if current_token != cleanup_token:
                 return False
             try:
                 os.unlink(self.path.name, dir_fd=parent_descriptor)
@@ -3058,6 +3053,140 @@ class RestartContextFile:
             return True
         finally:
             os.close(parent_descriptor)
+
+    def _acquire_parent_lock(
+        self,
+        parent_descriptor: int,
+        *,
+        deadline: float | None,
+    ) -> None:
+        now = self.monotonic_clock()
+        if isinstance(now, bool) or not isinstance(now, (int, float)) or not math.isfinite(now):
+            raise RestartContextFileError("restart-context clock returned an invalid time")
+        logical_deadline = now + _CONTEXT_LOCK_TIMEOUT_SECONDS if deadline is None else deadline
+        if (
+            isinstance(logical_deadline, bool)
+            or not isinstance(logical_deadline, (int, float))
+            or not math.isfinite(logical_deadline)
+        ):
+            raise TypeError("deadline must be a monotonic number or None")
+        wall_deadline = time.monotonic() + max(0.0, logical_deadline - now)
+        previous_logical_now = float(now)
+        while True:
+            try:
+                fcntl.flock(
+                    parent_descriptor,
+                    fcntl.LOCK_EX | fcntl.LOCK_NB,
+                )
+                return
+            except OSError as error:
+                if error.errno not in {errno.EACCES, errno.EAGAIN}:
+                    raise RestartContextFileError(
+                        f"failed to lock restart-context directory for {self.path}"
+                    ) from error
+            logical_now = self.monotonic_clock()
+            if (
+                isinstance(logical_now, bool)
+                or not isinstance(logical_now, (int, float))
+                or not math.isfinite(logical_now)
+                or logical_now < previous_logical_now
+            ):
+                raise RestartContextFileError("restart-context clock returned an invalid time")
+            previous_logical_now = float(logical_now)
+            wall_now = time.monotonic()
+            if logical_now >= logical_deadline or wall_now >= wall_deadline:
+                raise RestartContextFileError(
+                    f"timed out locking restart-context directory for {self.path}"
+                )
+            time.sleep(
+                min(
+                    _CONTEXT_LOCK_POLL_SECONDS,
+                    max(0.0, wall_deadline - wall_now),
+                )
+            )
+
+    def _read_encoded(
+        self,
+        parent_descriptor: int,
+        *,
+        missing_ok: bool = False,
+    ) -> bytes | None:
+        flags = (
+            os.O_RDONLY
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_NONBLOCK", 0)
+            | getattr(os, "O_CLOEXEC", 0)
+        )
+        try:
+            descriptor = os.open(
+                self.path.name,
+                flags,
+                dir_fd=parent_descriptor,
+            )
+        except FileNotFoundError:
+            if missing_ok:
+                return None
+            raise RestartContextFileError(
+                f"failed to open restart context at {self.path}"
+            ) from None
+        except OSError as error:
+            raise RestartContextFileError(
+                f"failed to open restart context at {self.path}"
+            ) from error
+        try:
+            metadata = os.fstat(descriptor)
+            self._validate_owned_private_file(metadata)
+            with os.fdopen(descriptor, "rb", closefd=False) as stream:
+                encoded = stream.read(_MAX_CONTEXT_BYTES + 1)
+            if len(encoded) > _MAX_CONTEXT_BYTES:
+                raise RestartContextFileError("restart-context file is too large")
+            return encoded
+        finally:
+            os.close(descriptor)
+
+    @classmethod
+    def _decode_envelope(
+        cls,
+        encoded: bytes,
+    ) -> tuple[_RestartContextCleanupToken, RestartContext]:
+        try:
+            value = json.loads(
+                encoded,
+                object_pairs_hook=_strict_object,
+            )
+            if not isinstance(value, Mapping):
+                raise RestartContextFileError("restart-context JSON must contain an object")
+            expected = {"schema_version", "cleanup_token", "context"}
+            if set(value) != expected:
+                raise RestartContextFileError("restart-context envelope fields are invalid")
+            if (
+                type(value["schema_version"]) is not int
+                or value["schema_version"] != _CONTEXT_FILE_SCHEMA_VERSION
+            ):
+                raise RestartContextFileError("restart-context envelope schema version is invalid")
+            cleanup_token = cls._validate_cleanup_token(value["cleanup_token"])
+            context_value = value["context"]
+            if not isinstance(context_value, Mapping):
+                raise RestartContextFileError(
+                    "restart-context envelope context must contain an object"
+                )
+            return cleanup_token, RestartContext.from_dict(context_value)
+        except _DuplicateJsonFieldError as error:
+            raise RestartContextFileError(str(error)) from error
+        except RestartContextFileError:
+            raise
+        except (TypeError, ValueError, UnicodeDecodeError) as error:
+            raise RestartContextFileError("restart-context file is malformed") from error
+
+    @staticmethod
+    def _validate_cleanup_token(value: object) -> _RestartContextCleanupToken:
+        if not isinstance(value, str) or len(value) != 64 or value != value.lower():
+            raise RestartContextFileError("restart-context cleanup token is invalid")
+        try:
+            int(value, 16)
+        except ValueError as error:
+            raise RestartContextFileError("restart-context cleanup token is invalid") from error
+        return value
 
     def _open_parent(self, *, create: bool) -> int | None:
         directory_flags = (

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -3870,7 +3870,22 @@ class RestartContextFile:
             self._reject_existing_symlink(parent_descriptor)
             encoded = self._read_encoded(parent_descriptor, missing_ok=True)
             if encoded is None:
-                return False
+                metadata = self._read_encoded(
+                    parent_descriptor,
+                    missing_ok=True,
+                    name=self._metadata_name(),
+                    maximum_bytes=_MAX_CONTEXT_METADATA_BYTES,
+                )
+                if metadata is None:
+                    return False
+                try:
+                    os.unlink(self._metadata_name(), dir_fd=parent_descriptor)
+                    self._fsync_directory(parent_descriptor)
+                except OSError as error:
+                    raise RestartContextFileError(
+                        f"failed to remove orphaned restart-context metadata at {self.path}"
+                    ) from error
+                return True
             context = self._decode_context(encoded)
             if context.run_id == run_id:
                 raise RestartContextFileError(

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -90,8 +90,10 @@ _ENVIRONMENT_DIGEST_ENV = "LM_RESILIENCY_ENVIRONMENT_DIGEST"
 _RESOURCE_IDS_ENV = "LM_RESILIENCY_RESOURCE_IDS"
 _RESTART_CONTEXT_ENV = "LM_RESILIENCY_RESTART_CONTEXT"
 _MAX_CONTEXT_BYTES = 64 * 1024
+_MAX_CONTEXT_INVALIDATION_BYTES = 1_024
 _MAX_POLICY_BYTES = 64 * 1024
 _CONTEXT_FILE_SCHEMA_VERSION = 1
+_CONTEXT_INVALIDATION_SCHEMA_VERSION = 1
 _CONTEXT_LOCK_TIMEOUT_SECONDS = 1.0
 _CONTEXT_LOCK_POLL_SECONDS = 0.01
 _CONTROL_PREFIX = "lm_resiliency/torchrun/v1"
@@ -588,13 +590,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                     )
         except BaseException:
             if context_token is not None:
-                try:
-                    self._restart_context.clear_if_token(
-                        context_token,
-                        deadline=self._context_cleanup_deadline(),
-                    )
-                except (OSError, RestartContextFileError):
-                    pass
+                self._invalidate_and_clear_restart_context(context_token)
             self._cleanup_local_resources()
             raise
 
@@ -1595,6 +1591,17 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         self,
         node_id: str,
     ) -> HeldAgentRegistration:
+        current = self._read_current_assigned_registration(node_id)
+        self._validate_registration_window(
+            current,
+            now_unix_ms=self._clock(),
+        )
+        return current
+
+    def _read_current_assigned_registration(
+        self,
+        node_id: str,
+    ) -> HeldAgentRegistration:
         try:
             history = AgentRegistrationHistoryReader(
                 self._control_store,
@@ -1610,24 +1617,32 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         current = history.current
         if current is None:
             raise RendezvousConnectionError("arrived agent no longer has a current registration")
-        now_unix_ms = self._clock()
+        return current
+
+    @staticmethod
+    def _validate_registration_window(
+        registration: HeldAgentRegistration,
+        *,
+        now_unix_ms: int,
+    ) -> None:
         if (
             isinstance(now_unix_ms, bool)
             or not isinstance(now_unix_ms, int)
-            or now_unix_ms < current.granted_at_unix_ms
+            or now_unix_ms < registration.granted_at_unix_ms
         ):
             raise RendezvousConnectionError(
                 "rendezvous arrival clock is invalid for its registration"
             )
-        if current.expires_at_unix_ms <= now_unix_ms:
+        if registration.expires_at_unix_ms <= now_unix_ms:
             raise RendezvousConnectionError("arrived agent registration has expired")
-        return current
 
     def _validate_final_admission_state(
         self,
         current: CurrentGeneration,
         recovery_state: RestartPlanPersistedRecoveryState | None = None,
         admission_deadline: float | None = None,
+        *,
+        validate_deadline: bool = True,
     ) -> None:
         if self._is_closed_bounded(admission_deadline):
             raise RendezvousClosedError
@@ -1644,7 +1659,8 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             raise RendezvousStateError(
                 "replacement rendezvous lacks its original admission deadline"
             )
-        self._validate_replacement_deadline(refreshed, admission_deadline)
+        if validate_deadline:
+            self._validate_replacement_deadline(refreshed, admission_deadline)
         expected_context = self._restart_context_for_plan(refreshed.plan)
         try:
             persisted_context = self._restart_context.read()
@@ -1656,6 +1672,29 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             raise RendezvousStateError(
                 "replacement restart context changed before rendezvous admission"
             )
+
+    def _validate_current_arrival_attempt(
+        self,
+        assignment: RankAssignment,
+        expected_attempt: int,
+    ) -> None:
+        key = self._arrival_attempt_key(assignment.generation)
+        try:
+            entry = self._control_store.get(key)
+        except Exception as error:
+            raise RendezvousConnectionError(
+                "failed to revalidate the rendezvous arrival attempt"
+            ) from error
+        if entry is None:
+            raise RendezvousConnectionError(
+                "rendezvous arrival attempt disappeared before admission"
+            )
+        self._validate_arrival_attempt_entry(
+            entry,
+            generation=assignment.generation,
+            expected_attempt=expected_attempt,
+            leader_node_id=assignment.slot_to_node_id[0],
+        )
 
     def _try_complete_arrival_attempt(
         self,
@@ -2293,6 +2332,8 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             if admission is not None:
                 self._validate_replacement_return(
                     current,
+                    assignment,
+                    attempt,
                     recovery_state,
                     deadline,
                 )
@@ -2315,6 +2356,8 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 if admission is not None:
                     self._validate_replacement_return(
                         current,
+                        assignment,
+                        attempt,
                         recovery_state,
                         deadline,
                     )
@@ -2329,6 +2372,8 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 if admission is not None:
                     self._validate_replacement_return(
                         current,
+                        assignment,
+                        attempt,
                         recovery_state,
                         deadline,
                     )
@@ -2338,6 +2383,8 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
     def _validate_replacement_return(
         self,
         current: CurrentGeneration,
+        assignment: RankAssignment,
+        attempt: int,
         recovery_state: RestartPlanPersistedRecoveryState,
         deadline: float,
     ) -> None:
@@ -2345,17 +2392,29 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             current,
             recovery_state,
             deadline,
+            validate_deadline=False,
         )
         self._raise_heartbeat_error()
         with self._registration_lock:
             registration = self._registration
         if registration is None:
             raise RendezvousConnectionError("replacement agent no longer owns its registration")
-        current_registration = self._current_assigned_registration(self._config.node_id)
+        current_registration = self._read_current_assigned_registration(self._config.node_id)
         if current_registration.record != registration.record:
             raise RendezvousConnectionError(
                 "replacement agent registration changed before admission"
             )
+        self._validate_current_arrival_attempt(assignment, attempt)
+        now_unix_ms = self._replacement_now_unix_ms(recovery_state)
+        self._validate_registration_window(
+            current_registration,
+            now_unix_ms=now_unix_ms,
+        )
+        self._validate_replacement_deadline(
+            recovery_state,
+            deadline,
+            now_unix_ms=now_unix_ms,
+        )
 
     def _try_commit_replacement_admission(
         self,
@@ -2788,11 +2847,15 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         self,
         recovery_state: RestartPlanPersistedRecoveryState,
         admission_deadline: float,
+        *,
+        now_unix_ms: int | None = None,
     ) -> None:
-        now_unix_ms = self._replacement_now_unix_ms(recovery_state)
+        observed_unix_ms = (
+            self._replacement_now_unix_ms(recovery_state) if now_unix_ms is None else now_unix_ms
+        )
         if (
             self._monotonic_clock() >= admission_deadline
-            or now_unix_ms >= recovery_state.plan.restart_deadline_unix_ms
+            or observed_unix_ms >= recovery_state.plan.restart_deadline_unix_ms
         ):
             raise RendezvousTimeoutError
 
@@ -2817,16 +2880,30 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             return self._restart_context.write(context, deadline=deadline)
         except (OSError, RestartContextFileError) as error:
             if isinstance(error, RestartContextFileError) and error.published_token is not None:
-                try:
-                    self._restart_context.clear_if_token(
-                        error.published_token,
-                        deadline=self._context_cleanup_deadline(),
-                    )
-                except (OSError, RestartContextFileError):
-                    pass
+                self._invalidate_and_clear_restart_context(error.published_token)
             raise RendezvousStateError(
                 "failed to publish the replacement restart context"
             ) from error
+
+    def _invalidate_and_clear_restart_context(
+        self,
+        cleanup_token: _RestartContextCleanupToken,
+    ) -> None:
+        invalidation_error: OSError | RestartContextFileError | None = None
+        try:
+            self._restart_context.invalidate(cleanup_token)
+        except (OSError, RestartContextFileError) as error:
+            invalidation_error = error
+        try:
+            self._restart_context.clear_if_token(
+                cleanup_token,
+                deadline=self._context_cleanup_deadline(),
+            )
+        except (OSError, RestartContextFileError) as cleanup_error:
+            if invalidation_error is not None:
+                raise RendezvousStateError(
+                    "failed to invalidate the replacement restart context"
+                ) from cleanup_error
 
     def _context_cleanup_deadline(self) -> float:
         return self._monotonic_clock() + _CONTEXT_LOCK_TIMEOUT_SECONDS
@@ -2996,11 +3073,73 @@ class RestartContextFile:
             )
         try:
             encoded = self._read_encoded(parent_descriptor)
+            assert encoded is not None
+            cleanup_token, context = self._decode_envelope(encoded)
+            invalidated_token = self._read_invalidated_token(parent_descriptor)
+            if invalidated_token == cleanup_token:
+                raise RestartContextFileError("restart context has been invalidated")
+            return context
         finally:
             os.close(parent_descriptor)
-        assert encoded is not None
-        _, context = self._decode_envelope(encoded)
-        return context
+
+    def invalidate(
+        self,
+        cleanup_token: _RestartContextCleanupToken,
+    ) -> None:
+        """Durably invalidate one published context without taking its directory lock."""
+
+        self._validate_cleanup_token(cleanup_token)
+        encoded = (
+            json.dumps(
+                {
+                    "schema_version": _CONTEXT_INVALIDATION_SCHEMA_VERSION,
+                    "cleanup_token": cleanup_token,
+                },
+                allow_nan=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+            + "\n"
+        ).encode("utf-8")
+        parent_descriptor = self._open_parent(create=True)
+        assert parent_descriptor is not None
+        descriptor = -1
+        temporary = ""
+        try:
+            descriptor, temporary = self._create_temporary_file(
+                parent_descriptor,
+                target_name=self._invalidation_name,
+            )
+            os.fchmod(descriptor, 0o600)
+            with os.fdopen(descriptor, "wb") as stream:
+                descriptor = -1
+                stream.write(encoded)
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(
+                temporary,
+                self._invalidation_name,
+                src_dir_fd=parent_descriptor,
+                dst_dir_fd=parent_descriptor,
+            )
+            temporary = ""
+            self._fsync_directory(parent_descriptor)
+        except OSError as error:
+            raise RestartContextFileError(
+                f"failed to invalidate restart context at {self.path}"
+            ) from error
+        finally:
+            if descriptor >= 0:
+                try:
+                    os.close(descriptor)
+                except OSError:
+                    pass
+            if temporary:
+                try:
+                    os.unlink(temporary, dir_fd=parent_descriptor)
+                except OSError:
+                    pass
+            os.close(parent_descriptor)
 
     def clear(self, *, deadline: float | None = None) -> None:
         parent_descriptor = self._open_parent(create=False)
@@ -3110,7 +3249,10 @@ class RestartContextFile:
         parent_descriptor: int,
         *,
         missing_ok: bool = False,
+        name: str | None = None,
+        maximum_bytes: int = _MAX_CONTEXT_BYTES,
     ) -> bytes | None:
+        target_name = self.path.name if name is None else name
         flags = (
             os.O_RDONLY
             | getattr(os, "O_NOFOLLOW", 0)
@@ -3119,7 +3261,7 @@ class RestartContextFile:
         )
         try:
             descriptor = os.open(
-                self.path.name,
+                target_name,
                 flags,
                 dir_fd=parent_descriptor,
             )
@@ -3137,12 +3279,46 @@ class RestartContextFile:
             metadata = os.fstat(descriptor)
             self._validate_owned_private_file(metadata)
             with os.fdopen(descriptor, "rb", closefd=False) as stream:
-                encoded = stream.read(_MAX_CONTEXT_BYTES + 1)
-            if len(encoded) > _MAX_CONTEXT_BYTES:
+                encoded = stream.read(maximum_bytes + 1)
+            if len(encoded) > maximum_bytes:
                 raise RestartContextFileError("restart-context file is too large")
             return encoded
         finally:
             os.close(descriptor)
+
+    def _read_invalidated_token(
+        self,
+        parent_descriptor: int,
+    ) -> _RestartContextCleanupToken | None:
+        encoded = self._read_encoded(
+            parent_descriptor,
+            missing_ok=True,
+            name=self._invalidation_name,
+            maximum_bytes=_MAX_CONTEXT_INVALIDATION_BYTES,
+        )
+        if encoded is None:
+            return None
+        try:
+            value = json.loads(
+                encoded,
+                object_pairs_hook=_strict_object,
+            )
+            if (
+                not isinstance(value, Mapping)
+                or set(value) != {"schema_version", "cleanup_token"}
+                or type(value["schema_version"]) is not int
+                or value["schema_version"] != _CONTEXT_INVALIDATION_SCHEMA_VERSION
+            ):
+                raise RestartContextFileError("restart-context invalidation marker is malformed")
+            return self._validate_cleanup_token(value["cleanup_token"])
+        except _DuplicateJsonFieldError as error:
+            raise RestartContextFileError(str(error)) from error
+        except RestartContextFileError:
+            raise
+        except (TypeError, ValueError, UnicodeDecodeError) as error:
+            raise RestartContextFileError(
+                "restart-context invalidation marker is malformed"
+            ) from error
 
     @classmethod
     def _decode_envelope(
@@ -3273,7 +3449,13 @@ class RestartContextFile:
         if stat.S_ISLNK(metadata.st_mode):
             raise RestartContextFileError("restart-context path must not be a symlink")
 
-    def _create_temporary_file(self, parent_descriptor: int) -> tuple[int, str]:
+    def _create_temporary_file(
+        self,
+        parent_descriptor: int,
+        *,
+        target_name: str | None = None,
+    ) -> tuple[int, str]:
+        filename = self.path.name if target_name is None else target_name
         flags = (
             os.O_WRONLY
             | os.O_CREAT
@@ -3282,7 +3464,7 @@ class RestartContextFile:
             | getattr(os, "O_CLOEXEC", 0)
         )
         for _ in range(128):
-            name = f".{self.path.name}.{secrets.token_hex(16)}.tmp"
+            name = f".{filename}.{secrets.token_hex(16)}.tmp"
             try:
                 descriptor = os.open(
                     name,
@@ -3300,6 +3482,10 @@ class RestartContextFile:
         raise RestartContextFileError(
             f"failed to allocate a temporary restart context for {self.path}"
         )
+
+    @property
+    def _invalidation_name(self) -> str:
+        return f".{self.path.name}.invalidated"
 
     @staticmethod
     def _validate_owned_private_file(metadata: os.stat_result) -> None:

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import importlib
 import json
@@ -118,8 +119,20 @@ class TorchrunRuntimeConfigError(ValueError):
     """Raised when torchrun runtime configuration is unsafe or contradictory."""
 
 
+_RestartContextFileVersion = tuple[int, int]
+
+
 class RestartContextFileError(RuntimeError):
     """Raised when the node-local restart-context file is unsafe or malformed."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        published_version: _RestartContextFileVersion | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.published_version = published_version
 
 
 class _DuplicateJsonFieldError(ValueError):
@@ -480,7 +493,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         """Admit one authoritative fixed-size generation and park passive standbys."""
 
         formation_deadline = self._monotonic_clock() + self._config.policy.join_timeout_ms / 1_000
-        context_written = False
+        context_version: _RestartContextFileVersion | None = None
         try:
             if self._is_closed_bounded(formation_deadline):
                 raise RendezvousClosedError
@@ -503,13 +516,9 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 self._raise_heartbeat_error()
                 if current is not None:
                     if slot is not None:
-                        context_written = current.snapshot.record.assignment.generation > 0
-                        context_written = (
-                            self._prepare_restart_context(
-                                current,
-                                recovery_state,
-                            )
-                            or context_written
+                        context_version = self._prepare_restart_context(
+                            current,
+                            recovery_state,
                         )
                         attempt, completion = self._wait_for_assigned_arrivals(
                             current,
@@ -569,9 +578,9 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                         self._monotonic_clock() + self._config.policy.join_timeout_ms / 1_000
                     )
         except BaseException:
-            if context_written:
+            if context_version is not None:
                 try:
-                    self._restart_context.clear()
+                    self._restart_context.clear_if_version(context_version)
                 except (OSError, RestartContextFileError):
                     pass
             self._cleanup_local_resources()
@@ -2270,6 +2279,11 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 recovery_state,
             )
             if admission is not None:
+                self._validate_replacement_return(
+                    current,
+                    recovery_state,
+                    deadline,
+                )
                 return admission
             if slot == 0:
                 self._try_commit_replacement_admission(
@@ -2287,6 +2301,11 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                     recovery_state,
                 )
                 if admission is not None:
+                    self._validate_replacement_return(
+                        current,
+                        recovery_state,
+                        deadline,
+                    )
                     return admission
             if not self._wait_for_change(deadline):
                 admission = self._read_replacement_admission(
@@ -2296,8 +2315,35 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                     recovery_state,
                 )
                 if admission is not None:
+                    self._validate_replacement_return(
+                        current,
+                        recovery_state,
+                        deadline,
+                    )
                     return admission
                 raise RendezvousTimeoutError
+
+    def _validate_replacement_return(
+        self,
+        current: CurrentGeneration,
+        recovery_state: RestartPlanPersistedRecoveryState,
+        deadline: float,
+    ) -> None:
+        self._validate_final_admission_state(
+            current,
+            recovery_state,
+            deadline,
+        )
+        self._raise_heartbeat_error()
+        with self._registration_lock:
+            registration = self._registration
+        if registration is None:
+            raise RendezvousConnectionError("replacement agent no longer owns its registration")
+        current_registration = self._current_assigned_registration(self._config.node_id)
+        if current_registration.record != registration.record:
+            raise RendezvousConnectionError(
+                "replacement agent registration changed before admission"
+            )
 
     def _try_commit_replacement_admission(
         self,
@@ -2735,7 +2781,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         self,
         current: CurrentGeneration,
         recovery_state: RestartPlanPersistedRecoveryState | None,
-    ) -> bool:
+    ) -> _RestartContextFileVersion | None:
         if current.snapshot.record.assignment.generation == 0:
             try:
                 self._restart_context.clear()
@@ -2743,17 +2789,21 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 raise RendezvousStateError(
                     "failed to clear stale initial restart context"
                 ) from error
-            return False
+            return None
         if recovery_state is None:
             raise RendezvousStateError("replacement generation lacks an authoritative restart plan")
         context = self._restart_context_for_plan(recovery_state.plan)
         try:
-            self._restart_context.write(context)
+            return self._restart_context.write(context)
         except (OSError, RestartContextFileError) as error:
+            if isinstance(error, RestartContextFileError) and error.published_version is not None:
+                try:
+                    self._restart_context.clear_if_version(error.published_version)
+                except (OSError, RestartContextFileError):
+                    pass
             raise RendezvousStateError(
                 "failed to publish the replacement restart context"
             ) from error
-        return True
 
     def _restart_context_for_plan(self, plan: RestartPlan) -> RestartContext:
         try:
@@ -2844,7 +2894,7 @@ class RestartContextFile:
         if self.path.name in {"", ".", ".."}:
             raise RestartContextFileError("restart-context path must name a file")
 
-    def write(self, context: RestartContext) -> None:
+    def write(self, context: RestartContext) -> _RestartContextFileVersion:
         if not isinstance(context, RestartContext):
             raise TypeError("context must be RestartContext")
         encoded = (context.to_json() + "\n").encode("utf-8")
@@ -2854,10 +2904,14 @@ class RestartContextFile:
         assert parent_descriptor is not None
         descriptor = -1
         temporary = ""
+        published_version: _RestartContextFileVersion | None = None
         try:
+            fcntl.flock(parent_descriptor, fcntl.LOCK_EX)
             self._reject_existing_symlink(parent_descriptor)
             descriptor, temporary = self._create_temporary_file(parent_descriptor)
             os.fchmod(descriptor, 0o600)
+            metadata = os.fstat(descriptor)
+            published_version = (metadata.st_dev, metadata.st_ino)
             with os.fdopen(descriptor, "wb") as stream:
                 descriptor = -1
                 stream.write(encoded)
@@ -2871,9 +2925,11 @@ class RestartContextFile:
             )
             temporary = ""
             self._fsync_directory(parent_descriptor)
+            return published_version
         except OSError as error:
             raise RestartContextFileError(
-                f"failed to publish restart context at {self.path}"
+                f"failed to publish restart context at {self.path}",
+                published_version=published_version if not temporary else None,
             ) from error
         finally:
             if descriptor >= 0:
@@ -2941,6 +2997,7 @@ class RestartContextFile:
         if parent_descriptor is None:
             return
         try:
+            fcntl.flock(parent_descriptor, fcntl.LOCK_EX)
             self._reject_existing_symlink(parent_descriptor)
             try:
                 os.unlink(self.path.name, dir_fd=parent_descriptor)
@@ -2952,6 +3009,53 @@ class RestartContextFile:
                     f"failed to remove restart context at {self.path}"
                 ) from error
             self._fsync_directory(parent_descriptor)
+        finally:
+            os.close(parent_descriptor)
+
+    def clear_if_version(
+        self,
+        version: _RestartContextFileVersion,
+    ) -> bool:
+        if (
+            not isinstance(version, tuple)
+            or len(version) != 2
+            or any(
+                isinstance(value, bool) or not isinstance(value, int) or value < 0
+                for value in version
+            )
+        ):
+            raise TypeError("version must contain nonnegative device and inode integers")
+        parent_descriptor = self._open_parent(create=False)
+        if parent_descriptor is None:
+            return False
+        try:
+            fcntl.flock(parent_descriptor, fcntl.LOCK_EX)
+            self._reject_existing_symlink(parent_descriptor)
+            try:
+                metadata = os.stat(
+                    self.path.name,
+                    dir_fd=parent_descriptor,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                return False
+            except OSError as error:
+                raise RestartContextFileError(
+                    f"failed to inspect restart context at {self.path}"
+                ) from error
+            self._validate_owned_private_file(metadata)
+            if (metadata.st_dev, metadata.st_ino) != version:
+                return False
+            try:
+                os.unlink(self.path.name, dir_fd=parent_descriptor)
+            except FileNotFoundError:
+                return False
+            except OSError as error:
+                raise RestartContextFileError(
+                    f"failed to remove restart context at {self.path}"
+                ) from error
+            self._fsync_directory(parent_descriptor)
+            return True
         finally:
             os.close(parent_descriptor)
 

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -93,6 +93,7 @@ _ARRIVAL_SCHEMA_VERSION = 1
 _ARRIVAL_ATTEMPT_SCHEMA_VERSION = 1
 _ARRIVAL_COMPLETION_SCHEMA_VERSION = 1
 _ARRIVAL_CONSUMPTION_SCHEMA_VERSION = 1
+_SUPPORTED_REPLACEMENT_GENERATIONS = 1
 _SHARED_FIELDS = {
     "control_endpoint",
     "replacement_only",
@@ -131,7 +132,7 @@ class TorchrunRendezvousPolicy:
 
     control_endpoint: str
     replacement_only: bool = True
-    max_replacement_generations: int = 2
+    max_replacement_generations: int = _SUPPORTED_REPLACEMENT_GENERATIONS
     registration_lease_duration_ms: int = 30_000
     poll_interval_ms: int = 1_000
     join_timeout_ms: int = 300_000
@@ -199,6 +200,10 @@ class TorchrunRuntimeConfig:
     def __post_init__(self) -> None:
         if not isinstance(self.policy, TorchrunRendezvousPolicy):
             raise TypeError("policy must be TorchrunRendezvousPolicy")
+        if self.policy.max_replacement_generations > _SUPPORTED_REPLACEMENT_GENERATIONS:
+            raise TorchrunRuntimeConfigError(
+                "the torchrun runtime currently supports exactly one replacement generation"
+            )
         _nonempty_string(self.run_id, "run_id")
         _nonempty_string(self.endpoint, "endpoint")
         _positive_integer(self.min_nodes, "min_nodes")
@@ -441,6 +446,8 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         self._closed_event = threading.Event()
         self._closure_lock = threading.Lock()
         self._closure_read_lock = threading.Lock()
+        self._replacement_clock_lock = threading.Lock()
+        self._last_replacement_now_unix_ms: int | None = None
         self._shutdown_lock = threading.Lock()
 
     @property
@@ -494,9 +501,13 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 self._raise_heartbeat_error()
                 if current is not None:
                     if slot is not None:
-                        context_written = self._prepare_restart_context(
-                            current,
-                            recovery_state,
+                        context_written = current.snapshot.record.assignment.generation > 0
+                        context_written = (
+                            self._prepare_restart_context(
+                                current,
+                                recovery_state,
+                            )
+                            or context_written
                         )
                         attempt, completion = self._wait_for_assigned_arrivals(
                             current,
@@ -527,6 +538,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                         self._validate_final_admission_state(
                             current,
                             recovery_state,
+                            admission_deadline,
                         )
                         return RendezvousInfo(
                             bootstrap_store,
@@ -1566,6 +1578,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         self,
         current: CurrentGeneration,
         recovery_state: RestartPlanPersistedRecoveryState | None = None,
+        admission_deadline: float | None = None,
     ) -> None:
         if self._is_closed_bounded(None):
             raise RendezvousClosedError
@@ -1578,7 +1591,11 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             raise RendezvousConnectionError(
                 "restart-plan recovery state changed before rendezvous admission"
             )
-        self._replacement_deadline(refreshed.plan, None)
+        if admission_deadline is None:
+            raise RendezvousStateError(
+                "replacement rendezvous lacks its original admission deadline"
+            )
+        self._validate_replacement_deadline(refreshed, admission_deadline)
         expected_context = self._restart_context_for_plan(refreshed.plan)
         try:
             persisted_context = self._restart_context.read()
@@ -2176,6 +2193,16 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             raise RendezvousStateError(
                 "generation assignment local world size does not match runtime configuration"
             )
+        slot = next(
+            (
+                slot
+                for slot, node_id in assignment.slot_to_node_id.items()
+                if node_id == self._config.node_id
+            ),
+            None,
+        )
+        if slot is None:
+            return None, None, formation_deadline
         recovery_state: RestartPlanPersistedRecoveryState | None = None
         admission_deadline = formation_deadline
         if assignment.generation > 0:
@@ -2206,15 +2233,12 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                     "replacement plan does not match the committed generation assignment"
                 )
             admission_deadline = self._replacement_deadline(
-                plan,
+                recovery_state,
                 formation_deadline,
             )
-        for slot, node_id in assignment.slot_to_node_id.items():
-            if node_id == self._config.node_id:
-                self._ensure_job_compatibility()
-                self._validate_assigned_registration_history()
-                return slot, recovery_state, admission_deadline
-        return None, recovery_state, admission_deadline
+        self._ensure_job_compatibility()
+        self._validate_assigned_registration_history()
+        return slot, recovery_state, admission_deadline
 
     def _read_recovery_state(self) -> RestartPlanPersistedRecoveryState | None:
         try:
@@ -2234,17 +2258,47 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
 
     def _replacement_deadline(
         self,
-        plan: RestartPlan,
+        recovery_state: RestartPlanPersistedRecoveryState,
         formation_deadline: float | None,
     ) -> float:
-        now_unix_ms = self._clock()
-        if isinstance(now_unix_ms, bool) or not isinstance(now_unix_ms, int) or now_unix_ms < 1:
-            raise RendezvousConnectionError("replacement rendezvous clock returned an invalid time")
+        now_unix_ms = self._replacement_now_unix_ms(recovery_state)
+        plan = recovery_state.plan
         remaining_seconds = (plan.restart_deadline_unix_ms - now_unix_ms) / 1_000
         if remaining_seconds <= 0:
             raise RendezvousTimeoutError
         deadline = self._monotonic_clock() + remaining_seconds
         return deadline if formation_deadline is None else min(deadline, formation_deadline)
+
+    def _replacement_now_unix_ms(
+        self,
+        recovery_state: RestartPlanPersistedRecoveryState,
+    ) -> int:
+        now_unix_ms = self._clock()
+        if isinstance(now_unix_ms, bool) or not isinstance(now_unix_ms, int) or now_unix_ms < 1:
+            raise RendezvousConnectionError("replacement rendezvous clock returned an invalid time")
+        publication_time = recovery_state.publication.committed_at_unix_ms
+        with self._replacement_clock_lock:
+            if now_unix_ms < publication_time or (
+                self._last_replacement_now_unix_ms is not None
+                and now_unix_ms < self._last_replacement_now_unix_ms
+            ):
+                raise RendezvousConnectionError(
+                    "replacement rendezvous clock regressed behind trusted state"
+                )
+            self._last_replacement_now_unix_ms = now_unix_ms
+        return now_unix_ms
+
+    def _validate_replacement_deadline(
+        self,
+        recovery_state: RestartPlanPersistedRecoveryState,
+        admission_deadline: float,
+    ) -> None:
+        now_unix_ms = self._replacement_now_unix_ms(recovery_state)
+        if (
+            self._monotonic_clock() >= admission_deadline
+            or now_unix_ms >= recovery_state.plan.restart_deadline_unix_ms
+        ):
+            raise RendezvousTimeoutError
 
     def _prepare_restart_context(
         self,
@@ -2650,7 +2704,10 @@ def _policy_from_values(values: Mapping[str, object]) -> TorchrunRendezvousPolic
                 "replacement_only",
             ),
             max_replacement_generations=_integer(
-                values.get("max_replacement_generations", 2),
+                values.get(
+                    "max_replacement_generations",
+                    _SUPPORTED_REPLACEMENT_GENERATIONS,
+                ),
                 "max_replacement_generations",
             ),
             registration_lease_duration_ms=_integer(

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -65,8 +65,18 @@ from lm_resiliency.integrations.torchrun._generation_reader import (
 )
 from lm_resiliency.integrations.torchrun._protocol import (
     AgentIdentity,
+    ProtocolValidationError,
     RankAssignment,
     RestartContext,
+    RestartPlan,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_publication import (
+    RestartPlanPublicationReadConflict,
+    RestartPlanPublicationReadCorrupt,
+    RestartPlanPublicationReader,
+)
+from lm_resiliency.integrations.torchrun._restart_plan_state import (
+    RestartPlanPersistedRecoveryState,
 )
 
 _BACKEND = "lm_resiliency"
@@ -382,6 +392,10 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
             control_store,
             run_id=config.run_id,
         )
+        self._publication_reader = RestartPlanPublicationReader(
+            control_store,
+            run_id=config.run_id,
+        )
         self._restart_context = RestartContextFile(config.restart_context_path)
         run_digest = hashlib.sha256(config.run_id.encode("utf-8")).hexdigest()
         self._run_digest = run_digest
@@ -454,33 +468,40 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         return self._config.run_id
 
     def next_rendezvous(self) -> RendezvousInfo:
-        """Block passive standbys and admit only the initial committed assignment."""
+        """Admit one authoritative fixed-size generation and park passive standbys."""
 
         formation_deadline = self._monotonic_clock() + self._config.policy.join_timeout_ms / 1_000
+        context_written = False
         try:
             if self._is_closed_bounded(formation_deadline):
                 raise RendezvousClosedError
             self._ensure_registered(formation_deadline)
             while True:
                 current = self._read_generation()
-                slot = None if current is None else self._initial_slot(current)
+                if current is None:
+                    slot = None
+                    recovery_state = None
+                    admission_deadline = formation_deadline
+                else:
+                    slot, recovery_state, admission_deadline = self._generation_admission(
+                        current,
+                        formation_deadline,
+                    )
                 if self._is_closed_bounded(
-                    formation_deadline if current is None or slot is not None else None
+                    admission_deadline if current is None or slot is not None else None
                 ):
                     raise RendezvousClosedError
                 self._raise_heartbeat_error()
                 if current is not None:
                     if slot is not None:
-                        try:
-                            self._restart_context.clear()
-                        except (OSError, RestartContextFileError) as error:
-                            raise RendezvousStateError(
-                                "failed to clear stale initial restart context"
-                            ) from error
+                        context_written = self._prepare_restart_context(
+                            current,
+                            recovery_state,
+                        )
                         attempt, completion = self._wait_for_assigned_arrivals(
                             current,
                             slot,
-                            formation_deadline,
+                            admission_deadline,
                         )
                         bootstrap_store = self._bootstrap_store(
                             current.snapshot.record.assignment.generation,
@@ -488,7 +509,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                         bootstrap = self._build_bootstrap(
                             slot,
                             bootstrap_store,
-                            formation_deadline,
+                            admission_deadline,
                         )
                         if self.is_closed():
                             raise RendezvousClosedError
@@ -501,9 +522,12 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                             attempt,
                             slot,
                             completion,
-                            formation_deadline,
+                            admission_deadline,
                         )
-                        self._validate_final_admission_state(current)
+                        self._validate_final_admission_state(
+                            current,
+                            recovery_state,
+                        )
                         return RendezvousInfo(
                             bootstrap_store,
                             slot,
@@ -515,7 +539,16 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                     wait_deadline = formation_deadline
                 if not self._wait_for_change(wait_deadline):
                     raise RendezvousTimeoutError
+                if current is not None and slot is None:
+                    formation_deadline = (
+                        self._monotonic_clock() + self._config.policy.join_timeout_ms / 1_000
+                    )
         except BaseException:
+            if context_written:
+                try:
+                    self._restart_context.clear()
+                except (OSError, RestartContextFileError):
+                    pass
             self._cleanup_local_resources()
             raise
 
@@ -1532,11 +1565,31 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
     def _validate_final_admission_state(
         self,
         current: CurrentGeneration,
+        recovery_state: RestartPlanPersistedRecoveryState | None = None,
     ) -> None:
         if self._is_closed_bounded(None):
             raise RendezvousClosedError
         if self._read_generation() != current:
             raise RendezvousConnectionError("generation changed before rendezvous admission")
+        if recovery_state is None:
+            return
+        refreshed = self._read_recovery_state()
+        if refreshed != recovery_state:
+            raise RendezvousConnectionError(
+                "restart-plan recovery state changed before rendezvous admission"
+            )
+        self._replacement_deadline(refreshed.plan, None)
+        expected_context = self._restart_context_for_plan(refreshed.plan)
+        try:
+            persisted_context = self._restart_context.read()
+        except (OSError, RestartContextFileError) as error:
+            raise RendezvousStateError(
+                "failed to validate the replacement restart context"
+            ) from error
+        if persisted_context != expected_context:
+            raise RendezvousStateError(
+                "replacement restart context changed before rendezvous admission"
+            )
 
     def _try_complete_arrival_attempt(
         self,
@@ -2109,26 +2162,121 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         ):
             raise RendezvousStateError("rendezvous consumption has invalid store provenance")
 
-    def _initial_slot(self, current: CurrentGeneration) -> int | None:
+    def _generation_admission(
+        self,
+        current: CurrentGeneration,
+        formation_deadline: float,
+    ) -> tuple[int | None, RestartPlanPersistedRecoveryState | None, float]:
         assignment = current.snapshot.record.assignment
-        if assignment.generation != 0:
-            raise RendezvousStateError(
-                "replacement generations are not supported by this handler revision"
-            )
         if assignment.active_nodes != self._config.min_nodes:
             raise RendezvousStateError(
-                "initial assignment active node count does not match min_nodes"
+                "generation assignment active node count does not match min_nodes"
             )
         if assignment.local_world_size != self._config.local_world_size:
             raise RendezvousStateError(
-                "initial assignment local world size does not match runtime configuration"
+                "generation assignment local world size does not match runtime configuration"
+            )
+        recovery_state: RestartPlanPersistedRecoveryState | None = None
+        admission_deadline = formation_deadline
+        if assignment.generation > 0:
+            if assignment.generation > self._config.policy.max_replacement_generations:
+                raise RendezvousStateError(
+                    "replacement generation exceeds the configured replacement budget"
+                )
+            recovery_state = self._read_recovery_state()
+            if recovery_state is None:
+                raise RendezvousStateError(
+                    "replacement generation lacks an authoritative restart-plan publication"
+                )
+            plan = recovery_state.plan
+            expected_assignment = RankAssignment.from_assignments(
+                run_id=plan.run_id,
+                generation=plan.to_generation,
+                assignments=plan.slot_assignments,
+                topology_digest=plan.topology_digest,
+            )
+            if (
+                plan.run_id != self._config.run_id
+                or plan.to_generation != assignment.generation
+                or expected_assignment != assignment
+                or plan.expected_world_size
+                != self._config.min_nodes * self._config.local_world_size
+            ):
+                raise RendezvousStateError(
+                    "replacement plan does not match the committed generation assignment"
+                )
+            admission_deadline = self._replacement_deadline(
+                plan,
+                formation_deadline,
             )
         for slot, node_id in assignment.slot_to_node_id.items():
             if node_id == self._config.node_id:
                 self._ensure_job_compatibility()
                 self._validate_assigned_registration_history()
-                return slot
-        return None
+                return slot, recovery_state, admission_deadline
+        return None, recovery_state, admission_deadline
+
+    def _read_recovery_state(self) -> RestartPlanPersistedRecoveryState | None:
+        try:
+            return self._publication_reader.read_recovery_state()
+        except RestartPlanPublicationReadCorrupt as error:
+            raise RendezvousStateError(
+                "restart-plan publication is corrupt during replacement rendezvous"
+            ) from error
+        except RestartPlanPublicationReadConflict as error:
+            raise RendezvousConnectionError(
+                "restart-plan publication changed during replacement rendezvous"
+            ) from error
+        except Exception as error:
+            raise RendezvousConnectionError(
+                "failed to read restart-plan publication during replacement rendezvous"
+            ) from error
+
+    def _replacement_deadline(
+        self,
+        plan: RestartPlan,
+        formation_deadline: float | None,
+    ) -> float:
+        now_unix_ms = self._clock()
+        if isinstance(now_unix_ms, bool) or not isinstance(now_unix_ms, int) or now_unix_ms < 1:
+            raise RendezvousConnectionError("replacement rendezvous clock returned an invalid time")
+        remaining_seconds = (plan.restart_deadline_unix_ms - now_unix_ms) / 1_000
+        if remaining_seconds <= 0:
+            raise RendezvousTimeoutError
+        deadline = self._monotonic_clock() + remaining_seconds
+        return deadline if formation_deadline is None else min(deadline, formation_deadline)
+
+    def _prepare_restart_context(
+        self,
+        current: CurrentGeneration,
+        recovery_state: RestartPlanPersistedRecoveryState | None,
+    ) -> bool:
+        if current.snapshot.record.assignment.generation == 0:
+            try:
+                self._restart_context.clear()
+            except (OSError, RestartContextFileError) as error:
+                raise RendezvousStateError(
+                    "failed to clear stale initial restart context"
+                ) from error
+            return False
+        if recovery_state is None:
+            raise RendezvousStateError("replacement generation lacks an authoritative restart plan")
+        context = self._restart_context_for_plan(recovery_state.plan)
+        try:
+            self._restart_context.write(context)
+        except (OSError, RestartContextFileError) as error:
+            raise RendezvousStateError(
+                "failed to publish the replacement restart context"
+            ) from error
+        return True
+
+    def _restart_context_for_plan(self, plan: RestartPlan) -> RestartContext:
+        try:
+            return RestartContext.from_plan(plan, self._config.node_id)
+        except ProtocolValidationError as error:
+            raise RendezvousStateError(
+                "replacement plan cannot produce this node's restart context"
+            ) from error
 
     def _ensure_job_compatibility(self) -> None:
         try:

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -589,9 +589,17 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                         self._monotonic_clock() + self._config.policy.join_timeout_ms / 1_000
                     )
         except BaseException:
-            if context_token is not None:
-                self._invalidate_and_clear_restart_context(context_token)
-            self._cleanup_local_resources()
+            try:
+                if context_token is not None:
+                    try:
+                        self._invalidate_and_clear_restart_context(context_token)
+                    except (OSError, RestartContextFileError, RendezvousStateError):
+                        pass
+            finally:
+                try:
+                    self._cleanup_local_resources()
+                except Exception:
+                    pass
             raise
 
     def is_closed(self) -> bool:
@@ -1598,6 +1606,38 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         )
         return current
 
+    def _try_current_assigned_registration(
+        self,
+        node_id: str,
+    ) -> HeldAgentRegistration | None:
+        try:
+            history = AgentRegistrationHistoryReader(
+                self._control_store,
+                run_id=self._config.run_id,
+                node_id=node_id,
+            ).read()
+        except AgentRegistrationHistoryCorrupt as error:
+            raise RendezvousStateError("arrived agent registration history is corrupt") from error
+        except AgentRegistrationHistoryError as error:
+            raise RendezvousConnectionError(
+                "arrived agent registration history changed repeatedly"
+            ) from error
+        current = history.current
+        if current is None:
+            return None
+        now_unix_ms = self._clock()
+        if (
+            isinstance(now_unix_ms, bool)
+            or not isinstance(now_unix_ms, int)
+            or now_unix_ms < current.granted_at_unix_ms
+        ):
+            raise RendezvousConnectionError(
+                "rendezvous arrival clock is invalid for its registration"
+            )
+        if current.expires_at_unix_ms <= now_unix_ms:
+            return None
+        return current
+
     def _read_current_assigned_registration(
         self,
         node_id: str,
@@ -2116,7 +2156,9 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         conditions: dict[str, int] = {}
         consumptions: dict[str, dict[str, Any]] = {}
         for slot, node_id in assignment.slot_to_node_id.items():
-            registration = self._current_assigned_registration(node_id)
+            registration = self._try_current_assigned_registration(node_id)
+            if registration is None:
+                return None
             entry = self._read_arrival_consumption(
                 assignment,
                 attempt,
@@ -2334,6 +2376,9 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                     current,
                     assignment,
                     attempt,
+                    slot,
+                    completion,
+                    admission,
                     recovery_state,
                     deadline,
                 )
@@ -2358,6 +2403,9 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                         current,
                         assignment,
                         attempt,
+                        slot,
+                        completion,
+                        admission,
                         recovery_state,
                         deadline,
                     )
@@ -2374,6 +2422,9 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                         current,
                         assignment,
                         attempt,
+                        slot,
+                        completion,
+                        admission,
                         recovery_state,
                         deadline,
                     )
@@ -2385,6 +2436,9 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         current: CurrentGeneration,
         assignment: RankAssignment,
         attempt: int,
+        slot: int,
+        completion: ControlStoreEntry,
+        admission: ControlStoreEntry,
         recovery_state: RestartPlanPersistedRecoveryState,
         deadline: float,
     ) -> None:
@@ -2403,6 +2457,36 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         if current_registration.record != registration.record:
             raise RendezvousConnectionError(
                 "replacement agent registration changed before admission"
+            )
+        consumptions = self._validate_replacement_admission_entry(
+            admission,
+            assignment=assignment,
+            attempt=attempt,
+            completion=completion,
+            recovery_state=recovery_state,
+        )
+        metadata = consumptions[str(slot)]
+        if (
+            metadata["registration_id"] != current_registration.record.registration_id
+            or metadata["agent_id"] != current_registration.record.agent_identity.agent_id
+            or metadata["registration_revision"] != current_registration.fencing_token
+        ):
+            raise RendezvousConnectionError(
+                "replacement admission does not include this agent registration"
+            )
+        consumption = self._read_arrival_consumption(
+            assignment,
+            attempt,
+            slot,
+            completion,
+            current_registration,
+        )
+        if consumption is None or (
+            metadata["consumption_revision"] != consumption.revision
+            or metadata["consumption_transaction_sequence"] != consumption.transaction_sequence
+        ):
+            raise RendezvousConnectionError(
+                "replacement admission does not include this agent consumption"
             )
         self._validate_current_arrival_attempt(assignment, attempt)
         now_unix_ms = self._replacement_now_unix_ms(recovery_state)
@@ -2483,7 +2567,9 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         now_unix_ms = self._replacement_now_unix_ms(recovery_state)
         store_deadline_unix_ms = recovery_state.plan.restart_deadline_unix_ms
         for metadata in consumptions.values():
-            registration = self._current_assigned_registration(metadata["node_id"])
+            registration = self._try_current_assigned_registration(metadata["node_id"])
+            if registration is None:
+                return
             if (
                 registration.record.registration_id != metadata["registration_id"]
                 or registration.record.agent_identity.agent_id != metadata["agent_id"]
@@ -2867,7 +2953,10 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
     ) -> _RestartContextCleanupToken | None:
         if current.snapshot.record.assignment.generation == 0:
             try:
-                self._restart_context.clear(deadline=deadline)
+                self._restart_context.clear_stale_for_run(
+                    self._config.run_id,
+                    deadline=deadline,
+                )
             except (OSError, RestartContextFileError) as error:
                 raise RendezvousStateError(
                     "failed to clear stale initial restart context"
@@ -3075,8 +3164,7 @@ class RestartContextFile:
             encoded = self._read_encoded(parent_descriptor)
             assert encoded is not None
             cleanup_token, context = self._decode_envelope(encoded)
-            invalidated_token = self._read_invalidated_token(parent_descriptor)
-            if invalidated_token == cleanup_token:
+            if self._is_invalidated(parent_descriptor, cleanup_token):
                 raise RestartContextFileError("restart context has been invalidated")
             return context
         finally:
@@ -3108,7 +3196,7 @@ class RestartContextFile:
         try:
             descriptor, temporary = self._create_temporary_file(
                 parent_descriptor,
-                target_name=self._invalidation_name,
+                target_name=self._invalidation_name(cleanup_token),
             )
             os.fchmod(descriptor, 0o600)
             with os.fdopen(descriptor, "wb") as stream:
@@ -3118,7 +3206,7 @@ class RestartContextFile:
                 os.fsync(stream.fileno())
             os.replace(
                 temporary,
-                self._invalidation_name,
+                self._invalidation_name(cleanup_token),
                 src_dir_fd=parent_descriptor,
                 dst_dir_fd=parent_descriptor,
             )
@@ -3161,6 +3249,41 @@ class RestartContextFile:
         finally:
             os.close(parent_descriptor)
 
+    def clear_stale_for_run(
+        self,
+        run_id: str,
+        *,
+        deadline: float | None = None,
+    ) -> bool:
+        if not isinstance(run_id, str) or not run_id:
+            raise TypeError("run_id must be a non-empty string")
+        parent_descriptor = self._open_parent(create=False)
+        if parent_descriptor is None:
+            return False
+        try:
+            self._acquire_parent_lock(parent_descriptor, deadline=deadline)
+            self._reject_existing_symlink(parent_descriptor)
+            encoded = self._read_encoded(parent_descriptor, missing_ok=True)
+            if encoded is None:
+                return False
+            _, context = self._decode_envelope(encoded)
+            if context.run_id == run_id:
+                raise RestartContextFileError(
+                    "refusing to remove a restart context for the current run"
+                )
+            try:
+                os.unlink(self.path.name, dir_fd=parent_descriptor)
+            except FileNotFoundError:
+                return False
+            except OSError as error:
+                raise RestartContextFileError(
+                    f"failed to remove restart context at {self.path}"
+                ) from error
+            self._fsync_directory(parent_descriptor)
+            return True
+        finally:
+            os.close(parent_descriptor)
+
     def clear_if_token(
         self,
         cleanup_token: _RestartContextCleanupToken,
@@ -3187,6 +3310,17 @@ class RestartContextFile:
             except OSError as error:
                 raise RestartContextFileError(
                     f"failed to remove restart context at {self.path}"
+                ) from error
+            try:
+                os.unlink(
+                    self._invalidation_name(cleanup_token),
+                    dir_fd=parent_descriptor,
+                )
+            except FileNotFoundError:
+                pass
+            except OSError as error:
+                raise RestartContextFileError(
+                    f"failed to remove restart-context invalidation for {self.path}"
                 ) from error
             self._fsync_directory(parent_descriptor)
             return True
@@ -3286,18 +3420,19 @@ class RestartContextFile:
         finally:
             os.close(descriptor)
 
-    def _read_invalidated_token(
+    def _is_invalidated(
         self,
         parent_descriptor: int,
-    ) -> _RestartContextCleanupToken | None:
+        cleanup_token: _RestartContextCleanupToken,
+    ) -> bool:
         encoded = self._read_encoded(
             parent_descriptor,
             missing_ok=True,
-            name=self._invalidation_name,
+            name=self._invalidation_name(cleanup_token),
             maximum_bytes=_MAX_CONTEXT_INVALIDATION_BYTES,
         )
         if encoded is None:
-            return None
+            return False
         try:
             value = json.loads(
                 encoded,
@@ -3310,7 +3445,7 @@ class RestartContextFile:
                 or value["schema_version"] != _CONTEXT_INVALIDATION_SCHEMA_VERSION
             ):
                 raise RestartContextFileError("restart-context invalidation marker is malformed")
-            return self._validate_cleanup_token(value["cleanup_token"])
+            return self._validate_cleanup_token(value["cleanup_token"]) == cleanup_token
         except _DuplicateJsonFieldError as error:
             raise RestartContextFileError(str(error)) from error
         except RestartContextFileError:
@@ -3483,9 +3618,9 @@ class RestartContextFile:
             f"failed to allocate a temporary restart context for {self.path}"
         )
 
-    @property
-    def _invalidation_name(self) -> str:
-        return f".{self.path.name}.invalidated"
+    def _invalidation_name(self, cleanup_token: _RestartContextCleanupToken) -> str:
+        self._validate_cleanup_token(cleanup_token)
+        return f".{self.path.name}.invalidated-{cleanup_token}"
 
     @staticmethod
     def _validate_owned_private_file(metadata: os.stat_result) -> None:

--- a/tests/unit/test_torchrun_control_store.py
+++ b/tests/unit/test_torchrun_control_store.py
@@ -382,6 +382,19 @@ def test_control_store_time_window_rejects_backward_clock():
     assert store.get("run/control") == created
 
 
+def test_control_store_observes_time_without_consuming_a_mutation():
+    clock = ManualClock(100)
+    store = InMemoryControlStore(clock=clock)
+
+    assert store.observe_time_unix_ms() == 100
+    created = store.compare_set("run/control", expected_revision=None, value=b"one")
+    assert created.transaction_sequence == 1
+
+    clock.now_unix_ms = 99
+    with pytest.raises(ControlStoreClockError, match="backward"):
+        store.observe_time_unix_ms()
+
+
 def test_control_store_guarded_delete_uses_same_time_window():
     clock = ManualClock(100)
     store = InMemoryControlStore(clock=clock)

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import fcntl
 import os
 import queue
 import stat
@@ -796,19 +797,19 @@ def test_restart_context_file_writes_reads_replaces_and_clears(tmp_path: Path):
     context_file.clear()
 
 
-def test_restart_context_file_clears_only_the_written_file_version(
+def test_restart_context_file_clears_only_the_matching_cleanup_token(
     tmp_path: Path,
 ):
     path = tmp_path / "private" / "restart-context.json"
     context_file = RestartContextFile(path)
 
-    first_version = context_file.write(_context())
-    second_context = _context(plan_id="plan-2")
-    second_version = context_file.write(second_context)
+    first_token = context_file.write(_context())
+    second_token = context_file.write(_context())
 
-    assert context_file.clear_if_version(first_version) is False
-    assert context_file.read() == second_context
-    assert context_file.clear_if_version(second_version) is True
+    assert first_token != second_token
+    assert context_file.clear_if_token(first_token) is False
+    assert context_file.read() == _context()
+    assert context_file.clear_if_token(second_token) is True
     assert not path.exists()
 
 
@@ -1002,6 +1003,25 @@ def test_restart_context_file_clear_accepts_missing_parent(tmp_path: Path):
     RestartContextFile(path).clear()
 
     assert not path.parent.exists()
+
+
+def test_restart_context_file_lock_acquisition_is_bounded(tmp_path: Path):
+    path = tmp_path / "private" / "restart-context.json"
+    path.parent.mkdir(mode=0o700)
+    directory_descriptor = os.open(path.parent, os.O_RDONLY)
+    try:
+        fcntl.flock(directory_descriptor, fcntl.LOCK_EX)
+
+        with pytest.raises(RestartContextFileError, match="timed out locking"):
+            RestartContextFile(path).write(
+                _context(),
+                deadline=time.monotonic() + 0.03,
+            )
+    finally:
+        fcntl.flock(directory_descriptor, fcntl.LOCK_UN)
+        os.close(directory_descriptor)
+
+    assert not path.exists()
 
 
 @pytest.mark.parametrize("path", [Path("relative.json"), cast(Any, "not-a-path")])
@@ -2158,10 +2178,14 @@ def test_slot_aware_handler_does_not_publish_arrival_before_context_cleanup(
     )
     original_clear = RestartContextFile.clear
 
-    def fail_peer_clear(context_file: RestartContextFile) -> None:
+    def fail_peer_clear(
+        context_file: RestartContextFile,
+        *,
+        deadline: float | None = None,
+    ) -> None:
         if context_file.path == peer._config.restart_context_path:
             raise RestartContextFileError("injected context cleanup failure")
-        original_clear(context_file)
+        original_clear(context_file, deadline=deadline)
 
     monkeypatch.setattr(RestartContextFile, "clear", fail_peer_clear)
     peer_thread, peer_outcome = _start_rendezvous(peer)
@@ -3003,6 +3027,7 @@ def test_slot_aware_handler_never_partially_admits_replacement_after_deadline(
         handler._prepare_restart_context(
             cast(Any, handler._read_generation()),
             recovery_state,
+            deadline,
         )
     generation = handlers[0]._read_generation()
     assert generation is not None
@@ -3255,11 +3280,16 @@ def test_slot_aware_handler_clears_context_when_publication_fails_after_replace(
     )
     original_write = RestartContextFile.write
 
-    def publish_then_fail(context_file: RestartContextFile, context: RestartContext) -> None:
-        version = original_write(context_file, context)
+    def publish_then_fail(
+        context_file: RestartContextFile,
+        context: RestartContext,
+        *,
+        deadline: float | None = None,
+    ) -> None:
+        token = original_write(context_file, context, deadline=deadline)
         raise RestartContextFileError(
             "injected post-publication failure",
-            published_version=version,
+            published_token=token,
         )
 
     monkeypatch.setattr(RestartContextFile, "write", publish_then_fail)
@@ -3343,6 +3373,31 @@ def test_slot_aware_handler_rejects_replacement_clock_behind_publication(
         handler._replacement_deadline(cast(Any, recovery_state), None)
 
 
+def test_slot_aware_handler_uses_authoritative_store_time_for_replacement_deadline(
+    tmp_path: Path,
+):
+    client_clock = ManualClock(1_000)
+    store_clock = ManualClock(1_100)
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=InMemoryControlStore(clock=store_clock),
+        clock=client_clock,
+        agent_id="agent-b",
+    )
+    recovery_state = _static_recovery_state(
+        _replacement_plan(restart_deadline_unix_ms=1_050),
+        committed_at_unix_ms=1_000,
+    )
+
+    with pytest.raises(RendezvousTimeoutError):
+        handler._replacement_deadline(cast(Any, recovery_state), None)
+
+
 def test_slot_aware_handler_rejects_clock_regression_and_retains_first_deadline(
     tmp_path: Path,
 ):
@@ -3364,7 +3419,10 @@ def test_slot_aware_handler_rejects_clock_regression_and_retains_first_deadline(
     deadline = handler._replacement_deadline(cast(Any, recovery_state), None)
 
     clock.set(clock() - 1)
-    with pytest.raises(RendezvousConnectionError, match="clock regressed"):
+    with pytest.raises(
+        RendezvousConnectionError,
+        match="authoritative replacement rendezvous time",
+    ):
         handler._validate_replacement_deadline(cast(Any, recovery_state), deadline)
 
     clock.set(1_000)

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -837,6 +837,24 @@ def test_restart_context_file_invalidates_context_while_directory_lock_is_held(
         os.close(directory)
 
 
+def test_restart_context_file_preserves_every_invalidated_token(
+    tmp_path: Path,
+):
+    path = tmp_path / "private" / "restart-context.json"
+    context_file = RestartContextFile(path)
+    old_token = context_file.write(_context(plan_id="plan-old"))
+    current_token = context_file.write(_context(plan_id="plan-current"))
+
+    context_file.invalidate(current_token)
+    context_file.invalidate(old_token)
+
+    with pytest.raises(RestartContextFileError, match="invalidated"):
+        context_file.read()
+
+    context_file.write(_context(plan_id="plan-new"))
+    assert context_file.read() == _context(plan_id="plan-new")
+
+
 def test_restart_context_file_preserves_previous_value_when_replace_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1212,6 +1230,40 @@ def _seed_assigned_arrival(
     threading.Thread(target=complete_attempt, daemon=True).start()
 
 
+def _stub_replacement_return_evidence(
+    handler: SlotAwareRendezvousHandler,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    slot: int = 0,
+) -> tuple[object, object]:
+    with handler._registration_lock:
+        registration = handler._registration
+    assert registration is not None
+    completion = object()
+    admission = object()
+    consumption = SimpleNamespace(revision=101, transaction_sequence=202)
+    monkeypatch.setattr(
+        handler,
+        "_validate_replacement_admission_entry",
+        lambda *_args, **_kwargs: {
+            str(slot): {
+                "agent_id": registration.record.agent_identity.agent_id,
+                "consumption_revision": consumption.revision,
+                "consumption_transaction_sequence": consumption.transaction_sequence,
+                "node_id": registration.record.agent_identity.node_id,
+                "registration_id": registration.record.registration_id,
+                "registration_revision": registration.fencing_token,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        handler,
+        "_read_arrival_consumption",
+        lambda *_args, **_kwargs: consumption,
+    )
+    return completion, admission
+
+
 def test_slot_aware_handler_refreshes_leader_registration_before_completion(
     tmp_path: Path,
 ):
@@ -1364,7 +1416,7 @@ def test_slot_aware_handler_admits_initial_assignment_with_stable_rank(
         max_nodes=3,
     )
     context_file = RestartContextFile(config.restart_context_path)
-    context_file.write(_context())
+    context_file.write(replace(_context(), run_id="previous-run"))
     handler = _handler(
         config,
         store=store,
@@ -2200,18 +2252,19 @@ def test_slot_aware_handler_does_not_publish_arrival_before_context_cleanup(
         clock=clock,
         agent_id="agent-a",
     )
-    original_clear = RestartContextFile.clear
+    original_clear = RestartContextFile.clear_stale_for_run
 
     def fail_peer_clear(
         context_file: RestartContextFile,
+        run_id: str,
         *,
         deadline: float | None = None,
-    ) -> None:
+    ) -> bool:
         if context_file.path == peer._config.restart_context_path:
             raise RestartContextFileError("injected context cleanup failure")
-        original_clear(context_file, deadline=deadline)
+        return original_clear(context_file, run_id, deadline=deadline)
 
-    monkeypatch.setattr(RestartContextFile, "clear", fail_peer_clear)
+    monkeypatch.setattr(RestartContextFile, "clear_stale_for_run", fail_peer_clear)
     peer_thread, peer_outcome = _start_rendezvous(peer)
 
     with pytest.raises(RendezvousTimeoutError):
@@ -2228,6 +2281,38 @@ def test_slot_aware_handler_does_not_publish_arrival_before_context_cleanup(
     assert store.get(leader._arrival_key(0, attempt, 1)) is None
     assert leader.shutdown() is True
     assert peer.shutdown() is True
+
+
+def test_slot_aware_handler_refuses_to_clear_current_run_context_for_initial_generation(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    _, _, current = _initialize_generation(store, clock, ("node-a",))
+    config = _handler_config(
+        tmp_path,
+        node_id="node-a",
+        min_nodes=1,
+        max_nodes=2,
+    )
+    context_file = RestartContextFile(config.restart_context_path)
+    context_file.write(_context())
+    handler = _handler(
+        config,
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+
+    with pytest.raises(RendezvousStateError, match="stale initial restart context"):
+        handler._prepare_restart_context(
+            current,
+            None,
+            time.monotonic() + 1,
+        )
+
+    assert context_file.read() == _context()
+    assert handler.shutdown() is True
 
 
 def test_slot_aware_handler_reads_registration_histories_linearly(
@@ -3373,6 +3458,64 @@ def test_slot_aware_handler_clears_replacement_context_after_admission_failure(
     assert handler.shutdown() is True
 
 
+def test_slot_aware_handler_always_cleans_registration_when_context_cleanup_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=InMemoryControlStore(clock=clock),
+        clock=clock,
+        agent_id="agent-b",
+    )
+    cleanup_token = "a" * 64
+    cleaned = False
+    current = SimpleNamespace()
+    monkeypatch.setattr(handler, "_is_closed_bounded", lambda _deadline: False)
+    monkeypatch.setattr(handler, "_ensure_registered", lambda _deadline: None)
+    monkeypatch.setattr(handler, "_read_generation", lambda: current)
+    monkeypatch.setattr(
+        handler,
+        "_generation_admission",
+        lambda *_args: (0, object(), time.monotonic() + 1),
+    )
+    monkeypatch.setattr(
+        handler,
+        "_prepare_restart_context",
+        lambda *_args: cleanup_token,
+    )
+    monkeypatch.setattr(
+        handler,
+        "_wait_for_assigned_arrivals",
+        lambda *_args: (_ for _ in ()).throw(
+            RendezvousConnectionError("original admission failure")
+        ),
+    )
+    monkeypatch.setattr(
+        handler,
+        "_invalidate_and_clear_restart_context",
+        lambda _token: (_ for _ in ()).throw(RendezvousStateError("context cleanup failure")),
+    )
+
+    def cleanup() -> bool:
+        nonlocal cleaned
+        cleaned = True
+        return True
+
+    monkeypatch.setattr(handler, "_cleanup_local_resources", cleanup)
+
+    with pytest.raises(RendezvousConnectionError, match="original admission failure"):
+        handler.next_rendezvous()
+
+    assert cleaned is True
+
+
 def test_slot_aware_handler_invalidates_context_when_cleanup_cannot_lock(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -3555,16 +3698,122 @@ def test_slot_aware_handler_rechecks_deadline_before_returning_admission(
         validate_after_blocking_work,
     )
     monkeypatch.setattr(handler, "_validate_current_arrival_attempt", lambda *_args: None)
+    completion, admission = _stub_replacement_return_evidence(
+        handler,
+        monkeypatch,
+    )
 
     with pytest.raises(RendezvousTimeoutError):
         handler._validate_replacement_return(
             cast(Any, object()),
             assignment,
             1,
+            0,
+            cast(Any, completion),
+            cast(Any, admission),
             cast(Any, recovery_state),
             deadline,
         )
     assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_binds_admission_to_returning_registration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=InMemoryControlStore(clock=clock),
+        clock=clock,
+        agent_id="agent-b",
+    )
+    handler._ensure_registered(time.monotonic() + 1)
+    with handler._registration_lock:
+        registration = handler._registration
+    assert registration is not None
+    plan = _replacement_plan()
+    assignment = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=1,
+        assignments=plan.slot_assignments,
+        topology_digest=plan.topology_digest,
+    )
+    monkeypatch.setattr(handler, "_validate_final_admission_state", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        handler,
+        "_validate_replacement_admission_entry",
+        lambda *_a, **_k: {
+            "0": {
+                "agent_id": "old-agent-b",
+                "consumption_revision": 10,
+                "consumption_transaction_sequence": 11,
+                "node_id": "node-b",
+                "registration_id": "old-registration",
+                "registration_revision": registration.fencing_token,
+            }
+        },
+    )
+
+    with pytest.raises(
+        RendezvousConnectionError,
+        match="does not include this agent registration",
+    ):
+        handler._validate_replacement_return(
+            cast(Any, object()),
+            assignment,
+            1,
+            0,
+            cast(Any, object()),
+            cast(Any, object()),
+            cast(Any, _static_recovery_state(plan)),
+            time.monotonic() + 1,
+        )
+
+    assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_treats_missing_peer_registration_as_not_ready(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=InMemoryControlStore(clock=clock),
+        clock=clock,
+        agent_id="agent-a",
+    )
+    assignment = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=1,
+        assignments=(SlotAssignment(0, "node-b", 0, 2),),
+        topology_digest="topology-v1",
+    )
+    monkeypatch.setattr(
+        handler,
+        "_try_current_assigned_registration",
+        lambda _node_id: None,
+    )
+
+    assert (
+        handler._arrival_consumption_state(
+            assignment,
+            1,
+            cast(Any, object()),
+        )
+        is None
+    )
 
 
 def test_slot_aware_handler_requires_live_registration_before_returning_admission(
@@ -3614,6 +3863,10 @@ def test_slot_aware_handler_requires_live_registration_before_returning_admissio
         assignments=plan.slot_assignments,
         topology_digest=plan.topology_digest,
     )
+    completion, admission = _stub_replacement_return_evidence(
+        handler,
+        monkeypatch,
+    )
 
     with pytest.raises(
         RendezvousConnectionError,
@@ -3623,6 +3876,9 @@ def test_slot_aware_handler_requires_live_registration_before_returning_admissio
             cast(Any, object()),
             assignment,
             1,
+            0,
+            cast(Any, completion),
+            cast(Any, admission),
             cast(Any, _static_recovery_state(plan)),
             deadline,
         )
@@ -3657,6 +3913,10 @@ def test_slot_aware_handler_uses_authoritative_time_for_final_registration_expir
     )
     monkeypatch.setattr(handler, "_validate_final_admission_state", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(handler, "_validate_current_arrival_attempt", lambda *_args: None)
+    completion, admission = _stub_replacement_return_evidence(
+        handler,
+        monkeypatch,
+    )
     store_clock.advance(handler._config.policy.registration_lease_duration_ms)
 
     with pytest.raises(
@@ -3667,6 +3927,9 @@ def test_slot_aware_handler_uses_authoritative_time_for_final_registration_expir
             cast(Any, object()),
             assignment,
             1,
+            0,
+            cast(Any, completion),
+            cast(Any, admission),
             cast(Any, _static_recovery_state(plan)),
             time.monotonic() + 1,
         )
@@ -3711,6 +3974,10 @@ def test_slot_aware_handler_rejects_advanced_attempt_before_returning_admission(
         ),
     )
     monkeypatch.setattr(handler, "_validate_final_admission_state", lambda *_args, **_kwargs: None)
+    completion, admission = _stub_replacement_return_evidence(
+        handler,
+        monkeypatch,
+    )
 
     with pytest.raises(
         RendezvousStateError,
@@ -3720,6 +3987,9 @@ def test_slot_aware_handler_rejects_advanced_attempt_before_returning_admission(
             cast(Any, object()),
             assignment,
             1,
+            0,
+            cast(Any, completion),
+            cast(Any, admission),
             cast(Any, _static_recovery_state(plan)),
             time.monotonic() + 1,
         )

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -58,7 +58,7 @@ POLICY = """\
 schema_version = 1
 control_endpoint = "control.example:443"
 replacement_only = true
-max_replacement_generations = 2
+max_replacement_generations = 1
 registration_lease_duration_ms = 30000
 poll_interval_ms = 1000
 join_timeout_ms = 300000
@@ -77,6 +77,10 @@ class ManualClock:
     def advance(self, duration_ms: int) -> None:
         with self._lock:
             self._now_unix_ms += duration_ms
+
+    def set(self, now_unix_ms: int) -> None:
+        with self._lock:
+            self._now_unix_ms = now_unix_ms
 
 
 class ManualMonotonicClock:
@@ -153,9 +157,22 @@ def _context(*, plan_id: str = "plan-1") -> RestartContext:
 class StaticRecoveryStateReader:
     def __init__(self, state: object) -> None:
         self._state = state
+        self.calls = 0
 
     def read_recovery_state(self) -> object:
+        self.calls += 1
         return self._state
+
+
+def _static_recovery_state(
+    plan: RestartPlan,
+    *,
+    committed_at_unix_ms: int = 1_000,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        plan=plan,
+        publication=SimpleNamespace(committed_at_unix_ms=committed_at_unix_ms),
+    )
 
 
 def _replacement_plan(
@@ -194,7 +211,7 @@ def test_runtime_config_loads_shared_policy_and_node_inputs(tmp_path: Path):
     )
 
     assert config.policy.control_endpoint == "control.example:443"
-    assert config.policy.max_replacement_generations == 2
+    assert config.policy.max_replacement_generations == 1
     assert (
         config.policy.digest
         == TorchrunRendezvousPolicy(
@@ -220,7 +237,7 @@ def test_runtime_config_digest_ignores_toml_formatting_and_node_inputs(tmp_path:
 join_timeout_ms=300000
 poll_interval_ms=1000
 registration_lease_duration_ms=30000
-max_replacement_generations=2
+max_replacement_generations=1
 replacement_only=true
 control_endpoint="control.example:443"
 schema_version=1
@@ -451,7 +468,7 @@ def test_runtime_config_rendezvous_overrides_change_resolved_policy(tmp_path: Pa
         _parameters(
             source,
             control_endpoint="override.example:8443",
-            max_replacement_generations="4",
+            max_replacement_generations="1",
             registration_lease_duration_ms="45000",
             poll_interval_ms="500",
             join_timeout_ms="120000",
@@ -461,7 +478,7 @@ def test_runtime_config_rendezvous_overrides_change_resolved_policy(tmp_path: Pa
     )
 
     assert config.policy.control_endpoint == "override.example:8443"
-    assert config.policy.max_replacement_generations == 4
+    assert config.policy.max_replacement_generations == 1
     assert config.policy.registration_lease_duration_ms == 45_000
     assert config.policy.poll_interval_ms == 500
     assert config.policy.join_timeout_ms == 120_000
@@ -493,6 +510,10 @@ def test_runtime_config_rendezvous_overrides_change_resolved_policy(tmp_path: Pa
         (
             'schema_version = 1\ncontrol_endpoint = "control"\nmax_replacement_generations = 1.5\n',
             "max_replacement_generations",
+        ),
+        (
+            'schema_version = 1\ncontrol_endpoint = "control"\nmax_replacement_generations = 2\n',
+            "exactly one replacement generation",
         ),
     ],
 )
@@ -2896,7 +2917,7 @@ def test_slot_aware_handler_admits_replacement_and_writes_restart_context(
         clock=clock,
         agent_id="agent-b",
     )
-    state = SimpleNamespace(plan=plan)
+    state = _static_recovery_state(plan)
     handler._publication_reader = cast(Any, StaticRecoveryStateReader(state))
 
     rendezvous = handler.next_rendezvous()
@@ -2935,7 +2956,7 @@ def test_slot_aware_handler_gives_selected_standby_a_fresh_formation_deadline(
     )
     handler._publication_reader = cast(
         Any,
-        StaticRecoveryStateReader(SimpleNamespace(plan=plan)),
+        StaticRecoveryStateReader(_static_recovery_state(plan)),
     )
     thread, outcome = _start_rendezvous(handler)
     _wait_until(
@@ -2969,6 +2990,55 @@ def test_slot_aware_handler_gives_selected_standby_a_fresh_formation_deadline(
     assert handler.shutdown() is True
 
 
+def test_slot_aware_handler_keeps_unselected_standby_outside_plan_deadline(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    manager, lease, current = _initialize_generation(store, clock, ("node-a",))
+    plan = _replacement_plan(restart_deadline_unix_ms=clock())
+    successor = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=1,
+        assignments=plan.slot_assignments,
+        topology_digest=plan.topology_digest,
+    )
+    manager.commit_successor(lease, current, successor)
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-c",
+            min_nodes=1,
+            max_nodes=3,
+            join_timeout_ms=50,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-c",
+    )
+    recovery_reader = StaticRecoveryStateReader(_static_recovery_state(plan))
+    handler._publication_reader = cast(Any, recovery_reader)
+
+    thread, outcome = _start_rendezvous(handler)
+    _wait_until(
+        lambda: (
+            AgentRegistrationReader(
+                store,
+                run_id=RUN_ID,
+                clock=clock,
+            ).get("node-c")
+            is not None
+        )
+    )
+    time.sleep(0.08)
+
+    assert thread.is_alive()
+    assert recovery_reader.calls == 0
+    assert handler.shutdown() is True
+    thread.join(timeout=2)
+    assert isinstance(outcome.get_nowait(), RendezvousClosedError)
+
+
 def test_slot_aware_handler_rejects_expired_replacement_without_leaving_context(
     tmp_path: Path,
 ):
@@ -2997,10 +3067,56 @@ def test_slot_aware_handler_rejects_expired_replacement_without_leaving_context(
     )
     handler._publication_reader = cast(
         Any,
-        StaticRecoveryStateReader(SimpleNamespace(plan=plan)),
+        StaticRecoveryStateReader(_static_recovery_state(plan)),
     )
 
     with pytest.raises(RendezvousTimeoutError):
+        handler.next_rendezvous()
+
+    assert not config.restart_context_path.exists()
+    assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_clears_context_when_publication_fails_after_replace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    manager, lease, current = _initialize_generation(store, clock, ("node-a",))
+    plan = _replacement_plan()
+    successor = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=1,
+        assignments=plan.slot_assignments,
+        topology_digest=plan.topology_digest,
+    )
+    manager.commit_successor(lease, current, successor)
+    config = _handler_config(
+        tmp_path,
+        node_id="node-b",
+        min_nodes=1,
+        max_nodes=2,
+    )
+    handler = _handler(
+        config,
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+    )
+    handler._publication_reader = cast(
+        Any,
+        StaticRecoveryStateReader(_static_recovery_state(plan)),
+    )
+    original_write = RestartContextFile.write
+
+    def publish_then_fail(context_file: RestartContextFile, context: RestartContext) -> None:
+        original_write(context_file, context)
+        raise RestartContextFileError("injected post-publication failure")
+
+    monkeypatch.setattr(RestartContextFile, "write", publish_then_fail)
+
+    with pytest.raises(RendezvousStateError, match="publish the replacement restart context"):
         handler.next_rendezvous()
 
     assert not config.restart_context_path.exists()
@@ -3036,7 +3152,7 @@ def test_slot_aware_handler_clears_replacement_context_after_admission_failure(
     )
     handler._publication_reader = cast(
         Any,
-        StaticRecoveryStateReader(SimpleNamespace(plan=plan)),
+        StaticRecoveryStateReader(_static_recovery_state(plan)),
     )
 
     def fail_after_context(*_args: object) -> object:
@@ -3053,6 +3169,60 @@ def test_slot_aware_handler_clears_replacement_context_after_admission_failure(
 
     assert not config.restart_context_path.exists()
     assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_rejects_replacement_clock_behind_publication(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=InMemoryControlStore(clock=clock),
+        clock=clock,
+        agent_id="agent-b",
+    )
+    recovery_state = _static_recovery_state(
+        _replacement_plan(),
+        committed_at_unix_ms=clock() + 1,
+    )
+
+    with pytest.raises(RendezvousConnectionError, match="clock regressed"):
+        handler._replacement_deadline(cast(Any, recovery_state), None)
+
+
+def test_slot_aware_handler_rejects_clock_regression_and_retains_first_deadline(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    monotonic_clock = ManualMonotonicClock()
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=InMemoryControlStore(clock=clock),
+        clock=clock,
+        agent_id="agent-b",
+        monotonic_clock=monotonic_clock,
+    )
+    recovery_state = _static_recovery_state(_replacement_plan())
+    deadline = handler._replacement_deadline(cast(Any, recovery_state), None)
+
+    clock.set(clock() - 1)
+    with pytest.raises(RendezvousConnectionError, match="clock regressed"):
+        handler._validate_replacement_deadline(cast(Any, recovery_state), deadline)
+
+    clock.set(1_000)
+    monotonic_clock.advance(deadline)
+    with pytest.raises(RendezvousTimeoutError):
+        handler._validate_replacement_deadline(cast(Any, recovery_state), deadline)
 
 
 def test_slot_aware_handler_rejects_assignment_size_mismatch(tmp_path: Path):

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -79,6 +79,20 @@ class ManualClock:
             self._now_unix_ms += duration_ms
 
 
+class ManualMonotonicClock:
+    def __init__(self) -> None:
+        self._now = 0.0
+        self._lock = threading.Lock()
+
+    def __call__(self) -> float:
+        with self._lock:
+            return self._now
+
+    def advance(self, duration_seconds: float) -> None:
+        with self._lock:
+            self._now += duration_seconds
+
+
 def _write_policy(path: Path, content: str = POLICY) -> Path:
     path.write_text(content, encoding="utf-8")
     return path
@@ -2901,6 +2915,7 @@ def test_slot_aware_handler_gives_selected_standby_a_fresh_formation_deadline(
     tmp_path: Path,
 ):
     clock = ManualClock()
+    monotonic_clock = ManualMonotonicClock()
     store = InMemoryControlStore(clock=clock)
     manager, lease, current = _initialize_generation(store, clock, ("node-a",))
     plan = _replacement_plan()
@@ -2916,6 +2931,7 @@ def test_slot_aware_handler_gives_selected_standby_a_fresh_formation_deadline(
         store=store,
         clock=clock,
         agent_id="agent-b",
+        monotonic_clock=monotonic_clock,
     )
     handler._publication_reader = cast(
         Any,
@@ -2932,7 +2948,7 @@ def test_slot_aware_handler_gives_selected_standby_a_fresh_formation_deadline(
             is not None
         )
     )
-    time.sleep(0.08)
+    monotonic_clock.advance(0.08)
     successor = RankAssignment.from_assignments(
         run_id=RUN_ID,
         generation=1,

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -949,6 +949,31 @@ def test_restart_context_file_preserves_previous_value_when_replace_fails(
     assert list(path.parent.glob(f".{path.name}.*.tmp")) == []
 
 
+def test_restart_context_file_removes_orphaned_metadata_durably(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    path = tmp_path / "private" / "restart-context.json"
+    context_file = RestartContextFile(path)
+    context_file.write(_context())
+    path.unlink()
+    metadata_path = path.parent / context_file._metadata_name()
+    assert metadata_path.exists()
+    sync_count = 0
+    original_fsync = RestartContextFile._fsync_directory
+
+    def record_fsync(descriptor: int) -> None:
+        nonlocal sync_count
+        sync_count += 1
+        original_fsync(descriptor)
+
+    monkeypatch.setattr(RestartContextFile, "_fsync_directory", staticmethod(record_fsync))
+
+    assert context_file.clear_stale_for_run(RUN_ID) is True
+    assert not metadata_path.exists()
+    assert sync_count == 1
+
+
 def test_restart_context_file_rejects_oversized_value_before_replace(tmp_path: Path):
     path = tmp_path / "private" / "restart-context.json"
     context_file = RestartContextFile(path)

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -855,6 +855,19 @@ def test_restart_context_file_preserves_every_invalidated_token(
     assert context_file.read() == _context(plan_id="plan-new")
 
 
+def test_restart_context_file_invalidates_long_valid_basename(
+    tmp_path: Path,
+):
+    path = tmp_path / "private" / ("c" * 180)
+    context_file = RestartContextFile(path)
+    cleanup_token = context_file.write(_context())
+
+    context_file.invalidate(cleanup_token)
+
+    with pytest.raises(RestartContextFileError, match="invalidated"):
+        context_file.read()
+
+
 def test_restart_context_file_preserves_previous_value_when_replace_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -3080,6 +3093,108 @@ def test_slot_aware_handler_admits_replacement_and_writes_restart_context(
     admission = store.get(handler._arrival_admission_key(1, 1))
     assert admission is not None
     assert handler.num_nodes_waiting() == 0
+    assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_waits_for_return_ack_before_advancing_attempt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    manager, lease, current = _initialize_generation(store, clock, ("node-a",))
+    plan = _replacement_plan()
+    successor = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=1,
+        assignments=plan.slot_assignments,
+        topology_digest=plan.topology_digest,
+    )
+    manager.commit_successor(lease, current, successor)
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+    )
+    handler._publication_reader = cast(
+        Any,
+        StaticRecoveryStateReader(_static_recovery_state(plan)),
+    )
+    reached_return_ack = threading.Event()
+    release_return_ack = threading.Event()
+    original_publish = handler._publish_replacement_return_acknowledgement
+
+    def delay_return_ack(*args: Any, **kwargs: Any) -> Any:
+        reached_return_ack.set()
+        assert release_return_ack.wait(timeout=2)
+        return original_publish(*args, **kwargs)
+
+    monkeypatch.setattr(
+        handler,
+        "_publish_replacement_return_acknowledgement",
+        delay_return_ack,
+    )
+    thread, outcome = _start_rendezvous(handler)
+    assert reached_return_ack.wait(timeout=2)
+    current_generation = handler._read_generation()
+    assert current_generation is not None
+    attempt_entry = store.get(handler._arrival_attempt_key(1))
+    completion = store.get(handler._arrival_completion_key(1, 1))
+    assert attempt_entry is not None
+    assert completion is not None
+    with handler._registration_lock:
+        registration = handler._registration
+    assert registration is not None
+
+    assert (
+        handler._advance_arrival_attempt(
+            successor,
+            attempt_entry,
+            1,
+            2,
+            handler._arrival_attempt_value(
+                generation=1,
+                attempt=2,
+                registration=registration,
+            ),
+            registration,
+            completion,
+        )
+        is None
+    )
+    release_return_ack.set()
+    thread.join(timeout=2)
+    assert not thread.is_alive()
+    assert isinstance(outcome.get_nowait(), RendezvousInfo)
+
+    advanced = handler._advance_arrival_attempt(
+        successor,
+        attempt_entry,
+        1,
+        2,
+        handler._arrival_attempt_value(
+            generation=1,
+            attempt=2,
+            registration=registration,
+        ),
+        registration,
+        completion,
+    )
+
+    assert advanced is not None
+    attempt, _, _ = handler._validate_arrival_attempt_entry(
+        advanced,
+        generation=1,
+        expected_attempt=2,
+        leader_node_id="node-b",
+    )
+    assert attempt == 2
     assert handler.shutdown() is True
 
 

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -796,6 +796,22 @@ def test_restart_context_file_writes_reads_replaces_and_clears(tmp_path: Path):
     context_file.clear()
 
 
+def test_restart_context_file_clears_only_the_written_file_version(
+    tmp_path: Path,
+):
+    path = tmp_path / "private" / "restart-context.json"
+    context_file = RestartContextFile(path)
+
+    first_version = context_file.write(_context())
+    second_context = _context(plan_id="plan-2")
+    second_version = context_file.write(second_context)
+
+    assert context_file.clear_if_version(first_version) is False
+    assert context_file.read() == second_context
+    assert context_file.clear_if_version(second_version) is True
+    assert not path.exists()
+
+
 def test_restart_context_file_preserves_previous_value_when_replace_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -3240,8 +3256,11 @@ def test_slot_aware_handler_clears_context_when_publication_fails_after_replace(
     original_write = RestartContextFile.write
 
     def publish_then_fail(context_file: RestartContextFile, context: RestartContext) -> None:
-        original_write(context_file, context)
-        raise RestartContextFileError("injected post-publication failure")
+        version = original_write(context_file, context)
+        raise RestartContextFileError(
+            "injected post-publication failure",
+            published_version=version,
+        )
 
     monkeypatch.setattr(RestartContextFile, "write", publish_then_fail)
 
@@ -3352,6 +3371,95 @@ def test_slot_aware_handler_rejects_clock_regression_and_retains_first_deadline(
     monotonic_clock.advance(deadline)
     with pytest.raises(RendezvousTimeoutError):
         handler._validate_replacement_deadline(cast(Any, recovery_state), deadline)
+
+
+def test_slot_aware_handler_rechecks_deadline_before_returning_admission(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    monotonic_clock = ManualMonotonicClock()
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=InMemoryControlStore(clock=clock),
+        clock=clock,
+        agent_id="agent-b",
+        monotonic_clock=monotonic_clock,
+    )
+    recovery_state = _static_recovery_state(
+        _replacement_plan(restart_deadline_unix_ms=clock() + 50)
+    )
+    deadline = monotonic_clock() + 0.05
+    monkeypatch.setattr(
+        handler,
+        "_validate_final_admission_state",
+        lambda _current, state, final_deadline: handler._validate_replacement_deadline(
+            state,
+            final_deadline,
+        ),
+    )
+
+    clock.advance(50)
+    monotonic_clock.advance(0.05)
+
+    with pytest.raises(RendezvousTimeoutError):
+        handler._validate_replacement_return(
+            cast(Any, object()),
+            cast(Any, recovery_state),
+            deadline,
+        )
+
+
+def test_slot_aware_handler_requires_live_registration_before_returning_admission(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+    )
+    deadline = time.monotonic() + 1
+    handler._ensure_registered(deadline)
+    with handler._registration_lock:
+        registration = handler._registration
+    assert registration is not None
+    assert handler._stop_heartbeat() is True
+    handler._registration_manager.release(registration)
+    replacement_manager = AgentRegistrationManager(
+        store,
+        agent_identity=replace(
+            handler.agent_identity,
+            agent_id="replacement-agent-b",
+        ),
+        lease_duration_ms=handler._config.policy.registration_lease_duration_ms,
+        clock=clock,
+    )
+    replacement_manager.register()
+    monkeypatch.setattr(handler, "_validate_final_admission_state", lambda *_args: None)
+
+    with pytest.raises(
+        RendezvousConnectionError,
+        match="registration changed before admission",
+    ):
+        handler._validate_replacement_return(
+            cast(Any, object()),
+            cast(Any, _static_recovery_state(_replacement_plan())),
+            deadline,
+        )
 
 
 def test_slot_aware_handler_rejects_assignment_size_mismatch(tmp_path: Path):

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -10,6 +10,7 @@ import time
 from dataclasses import replace
 from datetime import timedelta
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Callable, cast
 
 import pytest
@@ -38,6 +39,7 @@ from lm_resiliency.integrations.torchrun._protocol import (
     HardwareFaultReport,
     RankAssignment,
     RestartContext,
+    RestartPlan,
     SlotAssignment,
     WorkerIdentity,
     validate_event_reporter,
@@ -131,6 +133,40 @@ def _context(*, plan_id: str = "plan-1") -> RestartContext:
         checkpoint_id=None,
         checkpoint_manifest_id="manifest-40",
         reason_code="attributed_sdc",
+    )
+
+
+class StaticRecoveryStateReader:
+    def __init__(self, state: object) -> None:
+        self._state = state
+
+    def read_recovery_state(self) -> object:
+        return self._state
+
+
+def _replacement_plan(
+    *,
+    node_id: str = "node-b",
+    restart_deadline_unix_ms: int = 5_000,
+) -> RestartPlan:
+    return RestartPlan(
+        plan_id="plan-1",
+        intent_id="intent-1",
+        run_id=RUN_ID,
+        from_generation=0,
+        to_generation=1,
+        incident_ids=("incident-1",),
+        reason_code="attributed_sdc",
+        recovery_mode="latest",
+        checkpoint_source="gemini",
+        checkpoint_step=40,
+        checkpoint_id=None,
+        checkpoint_manifest_id="manifest-40",
+        slot_assignments=(SlotAssignment(0, node_id, 0, 2),),
+        quarantined_node_ids=("node-a",),
+        expected_world_size=2,
+        topology_digest="topology-v1",
+        restart_deadline_unix_ms=restart_deadline_unix_ms,
     )
 
 
@@ -2558,7 +2594,12 @@ def test_slot_aware_handler_rejects_job_wide_environment_drift(tmp_path: Path):
     first._ensure_registered(time.monotonic() + 1)
     current = first._read_generation()
     assert current is not None
-    assert first._initial_slot(current) == 0
+    slot, recovery_state, _ = first._generation_admission(
+        current,
+        time.monotonic() + 1,
+    )
+    assert slot == 0
+    assert recovery_state is None
     with pytest.raises(RendezvousStateError, match="committed workload environment"):
         second.next_rendezvous()
 
@@ -2784,7 +2825,7 @@ def test_slot_aware_handler_cleans_up_registration_on_cancellation(
     assert handler.shutdown() is True
 
 
-def test_slot_aware_handler_rejects_generation_after_initial_assignment(
+def test_slot_aware_handler_rejects_successor_without_restart_plan_publication(
     tmp_path: Path,
 ):
     clock = ManualClock()
@@ -2809,9 +2850,192 @@ def test_slot_aware_handler_rejects_generation_after_initial_assignment(
         agent_id="agent-b",
     )
 
-    with pytest.raises(RendezvousStateError, match="replacement generations"):
+    with pytest.raises(RendezvousStateError, match="restart-plan publication"):
         handler.next_rendezvous()
 
+    assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_admits_replacement_and_writes_restart_context(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    manager, lease, current = _initialize_generation(store, clock, ("node-a",))
+    plan = _replacement_plan()
+    successor = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=1,
+        assignments=plan.slot_assignments,
+        topology_digest=plan.topology_digest,
+    )
+    manager.commit_successor(lease, current, successor)
+    config = _handler_config(
+        tmp_path,
+        node_id="node-b",
+        min_nodes=1,
+        max_nodes=2,
+    )
+    handler = _handler(
+        config,
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+    )
+    state = SimpleNamespace(plan=plan)
+    handler._publication_reader = cast(Any, StaticRecoveryStateReader(state))
+
+    rendezvous = handler.next_rendezvous()
+
+    assert rendezvous.rank == 0
+    assert rendezvous.world_size == 1
+    assert RestartContextFile(config.restart_context_path).read() == RestartContext.from_plan(
+        plan,
+        "node-b",
+    )
+    assert handler.num_nodes_waiting() == 0
+    assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_gives_selected_standby_a_fresh_formation_deadline(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    manager, lease, current = _initialize_generation(store, clock, ("node-a",))
+    plan = _replacement_plan()
+    config = _handler_config(
+        tmp_path,
+        node_id="node-b",
+        min_nodes=1,
+        max_nodes=2,
+        join_timeout_ms=50,
+    )
+    handler = _handler(
+        config,
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+    )
+    handler._publication_reader = cast(
+        Any,
+        StaticRecoveryStateReader(SimpleNamespace(plan=plan)),
+    )
+    thread, outcome = _start_rendezvous(handler)
+    _wait_until(
+        lambda: (
+            AgentRegistrationReader(
+                store,
+                run_id=RUN_ID,
+                clock=clock,
+            ).get("node-b")
+            is not None
+        )
+    )
+    time.sleep(0.08)
+    successor = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=1,
+        assignments=plan.slot_assignments,
+        topology_digest=plan.topology_digest,
+    )
+    manager.commit_successor(lease, current, successor)
+
+    result = outcome.get(timeout=2)
+    thread.join(timeout=2)
+
+    assert isinstance(result, RendezvousInfo)
+    assert result.rank == 0
+    assert RestartContextFile(config.restart_context_path).read() == RestartContext.from_plan(
+        plan,
+        "node-b",
+    )
+    assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_rejects_expired_replacement_without_leaving_context(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    manager, lease, current = _initialize_generation(store, clock, ("node-a",))
+    plan = _replacement_plan(restart_deadline_unix_ms=clock())
+    successor = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=1,
+        assignments=plan.slot_assignments,
+        topology_digest=plan.topology_digest,
+    )
+    manager.commit_successor(lease, current, successor)
+    config = _handler_config(
+        tmp_path,
+        node_id="node-b",
+        min_nodes=1,
+        max_nodes=2,
+    )
+    handler = _handler(
+        config,
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+    )
+    handler._publication_reader = cast(
+        Any,
+        StaticRecoveryStateReader(SimpleNamespace(plan=plan)),
+    )
+
+    with pytest.raises(RendezvousTimeoutError):
+        handler.next_rendezvous()
+
+    assert not config.restart_context_path.exists()
+    assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_clears_replacement_context_after_admission_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    manager, lease, current = _initialize_generation(store, clock, ("node-a",))
+    plan = _replacement_plan()
+    successor = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=1,
+        assignments=plan.slot_assignments,
+        topology_digest=plan.topology_digest,
+    )
+    manager.commit_successor(lease, current, successor)
+    config = _handler_config(
+        tmp_path,
+        node_id="node-b",
+        min_nodes=1,
+        max_nodes=2,
+    )
+    handler = _handler(
+        config,
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+    )
+    handler._publication_reader = cast(
+        Any,
+        StaticRecoveryStateReader(SimpleNamespace(plan=plan)),
+    )
+
+    def fail_after_context(*_args: object) -> object:
+        assert RestartContextFile(config.restart_context_path).read() == RestartContext.from_plan(
+            plan,
+            "node-b",
+        )
+        raise RendezvousConnectionError("injected arrival failure")
+
+    monkeypatch.setattr(handler, "_wait_for_assigned_arrivals", fail_after_context)
+
+    with pytest.raises(RendezvousConnectionError, match="injected arrival failure"):
+        handler.next_rendezvous()
+
+    assert not config.restart_context_path.exists()
     assert handler.shutdown() is True
 
 

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import fcntl
+import json
 import os
 import queue
 import stat
@@ -782,9 +783,11 @@ def test_restart_context_file_writes_reads_replaces_and_clears(tmp_path: Path):
     path = tmp_path / "private" / "restart-context.json"
     context_file = RestartContextFile(path)
 
-    context_file.write(_context())
+    cleanup_token = context_file.write(_context())
 
     assert context_file.read() == _context()
+    assert context_file.read_with_token() == (cleanup_token, _context())
+    assert json.loads(path.read_text(encoding="utf-8")) == _context().to_dict()
     assert stat.S_IMODE(path.parent.stat().st_mode) == 0o700
     assert stat.S_IMODE(path.stat().st_mode) == 0o600
 
@@ -824,9 +827,6 @@ def test_restart_context_file_invalidates_context_while_directory_lock_is_held(
     fcntl.flock(directory, fcntl.LOCK_EX)
     try:
         context_file.invalidate(cleanup_token)
-
-        with pytest.raises(RestartContextFileError, match="invalidated"):
-            context_file.read()
         with pytest.raises(RestartContextFileError, match="timed out locking"):
             context_file.clear_if_token(
                 cleanup_token,
@@ -835,6 +835,9 @@ def test_restart_context_file_invalidates_context_while_directory_lock_is_held(
     finally:
         fcntl.flock(directory, fcntl.LOCK_UN)
         os.close(directory)
+
+    with pytest.raises(RestartContextFileError, match="invalidated"):
+        context_file.read()
 
 
 def test_restart_context_file_preserves_every_invalidated_token(
@@ -947,6 +950,19 @@ def test_restart_context_file_rejects_duplicate_json_fields(tmp_path: Path):
     path.chmod(0o600)
 
     with pytest.raises(RestartContextFileError, match="duplicate field"):
+        context_file.read()
+
+
+def test_restart_context_file_rejects_context_changed_without_metadata(
+    tmp_path: Path,
+):
+    path = tmp_path / "private" / "restart-context.json"
+    context_file = RestartContextFile(path)
+    context_file.write(_context())
+    path.write_text(_context(plan_id="substituted").to_json() + "\n", encoding="utf-8")
+    path.chmod(0o600)
+
+    with pytest.raises(RestartContextFileError, match="metadata does not match"):
         context_file.read()
 
 
@@ -3285,11 +3301,15 @@ def test_slot_aware_handler_never_partially_admits_replacement_after_deadline(
     )
     completion = store.get(handlers[0]._arrival_completion_key(1, attempt))
     assert completion is not None
+    context_tokens = []
     for handler in handlers:
+        context_tokens.append(handler._restart_context.read_with_token()[0])
+    for handler, context_token in zip(handlers, context_tokens, strict=True):
         handler._validate_final_admission_state(
             generation,
             recovery_state,
             deadline,
+            expected_context_token=context_token,
         )
     handlers[0]._publish_arrival_consumption(
         generation,
@@ -3828,6 +3848,7 @@ def test_slot_aware_handler_rechecks_deadline_before_returning_admission(
             cast(Any, admission),
             cast(Any, recovery_state),
             deadline,
+            "a" * 64,
         )
     assert handler.shutdown() is True
 
@@ -3888,9 +3909,109 @@ def test_slot_aware_handler_binds_admission_to_returning_registration(
             cast(Any, object()),
             cast(Any, _static_recovery_state(plan)),
             time.monotonic() + 1,
+            "a" * 64,
         )
 
     assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_accepts_heartbeat_renewal_before_return(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=InMemoryControlStore(clock=clock),
+        clock=clock,
+        agent_id="agent-b",
+    )
+    handler._ensure_registered(time.monotonic() + 1)
+    with handler._registration_lock:
+        original = handler._registration
+    assert original is not None
+    completion, admission = _stub_replacement_return_evidence(
+        handler,
+        monkeypatch,
+    )
+    renewed = handler._registration_manager.renew(original)
+    with handler._registration_lock:
+        handler._registration = renewed
+    plan = _replacement_plan()
+    assignment = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=1,
+        assignments=plan.slot_assignments,
+        topology_digest=plan.topology_digest,
+    )
+    monkeypatch.setattr(
+        handler,
+        "_validate_final_admission_state",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(handler, "_validate_current_arrival_attempt", lambda *_args: None)
+    monkeypatch.setattr(
+        handler,
+        "_publish_replacement_return_acknowledgement",
+        lambda *_args, **_kwargs: None,
+    )
+
+    handler._validate_replacement_return(
+        cast(Any, object()),
+        assignment,
+        1,
+        0,
+        cast(Any, completion),
+        cast(Any, admission),
+        cast(Any, _static_recovery_state(plan)),
+        time.monotonic() + 1,
+        "a" * 64,
+    )
+
+    assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_rejects_replaced_restart_context_token(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=InMemoryControlStore(clock=clock),
+        clock=clock,
+        agent_id="agent-b",
+    )
+    plan = _replacement_plan()
+    recovery_state = _static_recovery_state(plan)
+    current = object()
+    expected_context = handler._restart_context_for_plan(plan)
+    original_token = handler._restart_context.write(expected_context)
+    replacement_token = handler._restart_context.write(expected_context)
+    assert replacement_token != original_token
+    monkeypatch.setattr(handler, "_read_generation", lambda: current)
+    monkeypatch.setattr(handler, "_read_recovery_state", lambda: recovery_state)
+
+    with pytest.raises(RendezvousStateError, match="context changed"):
+        handler._validate_final_admission_state(
+            cast(Any, current),
+            cast(Any, recovery_state),
+            time.monotonic() + 1,
+            validate_deadline=False,
+            expected_context_token=original_token,
+        )
+
+    handler._restart_context.clear()
 
 
 def test_slot_aware_handler_treats_missing_peer_registration_as_not_ready(
@@ -3996,6 +4117,7 @@ def test_slot_aware_handler_requires_live_registration_before_returning_admissio
             cast(Any, admission),
             cast(Any, _static_recovery_state(plan)),
             deadline,
+            "a" * 64,
         )
 
 
@@ -4047,6 +4169,7 @@ def test_slot_aware_handler_uses_authoritative_time_for_final_registration_expir
             cast(Any, admission),
             cast(Any, _static_recovery_state(plan)),
             time.monotonic() + 1,
+            "a" * 64,
         )
     handler.shutdown()
 
@@ -4107,6 +4230,7 @@ def test_slot_aware_handler_rejects_advanced_attempt_before_returning_admission(
             cast(Any, admission),
             cast(Any, _static_recovery_state(plan)),
             time.monotonic() + 1,
+            "a" * 64,
         )
 
     assert handler.shutdown() is True

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -813,6 +813,30 @@ def test_restart_context_file_clears_only_the_matching_cleanup_token(
     assert not path.exists()
 
 
+def test_restart_context_file_invalidates_context_while_directory_lock_is_held(
+    tmp_path: Path,
+):
+    path = tmp_path / "private" / "restart-context.json"
+    monotonic_clock = ManualMonotonicClock()
+    context_file = RestartContextFile(path, monotonic_clock=monotonic_clock)
+    cleanup_token = context_file.write(_context())
+    directory = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+    fcntl.flock(directory, fcntl.LOCK_EX)
+    try:
+        context_file.invalidate(cleanup_token)
+
+        with pytest.raises(RestartContextFileError, match="invalidated"):
+            context_file.read()
+        with pytest.raises(RestartContextFileError, match="timed out locking"):
+            context_file.clear_if_token(
+                cleanup_token,
+                deadline=monotonic_clock(),
+            )
+    finally:
+        fcntl.flock(directory, fcntl.LOCK_UN)
+        os.close(directory)
+
+
 def test_restart_context_file_preserves_previous_value_when_replace_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -3349,6 +3373,66 @@ def test_slot_aware_handler_clears_replacement_context_after_admission_failure(
     assert handler.shutdown() is True
 
 
+def test_slot_aware_handler_invalidates_context_when_cleanup_cannot_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    manager, lease, current = _initialize_generation(store, clock, ("node-a",))
+    plan = _replacement_plan()
+    successor = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=1,
+        assignments=plan.slot_assignments,
+        topology_digest=plan.topology_digest,
+    )
+    manager.commit_successor(lease, current, successor)
+    config = _handler_config(
+        tmp_path,
+        node_id="node-b",
+        min_nodes=1,
+        max_nodes=2,
+    )
+    handler = _handler(
+        config,
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+    )
+    handler._publication_reader = cast(
+        Any,
+        StaticRecoveryStateReader(_static_recovery_state(plan)),
+    )
+
+    def fail_after_context(*_args: object) -> object:
+        assert RestartContextFile(config.restart_context_path).read() == RestartContext.from_plan(
+            plan,
+            "node-b",
+        )
+        raise RendezvousConnectionError("injected arrival failure")
+
+    def fail_cleanup(
+        _context_file: RestartContextFile,
+        _cleanup_token: str,
+        *,
+        deadline: float | None = None,
+    ) -> bool:
+        del deadline
+        raise RestartContextFileError("injected cleanup lock timeout")
+
+    monkeypatch.setattr(handler, "_wait_for_assigned_arrivals", fail_after_context)
+    monkeypatch.setattr(RestartContextFile, "clear_if_token", fail_cleanup)
+
+    with pytest.raises(RendezvousConnectionError, match="injected arrival failure"):
+        handler.next_rendezvous()
+
+    assert config.restart_context_path.exists()
+    with pytest.raises(RestartContextFileError, match="invalidated"):
+        RestartContextFile(config.restart_context_path).read()
+    handler.shutdown()
+
+
 def test_slot_aware_handler_rejects_replacement_clock_behind_publication(
     tmp_path: Path,
 ):
@@ -3436,6 +3520,7 @@ def test_slot_aware_handler_rechecks_deadline_before_returning_admission(
     monkeypatch: pytest.MonkeyPatch,
 ):
     clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
     monotonic_clock = ManualMonotonicClock()
     handler = _handler(
         _handler_config(
@@ -3444,33 +3529,42 @@ def test_slot_aware_handler_rechecks_deadline_before_returning_admission(
             min_nodes=1,
             max_nodes=2,
         ),
-        store=InMemoryControlStore(clock=clock),
+        store=store,
         clock=clock,
         agent_id="agent-b",
         monotonic_clock=monotonic_clock,
     )
-    recovery_state = _static_recovery_state(
-        _replacement_plan(restart_deadline_unix_ms=clock() + 50)
+    plan = _replacement_plan(restart_deadline_unix_ms=clock() + 50)
+    recovery_state = _static_recovery_state(plan)
+    assignment = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=1,
+        assignments=plan.slot_assignments,
+        topology_digest=plan.topology_digest,
     )
     deadline = monotonic_clock() + 0.05
+    handler._ensure_registered(time.monotonic() + 1)
+
+    def validate_after_blocking_work(*_args: object, **_kwargs: object) -> None:
+        clock.advance(50)
+        monotonic_clock.advance(0.05)
+
     monkeypatch.setattr(
         handler,
         "_validate_final_admission_state",
-        lambda _current, state, final_deadline: handler._validate_replacement_deadline(
-            state,
-            final_deadline,
-        ),
+        validate_after_blocking_work,
     )
-
-    clock.advance(50)
-    monotonic_clock.advance(0.05)
+    monkeypatch.setattr(handler, "_validate_current_arrival_attempt", lambda *_args: None)
 
     with pytest.raises(RendezvousTimeoutError):
         handler._validate_replacement_return(
             cast(Any, object()),
+            assignment,
+            1,
             cast(Any, recovery_state),
             deadline,
         )
+    assert handler.shutdown() is True
 
 
 def test_slot_aware_handler_requires_live_registration_before_returning_admission(
@@ -3507,7 +3601,19 @@ def test_slot_aware_handler_requires_live_registration_before_returning_admissio
         clock=clock,
     )
     replacement_manager.register()
-    monkeypatch.setattr(handler, "_validate_final_admission_state", lambda *_args: None)
+    monkeypatch.setattr(
+        handler,
+        "_validate_final_admission_state",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(handler, "_validate_current_arrival_attempt", lambda *_args: None)
+    plan = _replacement_plan()
+    assignment = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=1,
+        assignments=plan.slot_assignments,
+        topology_digest=plan.topology_digest,
+    )
 
     with pytest.raises(
         RendezvousConnectionError,
@@ -3515,9 +3621,110 @@ def test_slot_aware_handler_requires_live_registration_before_returning_admissio
     ):
         handler._validate_replacement_return(
             cast(Any, object()),
-            cast(Any, _static_recovery_state(_replacement_plan())),
+            assignment,
+            1,
+            cast(Any, _static_recovery_state(plan)),
             deadline,
         )
+
+
+def test_slot_aware_handler_uses_authoritative_time_for_final_registration_expiry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    client_clock = ManualClock()
+    store_clock = ManualClock()
+    store = InMemoryControlStore(clock=store_clock)
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=store,
+        clock=client_clock,
+        agent_id="agent-b",
+    )
+    handler._ensure_registered(time.monotonic() + 1)
+    assert handler._stop_heartbeat() is True
+    plan = _replacement_plan(restart_deadline_unix_ms=100_000)
+    assignment = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=1,
+        assignments=plan.slot_assignments,
+        topology_digest=plan.topology_digest,
+    )
+    monkeypatch.setattr(handler, "_validate_final_admission_state", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(handler, "_validate_current_arrival_attempt", lambda *_args: None)
+    store_clock.advance(handler._config.policy.registration_lease_duration_ms)
+
+    with pytest.raises(
+        RendezvousConnectionError,
+        match="registration has expired",
+    ):
+        handler._validate_replacement_return(
+            cast(Any, object()),
+            assignment,
+            1,
+            cast(Any, _static_recovery_state(plan)),
+            time.monotonic() + 1,
+        )
+    handler.shutdown()
+
+
+def test_slot_aware_handler_rejects_advanced_attempt_before_returning_admission(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+    )
+    handler._ensure_registered(time.monotonic() + 1)
+    with handler._registration_lock:
+        registration = handler._registration
+    assert registration is not None
+    plan = _replacement_plan()
+    assignment = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=1,
+        assignments=plan.slot_assignments,
+        topology_digest=plan.topology_digest,
+    )
+    store.compare_set(
+        handler._arrival_attempt_key(assignment.generation),
+        expected_revision=None,
+        value=handler._arrival_attempt_value(
+            generation=assignment.generation,
+            attempt=2,
+            registration=registration,
+        ),
+    )
+    monkeypatch.setattr(handler, "_validate_final_admission_state", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(
+        RendezvousStateError,
+        match="does not match its generation",
+    ):
+        handler._validate_replacement_return(
+            cast(Any, object()),
+            assignment,
+            1,
+            cast(Any, _static_recovery_state(plan)),
+            time.monotonic() + 1,
+        )
+
+    assert handler.shutdown() is True
 
 
 def test_slot_aware_handler_rejects_assignment_size_mismatch(tmp_path: Path):

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -53,6 +53,7 @@ from lm_resiliency.integrations.torchrun._runtime import (
     TorchrunRendezvousPolicy,
     TorchrunRuntimeConfig,
     TorchrunRuntimeConfigError,
+    _RestartContextOwnership,
 )
 
 RUN_ID = "training-run"
@@ -814,6 +815,38 @@ def test_restart_context_file_clears_only_the_matching_cleanup_token(
     assert context_file.read() == _context()
     assert context_file.clear_if_token(second_token) is True
     assert not path.exists()
+
+
+def test_restart_context_file_fences_registration_ownership(
+    tmp_path: Path,
+):
+    path = tmp_path / "private" / "restart-context.json"
+    context_file = RestartContextFile(path)
+    original = _RestartContextOwnership("registration-a", 1)
+    replacement = _RestartContextOwnership("registration-b", 2)
+
+    context_file.write(_context(plan_id="plan-a"), ownership=original)
+    replacement_token = context_file.write(
+        _context(plan_id="plan-b"),
+        ownership=replacement,
+    )
+
+    with pytest.raises(RestartContextFileError, match="stale registration"):
+        context_file.write(_context(plan_id="stale-plan"), ownership=original)
+
+    assert context_file.read_with_token() == (
+        replacement_token,
+        _context(plan_id="plan-b"),
+    )
+
+    renewed_token = context_file.write(
+        _context(plan_id="plan-b-renewed"),
+        ownership=_RestartContextOwnership("registration-b", 3),
+    )
+    assert context_file.read_with_token() == (
+        renewed_token,
+        _context(plan_id="plan-b-renewed"),
+    )
 
 
 def test_restart_context_file_invalidates_context_while_directory_lock_is_held(
@@ -3683,8 +3716,14 @@ def test_slot_aware_handler_clears_context_when_publication_fails_after_replace(
         context: RestartContext,
         *,
         deadline: float | None = None,
+        ownership: _RestartContextOwnership | None = None,
     ) -> None:
-        token = original_write(context_file, context, deadline=deadline)
+        token = original_write(
+            context_file,
+            context,
+            deadline=deadline,
+            ownership=ownership,
+        )
         raise RestartContextFileError(
             "injected post-publication failure",
             published_token=token,
@@ -4278,6 +4317,63 @@ def test_slot_aware_handler_requires_live_registration_before_returning_admissio
             deadline,
             "a" * 64,
         )
+
+
+def test_slot_aware_handler_cannot_borrow_replacement_registration_ownership(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    config = _handler_config(
+        tmp_path,
+        node_id="node-b",
+        min_nodes=1,
+        max_nodes=2,
+    )
+    stale_handler = _handler(
+        config,
+        store=store,
+        clock=clock,
+        agent_id="agent-b-stale",
+    )
+    deadline = time.monotonic() + 1
+    stale_handler._ensure_registered(deadline)
+    stale_ownership = stale_handler._current_restart_context_ownership()
+    with stale_handler._registration_lock:
+        stale_registration = stale_handler._registration
+    assert stale_registration is not None
+    assert stale_handler._stop_heartbeat() is True
+    stale_handler._registration_manager.release(stale_registration)
+
+    replacement_handler = _handler(
+        config,
+        store=store,
+        clock=clock,
+        agent_id="agent-b-replacement",
+    )
+    replacement_handler._ensure_registered(deadline)
+    replacement_ownership = replacement_handler._current_restart_context_ownership()
+    context_file = RestartContextFile(config.restart_context_path)
+    replacement_token = context_file.write(
+        _context(plan_id="replacement-plan"),
+        ownership=replacement_ownership,
+    )
+
+    with pytest.raises(
+        RendezvousConnectionError,
+        match="registration no longer belongs",
+    ):
+        stale_handler._current_restart_context_ownership()
+    with pytest.raises(RestartContextFileError, match="stale registration"):
+        context_file.write(
+            _context(plan_id="stale-plan"),
+            ownership=stale_ownership,
+        )
+    assert context_file.read_with_token() == (
+        replacement_token,
+        _context(plan_id="replacement-plan"),
+    )
+    assert replacement_handler.shutdown() is True
 
 
 def test_slot_aware_handler_uses_authoritative_time_for_final_registration_expiry(

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -2928,8 +2928,137 @@ def test_slot_aware_handler_admits_replacement_and_writes_restart_context(
         plan,
         "node-b",
     )
+    admission = store.get(handler._arrival_admission_key(1, 1))
+    assert admission is not None
     assert handler.num_nodes_waiting() == 0
     assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_never_partially_admits_replacement_after_deadline(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    manager, lease, current = _initialize_generation(
+        store,
+        clock,
+        ("node-a", "node-d"),
+    )
+    plan = replace(
+        _replacement_plan(restart_deadline_unix_ms=clock() + 50),
+        slot_assignments=(
+            SlotAssignment(0, "node-b", 0, 2),
+            SlotAssignment(1, "node-c", 2, 2),
+        ),
+        expected_world_size=4,
+    )
+    successor = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=1,
+        assignments=plan.slot_assignments,
+        topology_digest=plan.topology_digest,
+    )
+    manager.commit_successor(lease, current, successor)
+    handlers = tuple(
+        _handler(
+            _handler_config(
+                tmp_path,
+                node_id=node_id,
+                min_nodes=2,
+                max_nodes=4,
+            ),
+            store=store,
+            clock=clock,
+            agent_id=f"agent-{node_id}",
+        )
+        for node_id in ("node-b", "node-c")
+    )
+    recovery_state = cast(
+        Any,
+        _static_recovery_state(plan),
+    )
+    deadline = time.monotonic() + 1
+    for handler in handlers:
+        handler._publication_reader = cast(
+            Any,
+            StaticRecoveryStateReader(recovery_state),
+        )
+        handler._ensure_registered(deadline)
+        handler._prepare_restart_context(
+            cast(Any, handler._read_generation()),
+            recovery_state,
+        )
+    generation = handlers[0]._read_generation()
+    assert generation is not None
+    with handlers[0]._registration_lock:
+        leader_registration = handlers[0]._registration
+    assert leader_registration is not None
+    attempt = handlers[0]._claim_shared_arrival_attempt(
+        assignment=successor,
+        slot=0,
+        registration=leader_registration,
+        deadline=deadline,
+    )
+    for slot, handler in enumerate(handlers):
+        with handler._registration_lock:
+            registration = handler._registration
+        assert registration is not None
+        store.compare_set(
+            handler._arrival_key(1, attempt, slot),
+            expected_revision=None,
+            value=handler._arrival_value(
+                generation=1,
+                attempt=attempt,
+                slot=slot,
+                registration=registration,
+            ),
+        )
+    handlers[0]._try_complete_arrival_attempt(
+        successor,
+        attempt,
+        leader_registration,
+    )
+    completion = store.get(handlers[0]._arrival_completion_key(1, attempt))
+    assert completion is not None
+    for handler in handlers:
+        handler._validate_final_admission_state(
+            generation,
+            recovery_state,
+            deadline,
+        )
+    handlers[0]._publish_arrival_consumption(
+        generation,
+        successor,
+        attempt,
+        0,
+        completion,
+        deadline,
+        recovery_state,
+    )
+
+    clock.advance(50)
+    with pytest.raises(RendezvousTimeoutError):
+        handlers[1]._publish_arrival_consumption(
+            generation,
+            successor,
+            attempt,
+            1,
+            completion,
+            deadline,
+            recovery_state,
+        )
+    handlers[0]._try_commit_replacement_admission(
+        generation,
+        successor,
+        attempt,
+        completion,
+        recovery_state,
+        deadline,
+    )
+
+    assert store.get(handlers[0]._arrival_admission_key(1, attempt)) is None
+    for handler in handlers:
+        assert handler.shutdown() is True
 
 
 def test_slot_aware_handler_gives_selected_standby_a_fresh_formation_deadline(

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -858,6 +858,27 @@ def test_restart_context_file_preserves_every_invalidated_token(
     assert context_file.read() == _context(plan_id="plan-new")
 
 
+def test_restart_context_file_rejects_resurrected_invalidated_context(
+    tmp_path: Path,
+):
+    path = tmp_path / "private" / "restart-context.json"
+    context_file = RestartContextFile(path)
+    cleanup_token = context_file.write(_context())
+    metadata_path = path.parent / context_file._metadata_name()
+    encoded_context = path.read_bytes()
+    encoded_metadata = metadata_path.read_bytes()
+
+    context_file.invalidate(cleanup_token)
+    assert context_file.clear_if_token(cleanup_token) is True
+    path.write_bytes(encoded_context)
+    metadata_path.write_bytes(encoded_metadata)
+    path.chmod(0o600)
+    metadata_path.chmod(0o600)
+
+    with pytest.raises(RestartContextFileError, match="invalidated"):
+        context_file.read()
+
+
 def test_restart_context_file_invalidates_long_valid_basename(
     tmp_path: Path,
 ):
@@ -3156,8 +3177,9 @@ def test_slot_aware_handler_waits_for_return_ack_before_advancing_attempt(
         "_publish_replacement_return_acknowledgement",
         delay_return_ack,
     )
-    thread, outcome = _start_rendezvous(handler)
-    assert reached_return_ack.wait(timeout=2)
+    first = handler.next_rendezvous()
+    assert first.rank == 0
+    assert store.get(handler._arrival_return_key(1, 1, 0)) is None
     current_generation = handler._read_generation()
     assert current_generation is not None
     attempt_entry = store.get(handler._arrival_attempt_key(1))
@@ -3167,6 +3189,25 @@ def test_slot_aware_handler_waits_for_return_ack_before_advancing_attempt(
     with handler._registration_lock:
         registration = handler._registration
     assert registration is not None
+    assert (
+        handler._advance_arrival_attempt(
+            successor,
+            attempt_entry,
+            1,
+            2,
+            handler._arrival_attempt_value(
+                generation=1,
+                attempt=2,
+                registration=registration,
+            ),
+            registration,
+            completion,
+        )
+        is None
+    )
+
+    thread, outcome = _start_rendezvous(handler)
+    assert reached_return_ack.wait(timeout=2)
 
     assert (
         handler._advance_arrival_attempt(
@@ -3188,21 +3229,7 @@ def test_slot_aware_handler_waits_for_return_ack_before_advancing_attempt(
     thread.join(timeout=2)
     assert not thread.is_alive()
     assert isinstance(outcome.get_nowait(), RendezvousInfo)
-
-    advanced = handler._advance_arrival_attempt(
-        successor,
-        attempt_entry,
-        1,
-        2,
-        handler._arrival_attempt_value(
-            generation=1,
-            attempt=2,
-            registration=registration,
-        ),
-        registration,
-        completion,
-    )
-
+    advanced = store.get(handler._arrival_attempt_key(1))
     assert advanced is not None
     attempt, _, _ = handler._validate_arrival_attempt_entry(
         advanced,
@@ -3212,6 +3239,133 @@ def test_slot_aware_handler_waits_for_return_ack_before_advancing_attempt(
     )
     assert attempt == 2
     assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_retries_return_ack_after_heartbeat_refresh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    manager, lease, current = _initialize_generation(store, clock, ("node-a",))
+    plan = _replacement_plan()
+    successor = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=1,
+        assignments=plan.slot_assignments,
+        topology_digest=plan.topology_digest,
+    )
+    manager.commit_successor(lease, current, successor)
+    handler = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-b",
+    )
+    handler._publication_reader = cast(
+        Any,
+        StaticRecoveryStateReader(_static_recovery_state(plan)),
+    )
+    assert handler.next_rendezvous().rank == 0
+    original_compare = store.compare_set_many_guarded
+    refreshed = False
+    renewed_registration = None
+
+    def refresh_before_return_ack(*args: Any, **kwargs: Any) -> Any:
+        nonlocal refreshed, renewed_registration
+        writes = args[0]
+        if not refreshed and any("/returned/" in key for key in writes):
+            refreshed = True
+            with handler._registration_lock:
+                registration = handler._registration
+            assert registration is not None
+            renewed_registration = handler._registration_manager.renew(registration)
+            with handler._registration_lock:
+                handler._registration = renewed_registration
+        return original_compare(*args, **kwargs)
+
+    monkeypatch.setattr(
+        store,
+        "compare_set_many_guarded",
+        refresh_before_return_ack,
+    )
+
+    assert handler.next_rendezvous().rank == 0
+
+    assert refreshed
+    assert renewed_registration is not None
+    acknowledgement = store.get(handler._arrival_return_key(1, 1, 0))
+    assert acknowledgement is not None
+    assert acknowledgement.guard_revision == renewed_registration.fencing_token
+    assert handler.shutdown() is True
+
+
+def test_slot_aware_handler_replacement_incarnation_starts_fresh_attempt(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    manager, lease, current = _initialize_generation(store, clock, ("node-a",))
+    plan = _replacement_plan()
+    successor = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=1,
+        assignments=plan.slot_assignments,
+        topology_digest=plan.topology_digest,
+    )
+    manager.commit_successor(lease, current, successor)
+    config = _handler_config(
+        tmp_path,
+        node_id="node-b",
+        min_nodes=1,
+        max_nodes=2,
+    )
+    recovery_state = _static_recovery_state(plan)
+    original = _handler(
+        config,
+        store=store,
+        clock=clock,
+        agent_id="agent-b-original",
+    )
+    original._publication_reader = cast(
+        Any,
+        StaticRecoveryStateReader(recovery_state),
+    )
+    assert original.next_rendezvous().rank == 0
+    assert original.shutdown() is True
+
+    replacement = _handler(
+        config,
+        store=store,
+        clock=clock,
+        agent_id="agent-b-replacement",
+    )
+    replacement._publication_reader = cast(
+        Any,
+        StaticRecoveryStateReader(recovery_state),
+    )
+
+    assert replacement.next_rendezvous().rank == 0
+
+    attempt_entry = store.get(replacement._arrival_attempt_key(1))
+    acknowledgement = store.get(replacement._arrival_return_key(1, 1, 0))
+    assert attempt_entry is not None
+    assert acknowledgement is not None
+    attempt, _, _ = replacement._validate_arrival_attempt_entry(
+        attempt_entry,
+        generation=1,
+        expected_attempt=2,
+        leader_node_id="node-b",
+    )
+    payload = json.loads(acknowledgement.value)
+    assert attempt == 2
+    assert payload["agent_id"] == "agent-b-replacement"
+    assert replacement.shutdown() is True
 
 
 def test_slot_aware_handler_never_partially_admits_replacement_after_deadline(
@@ -3624,6 +3778,11 @@ def test_slot_aware_handler_always_cleans_registration_when_context_cleanup_fail
         handler,
         "_prepare_restart_context",
         lambda *_args: cleanup_token,
+    )
+    monkeypatch.setattr(
+        handler,
+        "_acknowledge_prior_replacement_return",
+        lambda *_args: None,
     )
     monkeypatch.setattr(
         handler,


### PR DESCRIPTION
## What changed

- reauthorize the persisted restart-plan publication before admitting a replacement generation
- publish canonical worker-visible `RestartContext` JSON, bind hidden cleanup metadata to the writer's verified registration ownership, and revalidate the exact publishing token before returning the inherited logical slot
- require one immutable, deadline-guarded group-admission proof after every assigned node publishes validated readiness
- bind admission to the exact live registration and arrival consumption for each returning agent
- advance replacement attempts only after every assigned slot enters a subsequent rendezvous and publishes a slot-scoped acknowledgement guarded by its current registration
- retry acknowledgement publication across same-incarnation heartbeat renewal and route replacement incarnations to a fresh attempt
- treat missing or expired peer registration as incomplete readiness while failing closed on corrupt history
- retain token-specific invalidation after physical context deletion and refuse generation-zero cleanup of current-run replacement state
- always release local registration ownership even when context cleanup fails
- keep removed nodes and passive standbys parked, and leave `num_nodes_waiting()` disabled for the following signaling PR
- fail closed above one replacement generation

## Why

The initial handler could form generation zero but rejected every successor generation. Failure-driven torchrun re-rendezvous therefore could not admit a coordinator-selected standby even after authoritative plan publication.

## Compatibility

This changes only private torchrun integration internals. The rendezvous backend still reports no waiting nodes, so healthy-worker membership signaling is not enabled by this PR.

## Validation

- 197 focused runtime, registration-history, and control-store tests
- 2,491 complete CPU tests with CUDA hidden
- repository-wide Ruff and formatting checks
- targeted mypy for the runtime and focused tests
- `git diff --check`

