### PR TITLE
[Examples] Add zero-import production loops

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -92,7 +92,9 @@ The production example validates its application-owned DDP loop.
 Dedicated lifecycle programs additionally validate FSDP2 and HSDP on the same two hosts.
 
 The executable one-host and two-host `torchrun` commands are documented in [Production-loop examples](../examples/README.md).
-The same examples enable the integration campaign directly with `--inject-fault`.
+Destructive injection is exercised separately through the
+[fault-injection evaluation](../examples/fault_injection/README.md), keeping
+the zero-import production loops free of validation-only fault controls.
 
 ## Native PyTorch
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -64,6 +64,7 @@ Run one example on a single eight-GPU host from the repository root:
 torchrun \
   --nnodes=1:1 \
   --nproc-per-node=8 \
+  --max-restarts=4 \
   --rdzv-backend=lm_resiliency \
   --rdzv-endpoint=/tmp/lm-resiliency-torchtitan-rdzv \
   --rdzv-id=torchtitan-production \

--- a/examples/README.md
+++ b/examples/README.md
@@ -45,8 +45,11 @@ manifests, target selection, supported faults, and safety boundaries.
 
 ## Production Loops
 
-The production-loop examples train tiny causal language models with deterministic synthetic tokens while preserving each framework's real training lifecycle.
-They support one or two hosts through standard `torchrun` arguments.
+The production-loop examples train tiny causal language models with
+deterministic synthetic tokens while preserving each framework's real training
+lifecycle. The four framework modules do not import `lm_resiliency`; the
+`lm_resiliency` rendezvous backend infers and installs the framework adapter
+from the user module's imports.
 
 | Framework | Example | Framework-owned path |
 |---|---|---|
@@ -55,28 +58,30 @@ They support one or two hosts through standard `torchrun` arguments.
 | Megatron Core | [megatron.py](production_loops/megatron.py) | `training.train()` and `train_step()` |
 | DeepSpeed | [deepspeed.py](production_loops/deepspeed.py) | `DeepSpeedEngine.backward()` and `DeepSpeedEngine.step()` |
 
-Run one example on a single eight-GPU host:
+Run one example on a single eight-GPU host from the repository root:
 
 ```bash
-torchrun --standalone --nproc-per-node=8 --module \
+torchrun \
+  --nnodes=1:1 \
+  --nproc-per-node=8 \
+  --rdzv-backend=lm_resiliency \
+  --rdzv-endpoint=/tmp/lm-resiliency-torchtitan-rdzv \
+  --rdzv-id=torchtitan-production \
+  --rdzv-conf="store_type=file,\
+lm_resiliency_restart_context_path=/tmp/lm-resiliency-torchtitan-context/context.json,\
+lm_resiliency_worker_config=$PWD/examples/production_loops/policies/resiliency.toml" \
+  --module \
   examples.production_loops.torchtitan \
-  --artifact-dir /tmp/torchtitan-production-loop
+  --validation-output-dir /tmp/torchtitan-production-loop
 ```
 
-Run it on two eight-GPU hosts:
+Replace the module, rendezvous paths, and validation output directory for
+PyTorch, Megatron Core, or DeepSpeed. The worker infers the framework from
+imports. The checked-in worker policy uses
+`replication_jump=4` for this eight-rank topology. Other world layouts must use
+a policy with a valid deployment-specific GEMINI pairing.
 
-```bash
-torchrun --nnodes=2 --nproc-per-node=8 --module \
-  --node-rank="$NODE_RANK" \
-  --master-addr="$MASTER_ADDR" --master-port=29800 \
-  examples.production_loops.torchtitan \
-  --artifact-dir /tmp/torchtitan-production-loop
-```
-
-Replace the module and artifact directory for PyTorch, Megatron Core, or DeepSpeed.
-Use a different rendezvous port for concurrent jobs.
-
-Each example runs ten steps by default.
-Set `--steps` to change the duration.
-Add `--inject-fault` to introduce one transient hidden-layer replay fault at step 4 on the last global rank.
-The fault campaign requires exact SCOUT localization, exclusion of the fault-step checkpoint, a recovery-verified manager decision, and clean post-fault certification.
+Each framework example runs ten steps by default; set `--steps` to change the
+duration. Rank zero writes a framework summary under
+`--validation-output-dir`; the directory is example validation output and is
+not used for restart contexts or GEMINI checkpoints.

--- a/examples/production_loops/_common.py
+++ b/examples/production_loops/_common.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -18,11 +19,32 @@ class RunArguments:
     steps: int
 
 
+_CHECKPOINT_STEP_ENV = "LM_RESILIENCY_TORCHRUN_CHECKPOINT_STEP"
+
+
 def _positive_steps(value: str) -> int:
     steps = int(value)
     if steps < 1:
         raise argparse.ArgumentTypeError("steps must be positive")
     return steps
+
+
+def torchrun_checkpoint_step() -> int:
+    """Return the manager-selected resume position published by bootstrap."""
+    value = os.environ.get(_CHECKPOINT_STEP_ENV, "0")
+    if not value.isdecimal():
+        raise RuntimeError(f"{_CHECKPOINT_STEP_ENV} must be a non-negative integer")
+    return int(value)
+
+
+def training_step_range(current_step: int, target_step: int) -> range:
+    """Return remaining deterministic training steps for one validation run."""
+    for value, name in ((current_step, "current_step"), (target_step, "target_step")):
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValueError(f"{name} must be a non-negative integer")
+    if target_step <= current_step:
+        raise ValueError("target_step must exceed the recovered current_step")
+    return range(current_step, target_step)
 
 
 def parse_run_arguments(arguments: Sequence[str] | None = None) -> RunArguments:

--- a/examples/production_loops/_common.py
+++ b/examples/production_loops/_common.py
@@ -1,235 +1,58 @@
-"""Shared controls for production-loop examples and integration validation."""
+"""Framework-neutral controls for user-owned production-loop examples."""
 
 from __future__ import annotations
 
 import argparse
-from dataclasses import dataclass, field
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
-import torch
-import torch.distributed as dist
-from torch.utils._pytree import tree_flatten, tree_unflatten
 
-from lm_resiliency import OrchestrationHooks
+@dataclass(frozen=True, slots=True)
+class RunArguments:
+    """Arguments shared by every framework-native production-loop example."""
 
-
-def add_run_arguments(
-    parser: argparse.ArgumentParser,
-    *,
-    inject_fault_by_default: bool,
-) -> None:
-    """Add the common training and optional fault-injection arguments."""
-    parser.add_argument("--steps", type=int, default=10)
-    parser.add_argument(
-        "--inject-fault",
-        action=argparse.BooleanOptionalAction,
-        default=inject_fault_by_default,
-        help="Inject a transient hidden-layer replay fault.",
-    )
-    parser.add_argument("--fault-step", type=int, default=4)
-    parser.add_argument(
-        "--fault-rank",
-        type=int,
-        default=-1,
-        help="Global fault rank; -1 selects the last rank.",
-    )
-
-
-@dataclass
-class ReplayFaultCampaign:
-    """Inject one replay-only fault and validate checkpoint trust transitions."""
-
+    validation_output_dir: Path
     steps: int
