### PR TITLE
[Docs] Rewrite torchrun resiliency guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ lm_resiliency_worker_config=${WORKER_CONFIG}" \
   --validation-output-dir "/tmp/lm-resiliency-${framework}"
 ```
 
-See [Examples](examples/README.md) for the framework loops, adapter-bootstrap checks, and additional commands.
+See [Torchrun Resiliency](docs/torchrun_resiliency.md) to understand how LM Resiliency provides closed-loop recovery for the training loop.
 
 ### Resiliency cycle
 
@@ -135,8 +135,6 @@ campaign configuration details.
 The package-root `enable_resiliency` entry point selects dense or expert replay peers from framework topology metadata.
 See the [API guide](docs/api.md) for framework invocation, configuration, recovery, callbacks, and lifecycle management.
 See the [compatibility policy](docs/compatibility.md) for supported and tested versions.
-Every [production-loop example](examples/README.md#production-loops) uses the
-native torchrun backend and leaves the framework-owned training loop unchanged.
 
 ## Documentation
 

--- a/docs/torchrun_resiliency.md
+++ b/docs/torchrun_resiliency.md
@@ -1,372 +1,161 @@
-# Torchrun Native Resiliency
+# Closed-Loop Recovery for Torchrun Training
 
-Status: implemented and validated
+Distributed training can fail without producing a clean process crash. A rank may stop making progress, run slowly, desynchronize from its peers, or continue with corrupted state. Restarting workers is only part of the solution. The system must first decide what failed, which training state is safe, and whether the current machines should restart or a standby should take over.
 
-Last updated: 2026-08-17
+Torchrun already provides the worker lifecycle. LM Resiliency adds the evidence and recovery decisions around that lifecycle:
 
-## Summary
+- **SCOUT** detects and localizes failures.
+- **GEMINI** maintains recent in-memory checkpoints and identifies trusted recovery state.
+- The **LM Resiliency torchrun integration** turns that decision into a coordinated restart or standby replacement.
 
-The integration uses fixed-size training with replacement:
+Together they create closed-loop recovery: protect the running job, detect a failure, select safe state, recover the worker group, and continue training.
 
-- the scheduler starts torchrun agents on an allocated fleet;
-- exactly `min_nodes` logical slots run trainers;
-- excess agents remain parked as standbys;
-- SCOUT localizes the faulty logical rank;
-- GEMINI selects and flushes one recovery-verified checkpoint;
-- the LM Resiliency manager publishes one immutable `RestartPlan`; and
-- the torchrun rendezvous handler consumes that plan, preserves logical slots,
-  restarts the healthy group, and admits only the selected standby.
+## Architecture at a Glance
 
-Torchrun is a lifecycle mechanism, not the recovery decision-maker. It does not
-re-evaluate SCOUT evidence, GEMINI trust, or placement policy.
-
-## Why `--nnodes=min:max` Is Not a Standby Contract
-
-Stock `--nnodes=min_nodes:max_nodes` permits any active rendezvous size in that
-range. It does not mean "`min_nodes` trainers plus reserved standby agents."
-
-For example, with `--nnodes=4:6`, late nodes are normally scale-up candidates.
-The simplified LM Resiliency handler instead keeps exactly four logical slots:
+The design has three layers:
 
 ```text
