### PR TITLE
[Examples][torchrun] Add adapter bootstrap and resiliency cycle

### DIFF
--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -350,6 +350,11 @@ DeepSpeed, Megatron Core, and TorchTitan also completed a focused
 restart-and-replacement campaign through their framework-owned training
 boundaries.
 
+Runnable bootstrap and manager-driven end-to-end programs live under
+[`examples/torchrun`](../examples/torchrun/README.md). The
+resiliency-cycle controller launches torchrun agents and is not itself a
+training worker.
+
 ## Current Boundaries
 
 - fixed-size replacement only; no scale-up or scale-down;

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,9 +1,18 @@
 # Examples
 
+The examples are organized by use case:
+
+| Path | Purpose |
+|---|---|
+| [`quickstart.py`](quickstart.py) | Single-process CPU training and GEMINI recovery |
+| [`production_loops/`](production_loops/) | Framework-native PyTorch, DeepSpeed, Megatron Core, and TorchTitan training loops |
+| [`torchrun/`](torchrun/README.md) | Native torchrun adapter bootstrap, restart, and standby replacement |
+
 ## Quick Start
 
-After installing `lm-resiliency`, run its packaged command to train a tiny causal LM on CPU.
-The example executes the complete forward, backward, optimizer, and GEMINI checkpoint lifecycle without requiring a GPU.
+After installing `lm-resiliency`, run its packaged command to train a tiny
+causal LM on CPU. The command executes the forward, backward, optimizer, and
+GEMINI checkpoint lifecycle without requiring a GPU:
 
 ```bash
 lm-resiliency-quickstart \
@@ -20,10 +29,9 @@ lm-resiliency-quickstart \
   --run-id my-quickstart
 ```
 
-The installed command and library come from the same wheel.
-Developers working from a source checkout can use the equivalent [quickstart.py](quickstart.py) wrapper.
-The single-process example validates training-loop integration and recovery.
-Use the distributed examples below to exercise SCOUT replay and multi-rank localization.
+The installed command and library come from the same wheel. Developers working
+from a source checkout can use the equivalent
+[`quickstart.py`](quickstart.py) wrapper.
 
 ## Production Loops
 
@@ -68,3 +76,11 @@ Each framework example runs ten steps by default; set `--steps` to change the
 duration. Rank zero writes a framework summary under
 `--validation-output-dir`; the directory is example validation output and is
 not used for restart contexts or GEMINI checkpoints.
+
+## Torchrun Workflows
+
+See the [torchrun guide](torchrun/README.md) for:
+
+- a CPU adapter-bootstrap smoke test;
+- clean automatic-adapter checks across all four frameworks; and
+- manager-driven same-node restart and SCOUT-localized standby replacement.

--- a/examples/torchrun/README.md
+++ b/examples/torchrun/README.md
@@ -128,6 +128,11 @@ baseline-*.log
 *.log
 ```
 
+Use a fresh directory for every run. Before launching any worker, the
+controller rejects a bundle containing anything other than `campaign.json`;
+this prevents reports or final artifacts from an earlier run satisfying the
+current campaign's waits.
+
 The checked-in short campaign uses four active GPU-nodes and one standby. It
 schedules one same-node restart followed by one SCOUT-localized replacement:
 
@@ -170,7 +175,10 @@ python -m examples.torchrun.resiliency_cycle.pressure orchestrate \
 ```
 
 SSH must work in batch mode. The controller copies the current source tree to
-`--remote-source-dir` before launching remote agents.
+`--remote-source-dir` before launching remote agents and installs it with the
+interpreter selected by `--remote-python`. Gloo and NCCL choose their normal
+host interfaces; set their standard environment variables in the launch
+environment only when the deployment requires an explicit interface.
 
 ### Acceptance Criteria
 
@@ -179,7 +187,8 @@ The controller exits successfully only when:
 - every scheduled incident produces reports from the full active world;
 - SCOUT localizes each replay-only SDC to the scheduled logical rank;
 - the selected standby inherits the failed rank and logical slot;
-- every successor rank restores the manager-selected checkpoint exactly;
+- every successor rank restores the manager-selected checkpoint step and
+  job-wide GEMINI topology exactly;
 - RNG and framework-owned recovery state match; and
 - final loss, model, and optimizer state remain within the
   framework-specific baseline tolerances.

--- a/examples/torchrun/README.md
+++ b/examples/torchrun/README.md
@@ -1,0 +1,187 @@
+# Torchrun Workflows
+
+This directory contains runnable qualification workflows for the native
+torchrun integration:
+
+| Directory | Purpose |
+|---|---|
+| [`adapter_bootstrap/`](adapter_bootstrap/) | Zero-import bootstrap and clean automatic-adapter checks |
+| [`resiliency_cycle/`](resiliency_cycle/) | Detection, recovery decision, restart, checkpoint restoration, and standby replacement |
+
+The framework-owned training loops remain under
+[`examples/production_loops`](../production_loops/). The bootstrap matrix and
+resiliency-cycle drivers reuse those framework components rather than defining
+another set of toy training loops.
+
+These programs require explicit hardware and framework environments and are not
+part of default pull-request CI.
+
+## Prerequisites
+
+Run commands from the repository root in a supported Python environment with
+the repository installed:
+
+```bash
+python -m pip install -e ".[dev]"
+```
+
+Install the relevant optional framework extra before selecting DeepSpeed,
+Megatron Core, or TorchTitan. The framework matrix requires an even world size
+of at least two; resiliency-cycle campaigns require an even active world size
+of at least four. The controller treats each supplied GPU as an independent
+synthetic torchrun node and starts one torchrun agent per GPU.
+
+## Adapter Bootstrap Smoke
+
+The smoke worker deliberately does not import `lm_resiliency`. Its disabled
+policy proves that the rendezvous backend installs an inferred framework
+adapter before user code runs, without enabling GEMINI or SCOUT or requiring
+CUDA:
+
+```bash
+torchrun \
+  --nnodes=1:1 \
+  --nproc-per-node=1 \
+  --max-restarts=0 \
+  --rdzv-backend=lm_resiliency \
+  --rdzv-endpoint=/tmp/lm-resiliency-smoke-rdzv \
+  --rdzv-id=lm-resiliency-smoke \
+  --rdzv-conf="store_type=file,\
+lm_resiliency_restart_context_path=/tmp/lm-resiliency-smoke-context/context.json,\
+lm_resiliency_worker_config=$PWD/examples/torchrun/adapter_bootstrap/policies/smoke.toml" \
+  --module \
+  examples.torchrun.adapter_bootstrap.smoke \
+  --validation-output-dir /tmp/lm-resiliency-smoke
+```
+
+The run succeeds only when the result JSON contains
+`"resiliency_adapter_attached": true`.
+
+## Framework Matrix
+
+The clean matrix launches the unchanged production loop for PyTorch,
+DeepSpeed, Megatron Core, or TorchTitan through the automatic worker adapter:
+
+```bash
+python -m examples.torchrun.adapter_bootstrap.matrix \
+  --framework all \
+  --nproc-per-node 8 \
+  --validation-output-dir /tmp/lm-resiliency-framework-matrix
+```
+
+`--nproc-per-node` must be an even integer of at least two. Repeat
+`--framework` to select a subset. The controller writes one framework summary
+per run and a combined `summary.json` under `--validation-output-dir`.
+
+## Resiliency Cycle
+
+The package keeps the user-facing controller and campaign manifests separate
+from implementation details:
+
+```text
+resiliency_cycle/
+  pressure.py
+  campaigns/
+  harness/
+    artifacts.py
+    campaign.py
+    launch.py
+    replay_fault.py
+    runtime.py
+    verify.py
+    worker.py
+    frameworks/
+```
+
+The outer `pressure.py` controller:
+
+1. runs an uninterrupted baseline;
+2. launches one torchrun agent per supplied GPU;
+3. waits for automatic active/standby admission;
+4. injects scheduled restart or replay-only SDC incidents;
+5. publishes manager-selected successor generations; and
+6. compares the final managed state with the baseline.
+
+The controller is not a training worker and must not itself be launched through
+torchrun. Select one framework with `--framework`:
+
+```text
+pytorch
+deepspeed
+megatron
+torchtitan
+```
+
+### Campaign Bundle
+
+`--fault-campaign-dir` is the run bundle. It contains:
+
+```text
+campaign.json
+state.json
+summary.json
+baseline-artifacts/
+campaign-artifacts/
+contexts/
+machine-ids/
+baseline-*.log
+*.log
+```
+
+The checked-in short campaign uses four active GPU-nodes and one standby. It
+schedules one same-node restart followed by one SCOUT-localized replacement:
+
+```bash
+campaign_dir=/shared/lm-resiliency-framework-recovery
+mkdir -p "$campaign_dir"
+cp examples/torchrun/resiliency_cycle/campaigns/framework_restart_replacement.json \
+  "$campaign_dir/campaign.json"
+
+python -m examples.torchrun.resiliency_cycle.pressure orchestrate \
+  --framework pytorch \
+  --fault-campaign-dir "$campaign_dir" \
+  --gpus 0,1,2,3,4
+```
+
+If `campaign.json` is absent, the controller creates the default pressure
+profile: eight active GPU-nodes, eight standbys, sixteen same-node restarts,
+and eight replacements.
+
+Fault injection is configured only through the campaign bundle. It is not a
+worker-policy or `--rdzv-conf` setting.
+
+### Multi-Host Run
+
+The campaign directory and its parent must be visible at the same path on both
+hosts. Supply local and remote GPU lists of the sizes required by the campaign,
+plus the remote Python environment, remote source directory, and a
+controller-reachable rendezvous address:
+
+```bash
+python -m examples.torchrun.resiliency_cycle.pressure orchestrate \
+  --framework pytorch \
+  --fault-campaign-dir /shared/lm-resiliency-pressure \
+  --gpus 0,1,2,3,4,5,6,7 \
+  --remote-gpus 0,1,2,3,4,5,6,7 \
+  --remote-host worker-b \
+  --remote-python /opt/lm-resiliency/bin/python \
+  --remote-source-dir /shared/lm-resiliency-source \
+  --rdzv-host 10.0.0.10
+```
+
+SSH must work in batch mode. The controller copies the current source tree to
+`--remote-source-dir` before launching remote agents.
+
+### Acceptance Criteria
+
+The controller exits successfully only when:
+
+- every scheduled incident produces reports from the full active world;
+- SCOUT localizes each replay-only SDC to the scheduled logical rank;
+- the selected standby inherits the failed rank and logical slot;
+- every successor rank restores the manager-selected checkpoint exactly;
+- RNG and framework-owned recovery state match; and
+- final loss, model, and optimizer state remain within the
+  framework-specific baseline tolerances.
+
+The final evidence is recorded in `<fault-campaign-dir>/summary.json`.

--- a/examples/torchrun/README.md
+++ b/examples/torchrun/README.md
@@ -153,7 +153,8 @@ profile: eight active GPU-nodes, eight standbys, sixteen same-node restarts,
 and eight replacements.
 
 Fault injection is configured only through the campaign bundle. It is not a
-worker-policy or `--rdzv-conf` setting.
+worker-policy or `--rdzv-conf` setting. Replacement incidents must run at step
+2 or later so a clean recovery-verified checkpoint exists before corruption.
 
 ### Multi-Host Run
 

--- a/examples/torchrun/__init__.py
+++ b/examples/torchrun/__init__.py
@@ -1,0 +1,1 @@
+"""Native torchrun bootstrap and fault-injection examples."""

--- a/examples/torchrun/adapter_bootstrap/__init__.py
+++ b/examples/torchrun/adapter_bootstrap/__init__.py
@@ -1,0 +1,1 @@
+"""Non-destructive torchrun bootstrap and adapter validation."""

--- a/examples/torchrun/adapter_bootstrap/_validation.py
+++ b/examples/torchrun/adapter_bootstrap/_validation.py
@@ -1,0 +1,11 @@
+"""Validation-only assertions for the native torchrun integration."""
+
+from __future__ import annotations
+
+import os
+
+
+def assert_torchrun_adapter_attached() -> None:
+    """Fail when automatic torchrun worker instrumentation did not attach."""
+    if os.environ.get("LM_RESILIENCY_TORCHRUN_ADAPTER_ATTACHED") != "1":
+        raise RuntimeError("the torchrun worker adapter did not attach")

--- a/examples/torchrun/adapter_bootstrap/_validation.py
+++ b/examples/torchrun/adapter_bootstrap/_validation.py
@@ -3,9 +3,48 @@
 from __future__ import annotations
 
 import os
+import threading
+from types import TracebackType
 
 
 def assert_torchrun_adapter_attached() -> None:
     """Fail when automatic torchrun worker instrumentation did not attach."""
     if os.environ.get("LM_RESILIENCY_TORCHRUN_ADAPTER_ATTACHED") != "1":
         raise RuntimeError("the torchrun worker adapter did not attach")
