### PR TITLE
[CI/Release] Prepare v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ The project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-19
+
 ### Added
 
+- A native `torchrun` rendezvous backend that provides closed-loop recovery through active/standby admission, same-node restart, faulty-node replacement, and exact manager-selected GEMINI recovery.
+- Automatic zero-import worker adapters for native PyTorch, DeepSpeed, Megatron Core, and TorchTitan while preserving each framework's training loop and recovery state.
+- Runnable production-loop, adapter-bootstrap, and resiliency-cycle examples, including a single-host campaign covering all 21 canonical fault types.
 - A runnable CPU quick-start example with a complete native PyTorch training loop and GEMINI checkpoint resume.
 - A scheduled and maintainer-dispatched two-GPU qualification workflow with machine-readable revision, environment, topology, command, log, and checksum evidence.
 - A framework-neutral fault injection evaluation kit with incident schedules, automatic training-iteration hooks, verified ground truth, capability-checked executors, neutral localization scoring, and a systematic eight-GPU DDP/SCOUT evaluation matrix.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ type: software
 authors:
   - family-names: "Wang"
     given-names: "Zhuang"
-version: 0.1.0
+version: 0.2.0
 license: BSD-3-Clause
 repository-code: "https://github.com/LMResiliency/lm-resiliency"
 url: "https://github.com/LMResiliency/lm-resiliency"

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -99,7 +99,7 @@ Contract tests require every declared Python and PyTorch minor series to appear 
 
 Stable exports from `lm_resiliency`, `lm_resiliency.manager_api`, explicit
 framework integration entry points, and `lm_resiliency.integrations.torchrun`
-remain backward compatible across `0.1.x` patch releases.
+remain backward compatible across `0.2.x` patch releases.
 The documented `lm-resiliency-quickstart` and `lm-resiliency-discover-moe-regimes` commands and their existing options follow the same patch-release compatibility policy.
 Removing or changing a stable interface requires a new minor release and migration notes.
 Objects under `lm_resiliency.experimental` and unlisted module paths may change in any `0.x` release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lm-resiliency"
-version = "0.1.0"
+version = "0.2.0"
 description = "GEMINI in-memory checkpointing and SCOUT fault localization for LLM training"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/tests/unit/test_gpu_qualification.py
+++ b/tests/unit/test_gpu_qualification.py
@@ -48,7 +48,7 @@ def test_gpu_qualification_writes_failure_evidence_without_required_gpus(tmp_pat
                 "cuda_available": False,
                 "cuda_runtime": None,
                 "nccl": None,
-                "frameworks": {"lm-resiliency": "0.1.0", "pytorch": "2.13.0"},
+                "frameworks": {"lm-resiliency": "0.2.0", "pytorch": "2.13.0"},
             },
             "runner": {"name": None, "os": None, "arch": None},
         },

--- a/tests/unit/test_validation_evidence.py
+++ b/tests/unit/test_validation_evidence.py
@@ -72,7 +72,7 @@ def test_seal_and_verify_revision_bound_bundle(tmp_path):
     verified = validation_evidence.verify_bundle(bundle, expected_commit=_COMMIT)
 
     assert verified == manifest
-    assert manifest["project"]["version"] == "0.1.0"
+    assert manifest["project"]["version"] == "0.2.0"
     assert manifest["campaign"]["command_ids"] == ["smoke"]
     assert manifest["qualification"]["boundaries"] == ["CPU only."]
     assert {record["path"] for record in manifest["files"]} == {


### PR DESCRIPTION
## Summary

- bump the package and citation metadata from `0.1.0` to `0.2.0`
- promote the accumulated changelog entries into the dated `0.2.0` release
- highlight native torchrun closed-loop recovery, automatic framework adapters, and runnable recovery examples
- advance the stable API compatibility series to `0.2.x`
- update version-bound validation contracts

## Release rationale

Native torchrun integration adds a new stable rendezvous backend and public framework-adapter surface while remaining backward compatible with existing APIs. This is therefore a minor release under the repository's compatibility policy.

## Validation

- 17 focused release/evidence tests passed
- built `lm_resiliency-0.2.0-py3-none-any.whl` and `lm_resiliency-0.2.0.tar.gz` with the pinned Python 3.12 release toolchain
- `twine check` passed for both distributions
- release manifest creation and digest verification passed
- `ruff check .`
- `ruff format --check .`
- `git diff --check`

After this PR merges and required checks pass, an organization administrator should create protected tag `v0.2.0` at the merge commit. The release workflow will validate, publish to PyPI, create the immutable GitHub release, and publish versioned documentation.