-generation 0:  node-a node-b node-c node-d
-standby:       node-e node-f
-
-failure:       node-d
-generation 1:  node-a node-b node-c node-e
-standby:       node-f
++-------------------------------------------------------------+
+|                           torchrun                          |
+|  +-------------------------------------------------------+  |
+|  |                active + standby agents                |  |
+|  |               launch and restart workers              |  |
+|  +-------------------------------------------------------+  |
++-------------------------------------------------------------+
+               ^                                |
+               |                                |
+    committed recovery plan         launch + monitor workers
+               |                                |
+               |                                v
++-------------------------------------------------------------+
+|                        LM Resiliency                        |
+|  +-------------------------------------------------------+  |
+|  |        rendezvous backend + framework adapters        |  |
+|  |              GEMINI in-memory checkpoints             |  |
+|  |      SCOUT detection, localization, certification     |  |
+|  |                committed recovery plan                |  |
+|  +-------------------------------------------------------+  |
++-------------------------------------------------------------+
+               ^                                |
+               |                                |
+   state + failure evidence             bootstrap + hooks
+               |                                |
+               |                                v
++-------------------------------------------------------------+
+|         PyTorch / DeepSpeed / Megatron / TorchTitan         |
++-------------------------------------------------------------+
 ```
 
-`node-e` inherits `node-d`'s logical slot and global-rank range. World size,
-local worker count, and framework topology do not change.
-
-## Ownership
-
-| Concern | Owner |
+| Layer | Responsibility |
 |---|---|
-| Fault detection and localization | SCOUT |
-| Checkpoint capture, trust, and recovery step | GEMINI |
-| Quarantine, replacement choice, and final plan | LM Resiliency manager |
-| Standby parking and stable slot admission | torchrun rendezvous handler |
-| Worker-group stop and relaunch | stock torchrun elastic agent |
-| Model, optimizer, RNG, scheduler, and input state | framework integration |
-| Host allocation and physical repair | scheduler/infrastructure |
+| torchrun | Run active and standby agents; launch, monitor, stop, and restart workers |
+| LM Resiliency | Protect training state, detect failures, select recovery state, and coordinate restart or replacement |
+| Training frameworks | Execute the model and optimizer loop through their normal framework APIs |
 
-The manager publishes only after it has one safe decision. The torchrun-facing
-contract is therefore one canonical `RestartPlan`, not a second evidence or
-consensus protocol.
+The scheduler or infrastructure layer sits outside the diagram. It allocates the fleet and repairs or retires physical hardware.
 
-## Recovery Plan
+## The Recovery Cycle
 
-The plan contains the information torchrun needs:
+The interaction is easiest to understand by following one failure.
 
-- run, plan, intent, and generation identities;
-- the exact node-to-slot assignment for the successor generation;
-- quarantined node IDs;
-- recovery mode and checkpoint source;
-- checkpoint step, checkpoint manifest ID, and optional durable checkpoint ID;
-- expected world size and topology digest; and
-- an exclusive restart deadline.
+**1. torchrun starts active and standby agents.**
 
-The runtime stores one create-once plan per successor generation. Publication
-advances the current generation by compare-and-set, so conflicting plans fail
-closed. The coordinator converts the manager's absolute deadline into a
-renewing store lease containing a sequence and remaining duration. Agents
-require locally observed lease progress and translate the remaining duration
-to their own monotonic clocks; they never compare wall-clock timestamps from
-different hosts. Lease freshness remains bounded by the heartbeat cadence, but
-the restart context carries the full manager window so worker startup is not
-limited to one heartbeat timeout.
-
-For GEMINI recovery the plan carries:
+Suppose an allocation contains six nodes and the job needs four:
 
 ```text