-    rank: int
-    world_size: int
-    inject_fault: bool
-    fault_step: int
-    fault_rank: int
-    faults: list[Any] = field(default_factory=list)
-    recovery_decisions: list[dict[str, Any]] = field(default_factory=list)
-    checkpoint_steps_at_fault: list[int] = field(default_factory=list)
-    _current_step: int = 0
-    _target_calls: int = 0
-    _injected_calls: int = 0
-    _handle: Any | None = None
-    _fault_hook: Any | None = None
-
-    @classmethod
-    def from_args(
-        cls,
-        args: argparse.Namespace,
-        *,
-        rank: int,
-        world_size: int,
-    ) -> "ReplayFaultCampaign":
-        fault_rank = world_size - 1 if args.fault_rank < 0 else args.fault_rank
-        if args.steps <= 0:
-            raise ValueError("--steps must be positive")
-        if args.inject_fault:
-            if args.steps < args.fault_step + 2:
-                raise ValueError("--steps must include at least two post-fault steps")
-            if args.fault_step < 2:
-                raise ValueError("--fault-step must follow at least one clean step")
-            if fault_rank < 0 or fault_rank >= world_size:
-                raise ValueError("--fault-rank must identify a global training rank")
-        return cls(
-            steps=args.steps,
-            rank=rank,
-            world_size=world_size,
-            inject_fault=bool(args.inject_fault),
-            fault_step=args.fault_step,
-            fault_rank=fault_rank,
-        )
-
-    @property
-    def orchestration(self) -> OrchestrationHooks:
-        """Return manager hooks used to capture automatic recovery decisions."""
-        return OrchestrationHooks(report_recovery=self.recovery_decisions.append)
-
-    def start_step(self, step: int) -> None:
-        """Mark the framework iteration before its model forward begins."""
-        self._current_step = step
-        self._target_calls = 0
-
-    def bind(self, handle: Any) -> None:
-        """Attach the replay-only fault after SCOUT has installed its hooks."""
-        self._handle = handle
-        if not self.inject_fault:
-            return
-        harness = _replay_harness(handle)
-        if harness is None:
-            raise AssertionError("SCOUT did not create a replay harness")
-        self._fault_hook = harness.target_layer.register_forward_hook(
-            self._inject_after_training_forward,
-            with_kwargs=True,
-        )
-
-    def record_fault(self, result: Any) -> None:
-        """Retain replay evidence and the checkpoint boundary visible at detection."""
-        self.faults.append(result)
-        manager = _checkpoint_manager(self._handle)
-        if manager is not None:
-            self.checkpoint_steps_at_fault.append(int(manager._last_saved_step))
-
-    def validate(self, handle: Any, final_result: Any, expected_recipes: set[str]) -> None:
-        """Validate clean completion or the complete transient-fault campaign."""
-        manager = _checkpoint_manager(handle)
-        if manager is None:
-            raise AssertionError("GEMINI did not create a checkpoint manager")
-        if final_result is None or any(final_result.sdc_bitmap):
-            raise AssertionError("the final production-loop replay was not clean")
-        if not expected_recipes.issubset(final_result.checked_recipe_ids):
-            raise AssertionError(f"missing replay recipes: {final_result.checked_recipe_ids}")
-        if int(manager._last_saved_step) != self.steps:
-            raise AssertionError("GEMINI did not capture the final clean optimizer step")
-        if int(manager.checkpoint_status.recovery_verified_step) != self.steps:
-            raise AssertionError("the final clean checkpoint was not recovery-verified")
-
-        if not self.inject_fault:
-            if self.faults or self.recovery_decisions:
-                raise AssertionError("the clean example reported an unexpected fault")
-            return
-
-        if len(self.faults) != 1:
-            raise AssertionError(f"expected one injected fault, observed {len(self.faults)}")
-        fault = self.faults[0]
-        expected_bitmap = [int(peer_rank == self.fault_rank) for peer_rank in fault.peer_ranks]
-        if fault.sdc_bitmap != expected_bitmap or any(fault.straggler_bitmap):
-            raise AssertionError(
-                f"fault localization mismatch: peers={fault.peer_ranks}, "
-                f"sdc={fault.sdc_bitmap}, expected={expected_bitmap}"
-            )
-        if not any(source.startswith("hidden.") for source in fault.sdc_sources):
-            raise AssertionError(f"hidden replay did not report the fault: {fault.sdc_sources}")
-        if self.checkpoint_steps_at_fault != [self.fault_step - 1]:
-            raise AssertionError(
-                "GEMINI exposed the fault-step checkpoint before SCOUT certification"
-            )
-        if len(self.recovery_decisions) != 1:
-            raise AssertionError(
-                f"expected one recovery decision, observed {self.recovery_decisions}"
-            )
-        decision = self.recovery_decisions[0]
-        expected_step = self.fault_step - 1
-        if (
-            decision["failure_kind"] != "sdc"
-            or decision["recovery_mode"] != "recovery_verified"
-            or decision["checkpoint_source"] != "gemini"
-            or decision["checkpoint_step"] != expected_step
-            or not decision["available"]
-        ):
-            raise AssertionError(f"invalid recovery decision: {decision}")
-        if self.rank == self.fault_rank:
-            if self._injected_calls == 0:
-                raise AssertionError("the selected fault rank did not inject a replay fault")
-        elif self._injected_calls != 0:
-            raise AssertionError("a healthy rank injected a replay fault")
-
-    def summary(self) -> dict[str, Any]:
-        """Return JSON-ready fault campaign evidence."""
-        if not self.inject_fault:
-            return {"fault_injection": "disabled"}
-        decision = self.recovery_decisions[0]
-        return {
-            "fault_injection": "transient hidden replay",
-            "fault_rank": self.fault_rank,
-            "fault_step": self.fault_step,
-            "localized_bitmap": list(self.faults[0].sdc_bitmap),
-            "recovery_mode": decision["recovery_mode"],
-            "recovery_checkpoint_step": decision["checkpoint_step"],
-            "post_fault_clean_steps": self.steps - self.fault_step,
-        }
-
-    def close(self) -> None:
-        """Remove the example-owned injection hook."""
-        if self._fault_hook is not None:
-            self._fault_hook.remove()
-            self._fault_hook = None
-
-    def _inject_after_training_forward(
-        self,
-        _module: Any,
-        _args: tuple[Any, ...],
-        _kwargs: dict[str, Any],
-        output: Any,
-    ) -> Any | None:
-        self._target_calls += 1
-        if (
-            self._current_step != self.fault_step
-            or self.rank != self.fault_rank
-            or self._target_calls == 1
-        ):
-            return None
-        corrupted, changed = _add_to_first_tensor(output)
-        if not changed:
-            raise RuntimeError("the replay target produced no tensor output")
-        self._injected_calls += 1
-        return corrupted
 
 
-def _add_to_first_tensor(value: Any) -> tuple[Any, bool]:
-    leaves, spec = tree_flatten(value)
-    changed = False
-    for index, leaf in enumerate(leaves):
-        if isinstance(leaf, torch.Tensor):
-            leaves[index] = leaf + 1.0
-            changed = True
-            break
-    return tree_unflatten(leaves, spec), changed
+def _positive_steps(value: str) -> int:
+    steps = int(value)
+    if steps < 1:
+        raise argparse.ArgumentTypeError("steps must be positive")
+    return steps
 
 
-def _checkpoint_manager(handle: Any | None) -> Any | None:
-    if handle is None:
-        return None
-    manager = getattr(handle, "ckpt_manager", None)
-    return manager if manager is not None else getattr(handle, "_ckpt_manager", None)
+def parse_run_arguments(arguments: Sequence[str] | None = None) -> RunArguments:
+    """Parse shared arguments and prepare the validation output directory."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--validation-output-dir", type=Path, required=True)
+    parser.add_argument("--steps", type=_positive_steps, default=10)
+    parsed = parser.parse_args(arguments)
+    parsed.validation_output_dir.mkdir(parents=True, exist_ok=True)
+    return RunArguments(
+        validation_output_dir=parsed.validation_output_dir,
+        steps=parsed.steps,
+    )
 
 
-def _replay_harness(handle: Any) -> Any | None:
-    harness = getattr(handle, "replay_harness", None)
-    return harness if harness is not None else getattr(handle, "_replay_harness", None)
-
-
-def distributed_rank() -> int:
-    """Return the initialized rank for examples that use framework launchers."""
-    return dist.get_rank() if dist.is_initialized() else 0
+def write_validation_summary(
+    output_dir: Path,
+    summary: Mapping[str, Any],
+    *,
+    writer: bool,
+) -> None:
+    """Write and print a framework validation summary from one worker."""
+    if not writer:
+        return
+    framework = summary.get("framework")
+    if not isinstance(framework, str) or not framework:
+        raise ValueError("validation summary requires a non-empty framework")
+    payload = dict(summary)
+    (output_dir / f"{framework}-production-loop.json").write_text(
+        json.dumps(payload, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(payload, sort_keys=True), flush=True)

--- a/examples/production_loops/deepspeed.py
+++ b/examples/production_loops/deepspeed.py
@@ -6,27 +6,20 @@ Only the deterministic token source is synthetic.
 
 Run on one eight-GPU host:
 
-    torchrun --standalone --nproc-per-node=8 --module \
+    torchrun --rdzv-backend=lm_resiliency \
+      --rdzv-endpoint=/tmp/lm-resiliency-deepspeed-rdzv \
+      --rdzv-id=deepspeed-production \
+      --rdzv-conf="store_type=file,\
+lm_resiliency_restart_context_path=/tmp/lm-resiliency-deepspeed-context/context.json,\
+lm_resiliency_worker_config=$PWD/examples/production_loops/policies/resiliency.toml" \
+      --nnodes=1:1 --nproc-per-node=8 --module \
       examples.production_loops.deepspeed \
-      --artifact-dir /tmp/deepspeed-production-loop
-
-Run the same program on two eight-GPU hosts:
-
-    torchrun --nnodes=2 --nproc-per-node=8 --module \
-      --node-rank=$NODE_RANK \
-      --master-addr=$MASTER_ADDR --master-port=29802 \
-      examples.production_loops.deepspeed \
-      --artifact-dir /tmp/deepspeed-production-loop
-
-Add ``--inject-fault`` to exercise localization and checkpoint rejection.
+      --validation-output-dir /tmp/deepspeed-production-loop
 """
 
 from __future__ import annotations
 
