### PR TITLE
[CI/Release] Make release publication resumable

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,6 +1,7 @@
 name: Deploy GitHub Pages
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows:
       - Documentation
@@ -19,8 +20,11 @@ jobs:
   deploy:
     name: Deploy staged documentation
     if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push'
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push'
+      )
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -364,25 +364,69 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           version=$(jq -r '.version' dist/release-manifest.json)
           release_flags=()
           if [[ "$(python scripts/release_versions.py is-prerelease "$version")" == "true" ]]; then
             release_flags+=(--prerelease)
           fi
-          gh release create "$GITHUB_REF_NAME" dist/* \
-            --repo "$GITHUB_REPOSITORY" \
-            --verify-tag \
-            --draft \
-            --title "lm-resiliency $GITHUB_REF_NAME" \
-            --generate-notes \
-            "${release_flags[@]}"
-          gh release edit "$GITHUB_REF_NAME" \
-            --repo "$GITHUB_REPOSITORY" \
-            --draft=false
-          gh release verify "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY"
+
+          release_json=$(
+            gh api --paginate \
+              "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+              --jq '.[] | select(.tag_name == env.GITHUB_REF_NAME)'
+          )
+          if [[ -n "$release_json" ]]; then
+            test "$(jq -r '.tag_name' <<<"$release_json")" = "$GITHUB_REF_NAME"
+            expected_prerelease=false
+            if [[ "${#release_flags[@]}" -gt 0 ]]; then
+              expected_prerelease=true
+            fi
+            test "$(jq -r '.prerelease' <<<"$release_json")" = "$expected_prerelease"
+            if [[ "$(jq -r '.draft' <<<"$release_json")" == "true" ]]; then
+              gh release upload "$GITHUB_REF_NAME" dist/* \
+                --repo "$GITHUB_REPOSITORY" \
+                --clobber
+              gh release edit "$GITHUB_REF_NAME" \
+                --repo "$GITHUB_REPOSITORY" \
+                --draft=false
+            fi
+          else
+            gh release create "$GITHUB_REF_NAME" dist/* \
+              --repo "$GITHUB_REPOSITORY" \
+              --verify-tag \
+              --draft \
+              --title "lm-resiliency $GITHUB_REF_NAME" \
+              --generate-notes \
+              "${release_flags[@]}"
+            gh release edit "$GITHUB_REF_NAME" \
+              --repo "$GITHUB_REPOSITORY" \
+              --draft=false
+          fi
+
+          for attempt in $(seq 1 12); do
+            if gh release verify "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY"; then
+              break
+            fi
+            if test "$attempt" -eq 12; then
+              echo "Release attestation was not available after $attempt attempts" >&2
+              exit 1
+            fi
+            sleep 5
+          done
+
           for artifact in dist/*; do
-            gh release verify-asset "$GITHUB_REF_NAME" "$artifact" \
-              --repo "$GITHUB_REPOSITORY"
+            for attempt in $(seq 1 12); do
+              if gh release verify-asset "$GITHUB_REF_NAME" "$artifact" \
+                --repo "$GITHUB_REPOSITORY"; then
+                break
+              fi
+              if test "$attempt" -eq 12; then
+                echo "Asset attestation was not available for $artifact after $attempt attempts" >&2
+                exit 1
+              fi
+              sleep 5
+            done
           done
 
   build-release-docs:

--- a/docs/release.md
+++ b/docs/release.md
@@ -17,9 +17,9 @@ Production releases use one identified wheel and source distribution from build 
 5. The workflow reruns the pinned primary CPU suite, builds with a pinned toolchain, and writes `release-manifest.json` and `SHA256SUMS` for the wheel and source distribution.
 6. The exact downloaded artifacts pass manifest verification, clean installation, Quick Start, `pip check`, dependency audit, and GitHub build-provenance verification.
 7. After protected-environment approval, the workflow re-resolves the remote tag against the identified commit and publishes the same artifact bundle to PyPI.
-8. The workflow rechecks the tag again, creates a draft GitHub release, attaches every artifact plus its manifest and checksums, publishes it, then verifies the immutable release and each local asset.
+8. The workflow rechecks the tag again, creates a draft GitHub release, attaches every artifact plus its manifest and checksums, publishes it, then polls for the immutable release attestation and verifies each local asset. A rerun reuses a matching draft or published release instead of attempting to recreate it.
 
-The workflow blocks PyPI publication when any source, tag, revision, version, digest, artifact-membership, validation, audit, provenance, or environment-approval check fails. GitHub release creation and immutable-asset verification necessarily follow PyPI publication; a failure in that final job leaves the workflow failed and requires operator intervention because published PyPI files cannot be rolled back.
+The workflow blocks PyPI publication when any source, tag, revision, version, digest, artifact-membership, validation, audit, provenance, or environment-approval check fails. GitHub release creation and immutable-asset verification necessarily follow PyPI publication; a failure in that final job leaves the workflow failed and requires operator intervention because published PyPI files cannot be rolled back. If release documentation was staged successfully but its normal deployment dependency failed, a trusted maintainer can manually dispatch the Pages workflow after verifying the exact release and `gh-pages` contents.
 
 ## TestPyPI
 

--- a/tests/unit/test_documentation.py
+++ b/tests/unit/test_documentation.py
@@ -65,11 +65,12 @@ def test_deployment_contracts_cover_every_destination():
     assert "--offline" not in online_links
 
     assert "workflow_run:" in pages
+    assert "workflow_dispatch:" in pages
     assert "- Documentation" in pages
     assert "- Release" in pages
     assert "github.event.workflow_run.conclusion == 'success'" in pages
     assert "github.event.workflow_run.event == 'push'" in pages
-    assert "workflow_dispatch" not in pages
+    assert "github.event_name == 'workflow_dispatch'" in pages
     assert "ref: gh-pages" in pages
     assert "group: pages-deploy" in pages
     assert "cancel-in-progress: true" in pages

--- a/tests/unit/test_release_artifacts.py
+++ b/tests/unit/test_release_artifacts.py
@@ -92,3 +92,9 @@ def test_production_release_jobs_require_tag_push_and_recheck_target():
     production_condition = "if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')"
     assert workflow.count(production_condition) == 2
     assert workflow.count("- name: Recheck release tag target") == 2
+    assert '"repos/$GITHUB_REPOSITORY/releases?per_page=100"' in workflow
+    assert "select(.tag_name == env.GITHUB_REF_NAME)" in workflow
+    assert 'gh release upload "$GITHUB_REF_NAME" dist/*' in workflow
+    assert workflow.count("for attempt in $(seq 1 12)") >= 3
+    assert "Release attestation was not available" in workflow
+    assert "Asset attestation was not available" in workflow


### PR DESCRIPTION
## Summary

- reuse a matching draft or published GitHub release when a release job is rerun
- retry immutable release and asset verification while GitHub propagates attestations
- allow trusted manual Pages deployment when a release dependency fails after documentation staging

## Root cause

The `v0.2.0` release was published successfully, but `gh release verify` ran immediately after publication and failed before GitHub generated the immutable release attestation. A failed-job rerun could not recover because the workflow attempted to create the already-published immutable release again.

## Validation

- `python -m pytest -q tests/unit/test_release_artifacts.py tests/unit/test_documentation.py`
- `ruff check .`
- `ruff format --check .`
- YAML parse validation for both changed workflows
- authenticated release lookup against the existing `v0.2.0` release
- current `v0.2.0` immutable release and all four assets verified with GitHub CLI 2.97.0