-recovery_mode = recovery_verified
-checkpoint_source = gemini
-checkpoint_step = <verified optimizer step>
-checkpoint_id = null
+active:   node-1, node-2, node-3, node-4
+standby:  node-5, node-6
 ```
 
-The shared GEMINI folder and stable checkpoint run ID remain deployment
-configuration. They are not duplicated in every restart plan.
+Every allocated node runs a torchrun agent. Four nodes launch the training job; the other two remain parked until a replacement is needed.
 
-## Rendezvous Lifecycle
+**2. LM Resiliency attaches to the training framework.**
 
-### Initial generation
+The active agents start the user module normally. LM Resiliency detects whether the job uses PyTorch, DeepSpeed, Megatron Core, or TorchTitan and attaches at the framework's initialization boundary.
 
-Each agent reads `/etc/machine-id`, validates the standard 32-hexadecimal
-machine identity, and registers a domain-separated SHA-256 identifier in the
-rendezvous store. The raw machine ID is not published. The first `min_nodes`
-unique registrations are committed once as generation zero and logical slot
-order. Later registrations remain standbys. Every agent then heartbeats under
-its committed machine identity.
+**3. The training framework runs its normal training loop.**
 
-- assigned nodes publish readiness and form the worker group;
-- unassigned nodes remain blocked in `next_rendezvous()`; and
-- parked standbys are hidden from `num_nodes_waiting()`.
+The framework continues to execute forward, backward, optimizer, and scheduler steps through its existing APIs. LM Resiliency observes the framework-owned step boundaries without taking control of the loop.
 
-Two live agents resolving to the same machine identity fail closed. This
-prevents two torchrun agents on one physical node from claiming separate
-failure domains. The validation campaign intentionally simulates multiple
-nodes on one host by setting `LM_RESILIENCY_MACHINE_ID_PATH` to a different
-synthetic machine-ID file for each agent.
+**4. LM Resiliency protects the healthy training loop.**
 
-### Replacement
+GEMINI captures frequent in-memory checkpoints while SCOUT observes replay, progress, and health evidence. Their combined evidence distinguishes recent state from recent state that is safe to recover.
 
-After the manager publishes generation `N + 1`:
+**5. LM Resiliency commits one recovery decision.**
 
-1. the coordinator renews the generation lease until the manager deadline;
-2. healthy active agents observe one live plan-selected replacement through
-   `num_nodes_waiting()`;
-3. stock torchrun performs its normal full-worker-group restart;
-4. the selected standby is admitted at the failed node's logical slot;
-5. every admitted node receives the same generation and world size;
-6. the handler writes a node-local canonical `RestartContext`; and
-7. workers enable LM Resiliency with the plan's recovery mode and restore the
-   selected GEMINI or durable checkpoint.
+Assume SCOUT localizes a persistent fault to `node-4`. LM Resiliency combines that result with GEMINI's trusted state. torchrun contributes worker-lifecycle and membership signals, while LM Resiliency combines the available evidence and publishes a committed recovery plan for torchrun to execute:
 
-Random late agents, unselected standbys, and plans without a progressing
-manager lease never create a restart signal.
+```text
+faulty node:          node-4
+recovery checkpoint: step 1240
+replacement node:    node-5
+```
 
-### Completion
+The decision is committed before torchrun changes the worker group. It names the recovery checkpoint, the machines that may continue, and the standby that may join.
 
-The manager closes the run after training completes. Parked agents exit cleanly
-without starting trainers.
+**6. torchrun restarts or replaces the workers.**
 
-## Restart Context
+Torchrun stops the current worker group and launches the approved successor:
 
-The handler writes one owner-only JSON file per node. The file contains:
+```text
+active:       node-1, node-2, node-3, node-5
+quarantined:  node-4
+standby:      node-6
+```
 
-- run, plan, and generation identity;
-- logical node slot and global-rank range;
-- recovery mode and checkpoint selection;
-- world size and topology digest; and
-- a node-local monotonic lease deadline.
+A process-only failure can restart the existing machines without consuming a standby. A persistent machine failure replaces only the affected machine.
 
-Publication uses same-directory atomic replacement. Workers reject malformed,
-noncanonical, oversized, nonregular, non-owner-only, or locally expired files.
-The handler creates a missing parent directory with owner-only permissions.
-An existing directory with different ownership or group/other access is
-rejected rather than modified.
+**7. LM Resiliency completes closed-loop recovery.**
 
-The framework consumes the context before training resumes. GEMINI then
-restores model, optimizer, caller-owned state, and RNG from the selected step.
+The framework adapter restores the selected model, optimizer, scheduler, RNG, and framework-owned progress state. After all workers agree on that state, the framework returns to its normal training loop and GEMINI and SCOUT resume protection. A later failure enters the same recovery cycle again.
 
-## Configuration
+## Running the Integrated Path
 
-The integration is registered through the supported `torchrun.handlers`
-entry-point group as rendezvous backend `lm_resiliency`.
-
-Required per-agent rendezvous configuration:
-
-| Key | Meaning |
-|---|---|
-| `lm_resiliency_restart_context_path` | Absolute node-local context path |
-
-Optional settings:
-
-| Key | Default | Meaning |
-|---|---:|---|
-| `lm_resiliency_join_timeout_ms` | `300000` | Bounded formation/bootstrap window |
-| `lm_resiliency_poll_interval_ms` | `250` | Store polling interval |
-| `lm_resiliency_heartbeat_timeout_ms` | `10000` | Standby/agent liveness window |
-| `lm_resiliency_worker_config` | unset | Absolute path to the strict worker policy; enables automatic framework instrumentation |
-
-The values are supplied through `--rdzv-conf`. The `lm_resiliency_` namespace
-prevents collisions with c10d and future torchrun rendezvous options.
-
-Physical node identity and initial admission are automatic. Production agents
-read `/etc/machine-id`. `LM_RESILIENCY_MACHINE_ID_PATH` can select another
-absolute machine-ID file for containerized deployments or test harnesses.
-
-Example agent command for a user module with no LM Resiliency imports:
+Without LM Resiliency, a single-node eight-GPU job can use torchrun's standard `c10d` rendezvous backend:
 
 ```bash
 torchrun \
   --nnodes=1:1 \
