### PR TITLE
[Feature][torchrun] Signal plan-selected replacements

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1611,8 +1611,13 @@ directory lock nonblocking under the admission or bounded-cleanup deadline, so
 a stale process cannot strand replacement admission. The replacement deadline
 is derived and revalidated from authoritative, nondecreasing control-store time
 rather than an agent wall clock. Passive standbys and removed nodes remain
-parked. The positive `num_nodes_waiting()` restart edge remains disabled until
-the following signaling slice.
+parked until a committed successor selects them. After one handler has returned
+workers for a generation, `num_nodes_waiting()` compares that exact admitted
+assignment with the latest authoritative successor. It reports only newly
+assigned standby nodes whose current registrations are live and compatible
+with the workload. A transient generation, plan, registration, or authoritative
+time read returns zero so healthy workers continue running; contradictory
+persisted state fails closed.
 
 All handler incarnations use one immutable generation-scoped `PrefixStore` for
 PyTorch's worker bootstrap keys. Slot zero publishes one address/port pair and
@@ -1626,12 +1631,15 @@ creates the worker-side TCP store. After bounded bootstrap reads complete, every
 returned store is restored to the shared configured join timeout so later stock
 agent coordination does not inherit rank-specific remaining-deadline values.
 
-Passive standbys are not reported by `num_nodes_waiting()`. In the following
-signaling slice, after a plan commits, the selected replacement becomes the only
-newly waiting node visible to active agents. This is the restart edge: a random
-late node must not trigger scale-up. The mechanism is used only when the next
-plan admits at least one standby; it is not a generic restart signal for
-unchanged membership.
+Passive standbys are not reported by `num_nodes_waiting()`. After a plan
+commits, the selected replacement becomes the only newly waiting node visible
+to handlers that already returned the prior active generation. This is the
+restart edge: a random late node, an unregistered selected node, an expired
+registration, or a handler that has not launched workers must not trigger
+scale-up. After a handler successfully admits the successor, its recorded
+assignment advances and the signal returns to zero. The mechanism is used only
+when the next plan admits at least one standby; it is not a generic restart
+signal for unchanged membership.
 
 Before returning an admitted node from `next_rendezvous()`, the handler:
 

--- a/lm_resiliency/integrations/torchrun/_runtime.py
+++ b/lm_resiliency/integrations/torchrun/_runtime.py
@@ -492,6 +492,8 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         self._closure_read_lock = threading.Lock()
         self._replacement_clock_lock = threading.Lock()
         self._last_replacement_now_unix_ms: int | None = None
+        self._admitted_assignment_lock = threading.Lock()
+        self._admitted_assignment: RankAssignment | None = None
         self._shutdown_lock = threading.Lock()
 
     @property
@@ -601,6 +603,9 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                                 admission_deadline,
                                 context_token,
                             )