-import argparse
-import json
 import os
-from pathlib import Path
 
 import deepspeed
 import torch
@@ -34,10 +27,9 @@ import torch.distributed as dist
 import torch.nn as nn
 
 from examples.production_loops._common import (
-    ReplayFaultCampaign,
-    add_run_arguments,
+    parse_run_arguments,
+    write_validation_summary,
 )
-from lm_resiliency import InMemoryCkptConfig, ReplayHarnessConfig, enable_resiliency
 
 VOCABULARY_SIZE = 256
 SEQUENCE_LENGTH = 16
@@ -121,27 +113,14 @@ def _tokens(rank: int, step: int, device: torch.device) -> tuple[torch.Tensor, .
     return values[:, :-1], values[:, 1:]
 
 
-def main(*, inject_fault_by_default: bool = False) -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--artifact-dir", type=Path, required=True)
-    add_run_arguments(
-        parser,
-        inject_fault_by_default=inject_fault_by_default,
-    )
-    args = parser.parse_args()
-    args.artifact_dir.mkdir(parents=True, exist_ok=True)
+def main() -> None:
+    args = parse_run_arguments()
 
     local_rank = int(os.environ["LOCAL_RANK"])
     torch.cuda.set_device(local_rank)
     deepspeed.init_distributed(dist_backend="nccl")
     rank = dist.get_rank()
     world_size = dist.get_world_size()
-    campaign = ReplayFaultCampaign.from_args(
-        args,
-        rank=rank,
-        world_size=world_size,
-    )
-
     torch.manual_seed(123)
     model = TinyCausalLM()
     optimizer = torch.optim.AdamW(model.parameters(), lr=2e-4)
@@ -157,48 +136,12 @@ def main(*, inject_fault_by_default: bool = False) -> None:
             "steps_per_print": 1_000,
         },
     )
-    resiliency = enable_resiliency(
-        engine,
-        interval=1,
-        checkpoint=InMemoryCkptConfig(
-            enable=True,
-            interval=1,
-            disk_flush_interval=0,
-            disk_folder=str(args.artifact_dir / "gemini"),
-            skip_replication_if_hsdp=True,
-        ),
-        replay=ReplayHarnessConfig(
-            check_interval=1,
-            rotate_layers=False,
-            enable_temporal=False,
-            scale_factors=[],
-            straggler_min_slowdown_ratio=100.0,
-            straggler_min_slowdown_ms=10_000.0,
-        ),
-        fault_callback=campaign.record_fault,
-        orchestration=campaign.orchestration,
-    )
-    campaign.bind(resiliency)
-
     try:
         for step in range(args.steps):
-            campaign.start_step(step + 1)
             tokens, labels = _tokens(rank, step, engine.device)
             loss = engine(tokens, labels)
             engine.backward(loss)
             engine.step()
-
-        resiliency._ckpt_manager.maybe_wait()
-        result = resiliency._replay_harness.last_result
-        if engine.global_steps != args.steps or resiliency.step_count != args.steps:
-            raise AssertionError(
-                "DeepSpeed and lm-resiliency optimizer steps did not remain aligned"
-            )
-        campaign.validate(
-            resiliency,
-            result,
-            {"embedding", "hidden", "output", "optimizer"},
-        )
 
         summary = {
             "framework": "deepspeed",
@@ -206,21 +149,14 @@ def main(*, inject_fault_by_default: bool = False) -> None:
             "model": "tiny causal language model",
             "world_size": world_size,
             "steps": engine.global_steps,
-            "resiliency_steps": resiliency.step_count,
-            "checkpoint_step": resiliency._ckpt_manager._last_saved_step,
-            "checked_recipes": sorted(result.checked_recipe_ids),
             "zero_stage": 2,
-            **campaign.summary(),
         }
-        if rank == 0:
-            (args.artifact_dir / "deepspeed-production-loop.json").write_text(
-                json.dumps(summary, indent=2) + "\n",
-                encoding="utf-8",
-            )
-            print(json.dumps(summary, sort_keys=True), flush=True)
+        write_validation_summary(
+            args.validation_output_dir,
+            summary,
+            writer=rank == 0,
+        )
     finally:
-        campaign.close()
-        resiliency.close()
         engine.destroy()
         dist.destroy_process_group()
 

--- a/examples/production_loops/deepspeed.py
+++ b/examples/production_loops/deepspeed.py
@@ -12,7 +12,7 @@ Run on one eight-GPU host:
       --rdzv-conf="store_type=file,\
 lm_resiliency_restart_context_path=/tmp/lm-resiliency-deepspeed-context/context.json,\
 lm_resiliency_worker_config=$PWD/examples/production_loops/policies/resiliency.toml" \