-  --nproc-per-node=1 \
+  --nproc-per-node=8 \
+  --max-restarts=4 \
+  --rdzv-backend=c10d \
+  --rdzv-endpoint="${RDZV_HOST}:29400" \
+  --rdzv-id="${RUN_ID}" \
+  --module your_training.module
+```
+
+This command can restart workers, but it does not add SCOUT detection, GEMINI checkpoint recovery, or standby replacement.
+
+To enable LM Resiliency, select its rendezvous backend, allocate a standby, and supply a worker policy:
+
+```bash
+torchrun \
+  --nnodes=1:2 \
+  --nproc-per-node=8 \
   --max-restarts=4 \
   --rdzv-backend=lm_resiliency \
-  --rdzv-endpoint="$STORE_ENDPOINT" \
-  --rdzv-id="$RUN_ID" \
-  --rdzv-conf="store_type=tcp,is_host=false,read_timeout=120,\
-lm_resiliency_restart_context_path=$CONTEXT_PATH,\
-lm_resiliency_worker_config=/absolute/path/worker.toml" \
-  --module your_training.module \
-  [application arguments...]
+  --rdzv-endpoint="${RDZV_HOST}:29400" \
+  --rdzv-id="${RUN_ID}" \
+  --rdzv-conf="store_type=tcp,\
+lm_resiliency_restart_context_path=${RESTART_CONTEXT},\
+lm_resiliency_worker_config=${WORKER_CONFIG}" \
+  --module your_training.module
 ```
 
-For a file-backed single-host run, set `store_type=file` and use a private
-local rendezvous path. Multi-host validation uses an orchestrator-owned
-`TCPStore`.
+In this example, one eight-GPU node trains while a second eight-GPU node waits as standby. Both hosts run the same command. The training loop in `your_training.module` does not need any changes.
 
-When `lm_resiliency_worker_config` is set, the rendezvous plugin installs framework-import
-monitoring before Python executes the user module. Native PyTorch is tentative;
-an import of TorchTitan, Megatron Core, or DeepSpeed selects the corresponding
-more specific adapter before attachment. Multiple higher-level supported
-frameworks fail closed. After the default process group initializes, every rank
-agrees on the inferred framework before a built-in adapter can enter GEMINI or
-SCOUT collectives. Missing or conflicting framework evidence fails all ranks
-before attachment. The user module still owns the ordinary framework training
-loop.
-If the default process group uses NCCL, framework agreement runs on a temporary
-Gloo group and destroys that group immediately afterward. Agreement therefore
-does not require user code to bind `LOCAL_RANK` to a CUDA device before
-`init_process_group()`.
+See the [torchrun examples](../examples/torchrun/README.md) for runnable bootstrap and recovery campaigns. See the [API guide](api.md#enable-through-torchrun) for configuration and extension contracts.
 
-Torchrun supplies `LOCAL_WORLD_SIZE` to every worker from
-`--nproc-per-node`. Replacement workers compare that value with the
-manager-selected rank range before framework initialization, so the same
-topology invariant is preserved without duplicating worker width in
-`--rdzv-conf`.
-Bootstrap exposes the manager-selected resume position as
-`LM_RESILIENCY_TORCHRUN_CHECKPOINT_STEP`; generation-zero workers receive `0`.
-Applications can use it for deterministic sampler or token positioning without
-importing LM Resiliency.
+## Validation and Boundaries
 
-Adapters select a framework, not a parallelism strategy. Each adapter passes the
-same objects accepted by that framework's existing `enable_resiliency()` API,
-and the existing integration discovers supported DDP/FSDP/HSDP/TP/PP/EP/ZeRO
-topology exactly as it does for explicit activation. Framework-object discovery
-is intentionally fail-closed; stacks with custom trainers, multiple optimizers,
-sharded optimizers, or caller-owned loop state provide a custom adapter rather
-than relying on process-wide object scanning.
+The integration has been exercised with native PyTorch, DeepSpeed, Megatron Core, and TorchTitan. Multi-generation validation covered same-node restarts, SCOUT-localized standby replacement, and exact checkpoint restoration.
 
-Distributed native PyTorch attachment requires a recognized DDP or FSDP
-construction boundary that all participating ranks cross. At the first
-recognized distributed forward, every rank collectively proves that it has
-exactly one valid model/optimizer pair before any rank starts LM Resiliency
-attachment collectives. Rank-local warmup forwards cannot initiate those
-collectives.
+The current design intentionally targets fixed-size recovery:
 
-After attachment, built-in adapters bind cleanup to the framework's normal
-distributed teardown boundary. The resiliency handle closes before process
-groups are destroyed, so asynchronous checkpoint and replay work completes
-before the application reports a clean exit.
-On generation zero, DeepSpeed may call `engine.load_checkpoint()` before its
-first resiliency-managed training step; a successful load seeds the resiliency
-counter from `engine.global_steps`. Successor generations reject framework
-loads after the manager-selected GEMINI state has been restored.
+- standby machines are allocated before failure;
+- active world size remains stable during recovery;
+- one shared rendezvous store coordinates the agents;
+- built-in adapters restore GEMINI-managed state; and
+- replacing a worker does not repair hardware or allocate a new host.
 
-The worker policy is schema-versioned and strict even for disabled features.
-Every assigned node publishes a digest of the exact policy bytes, rendezvous
-requires one cohort-wide value, and worker bootstrap revalidates the digest
-before parsing or installing an adapter.
-`checkpoint.replication_jump` must be `-1` or positive,
-`checkpoint.replication_chunk_size` must be positive, and
-`checkpoint.disk_flush_interval` must be nonnegative; zero disables periodic
-disk persistence.
-Custom stacks set `adapter = "package.module:factory"` in that policy; built-in
-frameworks omit `adapter` and use import inference.
-GEMINI topology settings remain deployment-owned: for example,
-`replication_jump` must divide the checkpoint world according to the pairing
-contract documented in [GEMINI](gemini.md#peer-replication).
-
-## Manager Interface
-
-The public `TorchrunRecoveryCoordinator` wraps the canonical store protocol:
-
-```python
-import time
-
-from lm_resiliency.integrations.torchrun import (
-    TorchrunRecoveryCoordinator,
-    TorchrunRecoveryRequest,
-)
-
-coordinator = TorchrunRecoveryCoordinator(store, run_id=run_id)
-initial = coordinator.initial_placement(
-    active_node_count=8,
-    allocated_node_count=16,
-)
-assert initial is not None
-
-successor = coordinator.publish_successor(
-    generation=0,
-    active_node_ids=initial.active_node_ids,
-    quarantined_node_ids=(),
-    request=TorchrunRecoveryRequest(...),
-    local_world_size=1,
-    replacement=(faulty_slot, selected_standby),
-)
-
-# Deployment-owned evidence determines when the successor group is running.
-while not successor_admitted(successor):
-    coordinator.check_health()
-    time.sleep(0.1)
-
-coordinator.close()
-```
-
-`publish_successor()` is called only after SCOUT localization, GEMINI checkpoint
-selection/flush, quarantine, and standby placement succeed. Omitting
-`replacement` restarts the same assignments. Supplying `(logical_slot,
-standby_node_id)` replaces exactly one physical node while preserving its
-logical rank range. The coordinator must remain alive through successor
-admission so it can renew the store lease. Managers call `check_health()` while
-waiting for admission. Transient store errors are retried, while persistent
-renewal failure is latched and raised by health checks and later coordinator
-operations. `close()` stops renewal and wakes parked standbys after successful
-completion.
-
-`TorchrunLaunchConfig` constructs the framework-neutral torchrun argument list.
-It deliberately does not launch subprocesses, select GPUs, invoke SSH, or
-implement scheduler policy.
-
-## Safety Properties
-
-- active world size remains fixed;
-- generation-zero placement is immutable after the first `min_nodes`
-  registrations are committed;
-- duplicate physical machine identities fail closed;
-- logical slots and global-rank ranges remain stable;
-- a plan is immutable and generation-fenced;
-- plan eligibility is proven through a manager-renewed store lease and
-  host-local monotonic time rather than cross-host wall clocks;
-- only manager-selected replacements become visible to healthy agents;
-- an expired plan cannot admit a worker;
-- unselected and quarantined nodes are absent from the successor assignment;
-- restart context is written before replacement workers train;
-- worker generation, rank ranges, world size, and local lease deadline must match
-  the rendezvous decision before framework initialization;
-- malformed plan/context state fails closed;
-- heartbeat loss suppresses restart signaling; and
-- transient control-store contention does not create a false restart edge.
-
-## Validation
-
-Source-owned tests cover handler construction, generation-zero admission,
-duplicate-identity rejection, standby parking, same-node successor plans,
-slot-preserving replacement, context publication, worker-width fencing,
-zero-import bootstrap, framework inference, exact recovery-step verification,
-and bounded shutdown.
-
-Distributed validation used one torchrun agent per A100 and exercised eight
-active agents with eight standbys. The manager published sixteen same-node
-successor generations and eight SCOUT-localized replacements while preserving
-the fixed eight-rank world. Every successor rank restored the selected
-recovery-verified GEMINI checkpoint before training resumed. Native PyTorch,
-DeepSpeed, Megatron Core, and TorchTitan also completed a focused
-restart-and-replacement campaign through their framework-owned training
-boundaries.
-
-Runnable bootstrap and manager-driven end-to-end programs live under
-[`examples/torchrun`](../examples/torchrun/README.md). The
-resiliency-cycle controller launches torchrun agents and is not itself a
-training worker.
-
-## Current Boundaries
-
-- fixed-size replacement only; no scale-up or scale-down;
-- stable topology and local worker count across generations;
-- standbys must already be allocated and running;
-- one torchrun agent per unique `/etc/machine-id` is required outside the
-  synthetic validation harness;
-- the manager, not torchrun, owns evidence evaluation and quarantine policy;
-- one shared control-store endpoint is required;
-- built-in injected adapters support exact manager-selected GEMINI recovery;
-  the selected step and checkpoint-topology digest are validated before load;
-  durable-source replacement requires a custom adapter with a framework loader;
-- replacement does not repair hardware or allocate new hosts; and
-- the production campaign uses DDP and tiny deterministic workloads, not
-  publication-scale convergence.
+Within those boundaries, LM Resiliency gives torchrun enough information to do more than relaunch processes: it recovers the training job from state that has already been checked for safety.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -91,7 +91,7 @@ Native PyTorch does not prescribe a trainer.
 The production example validates its application-owned DDP loop.
 Dedicated lifecycle programs additionally validate FSDP2 and HSDP on the same two hosts.
 
-The executable one-host and two-host `torchrun` commands are documented in [Production-loop examples](../examples/README.md).
+The executable `torchrun` commands are documented in the [torchrun resiliency guide](torchrun_resiliency.md) and [torchrun workflows](../examples/torchrun/README.md).
 Systematic injection is exercised separately through the
 [manual fault-injection qualification campaign](../tests/validation/fault_injection/README.md),
 keeping the zero-import production loops free of validation-only fault controls.

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,42 +27,11 @@ from the user module's imports.
 | Megatron Core | [megatron.py](production_loops/megatron.py) | `training.train()` and `train_step()` |
 | DeepSpeed | [deepspeed.py](production_loops/deepspeed.py) | `DeepSpeedEngine.backward()` and `DeepSpeedEngine.step()` |
 
-Run one example on two eight-GPU hosts from the repository root. Start the same
-command on both hosts and set `RDZV_HOST` to a hostname or IP address reachable
-from both:
-
-```bash
-RDZV_HOST=node-a
-
-# --nnodes=1:2 keeps one node active and parks a second node as standby.
-# --nproc-per-node=8 launches eight training workers only on the active node.
-# --max-restarts=4 allows each torchrun agent to restart its workers four times.
-# --rdzv-backend=lm_resiliency enables active/standby admission and recovery.
-torchrun \
-  --nnodes=1:2 \
-  --nproc-per-node=8 \
-  --max-restarts=4 \
-  --rdzv-backend=lm_resiliency \
-  --rdzv-endpoint="${RDZV_HOST}:29400" \
-  --rdzv-id=torchtitan-production \
-  --rdzv-conf="store_type=tcp,read_timeout=120,\
-lm_resiliency_restart_context_path=/tmp/lm-resiliency-torchtitan-context/context.json,\
-lm_resiliency_worker_config=$PWD/examples/production_loops/policies/resiliency.toml" \
-  --module \
-  examples.production_loops.torchtitan \
-  --validation-output-dir /tmp/torchtitan-production-loop
-```
-
-The first registered host receives the eight logical training ranks. The other
-host remains parked as a standby until torchrun selects it to replace a faulty
-host. Use `--nnodes=1:1` only for a single-host run without standby
-replacement.
-
-Replace the module, rendezvous paths, and validation output directory for
-PyTorch, Megatron Core, or DeepSpeed. The worker infers the framework from
-imports. The checked-in worker policy uses
-`replication_jump=4` for this eight-rank topology. Other world layouts must use
-a policy with a valid deployment-specific GEMINI pairing.
+See the [torchrun resiliency guide](../docs/torchrun_resiliency.md) for the
+integrated launch command and the [torchrun workflows](torchrun/README.md) for
+runnable bootstrap, framework-matrix, and recovery campaigns. Select the
+corresponding module under `examples.production_loops`; the worker infers the
+framework from its imports.
 
 Each framework example runs ten steps by default; set `--steps` to change the
 duration. Rank zero writes a framework summary under


### PR DESCRIPTION
## Summary

- rewrite `docs/torchrun_resiliency.md` as a technical narrative centered on the closed-loop recovery lifecycle
- explain how torchrun, LM Resiliency, and supported training frameworks interact
- compare standard torchrun launch with the LM Resiliency rendezvous backend
- remove duplicated production-loop commands from `examples/README.md` and update documentation links

## User impact

Readers now encounter the architecture and failure-to-recovery storyline before operational commands and implementation boundaries. Runnable commands remain in the dedicated torchrun guides instead of being repeated in the examples index.

## Validation

- `python -m pytest -q tests/unit/test_documentation.py tests/unit/test_readme_examples.py tests/unit/test_validation_evidence.py`
- `ruff check .`
- `ruff format --check .`
- `git diff --check`