+                        self._record_admitted_assignment(
+                            current.snapshot.record.assignment,
+                        )
                         return RendezvousInfo(
                             bootstrap_store,
                             slot,
@@ -768,12 +773,95 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         self._state_changed_event.set()
 
     def num_nodes_waiting(self) -> int:
-        """Hide passive standbys until a committed replacement plan exists."""
+        """Expose only live plan-selected replacement nodes to healthy workers."""
 
         if self.is_closed():
             return 0
         self._raise_heartbeat_error()
-        return 0
+        with self._admitted_assignment_lock:
+            admitted = self._admitted_assignment
+        if admitted is None:
+            return 0
+        try:
+            current = self._read_generation()
+            if (
+                current is None
+                or current.snapshot.record.assignment.generation <= admitted.generation
+            ):
+                return 0
+            successor = current.snapshot.record.assignment
+            if successor.generation != admitted.generation + 1:
+                raise RendezvousStateError("replacement signal skipped an admitted generation")
+            recovery_state = self._read_recovery_state()
+        except RendezvousConnectionError:
+            return 0
+        if recovery_state is None:
+            raise RendezvousStateError(
+                "replacement generation lacks an authoritative restart-plan publication"
+            )
+        self._validate_replacement_generation(current, recovery_state)
+        admitted_nodes = set(admitted.slot_to_node_id.values())
+        successor_nodes = set(successor.slot_to_node_id.values())
+        replacement_nodes = successor_nodes - admitted_nodes
+        if not replacement_nodes:
+            raise RendezvousStateError("replacement generation does not admit a new standby node")
+        if len(replacement_nodes) > self._config.max_nodes - self._config.min_nodes:
+            raise RendezvousStateError("replacement generation exceeds configured standby capacity")
+        try:
+            now_unix_ms = self._replacement_now_unix_ms(recovery_state)
+            if now_unix_ms >= recovery_state.plan.restart_deadline_unix_ms:
+                return 0
+            for node_id in sorted(replacement_nodes):
+                registration = self._replacement_signal_registration(node_id)
+                if registration is None:
+                    return 0
+                self._validate_registration_window(
+                    registration,
+                    now_unix_ms=now_unix_ms,
+                )
+        except RendezvousConnectionError:
+            return 0
+        return len(replacement_nodes)
+
+    def _record_admitted_assignment(self, assignment: RankAssignment) -> None:
+        with self._admitted_assignment_lock:
+            previous = self._admitted_assignment
+            if previous is not None and assignment.generation < previous.generation:
+                raise RendezvousStateError("admitted generation moved backward")
+            self._admitted_assignment = assignment
+
+    def _replacement_signal_registration(
+        self,
+        node_id: str,
+    ) -> HeldAgentRegistration | None:
+        try:
+            history = AgentRegistrationHistoryReader(
+                self._control_store,
+                run_id=self._config.run_id,
+                node_id=node_id,
+            ).read()
+        except AgentRegistrationHistoryCorrupt as error:
+            raise RendezvousStateError(
+                "selected replacement registration history is corrupt"
+            ) from error
+        except AgentRegistrationHistoryError:
+            return None
+        except Exception:
+            return None
+        registration = history.current
+        if registration is None:
+            return None
+        identity = registration.record.agent_identity
+        if identity.run_id != self._config.run_id or identity.node_id != node_id:
+            raise RendezvousStateError("selected replacement registration has the wrong identity")
+        if (
+            identity.local_world_size != self._config.local_world_size
+            or identity.environment_digest != self._agent_identity.environment_digest
+        ):
+            raise RendezvousStateError(
+                "selected replacement registration is incompatible with the workload"
+            )
+        return registration
 
     def shutdown(self) -> bool:
         self._closed_event.set()
@@ -3412,23 +3500,7 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
                 raise RendezvousStateError(
                     "replacement generation lacks an authoritative restart-plan publication"
                 )
-            plan = recovery_state.plan
-            expected_assignment = RankAssignment.from_assignments(
-                run_id=plan.run_id,
-                generation=plan.to_generation,
-                assignments=plan.slot_assignments,
-                topology_digest=plan.topology_digest,
-            )
-            if (
-                plan.run_id != self._config.run_id
-                or plan.to_generation != assignment.generation
-                or expected_assignment != assignment
-                or plan.expected_world_size
-                != self._config.min_nodes * self._config.local_world_size
-            ):
-                raise RendezvousStateError(
-                    "replacement plan does not match the committed generation assignment"
-                )
+            self._validate_replacement_generation(current, recovery_state)
             admission_deadline = self._replacement_deadline(
                 recovery_state,
                 formation_deadline,
@@ -3436,6 +3508,29 @@ class SlotAwareRendezvousHandler(RendezvousHandler):
         self._ensure_job_compatibility()
         self._validate_assigned_registration_history()
         return slot, recovery_state, admission_deadline
+
+    def _validate_replacement_generation(
+        self,
+        current: CurrentGeneration,
+        recovery_state: RestartPlanPersistedRecoveryState,
+    ) -> None:
+        assignment = current.snapshot.record.assignment
+        plan = recovery_state.plan
+        expected_assignment = RankAssignment.from_assignments(
+            run_id=plan.run_id,
+            generation=plan.to_generation,
+            assignments=plan.slot_assignments,
+            topology_digest=plan.topology_digest,
+        )
+        if (
+            plan.run_id != self._config.run_id
+            or plan.to_generation != assignment.generation
+            or expected_assignment != assignment
+            or plan.expected_world_size != self._config.min_nodes * self._config.local_world_size
+        ):
+            raise RendezvousStateError(
+                "replacement plan does not match the committed generation assignment"
+            )
 
     def _read_recovery_state(self) -> RestartPlanPersistedRecoveryState | None:
         try:

--- a/tests/unit/test_torchrun_runtime.py
+++ b/tests/unit/test_torchrun_runtime.py
@@ -167,6 +167,11 @@ class StaticRecoveryStateReader:
         return self._state
 
 
+class FailingRecoveryStateReader:
+    def read_recovery_state(self) -> object:
+        raise RuntimeError("control plane unavailable")
+
+
 def _static_recovery_state(
     plan: RestartPlan,
     *,
@@ -2545,6 +2550,196 @@ def test_slot_aware_handler_parks_standby_without_reporting_waiting_node(
     assert reader.get("node-b") is None
     assert standby.shutdown() is True
     assert closer.shutdown() is True
+
+
+def test_slot_aware_handler_reports_only_live_plan_selected_replacement(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    manager, lease, current = _initialize_generation(store, clock, ("node-a",))
+    active = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=1,
+            max_nodes=3,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+    assert active.next_rendezvous().rank == 0
+
+    random_config = _handler_config(
+        tmp_path,
+        node_id="node-c",
+        min_nodes=1,
+        max_nodes=3,
+    )
+    random_manager = AgentRegistrationManager(
+        store,
+        agent_identity=random_config.build_agent_identity(
+            agent_id="agent-c",
+            hostname="node-c.example",
+        ),
+        lease_duration_ms=random_config.policy.registration_lease_duration_ms,
+        clock=clock,
+    )
+    random_registration = random_manager.register()
+    plan = _replacement_plan(node_id="node-b")
+    successor = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=1,
+        assignments=plan.slot_assignments,
+        topology_digest=plan.topology_digest,
+    )
+    manager.commit_successor(lease, current, successor)
+    active._publication_reader = cast(Any, FailingRecoveryStateReader())
+
+    assert active.num_nodes_waiting() == 0
+
+    active._publication_reader = cast(
+        Any,
+        StaticRecoveryStateReader(_static_recovery_state(plan)),
+    )
+
+    assert active.num_nodes_waiting() == 0
+
+    selected_config = _handler_config(
+        tmp_path,
+        node_id="node-b",
+        min_nodes=1,
+        max_nodes=3,
+    )
+    selected_manager = AgentRegistrationManager(
+        store,
+        agent_identity=selected_config.build_agent_identity(
+            agent_id="agent-b",
+            hostname="node-b.example",
+        ),
+        lease_duration_ms=selected_config.policy.registration_lease_duration_ms,
+        clock=clock,
+    )
+    selected_registration = selected_manager.register()
+
+    assert active.num_nodes_waiting() == 1
+
+    selected_manager.release(selected_registration)
+    random_manager.release(random_registration)
+    assert active.shutdown() is True
+
+
+def test_slot_aware_handler_rejects_incompatible_selected_replacement(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    manager, lease, current = _initialize_generation(store, clock, ("node-a",))
+    active = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+    assert active.next_rendezvous().rank == 0
+    selected_config = replace(
+        _handler_config(
+            tmp_path,
+            node_id="node-b",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        environment_digest="environment-v2",
+    )
+    selected_manager = AgentRegistrationManager(
+        store,
+        agent_identity=selected_config.build_agent_identity(
+            agent_id="agent-b",
+            hostname="node-b.example",
+        ),
+        lease_duration_ms=selected_config.policy.registration_lease_duration_ms,
+        clock=clock,
+    )
+    selected_registration = selected_manager.register()
+    plan = _replacement_plan(node_id="node-b")
+    successor = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=1,
+        assignments=plan.slot_assignments,
+        topology_digest=plan.topology_digest,
+    )
+    manager.commit_successor(lease, current, successor)
+    active._publication_reader = cast(
+        Any,
+        StaticRecoveryStateReader(_static_recovery_state(plan)),
+    )
+
+    with pytest.raises(RendezvousStateError, match="incompatible"):
+        active.num_nodes_waiting()
+
+    selected_manager.release(selected_registration)
+    assert active.shutdown() is True
+
+
+def test_slot_aware_handler_hides_expired_selected_replacement(
+    tmp_path: Path,
+):
+    clock = ManualClock()
+    store = InMemoryControlStore(clock=clock)
+    manager, lease, current = _initialize_generation(store, clock, ("node-a",))
+    active = _handler(
+        _handler_config(
+            tmp_path,
+            node_id="node-a",
+            min_nodes=1,
+            max_nodes=2,
+        ),
+        store=store,
+        clock=clock,
+        agent_id="agent-a",
+    )
+    assert active.next_rendezvous().rank == 0
+    selected_config = _handler_config(
+        tmp_path,
+        node_id="node-b",
+        min_nodes=1,
+        max_nodes=2,
+    )
+    selected_manager = AgentRegistrationManager(
+        store,
+        agent_identity=selected_config.build_agent_identity(
+            agent_id="agent-b",
+            hostname="node-b.example",
+        ),
+        lease_duration_ms=50,
+        clock=clock,
+    )
+    selected_manager.register()
+    plan = _replacement_plan(
+        node_id="node-b",
+        restart_deadline_unix_ms=100_000,
+    )
+    successor = RankAssignment.from_assignments(
+        run_id=RUN_ID,
+        generation=1,
+        assignments=plan.slot_assignments,
+        topology_digest=plan.topology_digest,
+    )
+    manager.commit_successor(lease, current, successor)
+    active._publication_reader = cast(
+        Any,
+        StaticRecoveryStateReader(_static_recovery_state(plan)),
+    )
+    clock.advance(51)
+
+    assert active.num_nodes_waiting() == 0
+    assert active.shutdown() is True
 
 
 def test_slot_aware_handler_local_shutdown_does_not_close_shared_run(


### PR DESCRIPTION
## Summary
- record the exact generation assignment that successfully launched workers
- expose only live, compatible plan-selected replacement nodes through `num_nodes_waiting()`
- keep random, unregistered, expired, and transiently unreadable standbys hidden

## Scope
This PR enables the stock healthy-worker membership restart edge. Replacement admission and restart-context handoff were merged in PR #145. No new production module is added.

## Validation
- 126 focused runtime tests
- 2,495 full CPU tests
- Ruff check and formatting
- targeted mypy
- `git diff --check`