+
+
+class ObserveTorchrunAdapterAttachment:
+    """Latch the transient attachment marker across framework-owned teardown."""
+
+    def __init__(self) -> None:
+        self._attached = False
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def __enter__(self) -> ObserveTorchrunAdapterAttachment:
+        self._observe()
+        self._thread = threading.Thread(target=self._poll, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(
+        self,
+        error_type: type[BaseException] | None,
+        error: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        del error, traceback
+        self._stop.set()
+        assert self._thread is not None
+        self._thread.join(timeout=1)
+        self._observe()
+        if error_type is None and not self._attached:
+            raise RuntimeError("the torchrun worker adapter did not attach")
+
+    def _poll(self) -> None:
+        while not self._stop.wait(0.01):
+            self._observe()
+
+    def _observe(self) -> None:
+        if os.environ.get("LM_RESILIENCY_TORCHRUN_ADAPTER_ATTACHED") == "1":
+            self._attached = True

--- a/examples/torchrun/adapter_bootstrap/framework_worker.py
+++ b/examples/torchrun/adapter_bootstrap/framework_worker.py
@@ -6,23 +6,27 @@ import argparse
 import importlib
 import sys
 
-from examples.torchrun.adapter_bootstrap._validation import (
-    assert_torchrun_adapter_attached,
-)
+from examples.torchrun.adapter_bootstrap._validation import ObserveTorchrunAdapterAttachment
 
 FRAMEWORKS = ("pytorch", "deepspeed", "megatron", "torchtitan")
+FRAMEWORK_IMPORT_ROOTS = {
+    "pytorch": "torch",
+    "deepspeed": "deepspeed",
+    "megatron": "megatron",
+    "torchtitan": "torchtitan",
+}
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("--framework", choices=FRAMEWORKS, required=True)
     arguments, remaining = parser.parse_known_args()
-    importlib.import_module(arguments.framework)
+    importlib.import_module(FRAMEWORK_IMPORT_ROOTS[arguments.framework])
     module_name = f"examples.production_loops.{arguments.framework}"
     module = importlib.import_module(module_name)
     sys.argv = [module_name, *remaining]
-    module.main()
-    assert_torchrun_adapter_attached()
+    with ObserveTorchrunAdapterAttachment():
+        module.main()
 
 
 if __name__ == "__main__":

--- a/examples/torchrun/adapter_bootstrap/framework_worker.py
+++ b/examples/torchrun/adapter_bootstrap/framework_worker.py
@@ -1,0 +1,29 @@
+"""Validation wrapper around one unchanged framework production loop."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+
+from examples.torchrun.adapter_bootstrap._validation import (
+    assert_torchrun_adapter_attached,
+)
+
+FRAMEWORKS = ("pytorch", "deepspeed", "megatron", "torchtitan")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--framework", choices=FRAMEWORKS, required=True)
+    arguments, remaining = parser.parse_known_args()
+    importlib.import_module(arguments.framework)
+    module_name = f"examples.production_loops.{arguments.framework}"
+    module = importlib.import_module(module_name)
+    sys.argv = [module_name, *remaining]
+    module.main()
+    assert_torchrun_adapter_attached()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/torchrun/adapter_bootstrap/matrix.py
+++ b/examples/torchrun/adapter_bootstrap/matrix.py
@@ -1,0 +1,127 @@
+"""Launch the unchanged production loops through the torchrun adapters."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from lm_resiliency.integrations.torchrun import TorchrunLaunchConfig
+
+from .framework_worker import FRAMEWORKS
+
+
+def _write_worker_policy(path: Path, *, replication_jump: int) -> None:
+    path.write_text(
+        "\n".join(
+            (
+                "schema_version = 1",
+                "interval = 1",
+                "enable_checkpoint = true",
+                "enable_detection = true",
+                "",
+                "[checkpoint]",
+                f"replication_jump = {replication_jump}",
+                "disk_flush_interval = 0",
+                "",
+                "[replay]",
+                "rotate_layers = false",
+                "enable_temporal = false",
+                "scale_factors = []",
+                "straggler_min_slowdown_ratio = 100.0",
+                "straggler_min_slowdown_ms = 10000.0",
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+
+def _run_framework(
+    framework: str,
+    *,
+    nproc_per_node: int,
+    output_dir: Path,
+    policy: Path,
+    steps: int,
+    torchrun: str,
+) -> dict[str, object]:
+    framework_dir = output_dir / framework
+    framework_dir.mkdir(parents=True, exist_ok=True)
+    launch = TorchrunLaunchConfig(
+        run_id=f"torchrun-validation-{framework}-{os.getpid()}",
+        rendezvous_endpoint=str(framework_dir / "rdzv"),
+        restart_context_path=(framework_dir / "context" / "context.json").resolve(),
+        min_nodes=1,
+        max_nodes=1,
+        nproc_per_node=nproc_per_node,
+        max_restarts=0,
+        torchrun=torchrun,
+        store_type="file",
+        worker_config=policy.resolve(),
+    )
+    subprocess.run(
+        launch.command(
+            module="examples.torchrun.adapter_bootstrap.framework_worker",
+            module_args=(
+                f"--framework={framework}",
+                f"--validation-output-dir={framework_dir}",
+                f"--steps={steps}",
+            ),
+        ),
+        check=True,
+    )
+    summary_path = framework_dir / f"{framework}-production-loop.json"
+    if not summary_path.is_file():
+        raise RuntimeError(f"{framework} did not publish its validation summary")
+    value = json.loads(summary_path.read_text(encoding="utf-8"))
+    if value.get("framework") != framework:
+        raise RuntimeError(f"{framework} published a mismatched validation summary")
+    return value
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--framework",
+        action="append",
+        choices=(*FRAMEWORKS, "all"),
+        default=[],
+    )
+    parser.add_argument("--nproc-per-node", type=int, default=8)
+    parser.add_argument("--steps", type=int, default=2)
+    parser.add_argument("--torchrun", default=str(Path(sys.executable).with_name("torchrun")))
+    parser.add_argument("--validation-output-dir", type=Path, required=True)
+    arguments = parser.parse_args()
+    if arguments.nproc_per_node < 2 or arguments.nproc_per_node % 2:
+        raise ValueError("--nproc-per-node must be an even integer of at least two")
+    if arguments.steps < 1:
+        raise ValueError("--steps must be positive")
+    frameworks = arguments.framework or ["all"]
+    selected = FRAMEWORKS if "all" in frameworks else tuple(dict.fromkeys(frameworks))
+    output_dir = arguments.validation_output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    policy = output_dir / "worker.toml"
+    _write_worker_policy(policy, replication_jump=arguments.nproc_per_node // 2)
+    summaries = {
+        framework: _run_framework(
+            framework,
+            nproc_per_node=arguments.nproc_per_node,
+            output_dir=output_dir,
+            policy=policy,
+            steps=arguments.steps,
+            torchrun=arguments.torchrun,
+        )
+        for framework in selected
+    }
+    (output_dir / "summary.json").write_text(
+        json.dumps(summaries, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/torchrun/adapter_bootstrap/matrix.py
+++ b/examples/torchrun/adapter_bootstrap/matrix.py
@@ -26,6 +26,7 @@ def _write_worker_policy(path: Path, *, replication_jump: int) -> None:
                 "[checkpoint]",
                 f"replication_jump = {replication_jump}",
                 "disk_flush_interval = 0",
+                f"disk_folder = {json.dumps(str((path.parent / 'checkpoints').resolve()))}",
                 "",
                 "[replay]",
                 "rotate_layers = false",

--- a/examples/torchrun/adapter_bootstrap/policies/smoke.toml
+++ b/examples/torchrun/adapter_bootstrap/policies/smoke.toml
@@ -1,0 +1,4 @@
+schema_version = 1
+interval = 1
+enable_checkpoint = false
+enable_detection = false

--- a/examples/torchrun/adapter_bootstrap/smoke.py
+++ b/examples/torchrun/adapter_bootstrap/smoke.py
@@ -1,0 +1,70 @@
+"""Minimal DDP smoke worker activated entirely through torchrun flags.
+
+This module deliberately does not import ``lm_resiliency``. The
+``lm_resiliency`` rendezvous backend installs import monitoring before this
+module starts and infers the native PyTorch adapter from this module's imports.
+This is a bootstrap validation fixture, not a production-loop example.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+from torch.nn.parallel import DistributedDataParallel
+
+from examples.torchrun.adapter_bootstrap._validation import (
+    assert_torchrun_adapter_attached,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--validation-output-dir", type=Path, required=True)
+    parser.add_argument("--steps", type=int, default=2)
+    args = parser.parse_args()
+    if args.steps < 1:
+        raise ValueError("steps must be positive")
+
+    args.validation_output_dir.mkdir(parents=True, exist_ok=True)
+    dist.init_process_group("gloo")
+    rank = dist.get_rank()
+
+    torch.manual_seed(123)
+    model = DistributedDataParallel(torch.nn.Linear(4, 2))
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    losses: list[float] = []
+    for step in range(args.steps):
+        inputs = torch.full((2, 4), float(rank + step + 1))
+        optimizer.zero_grad(set_to_none=True)
+        loss = model(inputs).square().mean()
+        loss.backward()
+        optimizer.step()
+        losses.append(float(loss.detach()))
+
+    assert_torchrun_adapter_attached()
+    output_path = args.validation_output_dir / f"rank-{rank}.json"
+    output_path.write_text(
+        json.dumps(
+            {
+                "local_rank": int(os.environ["LOCAL_RANK"]),
+                "resiliency_adapter_attached": True,
+                "losses": losses,
+                "rank": rank,
+                "world_size": dist.get_world_size(),
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/torchrun/resiliency_cycle/__init__.py
+++ b/examples/torchrun/resiliency_cycle/__init__.py
@@ -1,0 +1,1 @@
+"""End-to-end torchrun resiliency-cycle example."""

--- a/examples/torchrun/resiliency_cycle/campaigns/framework_restart_replacement.json
+++ b/examples/torchrun/resiliency_cycle/campaigns/framework_restart_replacement.json
@@ -1,0 +1,76 @@
+{
+  "clock": {
+    "origin": "training_run",
+    "type": "training_iteration"
+  },
+  "incidents": [
+    {
+      "faults": [
+        {
+          "fault_id": "restart-01-process-stall",
+          "parameters": {},
+          "target": {
+            "model_part": 0,
+            "operation": "manager_restart",
+            "rank": 0,
+            "surface": "process"
+          },
+          "type": "hang"
+        }
+      ],
+      "incident_id": "restart-01",
+      "lifetime": {
+        "matching_calls": 1
+      },
+      "retrigger": "once",
+      "trigger": {
+        "at": [
+          1
+        ],
+        "probability": 1.0
+      }
+    },
+    {
+      "faults": [
+        {
+          "fault_id": "replacement-01-replay-sdc",
+          "parameters": {
+            "operation": "sign_flip",
+            "scope": "100%"
+          },
+          "target": {
+            "component": "transformer_block",
+            "index": 0,
+            "metadata": {
+              "injection_mode": "scout_replay_only"
+            },
+            "model_part": 0,
+            "rank": 0,
+            "surface": "output"
+          },
+          "type": "tensor_corruption"
+        }
+      ],
+      "incident_id": "replacement-01",
+      "lifetime": {
+        "matching_calls": 1
+      },
+      "retrigger": "once",
+      "trigger": {
+        "at": [
+          2
+        ],
+        "probability": 1.0
+      }
+    }
+  ],
+  "metadata": {
+    "active_nodes": 4,
+    "profile": "torchrun_pressure",
+    "standby_nodes": 1,
+    "total_steps": 4
+  },
+  "name": "torchrun-framework-restart-replacement",
+  "schema_version": 1,
+  "seed": 23
+}

--- a/examples/torchrun/resiliency_cycle/harness/__init__.py
+++ b/examples/torchrun/resiliency_cycle/harness/__init__.py
@@ -1,0 +1,1 @@
+"""Implementation harness for the torchrun resiliency-cycle example."""

--- a/examples/torchrun/resiliency_cycle/harness/artifacts.py
+++ b/examples/torchrun/resiliency_cycle/harness/artifacts.py
@@ -1,0 +1,58 @@
+"""File and process helpers shared by torchrun fault injection."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import torch
+
+
+def atomic_json(path: Path, value: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    with temporary.open("w", encoding="utf-8") as handle:
+        json.dump(value, handle, sort_keys=True)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temporary, path)
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise AssertionError(f"{path} does not contain a JSON object")
+    return value
+
+
+def atomic_torch(path: Path, value: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    with temporary.open("wb") as handle:
+        torch.save(dict(value), handle)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temporary, path)
+
+
+def wait_for_paths(
+    paths: Sequence[Path],
+    *,
+    processes: Sequence[subprocess.Popen[bytes]],
+    timeout: float,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while not all(path.exists() for path in paths):
+        failed = [process.returncode for process in processes if process.poll() not in (None, 0)]
+        if failed:
+            raise RuntimeError(f"torchrun agent failed with exit codes {failed}")
+        if time.monotonic() >= deadline:
+            missing = [str(path) for path in paths if not path.exists()]
+            raise TimeoutError(f"timed out waiting for artifacts: {missing}")
+        time.sleep(0.1)

--- a/examples/torchrun/resiliency_cycle/harness/artifacts.py
+++ b/examples/torchrun/resiliency_cycle/harness/artifacts.py
@@ -6,7 +6,7 @@ import json
 import os
 import subprocess
 import time
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -46,9 +46,14 @@ def wait_for_paths(
     *,
     processes: Sequence[subprocess.Popen[bytes]],
     timeout: float,
+    health_check: Callable[[], None] | None = None,
 ) -> None:
     deadline = time.monotonic() + timeout
-    while not all(path.exists() for path in paths):
+    while True:
+        if health_check is not None:
+            health_check()
+        if all(path.exists() for path in paths):
+            return
         failed = [process.returncode for process in processes if process.poll() not in (None, 0)]
         if failed:
             raise RuntimeError(f"torchrun agent failed with exit codes {failed}")

--- a/examples/torchrun/resiliency_cycle/harness/campaign.py
+++ b/examples/torchrun/resiliency_cycle/harness/campaign.py
@@ -1,0 +1,236 @@
+"""Campaign and GPU-node topology for torchrun pressure validation."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from lm_resiliency import (
+    FailureType,
+    FaultCampaign,
+    FaultIncident,
+    FaultSpec,
+    FaultSurface,
+    FaultTarget,
+    IncidentLifetime,
+    IncidentTrigger,
+)
+
+from .artifacts import atomic_json
+
+DEFAULT_ACTIVE_NODES = 8
+DEFAULT_STANDBY_NODES = 8
+RESTARTS_PER_REPLACEMENT = 2
+CAMPAIGN_FILENAME = "campaign.json"
+STATE_FILENAME = "state.json"
+
+
+@dataclass(frozen=True, slots=True)
+class PressureEvent:
+    """One manager action derived from a fault-campaign incident."""
+
+    incident_id: str
+    kind: str
+    step: int
+    fault_rank: int | None
+
+    @property
+    def checkpoint_step(self) -> int:
+        return self.step if self.kind == "restart" else self.step - 1
+
+
+@dataclass(frozen=True, slots=True)
+class GpuNodePlacement:
+    """One validation GPU modeled as an independent torchrun node."""
+
+    node_label: str
+    gpu_id: str
+    remote: bool
+
+
+@dataclass(frozen=True, slots=True)
+class PressureTopology:
+    """Validated active/standby layout for one campaign."""
+
+    placements: tuple[GpuNodePlacement, ...]
+    world_size: int
+    replication_jump: int
+    topology_digest: str
+
+
+def default_pressure_campaign() -> FaultCampaign:
+    incidents: list[FaultIncident] = []
+    for replacement_index in range(DEFAULT_STANDBY_NODES):
+        base_step = replacement_index * (RESTARTS_PER_REPLACEMENT + 1)
+        for restart_index in range(RESTARTS_PER_REPLACEMENT):
+            step = base_step + restart_index + 1
+            incident_id = f"restart-{replacement_index + 1:02d}-{restart_index + 1}"
+            incidents.append(
+                FaultIncident(
+                    incident_id=incident_id,
+                    trigger=IncidentTrigger(at=(step,)),
+                    lifetime=IncidentLifetime(matching_calls=1),
+                    faults=(
+                        FaultSpec(
+                            fault_id=f"{incident_id}-process-stall",
+                            type=FailureType.HANG,
+                            target=FaultTarget(
+                                rank=0,
+                                surface=FaultSurface.PROCESS,
+                                operation="manager_restart",
+                            ),
+                        ),
+                    ),
+                )
+            )
+        step = base_step + RESTARTS_PER_REPLACEMENT + 1
+        incident_id = f"replacement-{replacement_index + 1:02d}"
+        incidents.append(
+            FaultIncident(
+                incident_id=incident_id,
+                trigger=IncidentTrigger(at=(step,)),
+                lifetime=IncidentLifetime(matching_calls=1),
+                faults=(
+                    FaultSpec(
+                        fault_id=f"{incident_id}-replay-sdc",
+                        type=FailureType.TENSOR_CORRUPTION,
+                        target=FaultTarget(
+                            rank=replacement_index,
+                            component="transformer_block",
+                            index=0,
+                            surface=FaultSurface.OUTPUT,
+                            metadata={"injection_mode": "scout_replay_only"},
+                        ),
+                        parameters={"operation": "sign_flip", "scope": "100%"},
+                    ),
+                ),
+            )
+        )
+    return FaultCampaign(
+        name="torchrun-pressure-8-active-8-standby",
+        seed=17,
+        incidents=tuple(incidents),
+        metadata={
+            "active_nodes": DEFAULT_ACTIVE_NODES,
+            "profile": "torchrun_pressure",
+            "standby_nodes": DEFAULT_STANDBY_NODES,
+            "total_steps": len(incidents) + 1,
+        },
+    )
+
+
+def pressure_events(campaign: FaultCampaign) -> tuple[PressureEvent, ...]:
+    metadata = dict(campaign.metadata)
+    if metadata.get("profile") != "torchrun_pressure":
+        raise ValueError("fault campaign metadata.profile must be 'torchrun_pressure'")
+    events: list[PressureEvent] = []
+    for incident in campaign.incidents:
+        if (
+            len(incident.trigger.at) != 1
+            or incident.trigger.range is not None
+            or incident.trigger.probability != 1.0
+            or len(incident.faults) != 1
+        ):
+            raise ValueError("pressure incidents require one deterministic trigger and fault")
+        fault = incident.faults[0]
+        if fault.type is FailureType.HANG and fault.target.surface is FaultSurface.PROCESS:
+            kind = "restart"
+            fault_rank = None
+        elif (
+            fault.type is FailureType.TENSOR_CORRUPTION
+            and fault.target.surface is FaultSurface.OUTPUT
+            and fault.target.rank is not None
+        ):
+            kind = "replacement"
+            fault_rank = fault.target.rank
+        else:
+            raise ValueError(f"unsupported pressure incident {incident.incident_id!r}")
+        events.append(
+            PressureEvent(
+                incident_id=incident.incident_id,
+                kind=kind,
+                step=incident.trigger.at[0],
+                fault_rank=fault_rank,
+            )
+        )
+    events.sort(key=lambda event: event.step)
+    if len({event.step for event in events}) != len(events):
+        raise ValueError("pressure incident steps must be unique")
+    return tuple(events)
+
+
+def load_campaign_bundle(path: Path) -> tuple[FaultCampaign, tuple[PressureEvent, ...]]:
+    path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(path, 0o700)
+    manifest_path = path / CAMPAIGN_FILENAME
+    if manifest_path.exists():
+        campaign = FaultCampaign.from_json(manifest_path)
+    else:
+        campaign = default_pressure_campaign()
+        atomic_json(manifest_path, campaign.to_dict())
+    return campaign, pressure_events(campaign)
+
+
+def campaign_layout(
+    *,
+    gpus: str,
+    remote_gpus: str,
+    remote_enabled: bool,
+    campaign: FaultCampaign,
+    events: Sequence[PressureEvent],
+) -> PressureTopology:
+    local_gpu_ids = _gpu_ids(gpus, "--gpus")
+    remote_gpu_ids = _gpu_ids(remote_gpus, "--remote-gpus") if remote_enabled else ()
+    placements = tuple(
+        [
+            *(
+                GpuNodePlacement(f"local-gpu-{index:02d}", gpu_id, False)
+                for index, gpu_id in enumerate(local_gpu_ids)
+            ),
+            *(
+                GpuNodePlacement(f"remote-gpu-{index:02d}", gpu_id, True)
+                for index, gpu_id in enumerate(remote_gpu_ids)
+            ),
+        ]
+    )
+    active_nodes = campaign.metadata.get("active_nodes")
+    standby_nodes = campaign.metadata.get("standby_nodes")
+    if (
+        isinstance(active_nodes, bool)
+        or not isinstance(active_nodes, int)
+        or active_nodes < 4
+        or active_nodes % 2
+    ):
+        raise ValueError("campaign metadata.active_nodes must be an even integer of at least four")
+    if isinstance(standby_nodes, bool) or not isinstance(standby_nodes, int) or standby_nodes < 1:
+        raise ValueError("campaign metadata.standby_nodes must be a positive integer")
+    replacement_events = [event for event in events if event.kind == "replacement"]
+    if len(replacement_events) != standby_nodes:
+        raise ValueError("campaign must contain one replacement event per standby")
+    replacement_ranks = [event.fault_rank for event in replacement_events]
+    if len(set(replacement_ranks)) != len(replacement_ranks):
+        raise ValueError("replacement events must target distinct logical ranks")
+    if any(rank is None or rank < 0 or rank >= active_nodes for rank in replacement_ranks):
+        raise ValueError("replacement event target rank is outside the active world")
+    if len(placements) != active_nodes + standby_nodes:
+        raise ValueError(
+            "supplied GPU-node count must equal campaign active_nodes plus standby_nodes"
+        )
+    replication_jump = active_nodes // 2
+    return PressureTopology(
+        placements=placements,
+        world_size=active_nodes,
+        replication_jump=replication_jump,
+        topology_digest=(f"ddp-world-{active_nodes}-replication-jump-{replication_jump}-gpu-nodes"),
+    )
+
+
+def _gpu_ids(value: str, name: str) -> tuple[str, ...]:
+    gpu_ids = tuple(item.strip() for item in value.split(",") if item.strip())
+    if not gpu_ids:
+        raise ValueError(f"{name} must provide at least one GPU ID")
+    if len(gpu_ids) != len(set(gpu_ids)):
+        raise ValueError(f"{name} must not contain duplicate GPU IDs")
+    return gpu_ids

--- a/examples/torchrun/resiliency_cycle/harness/campaign.py
+++ b/examples/torchrun/resiliency_cycle/harness/campaign.py
@@ -155,6 +155,10 @@ def pressure_events(campaign: FaultCampaign) -> tuple[PressureEvent, ...]:
                     "replacement incidents require the supported replay-only "
                     "transformer-block sign_flip over 100% of the selected tensor"
                 )
+            if incident.trigger.at[0] < 2:
+                raise ValueError(
+                    "replacement incidents must follow at least one clean checkpoint step"
+                )
             kind = "replacement"
             fault_rank = fault.target.rank
         else:

--- a/examples/torchrun/resiliency_cycle/harness/campaign.py
+++ b/examples/torchrun/resiliency_cycle/harness/campaign.py
@@ -57,7 +57,6 @@ class PressureTopology:
     placements: tuple[GpuNodePlacement, ...]
     world_size: int
     replication_jump: int
-    topology_digest: str
 
 
 def default_pressure_campaign() -> FaultCampaign:
@@ -136,6 +135,8 @@ def pressure_events(campaign: FaultCampaign) -> tuple[PressureEvent, ...]:
             raise ValueError("pressure incidents require one deterministic trigger and fault")
         fault = incident.faults[0]
         if fault.type is FailureType.HANG and fault.target.surface is FaultSurface.PROCESS:
+            if fault.target.operation != "manager_restart":
+                raise ValueError("restart incidents require operation='manager_restart'")
             kind = "restart"
             fault_rank = None
         elif (
@@ -143,6 +144,17 @@ def pressure_events(campaign: FaultCampaign) -> tuple[PressureEvent, ...]:
             and fault.target.surface is FaultSurface.OUTPUT
             and fault.target.rank is not None
         ):
+            if (
+                fault.target.component != "transformer_block"
+                or fault.target.index != 0
+                or fault.target.metadata.get("injection_mode") != "scout_replay_only"
+                or fault.parameters.get("operation") != "sign_flip"
+                or fault.parameters.get("scope") != "100%"
+            ):
+                raise ValueError(
+                    "replacement incidents require the supported replay-only "
+                    "transformer-block sign_flip over 100% of the selected tensor"
+                )
             kind = "replacement"
             fault_rank = fault.target.rank
         else:
@@ -171,6 +183,17 @@ def load_campaign_bundle(path: Path) -> tuple[FaultCampaign, tuple[PressureEvent
         campaign = default_pressure_campaign()
         atomic_json(manifest_path, campaign.to_dict())
     return campaign, pressure_events(campaign)
+
+
+def require_fresh_campaign_run(path: Path) -> None:
+    """Reject bundle reuse so stale evidence cannot satisfy controller waits."""
+
+    unexpected = sorted(entry.name for entry in path.iterdir() if entry.name != CAMPAIGN_FILENAME)
+    if unexpected:
+        raise ValueError(
+            "fault campaign directory must be fresh and contain only campaign.json; "
+            f"found stale or unrelated entries: {unexpected!r}"
+        )
 
 
 def campaign_layout(
@@ -223,7 +246,6 @@ def campaign_layout(
         placements=placements,
         world_size=active_nodes,
         replication_jump=replication_jump,
-        topology_digest=(f"ddp-world-{active_nodes}-replication-jump-{replication_jump}-gpu-nodes"),
     )
 
 

--- a/examples/torchrun/resiliency_cycle/harness/frameworks/__init__.py
+++ b/examples/torchrun/resiliency_cycle/harness/frameworks/__init__.py
@@ -1,0 +1,1 @@
+"""Framework drivers for destructive torchrun validation."""

--- a/examples/torchrun/resiliency_cycle/harness/frameworks/deepspeed.py
+++ b/examples/torchrun/resiliency_cycle/harness/frameworks/deepspeed.py
@@ -16,7 +16,7 @@ from examples.production_loops.deepspeed import (
 from lm_resiliency.integrations.deepspeed import enable_resiliency
 from lm_resiliency.integrations.deepspeed.adapter import DeepSpeedAdapter
 
-from ..runtime import DriverConfig, clone_tensors
+from ..runtime import DriverConfig, clone_tensors, close_resources
 
 
 class DeepSpeedDriver:
@@ -90,7 +90,11 @@ class DeepSpeedDriver:
         }
 
     def close(self) -> None:
-        self.handle.close()
-        self.engine.destroy()
-        if dist.is_initialized():
-            dist.destroy_process_group()
+        close_resources(
+            ("resiliency handle", self.handle.close),
+            ("DeepSpeed engine", self.engine.destroy),
+            (
+                "default process group",
+                lambda: dist.destroy_process_group() if dist.is_initialized() else None,
+            ),
+        )

--- a/examples/torchrun/resiliency_cycle/harness/frameworks/deepspeed.py
+++ b/examples/torchrun/resiliency_cycle/harness/frameworks/deepspeed.py
@@ -56,7 +56,7 @@ class DeepSpeedDriver:
             device=self.device,
             fault_callback=config.fault_callback,
             orchestration=config.orchestration,
-            recovery_mode=config.recovery_mode,
+            **config.recovery_options(),
         )
         self._adapter = DeepSpeedAdapter(self.engine)
 

--- a/examples/torchrun/resiliency_cycle/harness/frameworks/deepspeed.py
+++ b/examples/torchrun/resiliency_cycle/harness/frameworks/deepspeed.py
@@ -1,0 +1,96 @@
+"""DeepSpeed ZeRO-2 driver for torchrun fault injection."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import torch
+import torch.distributed as dist
+
+from examples.production_loops.deepspeed import (
+    MICRO_BATCH_SIZE,
+    TinyCausalLM,
+    _tokens,
+)
+from lm_resiliency.integrations.deepspeed import enable_resiliency
+from lm_resiliency.integrations.deepspeed.adapter import DeepSpeedAdapter
+
+from ..runtime import DriverConfig, clone_tensors
+
+
+class DeepSpeedDriver:
+    framework = "deepspeed"
+    expected_recipes = {"hidden"}
+
+    def __init__(self, config: DriverConfig) -> None:
+        import deepspeed
+
+        environment = __import__("os").environ
+        self.rank = int(environment["RANK"])
+        self.world_size = int(environment["WORLD_SIZE"])
+        local_rank = int(environment["LOCAL_RANK"])
+        torch.cuda.set_device(local_rank)
+        self.device = torch.device("cuda", local_rank)
+        deepspeed.init_distributed(dist_backend="nccl")
+        torch.manual_seed(123)
+        model = TinyCausalLM()
+        optimizer = torch.optim.AdamW(model.parameters(), lr=2e-4)
+        self.engine, _, _, _ = deepspeed.initialize(
+            model=model,
+            optimizer=optimizer,
+            config={
+                "train_micro_batch_size_per_gpu": MICRO_BATCH_SIZE,
+                "gradient_accumulation_steps": 1,
+                "train_batch_size": MICRO_BATCH_SIZE * self.world_size,
+                "zero_optimization": {"stage": 2},
+                "bf16": {"enabled": True},
+                "steps_per_print": 1_000,
+            },
+        )
+        self.handle = enable_resiliency(
+            self.engine,
+            interval=1,
+            ckpt_config=config.checkpoint,
+            detection_config=config.replay,
+            device=self.device,
+            fault_callback=config.fault_callback,
+            orchestration=config.orchestration,
+            recovery_mode=config.recovery_mode,
+        )
+        self._adapter = DeepSpeedAdapter(self.engine)
+
+    def run(
+        self,
+        *,
+        before_step: Callable[[int], None],
+        after_step: Callable[[int, float | None], None],
+        total_steps: int,
+    ) -> None:
+        for step in range(self.handle.step_count + 1, total_steps + 1):
+            before_step(step)
+            tokens, labels = _tokens(self.rank, step - 1, self.engine.device)
+            loss = self.engine(tokens, labels)
+            self.engine.backward(loss)
+            self.engine.step()
+            after_step(step, float(loss.detach()))
+
+    def verification_state(self) -> dict[str, list[torch.Tensor]]:
+        tensors = self._adapter.collect_checkpoint_tensors()
+        model_group_count = len(self.engine.optimizer.bit16_groups_flat)
+        return {
+            "model": clone_tensors(tensors[:model_group_count]),
+            "optimizer": clone_tensors(tensors[model_group_count:]),
+        }
+
+    def framework_state(self) -> dict[str, Any]:
+        return {
+            "global_steps": int(self.engine.global_steps),
+            "step_count": int(self.handle.step_count),
+        }
+
+    def close(self) -> None:
+        self.handle.close()
+        self.engine.destroy()
+        if dist.is_initialized():
+            dist.destroy_process_group()

--- a/examples/torchrun/resiliency_cycle/harness/frameworks/megatron.py
+++ b/examples/torchrun/resiliency_cycle/harness/frameworks/megatron.py
@@ -18,7 +18,7 @@ from examples.production_loops.megatron import (
 )
 from lm_resiliency.integrations.megatron import MegatronAdapter, enable_resiliency
 
-from ..runtime import DriverConfig, clone_tensors
+from ..runtime import DriverConfig, clone_tensors, close_resources
 
 
 class MegatronDriver:
@@ -165,12 +165,21 @@ class MegatronDriver:
         }
 
     def close(self) -> None:
-        self.handle.close()
-        if dist.is_initialized():
+        def destroy_model_parallel() -> None:
+            if not dist.is_initialized():
+                return
             from megatron.core import parallel_state as mpu
 
             mpu.destroy_model_parallel()
-            dist.destroy_process_group()
+
+        close_resources(
+            ("resiliency handle", self.handle.close),
+            ("Megatron model parallel", destroy_model_parallel),
+            (
+                "default process group",
+                lambda: dist.destroy_process_group() if dist.is_initialized() else None,
+            ),
+        )
 
 
 def _nonnegative_int(value: Any, name: str) -> int:

--- a/examples/torchrun/resiliency_cycle/harness/frameworks/megatron.py
+++ b/examples/torchrun/resiliency_cycle/harness/frameworks/megatron.py
@@ -1,0 +1,154 @@
+"""Megatron Core driver for torchrun fault injection."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import torch
+import torch.distributed as dist
+
+from examples.production_loops.megatron import (
+    MICRO_BATCH_SIZE,
+    _arguments,
+    _build_model_optimizer_scheduler,
+    _forward_step,
+    _install_training_services,
+    _tokens,
+)
+from lm_resiliency.integrations.megatron import MegatronAdapter, enable_resiliency
+
+from ..runtime import DriverConfig, clone_tensors
+
+
+class MegatronDriver:
+    framework = "megatron"
+    expected_recipes = {"hidden"}
+
+    def __init__(self, config: DriverConfig) -> None:
+        environment = __import__("os").environ
+        self.rank = int(environment["RANK"])
+        self.world_size = int(environment["WORLD_SIZE"])
+        local_rank = int(environment["LOCAL_RANK"])
+        torch.cuda.set_device(local_rank)
+        self.device = torch.device("cuda", local_rank)
+        dist.init_process_group(backend="cpu:gloo,cuda:nccl")
+
+        from megatron.core.num_microbatches_calculator import (
+            init_num_microbatches_calculator,
+        )
+        from megatron.training import training
+
+        self._training = training
+        self.args = _arguments(self.rank, self.world_size, config.total_steps)
+        init_num_microbatches_calculator(
+            rank=self.rank,
+            global_batch_size=self.args.global_batch_size,
+            micro_batch_size=self.args.micro_batch_size,
+            data_parallel_size=self.args.data_parallel_size,
+            decrease_batch_size_if_needed=False,
+            step_batch_size_schedule=None,
+            seq_length=self.args.seq_length,
+        )
+        _install_training_services(training, self.args)
+        self.model, self.optimizer, self.scheduler, self.model_config = (
+            _build_model_optimizer_scheduler(self.device)
+        )
+        self._extra_state: dict[str, Any] = {"absolute_step": 0}
+        self.handle = enable_resiliency(
+            [self.model],
+            self.optimizer,
+            self.scheduler,
+            interval=1,
+            ckpt_config=config.checkpoint,
+            detection_config=config.replay,
+            device=self.device,
+            fault_callback=config.fault_callback,
+            orchestration=config.orchestration,
+            extra_state_fn=self._extra_state_dict,
+            load_extra_state_fn=self._load_extra_state_dict,
+            recovery_mode=config.recovery_mode,
+        )
+        self.args.iteration = self.handle.step_count
+        self._adapter = MegatronAdapter([self.model], self.optimizer, self.scheduler)
+
+    def _extra_state_dict(self) -> dict[str, Any]:
+        return {
+            "fault_validation": dict(self._extra_state),
+            "scheduler": self.scheduler.state_dict(),
+        }
+
+    def _load_extra_state_dict(self, value: dict[str, Any]) -> None:
+        state = value.get("fault_validation", {})
+        if not isinstance(state, dict):
+            raise RuntimeError("Megatron fault-validation state is malformed")
+        self._extra_state.clear()
+        self._extra_state.update(state)
+        scheduler = value.get("scheduler")
+        if scheduler is not None:
+            self.scheduler.load_state_dict(scheduler)
+
+    def _data_iterator(self, start_step: int) -> Iterator[tuple[torch.Tensor, ...]]:
+        step = start_step
+        while True:
+            yield _tokens(self.rank, step, self.device)
+            step += 1
+
+    def run(
+        self,
+        *,
+        before_step: Callable[[int], None],
+        after_step: Callable[[int, float | None], None],
+        total_steps: int,
+    ) -> None:
+        from megatron.core.pipeline_parallel.schedules import (
+            get_forward_backward_func,
+        )
+
+        data_iterator = self._data_iterator(self.handle.step_count)
+        forward_backward = get_forward_backward_func()
+        for step in range(self.handle.step_count + 1, total_steps + 1):
+            self._extra_state["absolute_step"] = step
+            before_step(step)
+            result = self._training.train_step(
+                _forward_step,
+                data_iterator,
+                [self.model],
+                self.optimizer,
+                self.scheduler,
+                self.model_config,
+                forward_backward,
+                iteration=step - 1,
+            )
+            loss_dict = result[0]
+            loss = loss_dict.get("lm loss")
+            self.args.iteration = step
+            self.args.consumed_train_samples += MICRO_BATCH_SIZE * self.world_size
+            after_step(
+                step,
+                float(loss.detach()) if isinstance(loss, torch.Tensor) else None,
+            )
+
+    def verification_state(self) -> dict[str, list[torch.Tensor]]:
+        tensors = self._adapter.collect_checkpoint_tensors()
+        model_count = sum(1 for parameter in self.model.parameters())
+        return {
+            "model": clone_tensors(tensors[:model_count]),
+            "optimizer": clone_tensors(tensors[model_count:]),
+        }
+
+    def framework_state(self) -> dict[str, Any]:
+        return {
+            "absolute_step": int(self._extra_state["absolute_step"]),
+            "iteration": int(self.args.iteration),
+            "scheduler_num_steps": int(self.scheduler.num_steps),
+            "step_count": int(self.handle.step_count),
+        }
+
+    def close(self) -> None:
+        self.handle.close()
+        if dist.is_initialized():
+            from megatron.core import parallel_state as mpu
+
+            mpu.destroy_model_parallel()
+            dist.destroy_process_group()

--- a/examples/torchrun/resiliency_cycle/harness/frameworks/megatron.py
+++ b/examples/torchrun/resiliency_cycle/harness/frameworks/megatron.py
@@ -67,14 +67,20 @@ class MegatronDriver:
             orchestration=config.orchestration,
             extra_state_fn=self._extra_state_dict,
             load_extra_state_fn=self._load_extra_state_dict,
-            recovery_mode=config.recovery_mode,
+            **config.recovery_options(),
         )
-        self.args.iteration = self.handle.step_count
+        if self.args.iteration != self.handle.step_count:
+            raise RuntimeError("Megatron loop iteration does not match the recovered GEMINI step")
         self._adapter = MegatronAdapter([self.model], self.optimizer, self.scheduler)
 
     def _extra_state_dict(self) -> dict[str, Any]:
         return {
             "fault_validation": dict(self._extra_state),
+            "iteration": int(self._extra_state["absolute_step"]),
+            "consumed_train_samples": (
+                int(self.args.consumed_train_samples) + MICRO_BATCH_SIZE * self.world_size
+            ),
+            "skipped_train_samples": int(self.args.skipped_train_samples),
             "scheduler": self.scheduler.state_dict(),
         }
 
@@ -84,9 +90,19 @@ class MegatronDriver:
             raise RuntimeError("Megatron fault-validation state is malformed")
         self._extra_state.clear()
         self._extra_state.update(state)
+        self.args.iteration = _nonnegative_int(value.get("iteration"), "iteration")
+        self.args.consumed_train_samples = _nonnegative_int(
+            value.get("consumed_train_samples"),
+            "consumed_train_samples",
+        )
+        self.args.skipped_train_samples = _nonnegative_int(
+            value.get("skipped_train_samples"),
+            "skipped_train_samples",
+        )
         scheduler = value.get("scheduler")
-        if scheduler is not None:
-            self.scheduler.load_state_dict(scheduler)
+        if not isinstance(scheduler, dict):
+            raise RuntimeError("Megatron scheduler state is malformed")
+        self.scheduler.load_state_dict(scheduler)
 
     def _data_iterator(self, start_step: int) -> Iterator[tuple[torch.Tensor, ...]]:
         step = start_step
@@ -109,6 +125,7 @@ class MegatronDriver:
         forward_backward = get_forward_backward_func()
         for step in range(self.handle.step_count + 1, total_steps + 1):
             self._extra_state["absolute_step"] = step
+            self.args.curr_iteration = step - 1
             before_step(step)
             result = self._training.train_step(
                 _forward_step,
@@ -140,8 +157,10 @@ class MegatronDriver:
     def framework_state(self) -> dict[str, Any]:
         return {
             "absolute_step": int(self._extra_state["absolute_step"]),
+            "consumed_train_samples": int(self.args.consumed_train_samples),
             "iteration": int(self.args.iteration),
             "scheduler_num_steps": int(self.scheduler.num_steps),
+            "skipped_train_samples": int(self.args.skipped_train_samples),
             "step_count": int(self.handle.step_count),
         }
 
@@ -152,3 +171,9 @@ class MegatronDriver:
 
             mpu.destroy_model_parallel()
             dist.destroy_process_group()
+
+
+def _nonnegative_int(value: Any, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise RuntimeError(f"Megatron {name} must be a non-negative integer")
+    return value

--- a/examples/torchrun/resiliency_cycle/harness/frameworks/pytorch.py
+++ b/examples/torchrun/resiliency_cycle/harness/frameworks/pytorch.py
@@ -1,0 +1,95 @@
+"""Native PyTorch DDP driver for torchrun fault injection."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import torch
+import torch.distributed as dist
+from torch.nn.parallel import DistributedDataParallel
+
+from examples.production_loops.pytorch import TinyCausalLM, _tokens
+from lm_resiliency.integrations.pytorch import enable_resiliency
+
+from ..runtime import DriverConfig, clone_tensors
+
+
+class PyTorchDriver:
+    framework = "pytorch"
+    expected_recipes = {"embedding", "hidden", "output", "optimizer"}
+
+    def __init__(self, config: DriverConfig) -> None:
+        self.rank = int(__import__("os").environ["RANK"])
+        self.world_size = int(__import__("os").environ["WORLD_SIZE"])
+        local_rank = int(__import__("os").environ["LOCAL_RANK"])
+        torch.cuda.set_device(local_rank)
+        self.device = torch.device("cuda", local_rank)
+        dist.init_process_group(backend="cpu:gloo,cuda:nccl")
+        torch.manual_seed(123)
+        self.model = DistributedDataParallel(
+            TinyCausalLM().to(self.device),
+            device_ids=[local_rank],
+        )
+        self.optimizer = torch.optim.AdamW(self.model.parameters(), lr=2e-4)
+        self._extra_state: dict[str, Any] = {"absolute_step": 0}
+        self.handle = enable_resiliency(
+            self.model,
+            self.optimizer,
+            interval=1,
+            checkpoint=config.checkpoint,
+            replay=config.replay,
+            device=self.device,
+            fault_callback=config.fault_callback,
+            orchestration=config.orchestration,
+            extra_state_fn=lambda: dict(self._extra_state),
+            load_extra_state_fn=self._load_extra_state,
+            recovery_mode=config.recovery_mode,
+        )
+
+    def _load_extra_state(self, value: dict[str, Any]) -> None:
+        self._extra_state.clear()
+        self._extra_state.update(value)
+
+    def run(
+        self,
+        *,
+        before_step: Callable[[int], None],
+        after_step: Callable[[int, float | None], None],
+        total_steps: int,
+    ) -> None:
+        for step in range(self.handle.step_count + 1, total_steps + 1):
+            self._extra_state["absolute_step"] = step
+            before_step(step)
+            tokens, labels = _tokens(self.rank, step - 1, self.device)
+            self.optimizer.zero_grad(set_to_none=True)
+            with torch.autocast("cuda", dtype=torch.bfloat16):
+                loss = self.model(tokens, labels)
+            loss.backward()
+            self.optimizer.step()
+            after_step(step, float(loss.detach()))
+
+    def verification_state(self) -> dict[str, list[torch.Tensor]]:
+        model = [parameter for parameter in self.model.parameters()]
+        optimizer: list[torch.Tensor] = []
+        for parameter in self.model.parameters():
+            state = self.optimizer.state.get(parameter, {})
+            for key in sorted(state):
+                value = state[key]
+                if isinstance(value, torch.Tensor):
+                    optimizer.append(value)
+        return {
+            "model": clone_tensors(model),
+            "optimizer": clone_tensors(optimizer),
+        }
+
+    def framework_state(self) -> dict[str, Any]:
+        return {
+            "absolute_step": int(self._extra_state["absolute_step"]),
+            "step_count": int(self.handle.step_count),
+        }
+
+    def close(self) -> None:
+        self.handle.close()
+        if dist.is_initialized():
+            dist.destroy_process_group()

--- a/examples/torchrun/resiliency_cycle/harness/frameworks/pytorch.py
+++ b/examples/torchrun/resiliency_cycle/harness/frameworks/pytorch.py
@@ -12,7 +12,7 @@ from torch.nn.parallel import DistributedDataParallel
 from examples.production_loops.pytorch import TinyCausalLM, _tokens
 from lm_resiliency.integrations.pytorch import enable_resiliency
 
-from ..runtime import DriverConfig, clone_tensors
+from ..runtime import DriverConfig, clone_tensors, close_resources
 
 
 class PyTorchDriver:
@@ -90,6 +90,10 @@ class PyTorchDriver:
         }
 
     def close(self) -> None:
-        self.handle.close()
-        if dist.is_initialized():
-            dist.destroy_process_group()
+        close_resources(
+            ("resiliency handle", self.handle.close),
+            (
+                "default process group",
+                lambda: dist.destroy_process_group() if dist.is_initialized() else None,
+            ),
+        )

--- a/examples/torchrun/resiliency_cycle/harness/frameworks/pytorch.py
+++ b/examples/torchrun/resiliency_cycle/harness/frameworks/pytorch.py
@@ -44,7 +44,7 @@ class PyTorchDriver:
             orchestration=config.orchestration,
             extra_state_fn=lambda: dict(self._extra_state),
             load_extra_state_fn=self._load_extra_state,
-            recovery_mode=config.recovery_mode,
+            **config.recovery_options(),
         )
 
     def _load_extra_state(self, value: dict[str, Any]) -> None:

--- a/examples/torchrun/resiliency_cycle/harness/frameworks/torchtitan.py
+++ b/examples/torchrun/resiliency_cycle/harness/frameworks/torchtitan.py
@@ -1,0 +1,149 @@
+"""TorchTitan Trainer driver for torchrun fault injection."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import torch
+import torch.distributed as dist
+
+from examples.production_loops.torchtitan import _job_config, _register_train_spec
+from lm_resiliency.integrations.torchtitan import enable_resiliency
+
+from ..runtime import DriverConfig, clone_tensors, tensor_leaves
+
+
+class _ObservedLoader:
+    def __init__(
+        self,
+        loader: Any,
+        *,
+        trainer: Any,
+        before_step: Callable[[int], None],
+    ) -> None:
+        self._loader = loader
+        self._trainer = trainer
+        self._before_step = before_step
+        self._iterator: Iterator[Any] | None = None
+        self._observed_step = -1
+
+    @property
+    def index(self) -> int:
+        return int(self._loader.index)
+
+    def __iter__(self) -> _ObservedLoader:
+        self._iterator = iter(self._loader)
+        return self
+
+    def __next__(self) -> Any:
+        step = int(self._trainer.step)
+        if step != self._observed_step:
+            self._before_step(step)
+            self._observed_step = step
+        if self._iterator is None:
+            self._iterator = iter(self._loader)
+        return next(self._iterator)
+
+    def state_dict(self) -> dict[str, Any]:
+        return self._loader.state_dict()
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        self._loader.load_state_dict(state_dict)
+
+
+class TorchTitanDriver:
+    framework = "torchtitan"
+    expected_recipes = {"hidden"}
+
+    def __init__(self, config: DriverConfig) -> None:
+        from torchtitan.train import Trainer
+
+        self.rank = int(__import__("os").environ["RANK"])
+        self.world_size = int(__import__("os").environ["WORLD_SIZE"])
+        torch.manual_seed(123)
+        model_name = _register_train_spec()
+        self.trainer = Trainer(
+            _job_config(
+                config.campaign_dir / "torchtitan-runtime",
+                model_name,
+                self.world_size,
+                config.total_steps,
+            )
+        )
+        self.device = self.trainer.device
+        self.handle = enable_resiliency(
+            self.trainer,
+            interval=1,
+            ckpt_config=config.checkpoint,
+            detection_config=config.replay,
+            device=self.device,
+            fault_callback=config.fault_callback,
+            orchestration=config.orchestration,
+            recovery_mode=config.recovery_mode,
+        )
+        self._latest_loss: float | None = None
+        self._original_loss = self.trainer.loss_fn
+
+        def observed_loss(*args: Any, **kwargs: Any) -> torch.Tensor:
+            loss = self._original_loss(*args, **kwargs)
+            self._latest_loss = float(loss.detach())
+            return loss
+
+        self.trainer.loss_fn = observed_loss
+        self._original_scheduler_step = self.trainer.lr_schedulers.step
+
+    def run(
+        self,
+        *,
+        before_step: Callable[[int], None],
+        after_step: Callable[[int, float | None], None],
+        total_steps: int,
+    ) -> None:
+        del total_steps
+        if self.trainer.dataloader is None:
+            raise RuntimeError("TorchTitan fault validation requires a dataloader")
+        self.trainer.dataloader = _ObservedLoader(
+            self.trainer.dataloader,
+            trainer=self.trainer,
+            before_step=before_step,
+        )
+
+        def scheduler_step(*args: Any, **kwargs: Any) -> Any:
+            result = self._original_scheduler_step(*args, **kwargs)
+            after_step(int(self.trainer.step), self._latest_loss)
+            return result
+
+        self.trainer.lr_schedulers.step = scheduler_step
+        self.trainer.train()
+
+    def verification_state(self) -> dict[str, list[torch.Tensor]]:
+        model = [
+            parameter
+            for model_part in self.trainer.model_parts
+            for parameter in model_part.parameters()
+        ]
+        optimizer = tensor_leaves(self.trainer.optimizers.state_dict())
+        return {
+            "model": clone_tensors(model),
+            "optimizer": clone_tensors(optimizer),
+        }
+
+    def framework_state(self) -> dict[str, Any]:
+        scheduler_state = self.trainer.lr_schedulers.state_dict()
+        dataloader = self.trainer.dataloader
+        return {
+            "dataloader_index": int(dataloader.index),
+            "ntokens_seen": int(self.trainer.ntokens_seen),
+            "scheduler_last_epoch": int(scheduler_state["last_epoch"]),
+            "step_count": int(self.handle.step_count),
+            "trainer_step": int(self.trainer.step),
+        }
+
+    def close(self) -> None:
+        self.trainer.loss_fn = self._original_loss
+        self.trainer.lr_schedulers.step = self._original_scheduler_step
+        self.handle.close()
+        self.trainer.close()
+        if dist.is_initialized():
+            dist.destroy_process_group()

--- a/examples/torchrun/resiliency_cycle/harness/frameworks/torchtitan.py
+++ b/examples/torchrun/resiliency_cycle/harness/frameworks/torchtitan.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 from examples.production_loops.torchtitan import _job_config, _register_train_spec
 from lm_resiliency.integrations.torchtitan import enable_resiliency
 
-from ..runtime import DriverConfig, clone_tensors, tensor_leaves
+from ..runtime import DriverConfig, clone_tensors, close_resources, tensor_leaves
 
 
 class _ObservedLoader:
@@ -141,9 +141,19 @@ class TorchTitanDriver:
         }
 
     def close(self) -> None:
-        self.trainer.loss_fn = self._original_loss
-        self.trainer.lr_schedulers.step = self._original_scheduler_step
-        self.handle.close()
-        self.trainer.close()
-        if dist.is_initialized():
-            dist.destroy_process_group()
+        def restore_loss() -> None:
+            self.trainer.loss_fn = self._original_loss
+
+        def restore_scheduler() -> None:
+            self.trainer.lr_schedulers.step = self._original_scheduler_step
+
+        close_resources(
+            ("TorchTitan loss hook", restore_loss),
+            ("TorchTitan scheduler hook", restore_scheduler),
+            ("resiliency handle", self.handle.close),
+            ("TorchTitan trainer", self.trainer.close),
+            (
+                "default process group",
+                lambda: dist.destroy_process_group() if dist.is_initialized() else None,
+            ),
+        )

--- a/examples/torchrun/resiliency_cycle/harness/frameworks/torchtitan.py
+++ b/examples/torchrun/resiliency_cycle/harness/frameworks/torchtitan.py
@@ -80,7 +80,7 @@ class TorchTitanDriver:
             device=self.device,
             fault_callback=config.fault_callback,
             orchestration=config.orchestration,
-            recovery_mode=config.recovery_mode,
+            **config.recovery_options(),
         )
         self._latest_loss: float | None = None
         self._original_loss = self.trainer.loss_fn

--- a/examples/torchrun/resiliency_cycle/harness/launch.py
+++ b/examples/torchrun/resiliency_cycle/harness/launch.py
@@ -129,7 +129,7 @@ def prepare_remote_source(options: PressureLaunchOptions) -> None:
 def terminate_remote_run(options: PressureLaunchOptions, run_id: str) -> None:
     if not options.remote_enabled:
         return
-    pattern = f"[r]dzv-id={re.escape(run_id)}"
+    pattern = _remote_run_pattern(run_id)
     command = (
         f"pkill -TERM -f -- {shlex.quote(pattern)} || true; "
         "sleep 1; "
@@ -231,17 +231,56 @@ def cleanup_agents(
     *,
     remote_run_id: str,
 ) -> None:
-    for agent in agents:
-        if agent.process.poll() is None:
-            agent.process.terminate()
-    terminate_remote_run(options, remote_run_id)
+    active_error = sys.exception()
+    failures: list[BaseException] = []
     for agent in agents:
         try:
-            agent.process.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            agent.process.kill()
-            agent.process.wait(timeout=10)
-        agent.log.close()
+            if agent.process.poll() is None:
+                agent.process.terminate()
+        except BaseException as error:
+            failures.append(error)
+    try:
+        terminate_remote_run(options, remote_run_id)
+    except BaseException as error:
+        failures.append(error)
+    for agent in agents:
+        try:
+            try:
+                agent.process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                agent.process.kill()
+                agent.process.wait(timeout=10)
+        except BaseException as error:
+            failures.append(error)
+        finally:
+            try:
+                agent.log.close()
+            except BaseException as error:
+                failures.append(error)
+    _handle_cleanup_failures(failures, active_error=active_error)
+
+
+def _remote_run_pattern(run_id: str) -> str:
+    """Return a pkill pattern matching one complete torchrun rendezvous ID."""
+
+    return rf"(^|[[:space:]])--[r]dzv-id={re.escape(run_id)}([[:space:]]|$)"
+
+
+def _handle_cleanup_failures(
+    failures: Sequence[BaseException],
+    *,
+    active_error: BaseException | None,
+) -> None:
+    if not failures:
+        return
+    details = "; ".join(f"{type(error).__name__}: {error}" for error in failures)
+    if active_error is not None:
+        active_error.add_note(f"additional agent cleanup failures: {details}")
+        return
+    signal = next((error for error in failures if not isinstance(error, Exception)), None)
+    if signal is not None:
+        raise signal
+    raise RuntimeError(f"agent cleanup failed: {details}") from failures[0]
 
 
 def _launch_managed_agent(

--- a/examples/torchrun/resiliency_cycle/harness/launch.py
+++ b/examples/torchrun/resiliency_cycle/harness/launch.py
@@ -275,7 +275,7 @@ def _handle_cleanup_failures(
         return
     details = "; ".join(f"{type(error).__name__}: {error}" for error in failures)
     if active_error is not None:
-        active_error.add_note(f"additional agent cleanup failures: {details}")
+        print(f"additional agent cleanup failures: {details}", file=sys.stderr)
         return
     signal = next((error for error in failures if not isinstance(error, Exception)), None)
     if signal is not None:

--- a/examples/torchrun/resiliency_cycle/harness/launch.py
+++ b/examples/torchrun/resiliency_cycle/harness/launch.py
@@ -1,0 +1,381 @@
+"""Local and SSH launch support for torchrun pressure validation."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import shlex
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import timedelta
+from pathlib import Path
+from typing import BinaryIO
+
+from torch.distributed import TCPStore
+
+from lm_resiliency.integrations.torchrun import (
+    TorchrunLaunchConfig,
+    derive_torchrun_node_id,
+)
+
+from .campaign import GpuNodePlacement, PressureTopology
+
+
+@dataclass(frozen=True, slots=True)
+class PressureLaunchOptions:
+    """Environment-specific options for the two-host validation harness."""
+
+    fault_campaign_dir: Path
+    framework: str
+    run_id: str
+    timeout: float
+    remote_host: str | None = None
+    remote_python: str | None = None
+    remote_source_dir: Path | None = None
+    rendezvous_host: str | None = None
+
+    @property
+    def remote_enabled(self) -> bool:
+        return self.remote_host is not None
+
+
+@dataclass(slots=True)
+class LaunchedAgent:
+    process: subprocess.Popen[bytes]
+    log: BinaryIO
+
+
+def synthetic_machine_id(node_label: str) -> str:
+    return hashlib.sha256(
+        f"lm-resiliency/torchrun/campaign/{node_label}".encode("utf-8")
+    ).hexdigest()[:32]
+
+
+def synthetic_node_id(node_label: str) -> str:
+    return derive_torchrun_node_id(synthetic_machine_id(node_label))
+
+
+def create_tcp_store(host: str, timeout: float) -> TCPStore:
+    return TCPStore(
+        host,
+        0,
+        is_master=True,
+        multi_tenant=True,
+        wait_for_workers=False,
+        timeout=timedelta(seconds=timeout),
+    )
+
+
+def prepare_remote_source(options: PressureLaunchOptions) -> None:
+    if not options.remote_enabled:
+        return
+    if options.remote_source_dir is None or options.remote_python is None:
+        raise ValueError("remote source and Python are required for remote validation")
+    source_root = Path(__file__).resolve().parents[4]
+    subprocess.run(
+        [
+            "ssh",
+            "-o",
+            "BatchMode=yes",
+            options.remote_host,
+            "mkdir",
+            "-p",
+            str(options.remote_source_dir),
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "rsync",
+            "-a",
+            "--exclude=.git",
+            "--exclude=.venv",
+            "--exclude=.mypy_cache",
+            "--exclude=.pytest_cache",
+            "--exclude=__pycache__",
+            "--exclude=*.egg-info",
+            f"{source_root}/",
+            f"{options.remote_host}:{options.remote_source_dir}/",
+        ],
+        check=True,
+    )
+    site_packages_code = 'import sysconfig; print(sysconfig.get_paths()["purelib"])'
+    install_command = (
+        f"site_packages=$({shlex.quote(options.remote_python)} -c "
+        f"{shlex.quote(site_packages_code)}) && "
+        f'/usr/bin/pip install --upgrade --no-deps --target "$site_packages" '
+        f"-e {shlex.quote(str(options.remote_source_dir))}"
+    )
+    subprocess.run(
+        [
+            "ssh",
+            "-o",
+            "BatchMode=yes",
+            options.remote_host,
+            install_command,
+        ],
+        check=True,
+    )
+
+
+def terminate_remote_run(options: PressureLaunchOptions, run_id: str) -> None:
+    if not options.remote_enabled:
+        return
+    pattern = f"[r]dzv-id={re.escape(run_id)}"
+    command = (
+        f"pkill -TERM -f -- {shlex.quote(pattern)} || true; "
+        "sleep 1; "
+        f"pkill -KILL -f -- {shlex.quote(pattern)} || true"
+    )
+    subprocess.run(
+        [
+            "ssh",
+            "-o",
+            "BatchMode=yes",
+            options.remote_host,
+            command,
+        ],
+        check=False,
+        timeout=10,
+    )
+
+
+def launch_baseline(
+    options: PressureLaunchOptions,
+    topology: PressureTopology,
+) -> None:
+    store_host = options.rendezvous_host if options.remote_enabled else "127.0.0.1"
+    if store_host is None:
+        raise ValueError("rendezvous host is required for remote validation")
+    store = create_tcp_store(store_host, options.timeout)
+    endpoint = f"{store.host}:{store.port}"
+    launched: list[LaunchedAgent] = []
+    try:
+        for placement in topology.placements[: topology.world_size]:
+            python = options.remote_python if placement.remote else sys.executable
+            if python is None:
+                raise ValueError("remote Python is required for remote placements")
+            command = [
+                str(Path(python).with_name("torchrun")),
+                f"--nnodes={topology.world_size}",
+                "--nproc-per-node=1",
+                "--rdzv-backend=c10d",
+                f"--rdzv-endpoint={endpoint}",
+                f"--rdzv-id={options.run_id}-baseline",
+                "--rdzv-conf=is_host=false,read_timeout=120",
+                "--module",
+                "examples.torchrun.resiliency_cycle.harness.worker",
+                f"--framework={options.framework}",
+                "--mode=baseline",
+                f"--fault-campaign-dir={options.fault_campaign_dir}",
+            ]
+            launched.append(
+                _launch_process(
+                    options=options,
+                    command=command,
+                    environment=_gpu_environment(placement.gpu_id),
+                    log_path=(options.fault_campaign_dir / f"baseline-{placement.node_label}.log"),
+                    remote=placement.remote,
+                )
+            )
+        for agent in launched:
+            agent.process.wait(timeout=options.timeout)
+            if agent.process.returncode != 0:
+                raise RuntimeError(
+                    f"baseline torchrun agent failed with exit code {agent.process.returncode}"
+                )
+    finally:
+        cleanup_agents(
+            options,
+            launched,
+            remote_run_id=f"{options.run_id}-baseline",
+        )
+
+
+def launch_managed_agents(
+    options: PressureLaunchOptions,
+    topology: PressureTopology,
+    *,
+    endpoint: str | None,
+    max_restarts: int,
+) -> list[LaunchedAgent]:
+    return [
+        _launch_managed_agent(
+            options=options,
+            placement=placement,
+            endpoint=endpoint,
+            max_restarts=max_restarts,
+            topology=topology,
+        )
+        for placement in topology.placements
+    ]
+
+
+def cleanup_agents(
+    options: PressureLaunchOptions,
+    agents: Sequence[LaunchedAgent],
+    *,
+    remote_run_id: str,
+) -> None:
+    for agent in agents:
+        if agent.process.poll() is None:
+            agent.process.terminate()
+    terminate_remote_run(options, remote_run_id)
+    for agent in agents:
+        try:
+            agent.process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            agent.process.kill()
+            agent.process.wait(timeout=10)
+        agent.log.close()
+
+
+def _launch_managed_agent(
+    *,
+    options: PressureLaunchOptions,
+    placement: GpuNodePlacement,
+    endpoint: str | None,
+    max_restarts: int,
+    topology: PressureTopology,
+) -> LaunchedAgent:
+    machine_id_path = _prepare_machine_id_file(
+        options,
+        node_label=placement.node_label,
+        remote=placement.remote,
+    )
+    python = options.remote_python if placement.remote else sys.executable
+    if python is None:
+        raise ValueError("remote Python is required for remote placements")
+    context_path = (
+        Path("/tmp") / options.run_id / placement.node_label / "restart-context.json"
+        if placement.remote
+        else (
+            options.fault_campaign_dir / "contexts" / placement.node_label / "restart-context.json"
+        )
+    )
+    launch = TorchrunLaunchConfig(
+        run_id=options.run_id,
+        rendezvous_endpoint=(
+            str(options.fault_campaign_dir / "rdzv") if endpoint is None else endpoint
+        ),
+        restart_context_path=context_path,
+        min_nodes=topology.world_size,
+        max_nodes=len(topology.placements),
+        nproc_per_node=1,
+        max_restarts=max_restarts,
+        torchrun=str(Path(python).with_name("torchrun")),
+        store_type="file" if endpoint is None else "tcp",
+        is_host=None if endpoint is None else False,
+        join_timeout_ms=120_000,
+        poll_interval_ms=100,
+        heartbeat_timeout_ms=10_000,
+    )
+    command = launch.command(
+        module="examples.torchrun.resiliency_cycle.harness.worker",
+        module_args=(
+            f"--framework={options.framework}",
+            "--mode=campaign",
+            f"--fault-campaign-dir={options.fault_campaign_dir}",
+        ),
+    )
+    environment = _gpu_environment(placement.gpu_id)
+    environment["LM_RESILIENCY_MACHINE_ID_PATH"] = str(machine_id_path)
+    return _launch_process(
+        options=options,
+        command=command,
+        environment=environment,
+        log_path=options.fault_campaign_dir / f"{placement.node_label}.log",
+        remote=placement.remote,
+    )
+
+
+def _prepare_machine_id_file(
+    options: PressureLaunchOptions,
+    *,
+    node_label: str,
+    remote: bool,
+) -> Path:
+    path = (
+        Path("/tmp") / options.run_id / "machine-ids" / f"{node_label}.machine-id"
+        if remote
+        else options.fault_campaign_dir / "machine-ids" / f"{node_label}.machine-id"
+    )
+    machine_id = synthetic_machine_id(node_label)
+    if remote:
+        command = (
+            "umask 077 && "
+            f"mkdir -p {shlex.quote(str(path.parent))} && "
+            f"printf '%s\\n' {shlex.quote(machine_id)} > {shlex.quote(str(path))}"
+        )
+        subprocess.run(
+            [
+                "ssh",
+                "-o",
+                "BatchMode=yes",
+                options.remote_host,
+                command,
+            ],
+            check=True,
+        )
+    else:
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        os.chmod(path.parent, 0o700)
+        path.write_text(machine_id + "\n", encoding="ascii")
+        os.chmod(path, 0o600)
+    return path
+
+
+def _launch_process(
+    *,
+    options: PressureLaunchOptions,
+    command: Sequence[str],
+    environment: Mapping[str, str],
+    log_path: Path,
+    remote: bool,
+) -> LaunchedAgent:
+    log = log_path.open("wb")
+    source_root = options.remote_source_dir if remote else Path(__file__).resolve().parents[4]
+    if source_root is None:
+        raise ValueError("source root is not initialized")
+    process_environment = dict(environment)
+    existing_python_path = process_environment.get("PYTHONPATH")
+    process_environment["PYTHONPATH"] = (
+        f"{source_root}:{existing_python_path}" if existing_python_path else str(source_root)
+    )
+    if remote:
+        remote_shell = (
+            f"cd {shlex.quote(str(options.remote_source_dir))} && "
+            f"{shlex.join(['env', *[f'{key}={value}' for key, value in process_environment.items()], *command])}"
+        )
+        process = subprocess.Popen(
+            [
+                "ssh",
+                "-o",
+                "BatchMode=yes",
+                options.remote_host,
+                remote_shell,
+            ],
+            stdout=log,
+            stderr=subprocess.STDOUT,
+        )
+    else:
+        local_environment = dict(os.environ)
+        local_environment.update(process_environment)
+        process = subprocess.Popen(
+            list(command),
+            env=local_environment,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+        )
+    return LaunchedAgent(process, log)
+
+
+def _gpu_environment(gpu_id: str) -> dict[str, str]:
+    return {
+        "CUDA_VISIBLE_DEVICES": gpu_id,
+        "GLOO_SOCKET_IFNAME": "ens32",
+        "NCCL_SOCKET_IFNAME": "ens32",
+    }

--- a/examples/torchrun/resiliency_cycle/harness/launch.py
+++ b/examples/torchrun/resiliency_cycle/harness/launch.py
@@ -102,12 +102,17 @@ def prepare_remote_source(options: PressureLaunchOptions) -> None:
         ],
         check=True,
     )
-    site_packages_code = 'import sysconfig; print(sysconfig.get_paths()["purelib"])'
-    install_command = (
-        f"site_packages=$({shlex.quote(options.remote_python)} -c "
-        f"{shlex.quote(site_packages_code)}) && "
-        f'/usr/bin/pip install --upgrade --no-deps --target "$site_packages" '
-        f"-e {shlex.quote(str(options.remote_source_dir))}"
+    install_command = shlex.join(
+        [
+            options.remote_python,
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+            "--no-deps",
+            "-e",
+            str(options.remote_source_dir),
+        ]
     )
     subprocess.run(
         [
@@ -202,16 +207,22 @@ def launch_managed_agents(
     endpoint: str | None,
     max_restarts: int,
 ) -> list[LaunchedAgent]:
-    return [
-        _launch_managed_agent(
-            options=options,
-            placement=placement,
-            endpoint=endpoint,
-            max_restarts=max_restarts,
-            topology=topology,
-        )
-        for placement in topology.placements
-    ]
+    launched: list[LaunchedAgent] = []
+    try:
+        for placement in topology.placements:
+            launched.append(
+                _launch_managed_agent(
+                    options=options,
+                    placement=placement,
+                    endpoint=endpoint,
+                    max_restarts=max_restarts,
+                    topology=topology,
+                )
+            )
+    except BaseException:
+        cleanup_agents(options, launched, remote_run_id=options.run_id)
+        raise
+    return launched
 
 
 def cleanup_agents(
@@ -337,45 +348,45 @@ def _launch_process(
     remote: bool,
 ) -> LaunchedAgent:
     log = log_path.open("wb")
-    source_root = options.remote_source_dir if remote else Path(__file__).resolve().parents[4]
-    if source_root is None:
-        raise ValueError("source root is not initialized")
-    process_environment = dict(environment)
-    existing_python_path = process_environment.get("PYTHONPATH")
-    process_environment["PYTHONPATH"] = (
-        f"{source_root}:{existing_python_path}" if existing_python_path else str(source_root)
-    )
-    if remote:
-        remote_shell = (
-            f"cd {shlex.quote(str(options.remote_source_dir))} && "
-            f"{shlex.join(['env', *[f'{key}={value}' for key, value in process_environment.items()], *command])}"
+    try:
+        source_root = options.remote_source_dir if remote else Path(__file__).resolve().parents[4]
+        if source_root is None:
+            raise ValueError("source root is not initialized")
+        process_environment = dict(environment)
+        existing_python_path = process_environment.get("PYTHONPATH")
+        process_environment["PYTHONPATH"] = (
+            f"{source_root}:{existing_python_path}" if existing_python_path else str(source_root)
         )
-        process = subprocess.Popen(
-            [
-                "ssh",
-                "-o",
-                "BatchMode=yes",
-                options.remote_host,
-                remote_shell,
-            ],
-            stdout=log,
-            stderr=subprocess.STDOUT,
-        )
-    else:
-        local_environment = dict(os.environ)
-        local_environment.update(process_environment)
-        process = subprocess.Popen(
-            list(command),
-            env=local_environment,
-            stdout=log,
-            stderr=subprocess.STDOUT,
-        )
+        if remote:
+            remote_shell = (
+                f"cd {shlex.quote(str(options.remote_source_dir))} && "
+                f"{shlex.join(['env', *[f'{key}={value}' for key, value in process_environment.items()], *command])}"
+            )
+            process = subprocess.Popen(
+                [
+                    "ssh",
+                    "-o",
+                    "BatchMode=yes",
+                    options.remote_host,
+                    remote_shell,
+                ],
+                stdout=log,
+                stderr=subprocess.STDOUT,
+            )
+        else:
+            local_environment = dict(os.environ)
+            local_environment.update(process_environment)
+            process = subprocess.Popen(
+                list(command),
+                env=local_environment,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+            )
+    except BaseException:
+        log.close()
+        raise
     return LaunchedAgent(process, log)
 
 
 def _gpu_environment(gpu_id: str) -> dict[str, str]:
-    return {
-        "CUDA_VISIBLE_DEVICES": gpu_id,
-        "GLOO_SOCKET_IFNAME": "ens32",
-        "NCCL_SOCKET_IFNAME": "ens32",
-    }
+    return {"CUDA_VISIBLE_DEVICES": gpu_id}

--- a/examples/torchrun/resiliency_cycle/harness/launch.py
+++ b/examples/torchrun/resiliency_cycle/harness/launch.py
@@ -231,7 +231,7 @@ def cleanup_agents(
     *,
     remote_run_id: str,
 ) -> None:
-    active_error = sys.exception()
+    active_error = sys.exc_info()[1]
     failures: list[BaseException] = []
     for agent in agents:
         try:

--- a/examples/torchrun/resiliency_cycle/harness/replay_fault.py
+++ b/examples/torchrun/resiliency_cycle/harness/replay_fault.py
@@ -177,19 +177,19 @@ class ReplayFaultCampaign:
             or self._target_calls == 1
         ):
             return None
-        corrupted, changed = _add_to_first_tensor(output)
+        corrupted, changed = _sign_flip_first_tensor(output)
         if not changed:
             raise RuntimeError("the replay target produced no tensor output")
         self._injected_calls += 1
         return corrupted
 
 
-def _add_to_first_tensor(value: Any) -> tuple[Any, bool]:
+def _sign_flip_first_tensor(value: Any) -> tuple[Any, bool]:
     leaves, spec = tree_flatten(value)
     changed = False
     for index, leaf in enumerate(leaves):
         if isinstance(leaf, torch.Tensor):
-            leaves[index] = leaf + 1.0
+            leaves[index] = -leaf
             changed = True
             break
     return tree_unflatten(leaves, spec), changed

--- a/examples/torchrun/resiliency_cycle/harness/replay_fault.py
+++ b/examples/torchrun/resiliency_cycle/harness/replay_fault.py
@@ -1,0 +1,207 @@
+"""Replay-only SDC controls for torchrun fault-injection campaigns."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+from torch.utils._pytree import tree_flatten, tree_unflatten
+
+from lm_resiliency import OrchestrationHooks
+
+
+@dataclass
+class ReplayFaultCampaign:
+    """Inject one replay-only fault and validate checkpoint trust transitions."""
+
+    steps: int
+    rank: int
+    world_size: int
+    inject_fault: bool
+    fault_step: int
+    fault_rank: int
+    faults: list[Any] = field(default_factory=list)
+    recovery_decisions: list[dict[str, Any]] = field(default_factory=list)
+    checkpoint_steps_at_fault: list[int] = field(default_factory=list)
+    _current_step: int = 0
+    _target_calls: int = 0
+    _injected_calls: int = 0
+    _handle: Any | None = None
+    _fault_hook: Any | None = None
+
+    @classmethod
+    def from_args(
+        cls,
+        args: argparse.Namespace,
+        *,
+        rank: int,
+        world_size: int,
+    ) -> ReplayFaultCampaign:
+        fault_rank = world_size - 1 if args.fault_rank < 0 else args.fault_rank
+        if args.steps <= 0:
+            raise ValueError("--steps must be positive")
+        if args.inject_fault:
+            if args.steps < args.fault_step + 2:
+                raise ValueError("--steps must include at least two post-fault steps")
+            if args.fault_step < 2:
+                raise ValueError("--fault-step must follow at least one clean step")
+            if fault_rank < 0 or fault_rank >= world_size:
+                raise ValueError("--fault-rank must identify a global training rank")
+        return cls(
+            steps=args.steps,
+            rank=rank,
+            world_size=world_size,
+            inject_fault=bool(args.inject_fault),
+            fault_step=args.fault_step,
+            fault_rank=fault_rank,
+        )
+
+    @property
+    def orchestration(self) -> OrchestrationHooks:
+        """Return manager hooks used to capture automatic recovery decisions."""
+        return OrchestrationHooks(report_recovery=self.recovery_decisions.append)
+
+    def start_step(self, step: int) -> None:
+        """Mark the framework iteration before its model forward begins."""
+        self._current_step = step
+        self._target_calls = 0
+
+    def bind(self, handle: Any) -> None:
+        """Attach the replay-only fault after SCOUT has installed its hooks."""
+        self._handle = handle
+        if not self.inject_fault:
+            return
+        harness = _replay_harness(handle)
+        if harness is None:
+            raise AssertionError("SCOUT did not create a replay harness")
+        self._fault_hook = harness.target_layer.register_forward_hook(
+            self._inject_after_training_forward,
+            with_kwargs=True,
+        )
+
+    def record_fault(self, result: Any) -> None:
+        """Retain replay evidence and the checkpoint boundary visible at detection."""
+        self.faults.append(result)
+        manager = _checkpoint_manager(self._handle)
+        if manager is not None:
+            self.checkpoint_steps_at_fault.append(int(manager._last_saved_step))
+
+    def validate(self, handle: Any, final_result: Any, expected_recipes: set[str]) -> None:
+        """Validate clean completion or the complete transient-fault campaign."""
+        manager = _checkpoint_manager(handle)
+        if manager is None:
+            raise AssertionError("GEMINI did not create a checkpoint manager")
+        if final_result is None or any(final_result.sdc_bitmap):
+            raise AssertionError("the final production-loop replay was not clean")
+        if not expected_recipes.issubset(final_result.checked_recipe_ids):
+            raise AssertionError(f"missing replay recipes: {final_result.checked_recipe_ids}")
+        if int(manager._last_saved_step) != self.steps:
+            raise AssertionError("GEMINI did not capture the final clean optimizer step")
+        if int(manager.checkpoint_status.recovery_verified_step) != self.steps:
+            raise AssertionError("the final clean checkpoint was not recovery-verified")
+
+        if not self.inject_fault:
+            if self.faults or self.recovery_decisions:
+                raise AssertionError("the clean example reported an unexpected fault")
+            return
+
+        if len(self.faults) != 1:
+            raise AssertionError(f"expected one injected fault, observed {len(self.faults)}")
+        fault = self.faults[0]
+        expected_bitmap = [int(peer_rank == self.fault_rank) for peer_rank in fault.peer_ranks]
+        if fault.sdc_bitmap != expected_bitmap or any(fault.straggler_bitmap):
+            raise AssertionError(
+                f"fault localization mismatch: peers={fault.peer_ranks}, "
+                f"sdc={fault.sdc_bitmap}, expected={expected_bitmap}"
+            )
+        if not any(source.startswith("hidden.") for source in fault.sdc_sources):
+            raise AssertionError(f"hidden replay did not report the fault: {fault.sdc_sources}")
+        if self.checkpoint_steps_at_fault != [self.fault_step - 1]:
+            raise AssertionError(
+                "GEMINI exposed the fault-step checkpoint before SCOUT certification"
+            )
+        if len(self.recovery_decisions) != 1:
+            raise AssertionError(
+                f"expected one recovery decision, observed {self.recovery_decisions}"
+            )
+        decision = self.recovery_decisions[0]
+        expected_step = self.fault_step - 1
+        if (
+            decision["failure_kind"] != "sdc"
+            or decision["recovery_mode"] != "recovery_verified"
+            or decision["checkpoint_source"] != "gemini"
+            or decision["checkpoint_step"] != expected_step
+            or not decision["available"]
+        ):
+            raise AssertionError(f"invalid recovery decision: {decision}")
+        if self.rank == self.fault_rank:
+            if self._injected_calls == 0:
+                raise AssertionError("the selected fault rank did not inject a replay fault")
+        elif self._injected_calls != 0:
+            raise AssertionError("a healthy rank injected a replay fault")
+
+    def summary(self) -> dict[str, Any]:
+        """Return JSON-ready fault campaign evidence."""
+        if not self.inject_fault:
+            return {"fault_injection": "disabled"}
+        decision = self.recovery_decisions[0]
+        return {
+            "fault_injection": "transient hidden replay",
+            "fault_rank": self.fault_rank,
+            "fault_step": self.fault_step,
+            "localized_bitmap": list(self.faults[0].sdc_bitmap),
+            "recovery_mode": decision["recovery_mode"],
+            "recovery_checkpoint_step": decision["checkpoint_step"],
+            "post_fault_clean_steps": self.steps - self.fault_step,
+        }
+
+    def close(self) -> None:
+        """Remove the example-owned injection hook."""
+        if self._fault_hook is not None:
+            self._fault_hook.remove()
+            self._fault_hook = None
+
+    def _inject_after_training_forward(
+        self,
+        _module: Any,
+        _args: tuple[Any, ...],
+        _kwargs: dict[str, Any],
+        output: Any,
+    ) -> Any | None:
+        self._target_calls += 1
+        if (
+            self._current_step != self.fault_step
+            or self.rank != self.fault_rank
+            or self._target_calls == 1
+        ):
+            return None
+        corrupted, changed = _add_to_first_tensor(output)
+        if not changed:
+            raise RuntimeError("the replay target produced no tensor output")
+        self._injected_calls += 1
+        return corrupted
+
+
+def _add_to_first_tensor(value: Any) -> tuple[Any, bool]:
+    leaves, spec = tree_flatten(value)
+    changed = False
+    for index, leaf in enumerate(leaves):
+        if isinstance(leaf, torch.Tensor):
+            leaves[index] = leaf + 1.0
+            changed = True
+            break
+    return tree_unflatten(leaves, spec), changed
+
+
+def _checkpoint_manager(handle: Any | None) -> Any | None:
+    if handle is None:
+        return None
+    manager = getattr(handle, "ckpt_manager", None)
+    return manager if manager is not None else getattr(handle, "_ckpt_manager", None)
+
+
+def _replay_harness(handle: Any) -> Any | None:
+    harness = getattr(handle, "replay_harness", None)
+    return harness if harness is not None else getattr(handle, "_replay_harness", None)

--- a/examples/torchrun/resiliency_cycle/harness/runtime.py
+++ b/examples/torchrun/resiliency_cycle/harness/runtime.py
@@ -1,0 +1,448 @@
+"""Framework-neutral worker runtime for torchrun fault injection."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import time
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+import torch
+import torch.distributed as dist
+
+from lm_resiliency import (
+    InMemoryCkptConfig,
+    OrchestrationHooks,
+    RecoveryDecision,
+    ReplayHarnessConfig,
+)
+from lm_resiliency.integrations.torchrun import TorchrunWorkerContext
+
+from .artifacts import atomic_json, atomic_torch, read_json
+from .campaign import PressureEvent
+from .replay_fault import ReplayFaultCampaign
+
+
+class FrameworkDriver(Protocol):
+    """Minimal framework surface consumed by the shared campaign runtime."""
+
+    framework: str
+    device: torch.device
+    rank: int
+    world_size: int
+    handle: Any
+    expected_recipes: set[str]
+
+    def run(
+        self,
+        *,
+        before_step: Callable[[int], None],
+        after_step: Callable[[int, float | None], None],
+        total_steps: int,
+    ) -> None: ...
+
+    def verification_state(self) -> dict[str, list[torch.Tensor]]: ...
+
+    def framework_state(self) -> dict[str, Any]: ...
+
+    def close(self) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class DriverConfig:
+    """Common resiliency configuration supplied to a framework driver."""
+
+    campaign_dir: Path
+    checkpoint: InMemoryCkptConfig
+    replay: ReplayHarnessConfig
+    recovery_mode: str | None
+    fault_callback: Callable[[Any], None]
+    orchestration: OrchestrationHooks
+    total_steps: int
+
+
+def replay_config() -> ReplayHarnessConfig:
+    return ReplayHarnessConfig(
+        check_interval=1,
+        rotate_layers=False,
+        enable_temporal=False,
+        scale_factors=[],
+        straggler_min_slowdown_ratio=100.0,
+        straggler_min_slowdown_ms=10_000.0,
+    )
+
+
+def checkpoint_config(
+    *,
+    campaign_dir: Path,
+    framework: str,
+    mode: str,
+    replication_jump: int,
+) -> InMemoryCkptConfig:
+    run_id = os.environ.get("TORCHELASTIC_RUN_ID")
+    if not run_id:
+        raise RuntimeError("fault-injection worker requires TORCHELASTIC_RUN_ID")
+    return InMemoryCkptConfig(
+        enable=True,
+        interval=1,
+        replication_jump=replication_jump,
+        replication_chunk_size=256 * 1024,
+        disk_flush_interval=0,
+        disk_folder=str(campaign_dir / f"{mode}-{framework}-checkpoints"),
+        run_id=run_id,
+        verify_integrity=True,
+        pin_memory=True,
+    )
+
+
+def checkpoint_is_safe_for_replacement(
+    checkpoint_manager: Any,
+    handle: Any,
+    *,
+    expected_step: int,
+) -> bool:
+    """Verify that only the last clean checkpoint is recoverable."""
+
+    verified_step = checkpoint_manager.checkpoint_status.recovery_verified_step
+    flushed_step = handle.flush_for_restart()
+    recoverable_step = checkpoint_manager.local_recovery_step("recovery_verified")
+    safe = (
+        verified_step == expected_step
+        and flushed_step in (-1, expected_step)
+        and recoverable_step == expected_step
+    )
+    if not safe:
+        print(
+            "replacement checkpoint diagnostics: "
+            f"rank={os.environ.get('RANK', 'unknown')} "
+            f"expected={expected_step} verified={verified_step} "
+            f"flushed={flushed_step} recoverable={recoverable_step}",
+            flush=True,
+        )
+    return safe
+
+
+def tensor_digest(values: Sequence[torch.Tensor]) -> str:
+    digest = hashlib.sha256()
+    for tensor in values:
+        value = tensor.detach().cpu().contiguous()
+        digest.update(str(tuple(value.shape)).encode("ascii"))
+        digest.update(str(value.dtype).encode("ascii"))
+        digest.update(value.reshape(-1).view(torch.uint8).numpy().tobytes())
+    return digest.hexdigest()
+
+
+def rng_digest(device: torch.device) -> str:
+    return tensor_digest(
+        [
+            torch.get_rng_state(),
+            torch.cuda.get_rng_state(device),
+        ]
+    )
+
+
+def clone_tensors(values: Sequence[torch.Tensor]) -> list[torch.Tensor]:
+    return [value.detach().cpu().clone() for value in values]
+
+
+def tensor_leaves(value: Any) -> list[torch.Tensor]:
+    """Collect tensors from nested framework state in deterministic order."""
+    tensors: list[torch.Tensor] = []
+    if isinstance(value, torch.Tensor):
+        tensors.append(value)
+    elif isinstance(value, Mapping):
+        for key in sorted(value, key=str):
+            tensors.extend(tensor_leaves(value[key]))
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            tensors.extend(tensor_leaves(item))
+    return tensors
+
+
+class CampaignRuntime:
+    """Shared incident handling around one framework-native training driver."""
+
+    def __init__(
+        self,
+        *,
+        campaign_dir: Path,
+        context: TorchrunWorkerContext | None,
+        event: PressureEvent | None,
+        framework: str,
+        generation: int,
+        mode: str,
+        node_id: str,
+        rank: int,
+        replay_campaign: ReplayFaultCampaign,
+        total_steps: int,
+    ) -> None:
+        self.campaign_dir = campaign_dir
+        self.context = context
+        self.event = event
+        self.framework = framework
+        self.generation = generation
+        self.mode = mode
+        self.node_id = node_id
+        self.rank = rank
+        self.replay_campaign = replay_campaign
+        self.total_steps = total_steps
+        self.artifact_dir = campaign_dir / f"{mode}-artifacts"
+        self.losses: dict[str, float] = {}
+        self.faults: list[Any] = []
+        self.decisions: list[RecoveryDecision] = []
+
+    def record_fault(self, result: Any) -> None:
+        self.faults.append(result)
+        self.replay_campaign.record_fault(result)
+
+    @property
+    def orchestration(self) -> OrchestrationHooks:
+        return OrchestrationHooks(report_recovery=self.decisions.append)
+
+    def initialize(self, driver: FrameworkDriver) -> None:
+        self.replay_campaign.bind(driver.handle)
+        if self.generation == 0:
+            _assert_all(
+                driver.handle.step_count == 0,
+                "fresh worker recovered unexpectedly",
+                driver.device,
+            )
+            return
+        if self.context is None or self.context.checkpoint_step is None:
+            raise AssertionError("successor generation requires a recovery context")
+        expected = read_json(
+            self.artifact_dir
+            / "checkpoints"
+            / f"step-{self.context.checkpoint_step}-rank-{self.rank}.json"
+        )
+        state = driver.verification_state()
+        recovered = (
+            driver.handle.step_count == self.context.checkpoint_step
+            and tensor_digest([*state["model"], *state["optimizer"]]) == expected["state_digest"]
+            and rng_digest(driver.device) == expected["rng_digest"]
+            and driver.framework_state() == expected["framework_state"]
+        )
+        _assert_all(recovered, "GEMINI fresh-process recovery was not exact", driver.device)
+        atomic_json(
+            self.artifact_dir / f"recovery-g{self.generation}-r{self.rank}.json",
+            {
+                "checkpoint_step": self.context.checkpoint_step,
+                "framework": self.framework,
+                "generation": self.generation,
+                "logical_node_slot": self.context.logical_node_slot,
+                "node_id": self.node_id,
+                "rank": self.rank,
+                "recovered_exact": recovered,
+            },
+        )
+
+    def before_step(self, step: int) -> None:
+        self.replay_campaign.start_step(step)
+
+    def after_step(
+        self,
+        driver: FrameworkDriver,
+        step: int,
+        loss: float | None,
+    ) -> None:
+        if loss is not None:
+            self.losses[str(step)] = loss
+        checkpoint_manager = _checkpoint_manager(driver.handle)
+        if checkpoint_manager is None:
+            raise AssertionError("GEMINI did not create a checkpoint manager")
+        checkpoint_manager.maybe_wait()
+        if checkpoint_manager.checkpoint_status.recovery_verified_step == step:
+            atomic_json(
+                self.artifact_dir / "checkpoints" / f"step-{step}-rank-{self.rank}.json",
+                self._snapshot(driver, step),
+            )
+        if self.event is not None and self.event.kind == "restart" and step == self.event.step:
+            restart_checkpoint = driver.handle.flush_for_restart()
+            _assert_all(
+                restart_checkpoint == self.event.checkpoint_step,
+                "restart-only failure did not flush the latest verified checkpoint",
+                driver.device,
+            )
+            self._write_incident("restart", checkpoint_step=self.event.checkpoint_step)
+            self._wait_for_restart()
+        if self.faults:
+            self._validate_and_report_fault(driver, checkpoint_manager)
+            self._wait_for_restart()
+
+    def finish(self, driver: FrameworkDriver) -> None:
+        checkpoint_manager = _checkpoint_manager(driver.handle)
+        replay_harness = _replay_harness(driver.handle)
+        if checkpoint_manager is None or replay_harness is None:
+            raise AssertionError("GEMINI and SCOUT must both be enabled")
+        checkpoint_manager.maybe_wait()
+        self.replay_campaign.validate(
+            driver.handle,
+            replay_harness.last_result,
+            driver.expected_recipes,
+        )
+        final = self._snapshot(driver, self.total_steps)
+        final.update(
+            {
+                "framework": self.framework,
+                "generation": self.generation,
+                "losses": self.losses,
+                "node_id": self.node_id,
+                "rank": self.rank,
+            }
+        )
+        prefix = "baseline" if self.mode == "baseline" else f"final-g{self.generation}"
+        atomic_torch(
+            self.artifact_dir / f"{prefix}-state-r{self.rank}.pt",
+            driver.verification_state(),
+        )
+        atomic_json(self.artifact_dir / f"{prefix}-r{self.rank}.json", final)
+        dist.barrier()
+
+    def close(self) -> None:
+        self.replay_campaign.close()
+
+    def _snapshot(self, driver: FrameworkDriver, step: int) -> dict[str, Any]:
+        state = driver.verification_state()
+        return {
+            "framework_state": driver.framework_state(),
+            "model_digest": tensor_digest(state["model"]),
+            "optimizer_digest": tensor_digest(state["optimizer"]),
+            "rng_digest": rng_digest(driver.device),
+            "state_digest": tensor_digest([*state["model"], *state["optimizer"]]),
+            "step": step,
+        }
+
+    def _validate_and_report_fault(
+        self,
+        driver: FrameworkDriver,
+        checkpoint_manager: Any,
+    ) -> None:
+        if len(self.faults) != 1 or len(self.decisions) != 1:
+            raise AssertionError("SCOUT emitted an unexpected fault/decision count")
+        fault = self.faults[0]
+        if self.event is None or self.event.kind != "replacement" or self.event.fault_rank is None:
+            replay_harness = _replay_harness(driver.handle)
+            replay_config = getattr(replay_harness, "_config", None)
+            runtime_topology = {
+                "compare_updated_weights": getattr(
+                    driver.handle,
+                    "_compare_updated_weights",
+                    None,
+                ),
+                "has_fsdp": getattr(driver.handle, "_has_fsdp", None),
+                "is_hsdp": getattr(driver.handle, "_is_hsdp", None),
+                "optimizer_interval": (
+                    None if replay_config is None else replay_config.optimizer_check_interval
+                ),
+            }
+            c3_statuses = {
+                name: {
+                    "bitmap": list(result.bitmap),
+                    "evidence": list(result.evidence),
+                    "status": result.status.value,
+                }
+                for name, result in fault.c3_results.items()
+            }
+            raise AssertionError(
+                "SCOUT reported an unscheduled replacement fault: "
+                f"sdc_bitmap={fault.sdc_bitmap}, sdc_sources={fault.sdc_sources}, "
+                f"c3_results={c3_statuses}, runtime_topology={runtime_topology}"
+            )
+        decision = self.decisions[0]
+        expected_bitmap = [
+            int(candidate == self.event.fault_rank) for candidate in fault.peer_ranks
+        ]
+        expected_step = self.event.checkpoint_step
+        localized = (
+            fault.peer_ranks == list(range(driver.world_size))
+            and fault.sdc_bitmap == expected_bitmap
+            and not any(fault.straggler_bitmap)
+            and any(source.startswith("hidden.") for source in fault.sdc_sources)
+        )
+        selected = (
+            decision["failure_kind"] == "sdc"
+            and decision["recovery_mode"] == "recovery_verified"
+            and decision["checkpoint_source"] == "gemini"
+            and decision["checkpoint_step"] == expected_step
+            and decision["checkpoint_id"] is None
+            and decision["available"]
+        )
+        checkpoint_safe = checkpoint_is_safe_for_replacement(
+            checkpoint_manager,
+            driver.handle,
+            expected_step=expected_step,
+        )
+        _assert_all(localized, "SCOUT did not localize the injected rank", driver.device)
+        _assert_all(selected, "SCOUT selected the wrong recovery checkpoint", driver.device)
+        _assert_all(
+            checkpoint_safe,
+            "GEMINI exposed or flushed the contaminated checkpoint",
+            driver.device,
+        )
+        self._write_incident(
+            "fault",
+            checkpoint_step=expected_step,
+            extra={
+                "decision": decision,
+                "peer_ranks": list(fault.peer_ranks),
+                "sdc_bitmap": list(fault.sdc_bitmap),
+                "sdc_sources": list(fault.sdc_sources),
+            },
+        )
+
+    def _write_incident(
+        self,
+        kind: str,
+        *,
+        checkpoint_step: int,
+        extra: Mapping[str, Any] | None = None,
+    ) -> None:
+        if self.event is None:
+            raise AssertionError("incident report requires an active event")
+        report = {
+            "checkpoint_step": checkpoint_step,
+            "framework": self.framework,
+            "generation": self.generation,
+            "incident_id": self.event.incident_id,
+            "node_id": self.node_id,
+            "rank": self.rank,
+        }
+        report.update(extra or {})
+        atomic_json(
+            self.artifact_dir / f"{kind}-g{self.generation}-r{self.rank}.json",
+            report,
+        )
+        atomic_json(
+            self.artifact_dir / f"losses-g{self.generation}-r{self.rank}.json",
+            {
+                "framework": self.framework,
+                "generation": self.generation,
+                "losses": self.losses,
+                "rank": self.rank,
+            },
+        )
+
+    @staticmethod
+    def _wait_for_restart() -> None:
+        while True:
+            time.sleep(1)
+
+
+def _checkpoint_manager(handle: Any) -> Any | None:
+    manager = getattr(handle, "ckpt_manager", None)
+    return manager if manager is not None else getattr(handle, "_ckpt_manager", None)
+
+
+def _replay_harness(handle: Any) -> Any | None:
+    harness = getattr(handle, "replay_harness", None)
+    return harness if harness is not None else getattr(handle, "_replay_harness", None)
+
+
+def _assert_all(condition: bool, message: str, device: torch.device) -> None:
+    value = torch.tensor([int(condition)], dtype=torch.int32, device=device)
+    dist.all_reduce(value, op=dist.ReduceOp.MIN)
+    if not value.item():
+        raise AssertionError(message)

--- a/examples/torchrun/resiliency_cycle/harness/runtime.py
+++ b/examples/torchrun/resiliency_cycle/harness/runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import sys
 import time
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
@@ -115,13 +116,15 @@ def checkpoint_is_safe_for_replacement(
     *,
     expected_step: int,
 ) -> bool:
-    """Verify that only the last clean checkpoint is recoverable."""
+    """Verify that the contaminated step was neither saved nor made recoverable."""
 
+    last_saved_step = int(checkpoint_manager._last_saved_step)
     verified_step = checkpoint_manager.checkpoint_status.recovery_verified_step
     flushed_step = handle.flush_for_restart()
     recoverable_step = checkpoint_manager.local_recovery_step("recovery_verified")
     safe = (
-        verified_step == expected_step
+        last_saved_step in (-1, expected_step)
+        and verified_step == expected_step
         and flushed_step in (-1, expected_step)
         and recoverable_step == expected_step
     )
@@ -129,11 +132,29 @@ def checkpoint_is_safe_for_replacement(
         print(
             "replacement checkpoint diagnostics: "
             f"rank={os.environ.get('RANK', 'unknown')} "
-            f"expected={expected_step} verified={verified_step} "
+            f"expected={expected_step} saved={last_saved_step} verified={verified_step} "
             f"flushed={flushed_step} recoverable={recoverable_step}",
             flush=True,
         )
     return safe
+
+
+def close_resources(*actions: tuple[str, Callable[[], None]]) -> None:
+    """Run every cleanup action and re-raise the first failure."""
+
+    failures: list[tuple[str, BaseException, Any]] = []
+    for name, action in actions:
+        try:
+            action()
+        except BaseException as error:
+            failures.append((name, error, error.__traceback__))
+    if not failures:
+        return
+
+    for name, error, _ in failures[1:]:
+        print(f"additional {name} cleanup failure: {error}", file=sys.stderr)
+    _, first_error, first_traceback = failures[0]
+    raise first_error.with_traceback(first_traceback)
 
 
 def checkpoint_topology_digest(handle: Any) -> str:

--- a/examples/torchrun/resiliency_cycle/harness/runtime.py
+++ b/examples/torchrun/resiliency_cycle/harness/runtime.py
@@ -59,9 +59,20 @@ class DriverConfig:
     checkpoint: InMemoryCkptConfig
     replay: ReplayHarnessConfig
     recovery_mode: str | None
+    recovery_step: int | None
+    expected_topology_id: str | None
     fault_callback: Callable[[Any], None]
     orchestration: OrchestrationHooks
     total_steps: int
+
+    def recovery_options(self) -> dict[str, Any]:
+        """Return the exact manager-selected recovery constraints."""
+
+        return {
+            "recovery_mode": self.recovery_mode,
+            "_recovery_step": self.recovery_step,
+            "_expected_topology_id": self.expected_topology_id,
+        }
 
 
 def replay_config() -> ReplayHarnessConfig:
@@ -123,6 +134,16 @@ def checkpoint_is_safe_for_replacement(
             flush=True,
         )
     return safe
+
+
+def checkpoint_topology_digest(handle: Any) -> str:
+    """Return the live GEMINI job-wide topology identity."""
+
+    manager = _checkpoint_manager(handle)
+    topology_digest = None if manager is None else manager.topology_id
+    if not isinstance(topology_digest, str) or not topology_digest:
+        raise AssertionError("GEMINI did not publish a checkpoint topology digest")
+    return topology_digest
 
 
 def tensor_digest(values: Sequence[torch.Tensor]) -> str:
@@ -219,8 +240,10 @@ class CampaignRuntime:
             / f"step-{self.context.checkpoint_step}-rank-{self.rank}.json"
         )
         state = driver.verification_state()
+        topology_digest = checkpoint_topology_digest(driver.handle)
         recovered = (
             driver.handle.step_count == self.context.checkpoint_step
+            and topology_digest == self.context.topology_digest
             and tensor_digest([*state["model"], *state["optimizer"]]) == expected["state_digest"]
             and rng_digest(driver.device) == expected["rng_digest"]
             and driver.framework_state() == expected["framework_state"]
@@ -236,6 +259,7 @@ class CampaignRuntime:
                 "node_id": self.node_id,
                 "rank": self.rank,
                 "recovered_exact": recovered,
+                "topology_digest": topology_digest,
             },
         )
 
@@ -266,7 +290,11 @@ class CampaignRuntime:
                 "restart-only failure did not flush the latest verified checkpoint",
                 driver.device,
             )
-            self._write_incident("restart", checkpoint_step=self.event.checkpoint_step)
+            self._write_incident(
+                "restart",
+                checkpoint_step=self.event.checkpoint_step,
+                topology_digest=checkpoint_topology_digest(driver.handle),
+            )
             self._wait_for_restart()
         if self.faults:
             self._validate_and_report_fault(driver, checkpoint_manager)
@@ -291,6 +319,7 @@ class CampaignRuntime:
                 "losses": self.losses,
                 "node_id": self.node_id,
                 "rank": self.rank,
+                "topology_digest": checkpoint_topology_digest(driver.handle),
             }
         )
         prefix = "baseline" if self.mode == "baseline" else f"final-g{self.generation}"
@@ -385,6 +414,7 @@ class CampaignRuntime:
         self._write_incident(
             "fault",
             checkpoint_step=expected_step,
+            topology_digest=checkpoint_topology_digest(driver.handle),
             extra={
                 "decision": decision,
                 "peer_ranks": list(fault.peer_ranks),
@@ -398,6 +428,7 @@ class CampaignRuntime:
         kind: str,
         *,
         checkpoint_step: int,
+        topology_digest: str,
         extra: Mapping[str, Any] | None = None,
     ) -> None:
         if self.event is None:
@@ -409,12 +440,14 @@ class CampaignRuntime:
             "incident_id": self.event.incident_id,
             "node_id": self.node_id,
             "rank": self.rank,
+            "topology_digest": topology_digest,
         }
         report.update(extra or {})
         atomic_json(
             self.artifact_dir / f"{kind}-g{self.generation}-r{self.rank}.json",
             report,
         )
+
         atomic_json(
             self.artifact_dir / f"losses-g{self.generation}-r{self.rank}.json",
             {

--- a/examples/torchrun/resiliency_cycle/harness/verify.py
+++ b/examples/torchrun/resiliency_cycle/harness/verify.py
@@ -1,0 +1,219 @@
+"""Evidence and numerical verification for torchrun pressure validation."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+import torch
+
+from .artifacts import read_json
+from .campaign import PressureEvent
+
+LOSS_MAX_ABS_DIFF = 1e-2
+TORCHTITAN_LOSS_MAX_ABS_DIFF = 1e-1
+MODEL_MAX_ABS_DIFF = 2e-3
+OPTIMIZER_MAX_ABS_DIFF = 5e-5
+DEEPSPEED_OPTIMIZER_MAX_ABS_DIFF = 1e-3
+
+
+def loss_difference_limit(framework: str) -> float:
+    if framework == "torchtitan":
+        return TORCHTITAN_LOSS_MAX_ABS_DIFF
+    return LOSS_MAX_ABS_DIFF
+
+
+def optimizer_difference_limit(framework: str) -> float:
+    if framework == "deepspeed":
+        return DEEPSPEED_OPTIMIZER_MAX_ABS_DIFF
+    return OPTIMIZER_MAX_ABS_DIFF
+
+
+def validate_fault_reports(
+    reports: Sequence[dict[str, object]],
+    *,
+    expected_generation: int,
+    expected_checkpoint_step: int,
+    fault_rank: int,
+    world_size: int,
+) -> None:
+    expected_bitmap = [int(rank == fault_rank) for rank in range(world_size)]
+    for report in reports:
+        if report["generation"] != expected_generation:
+            raise AssertionError("fault report generation mismatch")
+        if report["sdc_bitmap"] != expected_bitmap:
+            raise AssertionError(f"SCOUT localization mismatch: {report}")
+        decision = report["decision"]
+        if not isinstance(decision, dict):
+            raise AssertionError("fault report recovery decision is malformed")
+        if (
+            decision["recovery_mode"] != "recovery_verified"
+            or decision["checkpoint_source"] != "gemini"
+            or decision["checkpoint_step"] != expected_checkpoint_step
+            or not decision["available"]
+        ):
+            raise AssertionError(f"invalid recovery decision: {decision}")
+
+
+def validate_restart_reports(
+    reports: Sequence[dict[str, object]],
+    *,
+    event: PressureEvent,
+    expected_generation: int,
+) -> None:
+    for report in reports:
+        if report["generation"] != expected_generation:
+            raise AssertionError("restart report generation mismatch")
+        if report["incident_id"] != event.incident_id:
+            raise AssertionError("restart report incident mismatch")
+        if report["checkpoint_step"] != event.checkpoint_step:
+            raise AssertionError("restart report checkpoint mismatch")
+
+
+def compare_baseline(
+    fault_campaign_dir: Path,
+    *,
+    generations: int,
+    world_size: int,
+) -> tuple[float, float, float]:
+    baseline_dir = fault_campaign_dir / "baseline-artifacts"
+    campaign_dir = fault_campaign_dir / "campaign-artifacts"
+    campaign_losses = _merge_losses(
+        campaign_dir,
+        generations=generations,
+        world_size=world_size,
+    )
+    maximum_model_difference = 0.0
+    maximum_optimizer_difference = 0.0
+    maximum_loss_difference = 0.0
+    framework: str | None = None
+    for rank in range(world_size):
+        baseline = read_json(baseline_dir / f"baseline-r{rank}.json")
+        campaign = read_json(campaign_dir / f"final-g{generations - 1}-r{rank}.json")
+        if baseline["framework"] != campaign["framework"]:
+            raise AssertionError(f"rank {rank} framework identity diverged")
+        observed_framework = baseline["framework"]
+        if not isinstance(observed_framework, str):
+            raise AssertionError(f"rank {rank} framework identity is malformed")
+        if framework is None:
+            framework = observed_framework
+        elif framework != observed_framework:
+            raise AssertionError("baseline ranks disagree on the training framework")
+        if baseline["rng_digest"] != campaign["rng_digest"]:
+            raise AssertionError(f"rank {rank} final RNG state diverged")
+        if baseline["framework_state"] != campaign["framework_state"]:
+            raise AssertionError(f"rank {rank} final framework state diverged")
+        baseline_losses = {key: float(value) for key, value in baseline["losses"].items()}
+        for step, expected in baseline_losses.items():
+            actual = float(campaign_losses[rank][step])
+            difference = abs(expected - actual)
+            maximum_loss_difference = max(maximum_loss_difference, difference)
+            loss_limit = loss_difference_limit(observed_framework)
+            if difference > loss_limit:
+                raise AssertionError(
+                    f"rank {rank} loss at step {step} differs by {difference:.3e}, "
+                    f"above {loss_limit:.1e}"
+                )
+        baseline_state = _load_verification_state(baseline_dir / f"baseline-state-r{rank}.pt")
+        campaign_state = _load_verification_state(
+            campaign_dir / f"final-g{generations - 1}-state-r{rank}.pt"
+        )
+        maximum_model_difference = max(
+            maximum_model_difference,
+            _tensor_max_abs_diff(
+                baseline_state["model"],
+                campaign_state["model"],
+                limit=MODEL_MAX_ABS_DIFF,
+                label="model",
+                rank=rank,
+            ),
+        )
+        maximum_optimizer_difference = max(
+            maximum_optimizer_difference,
+            _tensor_max_abs_diff(
+                baseline_state["optimizer"],
+                campaign_state["optimizer"],
+                limit=optimizer_difference_limit(observed_framework),
+                label="optimizer",
+                rank=rank,
+            ),
+        )
+    return (
+        maximum_loss_difference,
+        maximum_model_difference,
+        maximum_optimizer_difference,
+    )
+
+
+def _merge_losses(
+    artifact_dir: Path,
+    *,
+    generations: int,
+    world_size: int,
+) -> dict[int, dict[str, float]]:
+    merged: dict[int, dict[str, float]] = {rank: {} for rank in range(world_size)}
+    for generation in range(generations):
+        for rank in range(world_size):
+            path = artifact_dir / f"losses-g{generation}-r{rank}.json"
+            if path.exists():
+                merged[rank].update(read_json(path)["losses"])
+    for rank in range(world_size):
+        final = read_json(artifact_dir / f"final-g{generations - 1}-r{rank}.json")
+        merged[rank].update(final["losses"])
+    return merged
+
+
+def _load_verification_state(path: Path) -> dict[str, list[torch.Tensor]]:
+    value = torch.load(path, map_location="cpu", weights_only=True)
+    if not isinstance(value, dict) or set(value) != {"model", "optimizer"}:
+        raise AssertionError(f"{path} does not contain a verification state")
+    result: dict[str, list[torch.Tensor]] = {}
+    for key in ("model", "optimizer"):
+        tensors = value[key]
+        if not isinstance(tensors, list) or not all(
+            isinstance(tensor, torch.Tensor) for tensor in tensors
+        ):
+            raise AssertionError(f"{path} has invalid {key} tensors")
+        result[key] = tensors
+    return result
+
+
+def _assert_same_tensor_layout(
+    baseline: Sequence[torch.Tensor],
+    campaign: Sequence[torch.Tensor],
+    *,
+    label: str,
+    rank: int,
+) -> None:
+    if len(baseline) != len(campaign):
+        raise AssertionError(f"rank {rank} final {label} tensor count diverged")
+    for index, (expected, actual) in enumerate(zip(baseline, campaign)):
+        if expected.shape != actual.shape or expected.dtype != actual.dtype:
+            raise AssertionError(f"rank {rank} final {label} tensor {index} layout diverged")
+
+
+def _tensor_max_abs_diff(
+    baseline: Sequence[torch.Tensor],
+    campaign: Sequence[torch.Tensor],
+    *,
+    limit: float,
+    label: str,
+    rank: int,
+) -> float:
+    _assert_same_tensor_layout(baseline, campaign, label=label, rank=rank)
+    maximum = 0.0
+    for index, (expected, actual) in enumerate(zip(baseline, campaign)):
+        if not expected.is_floating_point():
+            if not torch.equal(expected, actual):
+                raise AssertionError(f"rank {rank} final {label} tensor {index} diverged")
+            continue
+        if not torch.isfinite(expected).all() or not torch.isfinite(actual).all():
+            raise AssertionError(f"rank {rank} final {label} tensor {index} is non-finite")
+        difference = float((expected - actual).abs().max()) if expected.numel() else 0.0
+        maximum = max(maximum, difference)
+        if difference > limit:
+            raise AssertionError(
+                f"rank {rank} final {label} tensor {index} differs by "
+                f"{difference:.3e}, above {limit:.1e}"
+            )
+    return maximum

--- a/examples/torchrun/resiliency_cycle/harness/verify.py
+++ b/examples/torchrun/resiliency_cycle/harness/verify.py
@@ -29,6 +29,18 @@ def optimizer_difference_limit(framework: str) -> float:
     return OPTIMIZER_MAX_ABS_DIFF
 
 
+def checkpoint_topology_digest(reports: Sequence[dict[str, object]]) -> str:
+    """Return the one live GEMINI topology identity agreed by every report."""
+
+    values = [report.get("topology_digest") for report in reports]
+    if not values or any(not isinstance(value, str) or not value for value in values):
+        raise AssertionError("incident report checkpoint topology is malformed")
+    unique_values = set(values)
+    if len(unique_values) != 1:
+        raise AssertionError("incident reports disagree on checkpoint topology")
+    return unique_values.pop()
+
+
 def validate_fault_reports(
     reports: Sequence[dict[str, object]],
     *,
@@ -38,6 +50,7 @@ def validate_fault_reports(
     world_size: int,
 ) -> None:
     expected_bitmap = [int(rank == fault_rank) for rank in range(world_size)]
+    topology_digest = checkpoint_topology_digest(reports)
     for report in reports:
         if report["generation"] != expected_generation:
             raise AssertionError("fault report generation mismatch")
@@ -50,6 +63,7 @@ def validate_fault_reports(
             decision["recovery_mode"] != "recovery_verified"
             or decision["checkpoint_source"] != "gemini"
             or decision["checkpoint_step"] != expected_checkpoint_step
+            or decision.get("topology_digest") != topology_digest
             or not decision["available"]
         ):
             raise AssertionError(f"invalid recovery decision: {decision}")

--- a/examples/torchrun/resiliency_cycle/harness/verify.py
+++ b/examples/torchrun/resiliency_cycle/harness/verify.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -27,6 +28,15 @@ def optimizer_difference_limit(framework: str) -> float:
     if framework == "deepspeed":
         return DEEPSPEED_OPTIMIZER_MAX_ABS_DIFF
     return OPTIMIZER_MAX_ABS_DIFF
+
+
+def loss_difference(expected: float, actual: float, *, rank: int, step: str) -> float:
+    """Return a finite loss difference or reject invalid numerical evidence."""
+
+    difference = abs(expected - actual)
+    if not all(math.isfinite(value) for value in (expected, actual, difference)):
+        raise AssertionError(f"rank {rank} loss at step {step} is non-finite")
+    return difference
 
 
 def checkpoint_topology_digest(reports: Sequence[dict[str, object]]) -> str:
@@ -120,7 +130,7 @@ def compare_baseline(
         baseline_losses = {key: float(value) for key, value in baseline["losses"].items()}
         for step, expected in baseline_losses.items():
             actual = float(campaign_losses[rank][step])
-            difference = abs(expected - actual)
+            difference = loss_difference(expected, actual, rank=rank, step=step)
             maximum_loss_difference = max(maximum_loss_difference, difference)
             loss_limit = loss_difference_limit(observed_framework)
             if difference > loss_limit:

--- a/examples/torchrun/resiliency_cycle/harness/worker.py
+++ b/examples/torchrun/resiliency_cycle/harness/worker.py
@@ -1,0 +1,135 @@
+"""Framework-selecting worker for torchrun fault-injection campaigns."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from collections.abc import Callable
+from pathlib import Path
+
+from lm_resiliency import FaultCampaign
+from lm_resiliency.integrations.torchrun import get_torchrun_worker_context
+
+from .campaign import CAMPAIGN_FILENAME, pressure_events
+from .replay_fault import ReplayFaultCampaign
+from .runtime import (
+    CampaignRuntime,
+    DriverConfig,
+    FrameworkDriver,
+    checkpoint_config,
+    replay_config,
+)
+
+FRAMEWORKS = ("pytorch", "deepspeed", "megatron", "torchtitan")
+
+
+def _driver_factory(framework: str) -> Callable[[DriverConfig], FrameworkDriver]:
+    if framework == "pytorch":
+        from .frameworks.pytorch import PyTorchDriver
+
+        return PyTorchDriver
+    if framework == "deepspeed":
+        from .frameworks.deepspeed import DeepSpeedDriver
+
+        return DeepSpeedDriver
+    if framework == "megatron":
+        from .frameworks.megatron import MegatronDriver
+
+        return MegatronDriver
+    if framework == "torchtitan":
+        from .frameworks.torchtitan import TorchTitanDriver
+
+        return TorchTitanDriver
+    raise ValueError(f"unsupported framework {framework!r}")
+
+
+def run_worker(
+    *,
+    framework: str,
+    mode: str,
+    fault_campaign_dir: Path,
+) -> None:
+    if mode not in {"baseline", "campaign"}:
+        raise ValueError("mode must be 'baseline' or 'campaign'")
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    context = get_torchrun_worker_context() if mode == "campaign" else None
+    if context is not None and context.local_world_size != 1:
+        raise RuntimeError("fault-injection validation requires one worker per torchrun agent")
+    generation = 0 if context is None else context.generation
+    node_id = f"baseline-rank-{rank}" if context is None else context.node_id
+
+    manifest = FaultCampaign.from_json(fault_campaign_dir / CAMPAIGN_FILENAME)
+    events = pressure_events(manifest)
+    expected_world_size = int(manifest.metadata["active_nodes"])
+    if world_size != expected_world_size:
+        raise RuntimeError(f"expected {expected_world_size} ranks, got {world_size}")
+    if world_size < 4 or world_size % 2:
+        raise RuntimeError("fault-injection validation requires an even world of at least four")
+    total_steps = int(manifest.metadata["total_steps"])
+    event = None if mode == "baseline" or generation >= len(events) else events[generation]
+    replacement_event = event is not None and event.kind == "replacement"
+    replay_campaign = ReplayFaultCampaign(
+        steps=total_steps,
+        rank=rank,
+        world_size=world_size,
+        inject_fault=replacement_event,
+        fault_step=event.step if replacement_event else total_steps,
+        fault_rank=event.fault_rank if replacement_event else 0,
+    )
+    runtime = CampaignRuntime(
+        campaign_dir=fault_campaign_dir,
+        context=context,
+        event=event,
+        framework=framework,
+        generation=generation,
+        mode=mode,
+        node_id=node_id,
+        rank=rank,
+        replay_campaign=replay_campaign,
+        total_steps=total_steps,
+    )
+    driver = _driver_factory(framework)(
+        DriverConfig(
+            campaign_dir=fault_campaign_dir,
+            checkpoint=checkpoint_config(
+                campaign_dir=fault_campaign_dir,
+                framework=framework,
+                mode=mode,
+                replication_jump=world_size // 2,
+            ),
+            replay=replay_config(),
+            recovery_mode=context.recovery_mode if context is not None else None,
+            fault_callback=runtime.record_fault,
+            orchestration=runtime.orchestration,
+            total_steps=total_steps,
+        )
+    )
+    try:
+        runtime.initialize(driver)
+        driver.run(
+            before_step=runtime.before_step,
+            after_step=lambda step, loss: runtime.after_step(driver, step, loss),
+            total_steps=total_steps,
+        )
+        runtime.finish(driver)
+    finally:
+        runtime.close()
+        driver.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--framework", choices=FRAMEWORKS, required=True)
+    parser.add_argument("--mode", choices=("baseline", "campaign"), required=True)
+    parser.add_argument("--fault-campaign-dir", type=Path, required=True)
+    args = parser.parse_args()
+    run_worker(
+        framework=args.framework,
+        mode=args.mode,
+        fault_campaign_dir=args.fault_campaign_dir,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/torchrun/resiliency_cycle/harness/worker.py
+++ b/examples/torchrun/resiliency_cycle/harness/worker.py
@@ -8,7 +8,10 @@ from collections.abc import Callable
 from pathlib import Path
 
 from lm_resiliency import FaultCampaign
-from lm_resiliency.integrations.torchrun import get_torchrun_worker_context
+from lm_resiliency.integrations.torchrun import (
+    TorchrunWorkerContext,
+    get_torchrun_worker_context,
+)
 
 from .campaign import CAMPAIGN_FILENAME, pressure_events
 from .replay_fault import ReplayFaultCampaign
@@ -21,6 +24,15 @@ from .runtime import (
 )
 
 FRAMEWORKS = ("pytorch", "deepspeed", "megatron", "torchtitan")
+
+
+def _validate_worker_context(context: TorchrunWorkerContext | None) -> None:
+    if context is None:
+        return
+    if context.local_world_size != 1:
+        raise RuntimeError("fault-injection validation requires one worker per torchrun agent")
+    if context.generation > 0 and context.checkpoint_source != "gemini":
+        raise RuntimeError("resiliency-cycle successors require GEMINI recovery contexts")
 
 
 def _driver_factory(framework: str) -> Callable[[DriverConfig], FrameworkDriver]:
@@ -54,8 +66,7 @@ def run_worker(
     rank = int(os.environ["RANK"])
     world_size = int(os.environ["WORLD_SIZE"])
     context = get_torchrun_worker_context() if mode == "campaign" else None
-    if context is not None and context.local_world_size != 1:
-        raise RuntimeError("fault-injection validation requires one worker per torchrun agent")
+    _validate_worker_context(context)
     generation = 0 if context is None else context.generation
     node_id = f"baseline-rank-{rank}" if context is None else context.node_id
 
@@ -100,6 +111,8 @@ def run_worker(
             ),
             replay=replay_config(),
             recovery_mode=context.recovery_mode if context is not None else None,
+            recovery_step=context.checkpoint_step if context is not None else None,
+            expected_topology_id=context.topology_digest if context is not None else None,
             fault_callback=runtime.record_fault,
             orchestration=runtime.orchestration,
             total_steps=total_steps,
@@ -114,8 +127,10 @@ def run_worker(
         )
         runtime.finish(driver)
     finally:
-        runtime.close()
-        driver.close()
+        try:
+            runtime.close()
+        finally:
+            driver.close()
 
 
 def main() -> None:

--- a/examples/torchrun/resiliency_cycle/pressure.py
+++ b/examples/torchrun/resiliency_cycle/pressure.py
@@ -1,0 +1,372 @@
+"""Orchestrate repeated resiliency cycles through torchrun.
+
+The outer process is a validation controller, not a training worker. It starts
+an uninterrupted baseline, launches one torchrun agent per supplied GPU, acts
+as the recovery manager, and compares the final managed run with the baseline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import time
+from collections.abc import Sequence
+from pathlib import Path
+
+from torch.distributed import FileStore, Store
+
+from lm_resiliency.integrations.torchrun import (
+    TorchrunInitialPlacement,
+    TorchrunRecoveryCoordinator,
+    TorchrunRecoveryRequest,
+    TorchrunSuccessorPlacement,
+)
+
+from .harness.artifacts import atomic_json, read_json, wait_for_paths
+from .harness.campaign import (
+    STATE_FILENAME,
+    PressureEvent,
+    PressureTopology,
+    campaign_layout,
+    load_campaign_bundle,
+)
+from .harness.launch import (
+    PressureLaunchOptions,
+    cleanup_agents,
+    create_tcp_store,
+    launch_baseline,
+    launch_managed_agents,
+    prepare_remote_source,
+    synthetic_node_id,
+)
+from .harness.verify import (
+    MODEL_MAX_ABS_DIFF,
+    compare_baseline,
+    loss_difference_limit,
+    optimizer_difference_limit,
+    validate_fault_reports,
+    validate_restart_reports,
+)
+
+
+def _wait_for_initial_admission(
+    coordinator: TorchrunRecoveryCoordinator,
+    *,
+    expected_nodes: frozenset[str],
+    world_size: int,
+    processes: Sequence[subprocess.Popen[bytes]],
+    timeout: float,
+) -> TorchrunInitialPlacement:
+    deadline = time.monotonic() + timeout
+    while True:
+        failed = [process.returncode for process in processes if process.poll() not in (None, 0)]
+        if failed:
+            raise RuntimeError(f"torchrun agent failed with exit codes {failed}")
+        placement = coordinator.initial_placement(
+            active_node_count=world_size,
+            allocated_node_count=len(expected_nodes),
+        )
+        if placement is not None:
+            observed = frozenset([*placement.active_node_ids, *placement.standby_node_ids])
+            if observed != expected_nodes:
+                raise AssertionError("registered machine identities do not match the fleet")
+            return placement
+        if time.monotonic() >= deadline:
+            raise TimeoutError("timed out waiting for automatic initial node admission")
+        time.sleep(0.1)
+
+
+def _publish_plan(
+    *,
+    coordinator: TorchrunRecoveryCoordinator,
+    generation: int,
+    current_nodes: Sequence[str],
+    event: PressureEvent,
+    replacement_node: str | None,
+    quarantined: Sequence[str],
+    topology: PressureTopology,
+) -> TorchrunSuccessorPlacement:
+    replacement = None
+    if event.kind == "replacement":
+        if event.fault_rank is None or replacement_node is None:
+            raise AssertionError("replacement event requires a target rank and standby")
+        replacement = (event.fault_rank, replacement_node)
+        recovery_mode = "recovery_verified"
+        reason_code = "sdc_detected"
+    else:
+        recovery_mode = "latest"
+        reason_code = "process_stall"
+    return coordinator.publish_successor(
+        generation=generation,
+        active_node_ids=current_nodes,
+        quarantined_node_ids=quarantined,
+        request=TorchrunRecoveryRequest(
+            plan_id=f"pressure-{event.kind}-{generation + 1}",
+            intent_id=event.incident_id,
+            reason_code=reason_code,
+            recovery_mode=recovery_mode,
+            checkpoint_source="gemini",
+            checkpoint_step=event.checkpoint_step,
+            checkpoint_manifest_id=(f"gemini-{recovery_mode}-{event.checkpoint_step}"),
+            topology_digest=topology.topology_digest,
+            restart_deadline_unix_ms=time.time_ns() // 1_000_000 + 120_000,
+        ),
+        local_world_size=1,
+        replacement=replacement,
+    )
+
+
+def _validate_replacement_coverage(
+    *,
+    current_nodes: Sequence[str],
+    initial_nodes: Sequence[str],
+    replacement_failures: int,
+) -> None:
+    retained_initial = set(current_nodes) & set(initial_nodes)
+    expected_retained = len(initial_nodes) - replacement_failures
+    if len(retained_initial) != expected_retained:
+        raise AssertionError("pressure campaign replaced an unexpected number of initial GPU-nodes")
+
+
+def _orchestrate(args: argparse.Namespace) -> None:
+    campaign_dir = args.fault_campaign_dir.resolve()
+    options = PressureLaunchOptions(
+        fault_campaign_dir=campaign_dir,
+        framework=args.framework,
+        run_id=args.run_id,
+        timeout=args.timeout,
+        remote_host=args.remote_host,
+        remote_python=args.remote_python,
+        remote_source_dir=args.remote_source_dir,
+        rendezvous_host=args.rdzv_host,
+    )
+    campaign, events = load_campaign_bundle(campaign_dir)
+    topology = campaign_layout(
+        gpus=args.gpus,
+        remote_gpus=args.remote_gpus,
+        remote_enabled=options.remote_enabled,
+        campaign=campaign,
+        events=events,
+    )
+    standby_count = int(campaign.metadata["standby_nodes"])
+    total_steps = int(campaign.metadata["total_steps"])
+    if total_steps <= events[-1].step:
+        raise ValueError("campaign metadata.total_steps must include a clean final step")
+    if options.remote_enabled:
+        if not options.remote_python:
+            raise ValueError("--remote-python is required with --remote-host")
+        if options.remote_source_dir is None:
+            raise ValueError("--remote-source-dir is required with --remote-host")
+        if not options.rendezvous_host:
+            raise ValueError("--rdzv-host is required with --remote-host")
+        prepare_remote_source(options)
+        subprocess.run(
+            [
+                "ssh",
+                "-o",
+                "BatchMode=yes",
+                options.remote_host,
+                "test",
+                "-d",
+                str(campaign_dir.parent),
+            ],
+            check=True,
+        )
+    campaign_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(campaign_dir, 0o700)
+    for name in (
+        "baseline-artifacts",
+        "campaign-artifacts",
+    ):
+        (campaign_dir / name).mkdir(parents=True, exist_ok=True)
+
+    launch_baseline(options, topology)
+
+    control_store: Store
+    endpoint: str | None
+    if options.remote_enabled:
+        assert options.rendezvous_host is not None
+        tcp_store = create_tcp_store(options.rendezvous_host, options.timeout)
+        control_store = tcp_store
+        endpoint = f"{tcp_store.host}:{tcp_store.port}"
+    else:
+        endpoint = None
+        control_store = FileStore(str(campaign_dir / "rdzv"))
+    agents = launch_managed_agents(
+        options,
+        topology,
+        endpoint=endpoint,
+        max_restarts=len(events),
+    )
+    processes = [agent.process for agent in agents]
+    artifacts = campaign_dir / "campaign-artifacts"
+    coordinator = TorchrunRecoveryCoordinator(control_store, run_id=options.run_id)
+    expected_nodes = frozenset(
+        synthetic_node_id(placement.node_label) for placement in topology.placements
+    )
+    try:
+        initial = _wait_for_initial_admission(
+            coordinator,
+            expected_nodes=expected_nodes,
+            world_size=topology.world_size,
+            processes=processes,
+            timeout=options.timeout,
+        )
+        if len(initial.standby_node_ids) != standby_count:
+            raise AssertionError("initial admission selected the wrong standby count")
+        current_nodes = list(initial.active_node_ids)
+        replacements = iter(initial.standby_node_ids)
+        quarantined: list[str] = []
+        completed_events: list[str] = []
+        for generation, event in enumerate(events):
+            report_prefix = "fault" if event.kind == "replacement" else "restart"
+            report_paths = [
+                artifacts / f"{report_prefix}-g{generation}-r{rank}.json"
+                for rank in range(topology.world_size)
+            ]
+            wait_for_paths(report_paths, processes=processes, timeout=options.timeout)
+            reports = [read_json(path) for path in report_paths]
+            replacement_node = None
+            if event.kind == "replacement":
+                assert event.fault_rank is not None
+                validate_fault_reports(
+                    reports,
+                    expected_generation=generation,
+                    expected_checkpoint_step=event.checkpoint_step,
+                    fault_rank=event.fault_rank,
+                    world_size=topology.world_size,
+                )
+                replacement_node = next(replacements)
+            else:
+                validate_restart_reports(
+                    reports,
+                    event=event,
+                    expected_generation=generation,
+                )
+            successor = _publish_plan(
+                coordinator=coordinator,
+                generation=generation,
+                current_nodes=current_nodes,
+                event=event,
+                replacement_node=replacement_node,
+                quarantined=quarantined,
+                topology=topology,
+            )
+            current_nodes = list(successor.active_node_ids)
+            quarantined = list(successor.quarantined_node_ids)
+            completed_events.append(event.incident_id)
+            atomic_json(
+                campaign_dir / STATE_FILENAME,
+                {
+                    "campaign": campaign.name,
+                    "completed_incidents": completed_events,
+                    "generation": successor.generation,
+                    "manifest_identity": campaign.manifest_identity,
+                    "quarantined_nodes": quarantined,
+                },
+            )
+            recovery_paths = [
+                artifacts / f"recovery-g{successor.generation}-r{rank}.json"
+                for rank in range(topology.world_size)
+            ]
+            wait_for_paths(recovery_paths, processes=processes, timeout=options.timeout)
+            recovery = [read_json(path) for path in recovery_paths]
+            if not all(item["recovered_exact"] for item in recovery):
+                raise AssertionError("GEMINI recovery was not exact on every rank")
+            if event.kind == "replacement":
+                assert event.fault_rank is not None and replacement_node is not None
+                if recovery[event.fault_rank]["node_id"] != replacement_node:
+                    raise AssertionError("selected standby did not inherit the faulty logical rank")
+                if recovery[event.fault_rank]["logical_node_slot"] != event.fault_rank:
+                    raise AssertionError("selected standby did not inherit the faulty logical slot")
+
+        final_paths = [
+            artifacts / f"final-g{len(events)}-r{rank}.json" for rank in range(topology.world_size)
+        ]
+        wait_for_paths(final_paths, processes=processes, timeout=options.timeout)
+        loss_diff, model_diff, optimizer_diff = compare_baseline(
+            campaign_dir,
+            generations=len(events) + 1,
+            world_size=topology.world_size,
+        )
+        replacement_failures = sum(event.kind == "replacement" for event in events)
+        _validate_replacement_coverage(
+            current_nodes=current_nodes,
+            initial_nodes=initial.active_node_ids,
+            replacement_failures=replacement_failures,
+        )
+        coordinator.close()
+        for process in processes:
+            process.wait(timeout=options.timeout)
+            if process.returncode != 0:
+                raise RuntimeError(f"torchrun agent failed with exit code {process.returncode}")
+        atomic_json(
+            campaign_dir / "summary.json",
+            {
+                "campaign": campaign.name,
+                "campaign_manifest_identity": campaign.manifest_identity,
+                "framework": options.framework,
+                "final_nodes": current_nodes,
+                "final_step": total_steps,
+                "gpu_nodes": [
+                    {
+                        "gpu_id": placement.gpu_id,
+                        "location": "remote" if placement.remote else "local",
+                        "node_id": synthetic_node_id(placement.node_label),
+                        "node_label": placement.node_label,
+                    }
+                    for placement in topology.placements
+                ],
+                "initial_nodes": list(initial.active_node_ids),
+                "localization": "exact",
+                "replacement_failures": replacement_failures,
+                "replication_jump": topology.replication_jump,
+                "recoveries": "bitwise exact",
+                "restart_only_failures": sum(event.kind == "restart" for event in events),
+                "standbys": list(initial.standby_node_ids),
+                "total_failures": len(events),
+                "world_size": topology.world_size,
+                "training_vs_baseline": {
+                    "loss_max_abs_diff": loss_diff,
+                    "loss_max_abs_diff_limit": loss_difference_limit(options.framework),
+                    "model_max_abs_diff": model_diff,
+                    "model_max_abs_diff_limit": MODEL_MAX_ABS_DIFF,
+                    "optimizer_max_abs_diff": optimizer_diff,
+                    "optimizer_max_abs_diff_limit": optimizer_difference_limit(options.framework),
+                    "rng": "bitwise exact",
+                },
+            },
+        )
+    finally:
+        coordinator.close()
+        cleanup_agents(options, agents, remote_run_id=options.run_id)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    orchestrate = subparsers.add_parser("orchestrate")
+    orchestrate.add_argument("--fault-campaign-dir", type=Path, required=True)
+    orchestrate.add_argument(
+        "--framework",
+        choices=("pytorch", "deepspeed", "megatron", "torchtitan"),
+        required=True,
+    )
+    orchestrate.add_argument("--gpus", required=True)
+    orchestrate.add_argument("--remote-gpus", default="")
+    orchestrate.add_argument("--remote-host")
+    orchestrate.add_argument("--remote-python")
+    orchestrate.add_argument("--remote-source-dir", type=Path)
+    orchestrate.add_argument("--rdzv-host")
+    orchestrate.add_argument("--run-id", default=f"torchrun-pressure-{os.getpid()}")
+    orchestrate.add_argument("--timeout", type=float, default=1_800.0)
+    return parser
+
+
+def main() -> None:
+    _orchestrate(_parser().parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/torchrun/resiliency_cycle/pressure.py
+++ b/examples/torchrun/resiliency_cycle/pressure.py
@@ -243,7 +243,12 @@ def _orchestrate(args: argparse.Namespace) -> None:
                 artifacts / f"{report_prefix}-g{generation}-r{rank}.json"
                 for rank in range(topology.world_size)
             ]
-            wait_for_paths(report_paths, processes=processes, timeout=options.timeout)
+            wait_for_paths(
+                report_paths,
+                processes=processes,
+                timeout=options.timeout,
+                health_check=coordinator.check_health if generation > 0 else None,
+            )
             reports = [read_json(path) for path in report_paths]
             topology_digest = checkpoint_topology_digest(reports)
             if observed_topology_digest is not None and topology_digest != observed_topology_digest:
@@ -292,7 +297,12 @@ def _orchestrate(args: argparse.Namespace) -> None:
                 artifacts / f"recovery-g{successor.generation}-r{rank}.json"
                 for rank in range(topology.world_size)
             ]
-            wait_for_paths(recovery_paths, processes=processes, timeout=options.timeout)
+            wait_for_paths(
+                recovery_paths,
+                processes=processes,
+                timeout=options.timeout,
+                health_check=coordinator.check_health,
+            )
             recovery = [read_json(path) for path in recovery_paths]
             if not all(item["recovered_exact"] for item in recovery):
                 raise AssertionError("GEMINI recovery was not exact on every rank")
@@ -308,7 +318,12 @@ def _orchestrate(args: argparse.Namespace) -> None:
         final_paths = [
             artifacts / f"final-g{len(events)}-r{rank}.json" for rank in range(topology.world_size)
         ]
-        wait_for_paths(final_paths, processes=processes, timeout=options.timeout)
+        wait_for_paths(
+            final_paths,
+            processes=processes,
+            timeout=options.timeout,
+            health_check=coordinator.check_health,
+        )
         loss_diff, model_diff, optimizer_diff = compare_baseline(
             campaign_dir,
             generations=len(events) + 1,

--- a/examples/torchrun/resiliency_cycle/pressure.py
+++ b/examples/torchrun/resiliency_cycle/pressure.py
@@ -27,9 +27,9 @@ from .harness.artifacts import atomic_json, read_json, wait_for_paths
 from .harness.campaign import (
     STATE_FILENAME,
     PressureEvent,
-    PressureTopology,
     campaign_layout,
     load_campaign_bundle,
+    require_fresh_campaign_run,
 )
 from .harness.launch import (
     PressureLaunchOptions,
@@ -42,6 +42,7 @@ from .harness.launch import (
 )
 from .harness.verify import (
     MODEL_MAX_ABS_DIFF,
+    checkpoint_topology_digest,
     compare_baseline,
     loss_difference_limit,
     optimizer_difference_limit,
@@ -85,7 +86,7 @@ def _publish_plan(
     event: PressureEvent,
     replacement_node: str | None,
     quarantined: Sequence[str],
-    topology: PressureTopology,
+    topology_digest: str,
 ) -> TorchrunSuccessorPlacement:
     replacement = None
     if event.kind == "replacement":
@@ -109,7 +110,7 @@ def _publish_plan(
             checkpoint_source="gemini",
             checkpoint_step=event.checkpoint_step,
             checkpoint_manifest_id=(f"gemini-{recovery_mode}-{event.checkpoint_step}"),
-            topology_digest=topology.topology_digest,
+            topology_digest=topology_digest,
             restart_deadline_unix_ms=time.time_ns() // 1_000_000 + 120_000,
         ),
         local_world_size=1,
@@ -142,6 +143,7 @@ def _orchestrate(args: argparse.Namespace) -> None:
         rendezvous_host=args.rdzv_host,
     )
     campaign, events = load_campaign_bundle(campaign_dir)
+    require_fresh_campaign_run(campaign_dir)
     topology = campaign_layout(
         gpus=args.gpus,
         remote_gpus=args.remote_gpus,
@@ -219,6 +221,7 @@ def _orchestrate(args: argparse.Namespace) -> None:
         replacements = iter(initial.standby_node_ids)
         quarantined: list[str] = []
         completed_events: list[str] = []
+        observed_topology_digest: str | None = None
         for generation, event in enumerate(events):
             report_prefix = "fault" if event.kind == "replacement" else "restart"
             report_paths = [
@@ -227,6 +230,10 @@ def _orchestrate(args: argparse.Namespace) -> None:
             ]
             wait_for_paths(report_paths, processes=processes, timeout=options.timeout)
             reports = [read_json(path) for path in report_paths]
+            topology_digest = checkpoint_topology_digest(reports)
+            if observed_topology_digest is not None and topology_digest != observed_topology_digest:
+                raise AssertionError("GEMINI checkpoint topology changed across generations")
+            observed_topology_digest = topology_digest
             replacement_node = None
             if event.kind == "replacement":
                 assert event.fault_rank is not None
@@ -251,7 +258,7 @@ def _orchestrate(args: argparse.Namespace) -> None:
                 event=event,
                 replacement_node=replacement_node,
                 quarantined=quarantined,
-                topology=topology,
+                topology_digest=topology_digest,
             )
             current_nodes = list(successor.active_node_ids)
             quarantined = list(successor.quarantined_node_ids)
@@ -274,6 +281,8 @@ def _orchestrate(args: argparse.Namespace) -> None:
             recovery = [read_json(path) for path in recovery_paths]
             if not all(item["recovered_exact"] for item in recovery):
                 raise AssertionError("GEMINI recovery was not exact on every rank")
+            if checkpoint_topology_digest(recovery) != topology_digest:
+                raise AssertionError("successor workers recovered a different topology")
             if event.kind == "replacement":
                 assert event.fault_rank is not None and replacement_node is not None
                 if recovery[event.fault_rank]["node_id"] != replacement_node:
@@ -306,6 +315,7 @@ def _orchestrate(args: argparse.Namespace) -> None:
             {
                 "campaign": campaign.name,
                 "campaign_manifest_identity": campaign.manifest_identity,
+                "checkpoint_topology_digest": observed_topology_digest,
                 "framework": options.framework,
                 "final_nodes": current_nodes,
                 "final_step": total_steps,

--- a/examples/torchrun/resiliency_cycle/pressure.py
+++ b/examples/torchrun/resiliency_cycle/pressure.py
@@ -32,6 +32,7 @@ from .harness.campaign import (
     require_fresh_campaign_run,
 )
 from .harness.launch import (
+    LaunchedAgent,
     PressureLaunchOptions,
     cleanup_agents,
     create_tcp_store,
@@ -130,6 +131,19 @@ def _validate_replacement_coverage(
         raise AssertionError("pressure campaign replaced an unexpected number of initial GPU-nodes")
 
 
+def _cleanup_controller(
+    coordinator: TorchrunRecoveryCoordinator | None,
+    *,
+    options: PressureLaunchOptions,
+    agents: Sequence[LaunchedAgent],
+) -> None:
+    try:
+        if coordinator is not None:
+            coordinator.close()
+    finally:
+        cleanup_agents(options, agents, remote_run_id=options.run_id)
+
+
 def _orchestrate(args: argparse.Namespace) -> None:
     campaign_dir = args.fault_campaign_dir.resolve()
     options = PressureLaunchOptions(
@@ -203,11 +217,12 @@ def _orchestrate(args: argparse.Namespace) -> None:
     )
     processes = [agent.process for agent in agents]
     artifacts = campaign_dir / "campaign-artifacts"
-    coordinator = TorchrunRecoveryCoordinator(control_store, run_id=options.run_id)
     expected_nodes = frozenset(
         synthetic_node_id(placement.node_label) for placement in topology.placements
     )
+    coordinator: TorchrunRecoveryCoordinator | None = None
     try:
+        coordinator = TorchrunRecoveryCoordinator(control_store, run_id=options.run_id)
         initial = _wait_for_initial_admission(
             coordinator,
             expected_nodes=expected_nodes,
@@ -306,6 +321,7 @@ def _orchestrate(args: argparse.Namespace) -> None:
             replacement_failures=replacement_failures,
         )
         coordinator.close()
+        coordinator = None
         for process in processes:
             process.wait(timeout=options.timeout)
             if process.returncode != 0:
@@ -349,8 +365,7 @@ def _orchestrate(args: argparse.Namespace) -> None:
             },
         )
     finally:
-        coordinator.close()
-        cleanup_agents(options, agents, remote_run_id=options.run_id)
+        _cleanup_controller(coordinator, options=options, agents=agents)
 
 
 def _parser() -> argparse.ArgumentParser:

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,6 +21,8 @@ Distributed programs document their required `torchrun` command in the module do
 Production-loop integration is exercised through `examples/production_loops/`.
 Systematic fault injection and localization are covered by
 `validation/fault_injection/`.
+Native torchrun bootstrap, restart, and replacement workflows are documented
+under `examples/torchrun/`.
 The public fault injection evaluation kit is covered by `unit/test_fault_injection.py`.
 MoE validation is manual because it depends on specific GPU, Triton, Megatron Core, and Transformer Engine environments.
 Reproducible healthy-path performance commands and regression thresholds are documented in [benchmarks](../benchmarks/README.md).

--- a/tests/unit/test_torchrun_adapter_bootstrap.py
+++ b/tests/unit/test_torchrun_adapter_bootstrap.py
@@ -1,12 +1,19 @@
 """Tests for the torchrun adapter-bootstrap workflow."""
 
+import os
+import time
 from pathlib import Path
 
 import pytest
 
 from examples.torchrun.adapter_bootstrap._validation import (
+    ObserveTorchrunAdapterAttachment,
     assert_torchrun_adapter_attached,
 )
+from examples.torchrun.adapter_bootstrap.framework_worker import (
+    FRAMEWORK_IMPORT_ROOTS,
+)
+from examples.torchrun.adapter_bootstrap.matrix import _write_worker_policy
 from lm_resiliency.integrations.torchrun.worker_adapter import (
     TorchrunWorkerContext,
     _feature_options,
@@ -31,6 +38,31 @@ def test_validation_rejects_missing_torchrun_adapter_attachment(
         assert_torchrun_adapter_attached()
 
 
+def test_pytorch_framework_import_uses_torch_package() -> None:
+    assert FRAMEWORK_IMPORT_ROOTS["pytorch"] == "torch"
+
+
+def test_validation_observer_latches_attachment_across_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("LM_RESILIENCY_TORCHRUN_ADAPTER_ATTACHED", raising=False)
+
+    with ObserveTorchrunAdapterAttachment():
+        monkeypatch.setenv("LM_RESILIENCY_TORCHRUN_ADAPTER_ATTACHED", "1")
+        time.sleep(0.02)
+        monkeypatch.delenv("LM_RESILIENCY_TORCHRUN_ADAPTER_ATTACHED")
+
+
+def test_validation_observer_rejects_missing_attachment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("LM_RESILIENCY_TORCHRUN_ADAPTER_ATTACHED", raising=False)
+
+    with pytest.raises(RuntimeError, match="worker adapter did not attach"):
+        with ObserveTorchrunAdapterAttachment():
+            assert "LM_RESILIENCY_TORCHRUN_ADAPTER_ATTACHED" not in os.environ
+
+
 def test_checked_in_smoke_policy_is_disabled(tmp_path: Path) -> None:
     policy = (
         Path(__file__).parents[2]
@@ -53,3 +85,20 @@ def test_checked_in_smoke_policy_is_disabled(tmp_path: Path) -> None:
     assert options["enable_detection"] is False
     assert checkpoint is None
     assert replay is None
+
+
+def test_matrix_policy_scopes_checkpoints_to_output_directory(tmp_path: Path) -> None:
+    policy = tmp_path / "worker.toml"
+    _write_worker_policy(policy, replication_jump=1)
+    context = TorchrunWorkerContext(
+        run_id="matrix-policy-test",
+        node_id="node-a",
+        local_world_size=2,
+        restart_context_path=(tmp_path / "restart-context.json").resolve(),
+    )
+
+    checkpoint, replay, _options = _feature_options(_load_config(policy), context)
+
+    assert checkpoint is not None
+    assert checkpoint.disk_folder == str((tmp_path / "checkpoints").resolve())
+    assert replay is not None

--- a/tests/unit/test_torchrun_adapter_bootstrap.py
+++ b/tests/unit/test_torchrun_adapter_bootstrap.py
@@ -1,0 +1,55 @@
+"""Tests for the torchrun adapter-bootstrap workflow."""
+
+from pathlib import Path
+
+import pytest
+
+from examples.torchrun.adapter_bootstrap._validation import (
+    assert_torchrun_adapter_attached,
+)
+from lm_resiliency.integrations.torchrun.worker_adapter import (
+    TorchrunWorkerContext,
+    _feature_options,
+    _load_config,
+)
+
+
+def test_validation_asserts_torchrun_adapter_attachment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LM_RESILIENCY_TORCHRUN_ADAPTER_ATTACHED", "1")
+
+    assert_torchrun_adapter_attached()
+
+
+def test_validation_rejects_missing_torchrun_adapter_attachment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("LM_RESILIENCY_TORCHRUN_ADAPTER_ATTACHED", raising=False)
+
+    with pytest.raises(RuntimeError, match="worker adapter did not attach"):
+        assert_torchrun_adapter_attached()
+
+
+def test_checked_in_smoke_policy_is_disabled(tmp_path: Path) -> None:
+    policy = (
+        Path(__file__).parents[2]
+        / "examples"
+        / "torchrun"
+        / "adapter_bootstrap"
+        / "policies"
+        / "smoke.toml"
+    )
+    context = TorchrunWorkerContext(
+        run_id="smoke-policy-test",
+        node_id="node-a",
+        local_world_size=1,
+        restart_context_path=(tmp_path / "restart-context.json").resolve(),
+    )
+
+    checkpoint, replay, options = _feature_options(_load_config(policy), context)
+
+    assert options["enable_checkpoint"] is False
+    assert options["enable_detection"] is False
+    assert checkpoint is None
+    assert replay is None

--- a/tests/unit/test_torchrun_resiliency_cycle_example.py
+++ b/tests/unit/test_torchrun_resiliency_cycle_example.py
@@ -39,9 +39,11 @@ from examples.torchrun.resiliency_cycle.harness.replay_fault import (
 from examples.torchrun.resiliency_cycle.harness.runtime import (
     DriverConfig,
     checkpoint_is_safe_for_replacement,
+    close_resources,
 )
 from examples.torchrun.resiliency_cycle.harness.verify import (
     checkpoint_topology_digest,
+    loss_difference,
     loss_difference_limit,
     optimizer_difference_limit,
 )
@@ -200,8 +202,10 @@ def test_fault_campaign_requires_two_clean_post_fault_steps() -> None:
         ReplayFaultCampaign.from_args(args, rank=0, world_size=2)
 
 
+@pytest.mark.parametrize("last_saved_step", [-1, 2])
 @pytest.mark.parametrize("flushed_step", [-1, 2])
 def test_replacement_accepts_verified_disk_checkpoint_after_process_restart(
+    last_saved_step: int,
     flushed_step: int,
 ) -> None:
     state = {"flushed": False}
@@ -211,7 +215,7 @@ def test_replacement_accepts_verified_disk_checkpoint_after_process_restart(
         return flushed_step
 
     manager = SimpleNamespace(
-        _last_saved_step=-1,
+        _last_saved_step=last_saved_step,
         checkpoint_status=SimpleNamespace(recovery_verified_step=2),
         local_recovery_step=lambda mode: (
             2 if state["flushed"] and mode == "recovery_verified" else -1
@@ -220,6 +224,61 @@ def test_replacement_accepts_verified_disk_checkpoint_after_process_restart(
     handle = SimpleNamespace(flush_for_restart=flush_for_restart)
 
     assert checkpoint_is_safe_for_replacement(manager, handle, expected_step=2)
+
+
+def test_replacement_rejects_a_saved_contaminated_candidate() -> None:
+    manager = SimpleNamespace(
+        _last_saved_step=3,
+        checkpoint_status=SimpleNamespace(recovery_verified_step=2),
+        local_recovery_step=lambda mode: 2 if mode == "recovery_verified" else -1,
+    )
+    handle = SimpleNamespace(flush_for_restart=lambda: 2)
+
+    assert not checkpoint_is_safe_for_replacement(manager, handle, expected_step=2)
+
+
+def test_cleanup_runs_every_action_and_preserves_the_first_failure(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls: list[str] = []
+
+    def fail_handle() -> None:
+        calls.append("handle")
+        raise RuntimeError("handle close failed")
+
+    def close_framework() -> None:
+        calls.append("framework")
+
+    def fail_process_group() -> None:
+        calls.append("process-group")
+        raise RuntimeError("process group close failed")
+
+    with pytest.raises(RuntimeError, match="handle close failed"):
+        close_resources(
+            ("resiliency handle", fail_handle),
+            ("framework", close_framework),
+            ("default process group", fail_process_group),
+        )
+
+    assert calls == ["handle", "framework", "process-group"]
+    assert "additional default process group cleanup failure" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("expected", "actual"),
+    [
+        (float("nan"), 1.0),
+        (1.0, float("nan")),
+        (float("inf"), 1.0),
+        (1.0, float("-inf")),
+    ],
+)
+def test_loss_difference_rejects_non_finite_values(
+    expected: float,
+    actual: float,
+) -> None:
+    with pytest.raises(AssertionError, match="non-finite"):
+        loss_difference(expected, actual, rank=0, step="2")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_torchrun_resiliency_cycle_example.py
+++ b/tests/unit/test_torchrun_resiliency_cycle_example.py
@@ -463,6 +463,7 @@ def test_cleanup_reaps_every_agent_when_remote_termination_times_out(
 def test_cleanup_failure_does_not_replace_active_orchestration_error(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     process = SimpleNamespace(
         poll=lambda: 0,
@@ -490,7 +491,7 @@ def test_cleanup_failure_does_not_replace_active_orchestration_error(
         finally:
             launch.cleanup_agents(options, [agent], remote_run_id=options.run_id)
 
-    assert any("ssh failed" in note for note in captured.value.__notes__)
+    assert "ssh failed" in capsys.readouterr().err
     assert agent.log.closed
 
 

--- a/tests/unit/test_torchrun_resiliency_cycle_example.py
+++ b/tests/unit/test_torchrun_resiliency_cycle_example.py
@@ -14,6 +14,7 @@ import torch
 import torch.nn as nn
 
 from examples.torchrun.resiliency_cycle.harness import launch
+from examples.torchrun.resiliency_cycle.harness.artifacts import wait_for_paths
 from examples.torchrun.resiliency_cycle.harness.campaign import (
     CAMPAIGN_FILENAME,
     STATE_FILENAME,
@@ -128,6 +129,19 @@ def test_campaign_rejects_unsupported_replay_corruption() -> None:
     replacement["faults"][0]["parameters"]["operation"] = "scale"
 
     with pytest.raises(ValueError, match="sign_flip"):
+        pressure_events(FaultCampaign.from_dict(value))
+
+
+def test_campaign_rejects_replacement_before_a_clean_checkpoint() -> None:
+    value = default_pressure_campaign().to_dict()
+    replacement = next(
+        incident
+        for incident in value["incidents"]
+        if incident["faults"][0]["type"] == "tensor_corruption"
+    )
+    replacement["trigger"]["at"] = [1]
+
+    with pytest.raises(ValueError, match="at least one clean checkpoint"):
         pressure_events(FaultCampaign.from_dict(value))
 
 
@@ -318,6 +332,26 @@ def test_remote_install_uses_selected_python(
     ]
 
 
+def test_remote_process_pattern_matches_only_the_complete_run_id() -> None:
+    pattern = launch._remote_run_pattern("run-12")
+
+    exact = subprocess.run(
+        ["grep", "-Eq", pattern],
+        input="python torchrun --rdzv-id=run-12 --module worker",
+        text=True,
+        check=False,
+    )
+    prefix = subprocess.run(
+        ["grep", "-Eq", pattern],
+        input="python torchrun --rdzv-id=run-123 --module worker",
+        text=True,
+        check=False,
+    )
+
+    assert exact.returncode == 0
+    assert prefix.returncode == 1
+
+
 def test_partial_managed_launch_is_cleaned_up(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -369,6 +403,116 @@ def test_partial_managed_launch_is_cleaned_up(
         )
 
     assert cleaned == [first]
+
+
+def test_cleanup_reaps_every_agent_when_remote_termination_times_out(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class StubbornProcess:
+        returncode: int | None = None
+
+        def __init__(self) -> None:
+            self.killed = False
+            self.terminated = False
+            self.waits = 0
+
+        def poll(self) -> int | None:
+            return self.returncode
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+        def wait(self, timeout: float) -> int:
+            self.waits += 1
+            if self.waits == 1:
+                raise subprocess.TimeoutExpired("torchrun", timeout)
+            self.returncode = -9
+            return self.returncode
+
+        def kill(self) -> None:
+            self.killed = True
+
+    processes = [StubbornProcess(), StubbornProcess()]
+    agents = [
+        LaunchedAgent(process=process, log=io.BytesIO())  # type: ignore[arg-type]
+        for process in processes
+    ]
+    options = PressureLaunchOptions(
+        fault_campaign_dir=tmp_path,
+        framework="pytorch",
+        run_id="cleanup-timeout",
+        timeout=10,
+        remote_host="worker-b",
+    )
+    monkeypatch.setattr(
+        launch,
+        "terminate_remote_run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(subprocess.TimeoutExpired("ssh", 10)),
+    )
+
+    with pytest.raises(RuntimeError, match="agent cleanup failed"):
+        launch.cleanup_agents(options, agents, remote_run_id=options.run_id)
+
+    assert all(process.terminated for process in processes)
+    assert all(process.killed for process in processes)
+    assert all(process.waits == 2 for process in processes)
+    assert all(agent.log.closed for agent in agents)
+
+
+def test_cleanup_failure_does_not_replace_active_orchestration_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = SimpleNamespace(
+        poll=lambda: 0,
+        terminate=lambda: None,
+        wait=lambda timeout: 0,
+        kill=lambda: None,
+    )
+    agent = LaunchedAgent(process=process, log=io.BytesIO())  # type: ignore[arg-type]
+    options = PressureLaunchOptions(
+        fault_campaign_dir=tmp_path,
+        framework="pytorch",
+        run_id="preserve-error",
+        timeout=10,
+        remote_host="worker-b",
+    )
+    monkeypatch.setattr(
+        launch,
+        "terminate_remote_run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("ssh failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="orchestration failed") as captured:
+        try:
+            raise RuntimeError("orchestration failed")
+        finally:
+            launch.cleanup_agents(options, [agent], remote_run_id=options.run_id)
+
+    assert any("ssh failed" in note for note in captured.value.__notes__)
+    assert agent.log.closed
+
+
+def test_artifact_wait_polls_coordinator_health(
+    tmp_path: Path,
+) -> None:
+    calls = 0
+
+    def check_health() -> None:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("lease renewal failed")
+
+    with pytest.raises(RuntimeError, match="lease renewal failed"):
+        wait_for_paths(
+            [tmp_path / "missing.json"],
+            processes=(),
+            timeout=60,
+            health_check=check_health,
+        )
+
+    assert calls == 1
 
 
 def test_agent_cleanup_runs_when_coordinator_close_fails(

--- a/tests/unit/test_torchrun_resiliency_cycle_example.py
+++ b/tests/unit/test_torchrun_resiliency_cycle_example.py
@@ -1,0 +1,215 @@
+"""Tests for the torchrun resiliency-cycle example."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from examples.torchrun.resiliency_cycle.harness.campaign import (
+    CAMPAIGN_FILENAME,
+    STATE_FILENAME,
+    campaign_layout,
+    default_pressure_campaign,
+    load_campaign_bundle,
+    pressure_events,
+)
+from examples.torchrun.resiliency_cycle.harness.replay_fault import (
+    ReplayFaultCampaign,
+)
+from examples.torchrun.resiliency_cycle.harness.runtime import (
+    checkpoint_is_safe_for_replacement,
+)
+from examples.torchrun.resiliency_cycle.harness.verify import (
+    loss_difference_limit,
+    optimizer_difference_limit,
+)
+from examples.torchrun.resiliency_cycle.pressure import (
+    _validate_replacement_coverage,
+)
+
+
+class _CheckpointManager:
+    def __init__(self, step: int) -> None:
+        self._last_saved_step = step
+        self.checkpoint_status = SimpleNamespace(recovery_verified_step=step)
+
+
+def _result(*, fault: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        peer_ranks=[0, 1],
+        sdc_bitmap=[1, 0] if fault else [0, 0],
+        straggler_bitmap=[0, 0],
+        sdc_sources=["hidden.output"] if fault else [],
+        checked_recipe_ids={"embedding", "hidden", "output", "optimizer"},
+    )
+
+
+def test_default_pressure_campaign_has_sixteen_restarts_and_eight_replacements() -> None:
+    campaign = default_pressure_campaign()
+    events = pressure_events(campaign)
+
+    assert len(events) == 24
+    assert [event.step for event in events] == list(range(1, 25))
+    assert sum(event.kind == "restart" for event in events) == 16
+    replacements = [event for event in events if event.kind == "replacement"]
+    assert len(replacements) == 8
+    assert [event.fault_rank for event in replacements] == list(range(8))
+    assert campaign.metadata["total_steps"] == 25
+
+
+def test_sixteen_gpu_layout_treats_every_gpu_as_one_node() -> None:
+    campaign = default_pressure_campaign()
+    events = pressure_events(campaign)
+    topology = campaign_layout(
+        gpus="0,1,2,3,4,5,6,7",
+        remote_gpus="0,1,2,3,4,5,6,7",
+        remote_enabled=True,
+        campaign=campaign,
+        events=events,
+    )
+
+    assert len(topology.placements) == 16
+    assert len({placement.node_label for placement in topology.placements}) == 16
+    assert sum(placement.remote for placement in topology.placements) == 8
+    assert topology.world_size == 8
+    assert topology.replication_jump == 4
+    assert topology.topology_digest == "ddp-world-8-replication-jump-4-gpu-nodes"
+
+
+def test_campaign_bundle_creates_only_manifest_before_execution(tmp_path: Path) -> None:
+    campaign, events = load_campaign_bundle(tmp_path)
+
+    assert campaign == default_pressure_campaign()
+    assert events == pressure_events(campaign)
+    assert (tmp_path / CAMPAIGN_FILENAME).is_file()
+    assert not (tmp_path / STATE_FILENAME).exists()
+
+
+def test_fault_campaign_corrupts_replay_but_not_training_forward() -> None:
+    target = nn.Identity()
+    manager = _CheckpointManager(step=1)
+    handle = SimpleNamespace(
+        replay_harness=SimpleNamespace(target_layer=target),
+        ckpt_manager=manager,
+    )
+    campaign = ReplayFaultCampaign(
+        steps=5,
+        rank=0,
+        world_size=2,
+        inject_fault=True,
+        fault_step=2,
+        fault_rank=0,
+    )
+    campaign.bind(handle)
+    campaign.start_step(2)
+
+    value = torch.zeros(2)
+    torch.testing.assert_close(target(value), value)
+    torch.testing.assert_close(target(value), value + 1.0)
+
+    campaign.record_fault(_result(fault=True))
+    campaign.recovery_decisions.append(
+        {
+            "failure_kind": "sdc",
+            "recovery_mode": "recovery_verified",
+            "checkpoint_source": "gemini",
+            "checkpoint_step": 1,
+            "available": True,
+        }
+    )
+    manager._last_saved_step = 5
+    manager.checkpoint_status.recovery_verified_step = 5
+
+    campaign.validate(
+        handle,
+        _result(fault=False),
+        {"embedding", "hidden", "output", "optimizer"},
+    )
+    campaign.close()
+
+
+def test_fault_campaign_requires_two_clean_post_fault_steps() -> None:
+    args = SimpleNamespace(
+        steps=5,
+        inject_fault=True,
+        fault_step=4,
+        fault_rank=-1,
+    )
+
+    with pytest.raises(ValueError, match="post-fault"):
+        ReplayFaultCampaign.from_args(args, rank=0, world_size=2)
+
+
+@pytest.mark.parametrize("flushed_step", [-1, 2])
+def test_replacement_accepts_verified_disk_checkpoint_after_process_restart(
+    flushed_step: int,
+) -> None:
+    state = {"flushed": False}
+
+    def flush_for_restart() -> int:
+        state["flushed"] = True
+        return flushed_step
+
+    manager = SimpleNamespace(
+        _last_saved_step=-1,
+        checkpoint_status=SimpleNamespace(recovery_verified_step=2),
+        local_recovery_step=lambda mode: (
+            2 if state["flushed"] and mode == "recovery_verified" else -1
+        ),
+    )
+    handle = SimpleNamespace(flush_for_restart=flush_for_restart)
+
+    assert checkpoint_is_safe_for_replacement(manager, handle, expected_step=2)
+
+
+@pytest.mark.parametrize(
+    ("gpus", "remote_gpus", "message"),
+    [
+        ("0,0,1,2,3,4,5,6", "0,1,2,3,4,5,6,7", "duplicate GPU IDs"),
+        ("0,1,2,3,4,5,6,7", "0,1,2,3,4,5,6", "must equal"),
+    ],
+)
+def test_campaign_layout_rejects_invalid_gpu_fleets(
+    gpus: str,
+    remote_gpus: str,
+    message: str,
+) -> None:
+    campaign = default_pressure_campaign()
+
+    with pytest.raises(ValueError, match=message):
+        campaign_layout(
+            gpus=gpus,
+            remote_gpus=remote_gpus,
+            remote_enabled=True,
+            campaign=campaign,
+            events=pressure_events(campaign),
+        )
+
+
+def test_replacement_coverage_matches_campaign_incident_count() -> None:
+    _validate_replacement_coverage(
+        current_nodes=("standby-a", "node-b", "node-c", "node-d"),
+        initial_nodes=("node-a", "node-b", "node-c", "node-d"),
+        replacement_failures=1,
+    )
+
+    with pytest.raises(AssertionError, match="unexpected number"):
+        _validate_replacement_coverage(
+            current_nodes=("standby-a", "standby-b", "node-c", "node-d"),
+            initial_nodes=("node-a", "node-b", "node-c", "node-d"),
+            replacement_failures=1,
+        )
+
+
+def test_deepspeed_uses_bf16_continuation_tolerance() -> None:
+    assert optimizer_difference_limit("deepspeed") == 1e-3
+    assert optimizer_difference_limit("pytorch") == 5e-5
+
+
+def test_torchtitan_uses_bf16_loss_continuation_tolerance() -> None:
+    assert loss_difference_limit("torchtitan") == 1e-1
+    assert loss_difference_limit("pytorch") == 1e-2

--- a/tests/unit/test_torchrun_resiliency_cycle_example.py
+++ b/tests/unit/test_torchrun_resiliency_cycle_example.py
@@ -48,6 +48,7 @@ from examples.torchrun.resiliency_cycle.harness.worker import (
     _validate_worker_context,
 )
 from examples.torchrun.resiliency_cycle.pressure import (
+    _cleanup_controller,
     _validate_replacement_coverage,
 )
 from lm_resiliency import FaultCampaign
@@ -368,6 +369,40 @@ def test_partial_managed_launch_is_cleaned_up(
         )
 
     assert cleaned == [first]
+
+
+def test_agent_cleanup_runs_when_coordinator_close_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cleaned: list[LaunchedAgent] = []
+    options = PressureLaunchOptions(
+        fault_campaign_dir=tmp_path,
+        framework="pytorch",
+        run_id="close-failure",
+        timeout=10,
+    )
+    agent = LaunchedAgent(process=SimpleNamespace(), log=io.BytesIO())
+    coordinator = SimpleNamespace(close=lambda: (_ for _ in ()).throw(RuntimeError("store failed")))
+
+    def cleanup(
+        _options: PressureLaunchOptions,
+        agents: list[LaunchedAgent],
+        *,
+        remote_run_id: str,
+    ) -> None:
+        assert remote_run_id == "close-failure"
+        cleaned.extend(agents)
+
+    monkeypatch.setattr(
+        "examples.torchrun.resiliency_cycle.pressure.cleanup_agents",
+        cleanup,
+    )
+
+    with pytest.raises(RuntimeError, match="store failed"):
+        _cleanup_controller(coordinator, options=options, agents=[agent])
+
+    assert cleaned == [agent]
 
 
 def test_megatron_extra_state_restores_sample_counters() -> None:

--- a/tests/unit/test_torchrun_resiliency_cycle_example.py
+++ b/tests/unit/test_torchrun_resiliency_cycle_example.py
@@ -2,34 +2,55 @@
 
 from __future__ import annotations
 
+import io
+import shlex
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 import torch
 import torch.nn as nn
 
+from examples.torchrun.resiliency_cycle.harness import launch
 from examples.torchrun.resiliency_cycle.harness.campaign import (
     CAMPAIGN_FILENAME,
     STATE_FILENAME,
+    GpuNodePlacement,
+    PressureTopology,
     campaign_layout,
     default_pressure_campaign,
     load_campaign_bundle,
     pressure_events,
+    require_fresh_campaign_run,
+)
+from examples.torchrun.resiliency_cycle.harness.frameworks.megatron import (
+    MegatronDriver,
+)
+from examples.torchrun.resiliency_cycle.harness.launch import (
+    LaunchedAgent,
+    PressureLaunchOptions,
 )
 from examples.torchrun.resiliency_cycle.harness.replay_fault import (
     ReplayFaultCampaign,
 )
 from examples.torchrun.resiliency_cycle.harness.runtime import (
+    DriverConfig,
     checkpoint_is_safe_for_replacement,
 )
 from examples.torchrun.resiliency_cycle.harness.verify import (
+    checkpoint_topology_digest,
     loss_difference_limit,
     optimizer_difference_limit,
+)
+from examples.torchrun.resiliency_cycle.harness.worker import (
+    _validate_worker_context,
 )
 from examples.torchrun.resiliency_cycle.pressure import (
     _validate_replacement_coverage,
 )
+from lm_resiliency import FaultCampaign
 
 
 class _CheckpointManager:
@@ -77,7 +98,6 @@ def test_sixteen_gpu_layout_treats_every_gpu_as_one_node() -> None:
     assert sum(placement.remote for placement in topology.placements) == 8
     assert topology.world_size == 8
     assert topology.replication_jump == 4
-    assert topology.topology_digest == "ddp-world-8-replication-jump-4-gpu-nodes"
 
 
 def test_campaign_bundle_creates_only_manifest_before_execution(tmp_path: Path) -> None:
@@ -87,6 +107,27 @@ def test_campaign_bundle_creates_only_manifest_before_execution(tmp_path: Path) 
     assert events == pressure_events(campaign)
     assert (tmp_path / CAMPAIGN_FILENAME).is_file()
     assert not (tmp_path / STATE_FILENAME).exists()
+
+
+def test_campaign_bundle_rejects_stale_run_artifacts(tmp_path: Path) -> None:
+    load_campaign_bundle(tmp_path)
+    (tmp_path / STATE_FILENAME).write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must be fresh"):
+        require_fresh_campaign_run(tmp_path)
+
+
+def test_campaign_rejects_unsupported_replay_corruption() -> None:
+    value = default_pressure_campaign().to_dict()
+    replacement = next(
+        incident
+        for incident in value["incidents"]
+        if incident["faults"][0]["type"] == "tensor_corruption"
+    )
+    replacement["faults"][0]["parameters"]["operation"] = "scale"
+
+    with pytest.raises(ValueError, match="sign_flip"):
+        pressure_events(FaultCampaign.from_dict(value))
 
 
 def test_fault_campaign_corrupts_replay_but_not_training_forward() -> None:
@@ -107,9 +148,9 @@ def test_fault_campaign_corrupts_replay_but_not_training_forward() -> None:
     campaign.bind(handle)
     campaign.start_step(2)
 
-    value = torch.zeros(2)
+    value = torch.tensor([1.0, -2.0])
     torch.testing.assert_close(target(value), value)
-    torch.testing.assert_close(target(value), value + 1.0)
+    torch.testing.assert_close(target(value), -value)
 
     campaign.record_fault(_result(fault=True))
     campaign.recovery_decisions.append(
@@ -203,6 +244,163 @@ def test_replacement_coverage_matches_campaign_incident_count() -> None:
             initial_nodes=("node-a", "node-b", "node-c", "node-d"),
             replacement_failures=1,
         )
+
+
+def test_driver_config_forwards_exact_recovery_constraints(tmp_path: Path) -> None:
+    config = DriverConfig(
+        campaign_dir=tmp_path,
+        checkpoint=object(),  # type: ignore[arg-type]
+        replay=object(),  # type: ignore[arg-type]
+        recovery_mode="recovery_verified",
+        recovery_step=7,
+        expected_topology_id="checkpoint-topology",
+        fault_callback=lambda _result: None,
+        orchestration=object(),  # type: ignore[arg-type]
+        total_steps=9,
+    )
+
+    assert config.recovery_options() == {
+        "recovery_mode": "recovery_verified",
+        "_recovery_step": 7,
+        "_expected_topology_id": "checkpoint-topology",
+    }
+
+
+def test_generation_zero_context_does_not_require_recovery_source() -> None:
+    _validate_worker_context(SimpleNamespace(local_world_size=1, generation=0))
+
+
+def test_incident_reports_require_one_checkpoint_topology() -> None:
+    reports = [
+        {"topology_digest": "checkpoint-topology"},
+        {"topology_digest": "checkpoint-topology"},
+    ]
+
+    assert checkpoint_topology_digest(reports) == "checkpoint-topology"
+    reports[1]["topology_digest"] = "other-topology"
+    with pytest.raises(AssertionError, match="disagree"):
+        checkpoint_topology_digest(reports)
+
+
+def test_gpu_environment_does_not_assume_network_interface() -> None:
+    assert launch._gpu_environment("3") == {"CUDA_VISIBLE_DEVICES": "3"}
+
+
+def test_remote_install_uses_selected_python(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+
+    def run(command: list[str], **_kwargs: Any) -> SimpleNamespace:
+        calls.append(command)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", run)
+    options = PressureLaunchOptions(
+        fault_campaign_dir=tmp_path / "campaign",
+        framework="pytorch",
+        run_id="remote-install",
+        timeout=10,
+        remote_host="worker-b",
+        remote_python="/opt/lm/bin/python",
+        remote_source_dir=tmp_path / "remote-source",
+    )
+
+    launch.prepare_remote_source(options)
+
+    assert shlex.split(calls[-1][-1])[:4] == [
+        "/opt/lm/bin/python",
+        "-m",
+        "pip",
+        "install",
+    ]
+
+
+def test_partial_managed_launch_is_cleaned_up(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = SimpleNamespace()
+    first = LaunchedAgent(process=process, log=io.BytesIO())
+    calls = 0
+    cleaned: list[LaunchedAgent] = []
+
+    def start(**_kwargs: Any) -> LaunchedAgent:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("launch failed")
+        return first
+
+    def cleanup(
+        _options: PressureLaunchOptions,
+        agents: list[LaunchedAgent],
+        *,
+        remote_run_id: str,
+    ) -> None:
+        assert remote_run_id == "partial-launch"
+        cleaned.extend(agents)
+
+    monkeypatch.setattr(launch, "_launch_managed_agent", start)
+    monkeypatch.setattr(launch, "cleanup_agents", cleanup)
+    options = PressureLaunchOptions(
+        fault_campaign_dir=tmp_path,
+        framework="pytorch",
+        run_id="partial-launch",
+        timeout=10,
+    )
+    topology = PressureTopology(
+        placements=(
+            GpuNodePlacement("node-a", "0", False),
+            GpuNodePlacement("node-b", "1", False),
+        ),
+        world_size=1,
+        replication_jump=1,
+    )
+
+    with pytest.raises(RuntimeError, match="launch failed"):
+        launch.launch_managed_agents(
+            options,
+            topology,
+            endpoint=None,
+            max_restarts=1,
+        )
+
+    assert cleaned == [first]
+
+
+def test_megatron_extra_state_restores_sample_counters() -> None:
+    loaded_scheduler: list[dict[str, int]] = []
+    driver = MegatronDriver.__new__(MegatronDriver)
+    driver.world_size = 4
+    driver._extra_state = {"absolute_step": 2}
+    driver.args = SimpleNamespace(
+        iteration=1,
+        consumed_train_samples=8,
+        skipped_train_samples=3,
+    )
+    driver.scheduler = SimpleNamespace(
+        num_steps=2,
+        state_dict=lambda: {"num_steps": 2},
+        load_state_dict=loaded_scheduler.append,
+    )
+    driver.handle = SimpleNamespace(step_count=2)
+
+    saved = driver._extra_state_dict()
+    assert saved["iteration"] == 2
+    assert saved["consumed_train_samples"] == 16
+    assert saved["skipped_train_samples"] == 3
+
+    driver.args.iteration = 0
+    driver.args.consumed_train_samples = 0
+    driver.args.skipped_train_samples = 0
+    driver._load_extra_state_dict(saved)
+
+    assert driver.framework_state()["iteration"] == 2
+    assert driver.framework_state()["consumed_train_samples"] == 16
+    assert driver.framework_state()["skipped_train_samples"] == 3
+    assert loaded_scheduler == [{"num_steps": 2}]
 
 
 def test_deepspeed_uses_bf16_continuation_tolerance() -> None:


### PR DESCRIPTION
## Summary

- add a zero-import torchrun adapter-bootstrap smoke worker and clean framework matrix
- add a manager-driven resiliency-cycle controller with one torchrun agent per GPU, same-node restart, SCOUT-localized standby replacement, and exact GEMINI recovery checks
- isolate controller implementation under `resiliency_cycle/harness/` while keeping `pressure.py` and campaign manifests as the user-facing surface
- document the workflow boundaries and add focused example contracts

## Why

The native torchrun integration is merged, but the repository lacks runnable examples that prove bootstrap occurs before user code and exercise the complete detect, decide, restart, recover, and resume cycle. The new layout also keeps this advanced recovery workflow distinct from the public `enable_fault_injection()` API qualification under `tests/validation/fault_injection/`.

## Compatibility

This PR adds examples, documentation, and source-owned example tests only. It does not change the `lm_resiliency` package API or runtime behavior. Optional framework imports remain lazy.

## Validation

- `17 passed` across documentation, adapter-bootstrap, and resiliency-cycle focused tests
- Ruff lint, Ruff formatting, and `git diff --check` passed
- real one-process CPU torchrun smoke reported `resiliency_adapter_attached: true`
- five A100 GPUs: four active synthetic GPU-nodes plus one standby, one same-node restart, one SCOUT-localized replacement, four fault reports, eight bitwise-exact recovery reports, and four final-rank reports
- final PyTorch comparison: zero loss/model difference, optimizer max absolute difference `2.3283064365386963e-10`, and bitwise-exact RNG

## Remaining hardware qualification

The DeepSpeed, Megatron Core, and TorchTitan resiliency-cycle drivers were not rerun on this exact commit. Their optional environments and full GPU qualification remain manual.