-      --nnodes=1:1 --nproc-per-node=8 --module \
+      --nnodes=1:1 --nproc-per-node=8 --max-restarts=4 --module \
       examples.production_loops.deepspeed \
       --validation-output-dir /tmp/deepspeed-production-loop
 """
@@ -28,6 +28,7 @@ import torch.nn as nn
 
 from examples.production_loops._common import (
     parse_run_arguments,
+    training_step_range,
     write_validation_summary,
 )
 
@@ -136,13 +137,18 @@ def main() -> None:
             "steps_per_print": 1_000,
         },
     )
+    summary = None
     try:
-        for step in range(args.steps):
+        for step in training_step_range(engine.global_steps, args.steps):
             tokens, labels = _tokens(rank, step, engine.device)
             loss = engine(tokens, labels)
             engine.backward(loss)
             engine.step()
 
+        if engine.global_steps != args.steps:
+            raise AssertionError(
+                f"step mismatch: deepspeed={engine.global_steps}, target={args.steps}"
+            )
         summary = {
             "framework": "deepspeed",
             "framework_loop": "DeepSpeedEngine.backward/step",
@@ -151,14 +157,15 @@ def main() -> None:
             "steps": engine.global_steps,
             "zero_stage": 2,
         }
-        write_validation_summary(
-            args.validation_output_dir,
-            summary,
-            writer=rank == 0,
-        )
     finally:
         engine.destroy()
         dist.destroy_process_group()
+    assert summary is not None
+    write_validation_summary(
+        args.validation_output_dir,
+        summary,
+        writer=rank == 0,
+    )
 
 
 if __name__ == "__main__":

--- a/examples/production_loops/megatron.py
+++ b/examples/production_loops/megatron.py
@@ -1,4 +1,4 @@
-"""Run lm-resiliency inside Megatron Core's production training loop.
+"""Run Megatron Core's production training loop with injected resiliency.
 
 The job uses a real Megatron GPTModel, Megatron DDP, distributed Adam, the
 framework forward/backward schedule, ``train_step()``, and ``train()``.
@@ -6,28 +6,21 @@ Only token generation and external logging/checkpoint services are synthetic.
 
 Run on one eight-GPU host:
 
-    torchrun --standalone --nproc-per-node=8 --module \
+    torchrun --rdzv-backend=lm_resiliency \
+      --rdzv-endpoint=/tmp/lm-resiliency-megatron-rdzv \
+      --rdzv-id=megatron-production \
+      --rdzv-conf="store_type=file,\
+lm_resiliency_restart_context_path=/tmp/lm-resiliency-megatron-context/context.json,\
+lm_resiliency_worker_config=$PWD/examples/production_loops/policies/resiliency.toml" \
+      --nnodes=1:1 --nproc-per-node=8 --module \
       examples.production_loops.megatron \
-      --artifact-dir /tmp/megatron-production-loop
-
-Run the same program on two eight-GPU hosts:
-
-    torchrun --nnodes=2 --nproc-per-node=8 --module \
-      --node-rank=$NODE_RANK \
-      --master-addr=$MASTER_ADDR --master-port=29801 \
-      examples.production_loops.megatron \
-      --artifact-dir /tmp/megatron-production-loop
-
-Add ``--inject-fault`` to exercise localization and checkpoint rejection.
+      --validation-output-dir /tmp/megatron-production-loop
 """
 
 from __future__ import annotations
 
-import argparse
-import json
 import sys
 from functools import partial
-from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Iterator
 
@@ -35,10 +28,9 @@ import torch
 import torch.distributed as dist
 
 from examples.production_loops._common import (
-    ReplayFaultCampaign,
-    add_run_arguments,
+    parse_run_arguments,
+    write_validation_summary,
 )
-from lm_resiliency import InMemoryCkptConfig, ReplayHarnessConfig, enable_resiliency
 
 VOCABULARY_SIZE = 128
 SEQUENCE_LENGTH = 16
@@ -223,11 +215,9 @@ def _tokens(rank: int, step: int, device: torch.device) -> tuple[torch.Tensor, .
 def _data_iterator(
     rank: int,
     device: torch.device,
-    campaign: ReplayFaultCampaign,
 ) -> Iterator[tuple[torch.Tensor, ...]]:
     step = 0
     while True:
-        campaign.start_step(step + 1)
         yield _tokens(rank, step, device)
         step += 1
 
@@ -322,15 +312,8 @@ def _build_model_optimizer_scheduler(device: torch.device):
     return model, optimizer, scheduler, config
 
 
-def main(*, inject_fault_by_default: bool = False) -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--artifact-dir", type=Path, required=True)
-    add_run_arguments(
-        parser,
-        inject_fault_by_default=inject_fault_by_default,
-    )
-    parsed = parser.parse_args()
-    parsed.artifact_dir.mkdir(parents=True, exist_ok=True)
+def main() -> None:
+    parsed = parse_run_arguments()
 
     dist.init_process_group(backend="cpu:gloo,cuda:nccl")
     rank = dist.get_rank()
@@ -344,11 +327,6 @@ def main(*, inject_fault_by_default: bool = False) -> None:
     )
     from megatron.training import training
 
-    campaign = ReplayFaultCampaign.from_args(
-        parsed,
-        rank=rank,
-        world_size=world_size,
-    )
     args = _arguments(rank, world_size, parsed.steps)
     init_num_microbatches_calculator(
         rank=rank,
@@ -362,81 +340,21 @@ def main(*, inject_fault_by_default: bool = False) -> None:
     _install_training_services(training, args)
     model, optimizer, scheduler, config = _build_model_optimizer_scheduler(device)
 
-    state_holder: dict[str, Any] = {}
-
-    def capture_loop_state() -> dict[str, Any]:
-        handle = state_holder["handle"]
-        return {
-            "megatron_loop": {
-                "iteration": handle.step_count,
-                "consumed_train_samples": args.consumed_train_samples,
-                "skipped_train_samples": args.skipped_train_samples,
-            }
-        }
-
-    def restore_loop_state(state: dict[str, Any]) -> None:
-        loop = state.get("megatron_loop", {})
-        args.iteration = int(loop.get("iteration", args.iteration))
-        args.consumed_train_samples = int(
-            loop.get("consumed_train_samples", args.consumed_train_samples)
-        )
-        args.skipped_train_samples = int(
-            loop.get("skipped_train_samples", args.skipped_train_samples)
-        )
-
-    handle = enable_resiliency(
-        [model],
-        optimizer,
-        opt_param_scheduler=scheduler,
-        interval=1,
-        checkpoint=InMemoryCkptConfig(
-            enable=True,
-            interval=1,
-            replication_jump=max(1, world_size // 2),
-            disk_flush_interval=0,
-            disk_folder=str(parsed.artifact_dir / "gemini"),
-        ),
-        replay=ReplayHarnessConfig(
-            check_interval=1,
-            rotate_layers=False,
-            enable_temporal=False,
-            scale_factors=[],
-            straggler_min_slowdown_ratio=100.0,
-            straggler_min_slowdown_ms=10_000.0,
-        ),
-        extra_state_fn=capture_loop_state,
-        load_extra_state_fn=restore_loop_state,
-        fault_callback=campaign.record_fault,
-        orchestration=campaign.orchestration,
-    )
-    state_holder["handle"] = handle
-    campaign.bind(handle)
-    args.iteration = handle.step_count
-
     try:
         iteration, _ = training.train(
             _forward_step,
             [model],
             optimizer,
             scheduler,
-            _data_iterator(rank, device, campaign),
+            _data_iterator(rank, device),
             None,
             None,
             config,
             {},
             None,
         )
-        handle._ckpt_manager.maybe_wait()
-        result = handle._replay_harness.last_result
-        if iteration != parsed.steps or handle.step_count != parsed.steps:
-            raise AssertionError(
-                f"step mismatch: megatron={iteration}, resiliency={handle.step_count}"
-            )
-        campaign.validate(
-            handle,
-            result,
-            {"embedding", "hidden", "output", "optimizer"},
-        )
+        if iteration != parsed.steps:
+            raise AssertionError(f"step mismatch: megatron={iteration}")
 
         summary = {
             "framework": "megatron",
@@ -444,22 +362,15 @@ def main(*, inject_fault_by_default: bool = False) -> None:
             "model": "megatron.core.models.gpt.GPTModel",
             "world_size": world_size,
             "steps": iteration,
-            "resiliency_steps": handle.step_count,
-            "checkpoint_step": handle._ckpt_manager._last_saved_step,
-            "checked_recipes": sorted(result.checked_recipe_ids),
             "consumed_train_samples": args.consumed_train_samples,
-            **campaign.summary(),
         }
-        if rank == 0:
-            (parsed.artifact_dir / "megatron-production-loop.json").write_text(
-                json.dumps(summary, indent=2) + "\n",
-                encoding="utf-8",
-            )
-            print(json.dumps(summary, sort_keys=True), flush=True)
+        write_validation_summary(
+            parsed.validation_output_dir,
+            summary,
+            writer=rank == 0,
+        )
     finally:
         failed = sys.exc_info()[0] is not None
-        campaign.close()
-        handle.close()
         if not failed:
             dist.barrier()
             from megatron.core import parallel_state as mpu

--- a/examples/production_loops/megatron.py
+++ b/examples/production_loops/megatron.py
@@ -12,14 +12,13 @@ Run on one eight-GPU host:
       --rdzv-conf="store_type=file,\
 lm_resiliency_restart_context_path=/tmp/lm-resiliency-megatron-context/context.json,\
 lm_resiliency_worker_config=$PWD/examples/production_loops/policies/resiliency.toml" \
-      --nnodes=1:1 --nproc-per-node=8 --module \
+      --nnodes=1:1 --nproc-per-node=8 --max-restarts=4 --module \
       examples.production_loops.megatron \
       --validation-output-dir /tmp/megatron-production-loop
 """
 
 from __future__ import annotations
 
-import sys
 from functools import partial
 from types import SimpleNamespace
 from typing import Any, Iterator
@@ -215,8 +214,9 @@ def _tokens(rank: int, step: int, device: torch.device) -> tuple[torch.Tensor, .
 def _data_iterator(
     rank: int,
     device: torch.device,
+    args: _DefaultArgs,
 ) -> Iterator[tuple[torch.Tensor, ...]]:
-    step = 0
+    step = int(args.iteration)
     while True:
         yield _tokens(rank, step, device)
         step += 1
@@ -340,13 +340,14 @@ def main() -> None:
     _install_training_services(training, args)
     model, optimizer, scheduler, config = _build_model_optimizer_scheduler(device)
 
+    summary = None
     try:
         iteration, _ = training.train(
             _forward_step,
             [model],
             optimizer,
             scheduler,
-            _data_iterator(rank, device),
+            _data_iterator(rank, device, args),
             None,
             None,
             config,
@@ -364,19 +365,18 @@ def main() -> None:
             "steps": iteration,
             "consumed_train_samples": args.consumed_train_samples,
         }
-        write_validation_summary(
-            parsed.validation_output_dir,
-            summary,
-            writer=rank == 0,
-        )
     finally:
-        failed = sys.exc_info()[0] is not None
-        if not failed:
-            dist.barrier()
+        if dist.is_initialized():
             from megatron.core import parallel_state as mpu
 
             mpu.destroy_model_parallel()
             dist.destroy_process_group()
+    assert summary is not None
+    write_validation_summary(
+        parsed.validation_output_dir,
+        summary,
+        writer=rank == 0,
+    )
 
 
 if __name__ == "__main__":

--- a/examples/production_loops/policies/resiliency.toml
+++ b/examples/production_loops/policies/resiliency.toml
@@ -1,0 +1,15 @@
+schema_version = 1
+interval = 1
+enable_checkpoint = true
+enable_detection = true
+
+[checkpoint]
+replication_jump = 4
+disk_flush_interval = 0
+
+[replay]
+rotate_layers = false
+enable_temporal = false
+scale_factors = []
+straggler_min_slowdown_ratio = 100.0
+straggler_min_slowdown_ms = 10000.0

--- a/examples/production_loops/pytorch.py
+++ b/examples/production_loops/pytorch.py
@@ -12,7 +12,7 @@ Run on one eight-GPU host:
       --rdzv-conf="store_type=file,\
 lm_resiliency_restart_context_path=/tmp/lm-resiliency-pytorch-context/context.json,\
 lm_resiliency_worker_config=$PWD/examples/production_loops/policies/resiliency.toml" \
-      --nnodes=1:1 --nproc-per-node=8 --module \
+      --nnodes=1:1 --nproc-per-node=8 --max-restarts=4 --module \
       examples.production_loops.pytorch \
       --validation-output-dir /tmp/pytorch-production-loop
 """
@@ -28,6 +28,8 @@ from torch.nn.parallel import DistributedDataParallel
 
 from examples.production_loops._common import (
     parse_run_arguments,
+    torchrun_checkpoint_step,
+    training_step_range,
     write_validation_summary,
 )
 
@@ -128,8 +130,9 @@ def main() -> None:
         device_ids=[local_rank],
     )
     optimizer = torch.optim.AdamW(model.parameters(), lr=2e-4)
+    summary = None
     try:
-        for step in range(args.steps):
+        for step in training_step_range(torchrun_checkpoint_step(), args.steps):
             tokens, labels = _tokens(rank, step, device)
             optimizer.zero_grad(set_to_none=True)
             with torch.autocast("cuda", dtype=torch.bfloat16):
@@ -145,14 +148,14 @@ def main() -> None:
             "world_size": world_size,
             "steps": args.steps,
         }
-        write_validation_summary(
-            args.validation_output_dir,
-            summary,
-            writer=rank == 0,
-        )
     finally:
-        dist.barrier()
         dist.destroy_process_group()
+    assert summary is not None
+    write_validation_summary(
+        args.validation_output_dir,
+        summary,
+        writer=rank == 0,
+    )
 
 
 if __name__ == "__main__":

--- a/examples/production_loops/pytorch.py
+++ b/examples/production_loops/pytorch.py
@@ -6,27 +6,20 @@ Only the deterministic token source is synthetic.
 
 Run on one eight-GPU host:
 
-    torchrun --standalone --nproc-per-node=8 --module \
+    torchrun --rdzv-backend=lm_resiliency \
+      --rdzv-endpoint=/tmp/lm-resiliency-pytorch-rdzv \
+      --rdzv-id=pytorch-production \
+      --rdzv-conf="store_type=file,\
+lm_resiliency_restart_context_path=/tmp/lm-resiliency-pytorch-context/context.json,\
+lm_resiliency_worker_config=$PWD/examples/production_loops/policies/resiliency.toml" \
+      --nnodes=1:1 --nproc-per-node=8 --module \
       examples.production_loops.pytorch \
-      --artifact-dir /tmp/pytorch-production-loop
-
-Run the same program on two eight-GPU hosts:
-
-    torchrun --nnodes=2 --nproc-per-node=8 --module \
-      --node-rank=$NODE_RANK \
-      --master-addr=$MASTER_ADDR --master-port=29803 \
-      examples.production_loops.pytorch \
-      --artifact-dir /tmp/pytorch-production-loop
-
-Add ``--inject-fault`` to exercise localization and checkpoint rejection.
+      --validation-output-dir /tmp/pytorch-production-loop
 """
 
 from __future__ import annotations
 
-import argparse
-import json
 import os
-from pathlib import Path
 
 import torch
 import torch.distributed as dist
@@ -34,10 +27,9 @@ import torch.nn as nn
 from torch.nn.parallel import DistributedDataParallel
 
 from examples.production_loops._common import (
-    ReplayFaultCampaign,
-    add_run_arguments,
+    parse_run_arguments,
+    write_validation_summary,
 )
-from lm_resiliency import InMemoryCkptConfig, ReplayHarnessConfig, enable_resiliency
 
 VOCABULARY_SIZE = 256
 SEQUENCE_LENGTH = 16
@@ -121,15 +113,8 @@ def _tokens(rank: int, step: int, device: torch.device) -> tuple[torch.Tensor, .
     return values[:, :-1], values[:, 1:]
 
 
-def main(*, inject_fault_by_default: bool = False) -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--artifact-dir", type=Path, required=True)
-    add_run_arguments(
-        parser,
-        inject_fault_by_default=inject_fault_by_default,
-    )
-    args = parser.parse_args()
-    args.artifact_dir.mkdir(parents=True, exist_ok=True)
+def main() -> None:
+    args = parse_run_arguments()
 
     local_rank = int(os.environ["LOCAL_RANK"])
     torch.cuda.set_device(local_rank)
@@ -137,64 +122,20 @@ def main(*, inject_fault_by_default: bool = False) -> None:
     dist.init_process_group(backend="cpu:gloo,cuda:nccl")
     rank = dist.get_rank()
     world_size = dist.get_world_size()
-    if world_size < 3:
-        raise RuntimeError("SCOUT localization requires at least three DDP replicas")
-    campaign = ReplayFaultCampaign.from_args(
-        args,
-        rank=rank,
-        world_size=world_size,
-    )
-
     torch.manual_seed(123)
     model = DistributedDataParallel(
         TinyCausalLM().to(device),
         device_ids=[local_rank],
     )
     optimizer = torch.optim.AdamW(model.parameters(), lr=2e-4)
-    resiliency = enable_resiliency(
-        model,
-        optimizer,
-        interval=1,
-        checkpoint=InMemoryCkptConfig(
-            enable=True,
-            interval=1,
-            replication_jump=max(1, world_size // 2),
-            disk_flush_interval=0,
-            disk_folder=str(args.artifact_dir / "gemini"),
-        ),
-        replay=ReplayHarnessConfig(
-            check_interval=1,
-            rotate_layers=False,
-            enable_temporal=False,
-            scale_factors=[],
-            straggler_min_slowdown_ratio=100.0,
-            straggler_min_slowdown_ms=10_000.0,
-        ),
-        device=device,
-        fault_callback=campaign.record_fault,
-        orchestration=campaign.orchestration,
-    )
-    campaign.bind(resiliency)
-
     try:
         for step in range(args.steps):
-            campaign.start_step(step + 1)
             tokens, labels = _tokens(rank, step, device)
             optimizer.zero_grad(set_to_none=True)
             with torch.autocast("cuda", dtype=torch.bfloat16):
                 loss = model(tokens, labels)
             loss.backward()
             optimizer.step()
-
-        resiliency.ckpt_manager.maybe_wait()
-        result = resiliency.replay_harness.last_result
-        if resiliency.step_count != args.steps:
-            raise AssertionError("PyTorch and lm-resiliency optimizer steps did not remain aligned")
-        campaign.validate(
-            resiliency,
-            result,
-            {"embedding", "hidden", "output", "optimizer"},
-        )
 
         summary = {
             "framework": "pytorch",
@@ -203,20 +144,13 @@ def main(*, inject_fault_by_default: bool = False) -> None:
             "parallelism": "DDP",
             "world_size": world_size,
             "steps": args.steps,
-            "resiliency_steps": resiliency.step_count,
-            "checkpoint_step": resiliency.ckpt_manager._last_saved_step,
-            "checked_recipes": sorted(result.checked_recipe_ids),
-            **campaign.summary(),
         }
-        if rank == 0:
-            (args.artifact_dir / "pytorch-production-loop.json").write_text(
-                json.dumps(summary, indent=2) + "\n",
-                encoding="utf-8",
-            )
-            print(json.dumps(summary, sort_keys=True), flush=True)
+        write_validation_summary(
+            args.validation_output_dir,
+            summary,
+            writer=rank == 0,
+        )
     finally:
-        campaign.close()
-        resiliency.close()
         dist.barrier()
         dist.destroy_process_group()
 

--- a/examples/production_loops/torchtitan.py
+++ b/examples/production_loops/torchtitan.py
@@ -12,7 +12,7 @@ Run on one eight-GPU host:
       --rdzv-conf="store_type=file,\
 lm_resiliency_restart_context_path=/tmp/lm-resiliency-torchtitan-context/context.json,\
 lm_resiliency_worker_config=$PWD/examples/production_loops/policies/resiliency.toml" \
-      --nnodes=1:1 --nproc-per-node=8 --module \
+      --nnodes=1:1 --nproc-per-node=8 --max-restarts=4 --module \
       examples.production_loops.torchtitan \
       --validation-output-dir /tmp/torchtitan-production-loop
 """
@@ -148,6 +148,8 @@ def main() -> None:
             args.steps,
         )
     )
+    rank = dist.get_rank()
+    summary = None
     try:
         trainer.train()
         if trainer.step != args.steps:
@@ -163,15 +165,15 @@ def main() -> None:
             "steps": trainer.step,
             "dataloader_index": trainer.dataloader.index,
         }
-        write_validation_summary(
-            args.validation_output_dir,
-            summary,
-            writer=dist.get_rank() == 0,
-        )
     finally:
         if dist.is_initialized():
-            dist.barrier()
             dist.destroy_process_group()
+    assert summary is not None
+    write_validation_summary(
+        args.validation_output_dir,
+        summary,
+        writer=rank == 0,
+    )
 
 
 if __name__ == "__main__":

--- a/examples/production_loops/torchtitan.py
+++ b/examples/production_loops/torchtitan.py
@@ -1,4 +1,4 @@
-"""Run lm-resiliency inside TorchTitan's production Trainer loop.
+"""Run TorchTitan's native production Trainer loop with injected resiliency.
 
 The job uses TorchTitan's Llama 3 debug model and deterministic synthetic token
 data. TorchTitan owns model construction, parallelization, forward/backward,
@@ -6,26 +6,20 @@ optimizer stepping, scheduling, and checkpoint loading.
 
 Run on one eight-GPU host:
 
-    torchrun --standalone --nproc-per-node=8 --module \
+    torchrun --rdzv-backend=lm_resiliency \
+      --rdzv-endpoint=/tmp/lm-resiliency-torchtitan-rdzv \
+      --rdzv-id=torchtitan-production \
+      --rdzv-conf="store_type=file,\
+lm_resiliency_restart_context_path=/tmp/lm-resiliency-torchtitan-context/context.json,\
+lm_resiliency_worker_config=$PWD/examples/production_loops/policies/resiliency.toml" \
+      --nnodes=1:1 --nproc-per-node=8 --module \
       examples.production_loops.torchtitan \
-      --artifact-dir /tmp/torchtitan-production-loop
-
-Run the same program on two eight-GPU hosts:
-
-    torchrun --nnodes=2 --nproc-per-node=8 --module \
-      --node-rank=$NODE_RANK \
-      --master-addr=$MASTER_ADDR --master-port=29800 \
-      examples.production_loops.torchtitan \
-      --artifact-dir /tmp/torchtitan-production-loop
-
-Add ``--inject-fault`` to exercise localization and checkpoint rejection.
+      --validation-output-dir /tmp/torchtitan-production-loop
 """
 
 from __future__ import annotations
 
-import argparse
 import copy
-import json
 from dataclasses import replace
 from pathlib import Path
 from typing import Any, Iterator
@@ -34,10 +28,9 @@ import torch
 import torch.distributed as dist
 
 from examples.production_loops._common import (
-    ReplayFaultCampaign,
-    add_run_arguments,
+    parse_run_arguments,
+    write_validation_summary,
 )
-from lm_resiliency import InMemoryCkptConfig, ReplayHarnessConfig, enable_resiliency
 
 
 class SyntheticTokenLoader:
@@ -50,18 +43,15 @@ class SyntheticTokenLoader:
         batch_size: int,
         sequence_length: int,
         vocabulary_size: int,
-        campaign: ReplayFaultCampaign,
     ) -> None:
         self.dp_rank = dp_rank
         self.batch_size = batch_size
         self.sequence_length = sequence_length
         self.vocabulary_size = vocabulary_size
-        self.campaign = campaign
         self.index = 0
 
     def __iter__(self) -> Iterator[tuple[dict[str, torch.Tensor], torch.Tensor]]:
         while True:
-            self.campaign.start_step(self.index + 1)
             generator = torch.Generator().manual_seed(1_000_003 * self.dp_rank + self.index)
             tokens = torch.randint(
                 0,
@@ -83,7 +73,6 @@ def _build_synthetic_dataloader(
     *,
     dp_rank: int,
     job_config: Any,
-    campaign: ReplayFaultCampaign,
     **_: Any,
 ) -> SyntheticTokenLoader:
     return SyntheticTokenLoader(
@@ -91,11 +80,10 @@ def _build_synthetic_dataloader(
         batch_size=job_config.training.local_batch_size,
         sequence_length=job_config.training.seq_len,
         vocabulary_size=2048,
-        campaign=campaign,
     )
 
 
-def _register_train_spec(campaign: ReplayFaultCampaign) -> str:
+def _register_train_spec() -> str:
     from functools import partial
 
     from torchtitan.models.llama3 import get_train_spec, llama3_args
@@ -106,10 +94,7 @@ def _register_train_spec(campaign: ReplayFaultCampaign) -> str:
     spec = replace(
         base,
         model_args={"debugmodel": copy.deepcopy(llama3_args["debugmodel"])},
-        build_dataloader_fn=partial(
-            _build_synthetic_dataloader,
-            campaign=campaign,
-        ),
+        build_dataloader_fn=partial(_build_synthetic_dataloader),
         build_tokenizer_fn=None,
         build_validator_fn=None,
         state_dict_adapter=None,
@@ -118,42 +103,8 @@ def _register_train_spec(campaign: ReplayFaultCampaign) -> str:
     return name
 
 
-def _trainer_type(campaign: ReplayFaultCampaign):
-    from torchtitan.train import Trainer
-
-    class ProductionResilientTrainer(Trainer):
-        resiliency = None
-
-        def train(self) -> None:
-            self.resiliency = enable_resiliency(
-                self,
-                interval=1,
-                checkpoint=InMemoryCkptConfig(
-                    enable=True,
-                    interval=1,
-                    replication_jump=max(1, dist.get_world_size() // 2),
-                    disk_flush_interval=0,
-                    disk_folder=str(self._lm_resiliency_artifact_dir / "gemini"),
-                ),
-                replay=ReplayHarnessConfig(
-                    check_interval=1,
-                    rotate_layers=False,
-                    enable_temporal=False,
-                    scale_factors=[],
-                    straggler_min_slowdown_ratio=100.0,
-                    straggler_min_slowdown_ms=10_000.0,
-                ),
-                fault_callback=campaign.record_fault,
-                orchestration=campaign.orchestration,
-            )
-            campaign.bind(self.resiliency)
-            super().train()
-
-    return ProductionResilientTrainer
-
-
 def _job_config(
-    artifact_dir: Path,
+    validation_output_dir: Path,
     model_name: str,
     world_size: int,
     steps: int,
@@ -162,7 +113,7 @@ def _job_config(
 
     config = JobConfig()
     config.job.description = "lm-resiliency production-loop validation"
-    config.job.dump_folder = str(artifact_dir / "torchtitan")
+    config.job.dump_folder = str(validation_output_dir / "torchtitan")
     config.model.name = model_name
     config.model.flavor = "debugmodel"
     config.training.steps = steps
@@ -181,53 +132,28 @@ def _job_config(
     return config
 
 
-def main(*, inject_fault_by_default: bool = False) -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--artifact-dir", type=Path, required=True)
-    add_run_arguments(
-        parser,
-        inject_fault_by_default=inject_fault_by_default,
-    )
-    args = parser.parse_args()
-    args.artifact_dir.mkdir(parents=True, exist_ok=True)
+def main() -> None:
+    args = parse_run_arguments()
 
     environment = __import__("os").environ
     world_size = int(environment["WORLD_SIZE"])
-    campaign = ReplayFaultCampaign.from_args(
-        args,
-        rank=int(environment["RANK"]),
-        world_size=world_size,
-    )
-    model_name = _register_train_spec(campaign)
-    trainer_cls = _trainer_type(campaign)
-    trainer = trainer_cls(
+    model_name = _register_train_spec()
+    from torchtitan.train import Trainer
+
+    trainer = Trainer(
         _job_config(
-            args.artifact_dir,
+            args.validation_output_dir,
             model_name,
             world_size,
             args.steps,
         )
     )
-    trainer._lm_resiliency_artifact_dir = args.artifact_dir
-
     try:
         trainer.train()
-        handle = trainer.resiliency
-        if handle is None:
-            raise AssertionError("TorchTitan Trainer did not retain the resiliency handle")
-        if trainer.step != args.steps or handle.step_count != args.steps:
-            raise AssertionError(
-                f"step mismatch: trainer={trainer.step}, resiliency={handle.step_count}"
-            )
+        if trainer.step != args.steps:
+            raise AssertionError(f"step mismatch: trainer={trainer.step}")
         if trainer.lr_schedulers.schedulers[0].last_epoch != args.steps:
             raise AssertionError("TorchTitan scheduler did not advance through the production loop")
-        handle.ckpt_manager.maybe_wait()
-        result = handle.replay_harness.last_result
-        campaign.validate(
-            handle,
-            result,
-            {"embedding", "hidden", "output", "optimizer"},
-        )
 
         summary = {
             "framework": "torchtitan",
@@ -235,22 +161,14 @@ def main(*, inject_fault_by_default: bool = False) -> None:
             "model": "torchtitan Llama 3 debugmodel",
             "world_size": dist.get_world_size(),
             "steps": trainer.step,
-            "resiliency_steps": handle.step_count,
-            "checkpoint_step": handle.ckpt_manager._last_saved_step,
-            "checked_recipes": sorted(result.checked_recipe_ids),
             "dataloader_index": trainer.dataloader.index,
-            **campaign.summary(),
         }
-        if dist.get_rank() == 0:
-            (args.artifact_dir / "torchtitan-production-loop.json").write_text(
-                json.dumps(summary, indent=2) + "\n",
-                encoding="utf-8",
-            )
-            print(json.dumps(summary, sort_keys=True), flush=True)
+        write_validation_summary(
+            args.validation_output_dir,
+            summary,
+            writer=dist.get_rank() == 0,
+        )
     finally:
-        campaign.close()
-        if trainer.resiliency is not None:
-            trainer.resiliency.close()
         if dist.is_initialized():
             dist.barrier()
             dist.destroy_process_group()

--- a/tests/README.md
+++ b/tests/README.md
@@ -17,7 +17,8 @@ python -m pytest -q
 ```
 
 Distributed programs document their required `torchrun` command in the module docstring.
-Production-loop integration is exercised directly through `examples/production_loops/` with `--inject-fault`.
+Production-loop integration is exercised through `examples/production_loops/`.
+Destructive injection is covered separately by `examples/fault_injection/`.
 The public fault injection evaluation kit is covered by `unit/test_fault_injection.py`.
 MoE validation is manual because it depends on specific GPU, Triton, Megatron Core, and Transformer Engine environments.
 Reproducible healthy-path performance commands and regression thresholds are documented in [benchmarks](../benchmarks/README.md).

--- a/tests/unit/test_production_loop_examples.py
+++ b/tests/unit/test_production_loop_examples.py
@@ -6,6 +6,8 @@ import pytest
 
 from examples.production_loops._common import (
     parse_run_arguments,
+    torchrun_checkpoint_step,
+    training_step_range,
     write_validation_summary,
 )
 from lm_resiliency.integrations.torchrun.worker_adapter import (
@@ -48,6 +50,31 @@ def test_shared_summary_writer_skips_non_writer_rank(tmp_path: Path) -> None:
     assert not list(tmp_path.iterdir())
 
 
+def test_shared_training_range_resumes_from_torchrun_checkpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LM_RESILIENCY_TORCHRUN_CHECKPOINT_STEP", "4")
+
+    assert torchrun_checkpoint_step() == 4
+    assert list(training_step_range(torchrun_checkpoint_step(), 7)) == [4, 5, 6]
+
+
+@pytest.mark.parametrize(
+    ("current_step", "target_step"),
+    [
+        (4, 4),
+        (5, 4),
+        (-1, 4),
+    ],
+)
+def test_shared_training_range_rejects_invalid_resume_target(
+    current_step: int,
+    target_step: int,
+) -> None:
+    with pytest.raises(ValueError):
+        training_step_range(current_step, target_step)
+
+
 @pytest.mark.parametrize(
     "module_name",
     [
@@ -81,6 +108,7 @@ def test_user_training_examples_have_no_lm_resiliency_imports(
     )
     assert "LM_RESILIENCY_TORCHRUN_ADAPTER_ATTACHED" not in source
     assert "assert_torchrun_adapter_attached" not in source
+    assert "--max-restarts=4" in source
 
 
 def test_checked_in_production_policy_is_valid(tmp_path: Path) -> None:

--- a/tests/unit/test_production_loop_examples.py
+++ b/tests/unit/test_production_loop_examples.py
@@ -1,78 +1,108 @@
-from types import SimpleNamespace
+import ast
+import json
+from pathlib import Path
 
 import pytest
-import torch
-import torch.nn as nn
 
-from examples.production_loops._common import ReplayFaultCampaign
+from examples.production_loops._common import (
+    parse_run_arguments,
+    write_validation_summary,
+)
+from lm_resiliency.integrations.torchrun.worker_adapter import (
+    TorchrunWorkerContext,
+    _feature_options,
+    _load_config,
+)
 
 
-class _CheckpointManager:
-    def __init__(self, step: int) -> None:
-        self._last_saved_step = step
-        self.checkpoint_status = SimpleNamespace(recovery_verified_step=step)
+def test_shared_run_arguments_prepare_validation_output_dir(tmp_path: Path) -> None:
+    output_dir = tmp_path / "validation"
+
+    arguments = parse_run_arguments(["--validation-output-dir", str(output_dir), "--steps", "3"])
+
+    assert arguments.validation_output_dir == output_dir
+    assert arguments.steps == 3
+    assert output_dir.is_dir()
 
 
-def _result(*, fault: bool) -> SimpleNamespace:
-    return SimpleNamespace(
-        peer_ranks=[0, 1],
-        sdc_bitmap=[1, 0] if fault else [0, 0],
-        straggler_bitmap=[0, 0],
-        sdc_sources=["hidden.output"] if fault else [],
-        checked_recipe_ids={"embedding", "hidden", "output", "optimizer"},
+def test_shared_summary_writer_publishes_framework_result(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    summary = {"framework": "pytorch", "steps": 3}
+
+    write_validation_summary(tmp_path, summary, writer=True)
+
+    summary_path = tmp_path / "pytorch-production-loop.json"
+    assert json.loads(summary_path.read_text(encoding="utf-8")) == summary
+    assert json.loads(capsys.readouterr().out) == summary
+
+
+def test_shared_summary_writer_skips_non_writer_rank(tmp_path: Path) -> None:
+    write_validation_summary(
+        tmp_path,
+        {"framework": "pytorch", "steps": 3},
+        writer=False,
     )
 
-
-def test_fault_campaign_corrupts_replay_but_not_training_forward() -> None:
-    target = nn.Identity()
-    manager = _CheckpointManager(step=1)
-    handle = SimpleNamespace(
-        replay_harness=SimpleNamespace(target_layer=target),
-        ckpt_manager=manager,
-    )
-    campaign = ReplayFaultCampaign(
-        steps=5,
-        rank=0,
-        world_size=2,
-        inject_fault=True,
-        fault_step=2,
-        fault_rank=0,
-    )
-    campaign.bind(handle)
-    campaign.start_step(2)
-
-    value = torch.zeros(2)
-    torch.testing.assert_close(target(value), value)
-    torch.testing.assert_close(target(value), value + 1.0)
-
-    campaign.record_fault(_result(fault=True))
-    campaign.recovery_decisions.append(
-        {
-            "failure_kind": "sdc",
-            "recovery_mode": "recovery_verified",
-            "checkpoint_source": "gemini",
-            "checkpoint_step": 1,
-            "available": True,
-        }
-    )
-    manager._last_saved_step = 5
-    manager.checkpoint_status.recovery_verified_step = 5
-
-    campaign.validate(
-        handle,
-        _result(fault=False),
-        {"embedding", "hidden", "output", "optimizer"},
-    )
-    campaign.close()
+    assert not list(tmp_path.iterdir())
 
 
-def test_fault_campaign_requires_two_clean_post_fault_steps() -> None:
-    args = SimpleNamespace(
-        steps=5,
-        inject_fault=True,
-        fault_step=4,
-        fault_rank=-1,
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "deepspeed.py",
+        "megatron.py",
+        "pytorch.py",
+        "torchtitan.py",
+    ],
+)
+def test_user_training_examples_have_no_lm_resiliency_imports(
+    module_name: str,
+) -> None:
+    source_path = Path(__file__).parents[2] / "examples" / "production_loops" / module_name
+    source = source_path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(source_path))
+    imported_modules = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    imported_modules.update(
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module is not None
     )
 
-    with pytest.raises(ValueError, match="post-fault"):
-        ReplayFaultCampaign.from_args(args, rank=0, world_size=2)
+    assert not any(
+        module == "lm_resiliency" or module.startswith("lm_resiliency.")
+        for module in imported_modules
+    )
+    assert "LM_RESILIENCY_TORCHRUN_ADAPTER_ATTACHED" not in source
+    assert "assert_torchrun_adapter_attached" not in source
+
+
+def test_checked_in_production_policy_is_valid(tmp_path: Path) -> None:
+    policy = (
+        Path(__file__).parents[2] / "examples" / "production_loops" / "policies" / "resiliency.toml"
+    )
+    context = TorchrunWorkerContext(
+        run_id="production-policy-test",
+        node_id="node-a",
+        local_world_size=1,
+        restart_context_path=(tmp_path / "restart-context.json").resolve(),
+    )
+
+    checkpoint, replay, options = _feature_options(_load_config(policy), context)
+
+    assert options == {
+        "enable_checkpoint": True,
+        "enable_detection": True,
+        "interval": 1,
+    }
+    assert checkpoint is not None
+    assert checkpoint.replication_jump == 4
+    assert checkpoint.disk_flush_interval == 0
+    assert replay is not None
+    assert replay.rotate_layers is False


### PR DESCRIPTION
## Summary

- migrate native PyTorch, DeepSpeed, Megatron Core, and TorchTitan production-loop examples to automatic torchrun worker adapters
- remove LM Resiliency imports and fault-injection logic from the user training modules
- resume deterministic input position from the manager-selected checkpoint and preserve framework-owned progress state
- add positive torchrun restart budgets and publish success only after automatic resiliency teardown completes
- consolidate shared `--validation-output-dir`, step parsing, resume ranges, directory creation, JSON publication, and rank-zero printing in `_common.py`

## Why

These examples should represent ordinary framework-owned training code. Resiliency activation and recovery now occur before the user module's training boundary, so the modules no longer initialize LM Resiliency or contain destructive validation hooks.

The output directory contains only example result summaries and TorchTitan runtime dumps. It is not a restart-context path or GEMINI checkpoint directory.

## Scope

This PR is stacked on PR #152. It contains production-loop modules, their shared policy/helper, directly related documentation, and production-owned tests. `examples/torchrun_validation` and `examples/torchrun_fault_injection` are intentionally excluded.

## Validation

- 12 focused production-loop tests passed locally
- 50 combined production/source adapter contract tests passed locally
- Ruff, formatting, and `git diff --check` passed
- all required CI, packaging, and supported-version checks passed
- clean adapter matrix completed for native PyTorch, DeepSpeed, Megatron Core, and TorchTitan
- each framework completed a targeted same-node restart and standby-replacement campaign through its native training boundary